### PR TITLE
Optimized Hessian Vector Products

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt
+            cd timemachine/cpu_functionals && sh make.sh
 
       - save_cache:
           paths:
@@ -41,7 +42,6 @@ jobs:
           key: v1-dependencies-{{ checksum "requirements.txt" }}
         
       # run tests!
-      # this example uses Django's built-in test-runner
       # other common Python testing frameworks include pytest and nose
       # https://pytest.org
       # https://nose.readthedocs.io

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt
+            gcc --version
             cd timemachine/cpu_functionals && sh make.sh
 
       - save_cache:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 nose==1.3.7
-pybind11=2.2.4
+pybind11==2.2.4
 scipy==1.1.0
 tensorflow==1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 nose==1.3.7
+pybind11=2.2.4
 scipy==1.1.0
 tensorflow==1.12.0

--- a/tests/test_bonded_force.py
+++ b/tests/test_bonded_force.py
@@ -260,7 +260,7 @@ class TestPeriodicTorsion(unittest.TestCase):
             angle_op = ref_nrg.angles(x_ph)
             ref_grad, ref_hessians, ref_mixed_partials = derivatives.compute_ghm(nrg_op, x_ph, [params_tf])
 
-            np.random.seed(0)
+            # np.random.seed(0)
             dxdp = np.random.rand(params_np.shape[0], conf.shape[0], 3)
 
             test_nrg, test_grads, test_totals = test_torsion.total_derivative(conf, dxdp)

--- a/tests/test_bonded_force.py
+++ b/tests/test_bonded_force.py
@@ -4,6 +4,8 @@ import tensorflow as tf
 from timemachine.functionals import bonded
 from tensorflow.python.ops.parallel_for.gradients import jacobian
 from timemachine import derivatives
+from timemachine.cpu_functionals import energy
+
 
 class PeriodicTorsionForceOpenMM():
 
@@ -56,10 +58,8 @@ class PeriodicTorsionForceOpenMM():
         e0 = ks*(1+tf.cos(period * angle - phase)) # cos(a) cos(t0) + sin(a) sin(t0)
         return tf.reduce_sum(e0, axis=-1)
 
-class TestBonded(unittest.TestCase):
 
-    def tearDown(self):
-        tf.reset_default_graph()
+class TestBonded(unittest.TestCase):
 
     def test_harmonic_bond(self):
         x0 = np.array([
@@ -67,34 +67,44 @@ class TestBonded(unittest.TestCase):
             [-0.5,-1.1,-0.9], # C
         ], dtype=np.float64)
 
-        bond_params = [
-            tf.get_variable("HC_kb", shape=tuple(), dtype=tf.float64, initializer=tf.constant_initializer(10.0)),
-            tf.get_variable("HC_b0", shape=tuple(), dtype=tf.float64, initializer=tf.constant_initializer(3.0))
-        ]
+        dxdp = np.array([
+            [[1.0, 0.5, 3.3], # H 
+            [-0.5,-1.3,-0.9]], # C
 
-        hb = bonded.HarmonicBond(
-            params=bond_params,
-            bond_idxs=np.array([[0,1]], dtype=np.int32),
-            param_idxs=np.array([[0,1]], dtype=np.int32)
+            [[0.3, 0.2, 3.1], # H 
+            [ 0.8,-1.1,-0.2]], # C
+
+        ], dtype=np.float64)
+
+        bond_params_np = np.array([10.0, 3.0], dtype=np.float64)
+        bond_params_tf = tf.convert_to_tensor(bond_params_np)
+        param_idxs = np.array([[0,1]], dtype=np.int32)
+        bond_idxs = np.array([[0,1]], dtype=np.int32)
+
+        ref_hb = bonded.HarmonicBond(
+            params=bond_params_tf,
+            param_idxs=param_idxs,
+            bond_idxs=bond_idxs,
+        )
+
+        test_hb = energy.HarmonicBond_double(
+            bond_params_np.reshape(-1).tolist(),
+            param_idxs.reshape(-1).tolist(),
+            bond_idxs.reshape(-1).tolist(),
         )
 
         x_ph = tf.placeholder(shape=(2,3), dtype=np.float64)
-
-        nrg_op = hb.energy(x_ph)
-
-        hess_op = tf.hessians(nrg_op, x_ph)
-
+        nrg_op = ref_hb.energy(x_ph)
+        ref_grad, ref_hessians, ref_mixed_partials = derivatives.compute_ghm(nrg_op, x_ph, [bond_params_tf])
+        test_nrg, test_grads, test_totals = test_hb.total_derivative(x0, dxdp)
 
         sess = tf.Session()
-        sess.run(tf.initializers.global_variables())
+        np.testing.assert_array_almost_equal(test_nrg, sess.run(nrg_op, feed_dict={x_ph: x0}), decimal=13)
+        np.testing.assert_array_almost_equal(test_grads, sess.run(ref_grad, feed_dict={x_ph: x0}), decimal=13)
 
-        jac_op = jacobian(derivatives.densify(tf.gradients(nrg_op, x_ph)[0]), bond_params, use_pfor=False)
-
-        print(sess.run(hess_op, feed_dict={x_ph: x0})[0].reshape((2, -1)))
-
-        print(sess.run(jac_op, feed_dict={x_ph: x0})[0].reshape((2, -1)))
-        print(sess.run(jac_op, feed_dict={x_ph: x0})[1].reshape((2, -1)))
-
+        td_op = derivatives.total_derivative(ref_hessians, dxdp, ref_mixed_partials)
+        total_deriv = sess.run(td_op, feed_dict={x_ph: x0})
+        np.testing.assert_array_almost_equal(total_deriv, test_totals)
 
 
 
@@ -142,6 +152,7 @@ class TestBondedForce(unittest.TestCase):
     def tearDown(self):
         tf.reset_default_graph()
 
+    @unittest.skip("fast")
     def test_torsions_with_openmm(self):
         """
         Test agreement of torsions with OpenMM's implementation of torsion terms.

--- a/tests/test_bonded_force.py
+++ b/tests/test_bonded_force.py
@@ -152,7 +152,6 @@ class TestBondedForce(unittest.TestCase):
     def tearDown(self):
         tf.reset_default_graph()
 
-    @unittest.skip("fast")
     def test_torsions_with_openmm(self):
         """
         Test agreement of torsions with OpenMM's implementation of torsion terms.

--- a/tests/test_bonded_force.py
+++ b/tests/test_bonded_force.py
@@ -7,6 +7,118 @@ from timemachine import derivatives
 from timemachine.cpu_functionals import energy
 
 
+class TestAngles(unittest.TestCase):
+
+    def test_harmonic_angle(self):
+        masses = np.array([6.0, 1.0, 1.0, 1.0, 1.0])
+        x0 = np.array([
+            [ 0.0637,   0.0126,   0.2203], # C
+            [ 1.0573,  -0.2011,   1.2864], # H
+            [ 2.3928,   1.2209,  -0.2230], # H
+            [-0.6891,   1.6983,   0.0780], # H
+            [-0.6312,  -1.6261,  -0.2601], # H
+        ], dtype=np.float64)
+        num_atoms = len(masses)
+        angle_params_np = np.array([75, 1.91, 0.45], dtype=np.float64)
+        angle_params_tf = tf.convert_to_tensor(angle_params_np)
+
+
+        angle_idxs = np.array([[1,0,2],[1,0,3],[1,0,4],[2,0,3],[2,0,4],[3,0,4]])
+        param_idxs = np.array([[0,1],[0,1],[0,2],[0,1],[0,1],[0,2]])
+
+        ref_ha = bonded.HarmonicAngle(
+            params=angle_params_tf,
+            angle_idxs=angle_idxs,
+            param_idxs=param_idxs,
+            cos_angles=True
+        )
+
+        test_ha = energy.HarmonicAngle_double(
+            angle_params_np.reshape(-1).tolist(),
+            param_idxs.reshape(-1).tolist(),
+            angle_idxs.reshape(-1).tolist(),
+            True,
+        )
+
+        dxdp = np.random.rand(angle_params_np.shape[0], len(masses), 3)
+
+        x_ph = tf.placeholder(shape=x0.shape, dtype=np.float64)
+        nrg_op = ref_ha.energy(x_ph)
+        ref_grad, ref_hessians, ref_mixed_partials = derivatives.compute_ghm(nrg_op, x_ph, [angle_params_tf])
+        test_nrg, test_grads, test_totals = test_ha.total_derivative(x0, dxdp)
+
+        sess = tf.Session()
+        np.testing.assert_array_almost_equal(test_nrg, sess.run(nrg_op, feed_dict={x_ph: x0}), decimal=13)
+        np.testing.assert_array_almost_equal(test_grads, sess.run(ref_grad, feed_dict={x_ph: x0}), decimal=13)
+
+        td_op = derivatives.total_derivative(ref_hessians, dxdp, ref_mixed_partials)
+        total_deriv = sess.run(td_op, feed_dict={x_ph: x0})
+        np.testing.assert_array_almost_equal(total_deriv, test_totals)
+
+
+class TestBonded(unittest.TestCase):
+
+    def test_harmonic_bond(self):
+        x0 = np.array([
+            [1.0, 0.2, 3.3], # H 
+            [-0.5,-1.1,-0.9], # C
+            [3.4, 5.5, 0.2], # H 
+        ], dtype=np.float64)
+
+        dxdp = np.array([
+            [
+             [1.0, 0.5, 3.3], # H 
+             [-0.5,-1.3,-0.9],
+             [-0.7,0.4,0.5],
+            ], # C
+
+            [
+             [0.3, 0.2, 3.1], # H 
+             [0.8,-1.1,-0.2],
+             [-0.2,0.1,0.9]
+            ],
+
+            [
+             [0.5, 0.7, 3.5], # H 
+             [0.2,-1.8,-0.2],
+             [-0.3,0.9, 0.5]
+            ], # C
+
+        ], dtype=np.float64)
+
+        bond_params_np = np.array([10.0, 3.0, 5.5], dtype=np.float64)
+        bond_params_tf = tf.convert_to_tensor(bond_params_np)
+        param_idxs = np.array([
+            [0,1],
+            [1,2],
+        ], dtype=np.int32)
+        bond_idxs = np.array([[0,1], [1,2]], dtype=np.int32)
+
+        ref_hb = bonded.HarmonicBond(
+            params=bond_params_tf,
+            param_idxs=param_idxs,
+            bond_idxs=bond_idxs,
+        )
+
+        test_hb = energy.HarmonicBond_double(
+            bond_params_np.reshape(-1).tolist(),
+            param_idxs.reshape(-1).tolist(),
+            bond_idxs.reshape(-1).tolist(),
+        )
+
+        x_ph = tf.placeholder(shape=x0.shape, dtype=np.float64)
+        nrg_op = ref_hb.energy(x_ph)
+        ref_grad, ref_hessians, ref_mixed_partials = derivatives.compute_ghm(nrg_op, x_ph, [bond_params_tf])
+        test_nrg, test_grads, test_totals = test_hb.total_derivative(x0, dxdp)
+
+        sess = tf.Session()
+        np.testing.assert_array_almost_equal(test_nrg, sess.run(nrg_op, feed_dict={x_ph: x0}), decimal=13)
+        np.testing.assert_array_almost_equal(test_grads, sess.run(ref_grad, feed_dict={x_ph: x0}), decimal=13)
+
+        td_op = derivatives.total_derivative(ref_hessians, dxdp, ref_mixed_partials)
+        total_deriv = sess.run(td_op, feed_dict={x_ph: x0})
+        np.testing.assert_array_almost_equal(total_deriv, test_totals)
+
 class PeriodicTorsionForceOpenMM():
 
     def __init__(self,
@@ -59,56 +171,7 @@ class PeriodicTorsionForceOpenMM():
         return tf.reduce_sum(e0, axis=-1)
 
 
-class TestBonded(unittest.TestCase):
-
-    def test_harmonic_bond(self):
-        x0 = np.array([
-            [1.0, 0.2, 3.3], # H 
-            [-0.5,-1.1,-0.9], # C
-        ], dtype=np.float64)
-
-        dxdp = np.array([
-            [[1.0, 0.5, 3.3], # H 
-            [-0.5,-1.3,-0.9]], # C
-
-            [[0.3, 0.2, 3.1], # H 
-            [ 0.8,-1.1,-0.2]], # C
-
-        ], dtype=np.float64)
-
-        bond_params_np = np.array([10.0, 3.0], dtype=np.float64)
-        bond_params_tf = tf.convert_to_tensor(bond_params_np)
-        param_idxs = np.array([[0,1]], dtype=np.int32)
-        bond_idxs = np.array([[0,1]], dtype=np.int32)
-
-        ref_hb = bonded.HarmonicBond(
-            params=bond_params_tf,
-            param_idxs=param_idxs,
-            bond_idxs=bond_idxs,
-        )
-
-        test_hb = energy.HarmonicBond_double(
-            bond_params_np.reshape(-1).tolist(),
-            param_idxs.reshape(-1).tolist(),
-            bond_idxs.reshape(-1).tolist(),
-        )
-
-        x_ph = tf.placeholder(shape=(2,3), dtype=np.float64)
-        nrg_op = ref_hb.energy(x_ph)
-        ref_grad, ref_hessians, ref_mixed_partials = derivatives.compute_ghm(nrg_op, x_ph, [bond_params_tf])
-        test_nrg, test_grads, test_totals = test_hb.total_derivative(x0, dxdp)
-
-        sess = tf.Session()
-        np.testing.assert_array_almost_equal(test_nrg, sess.run(nrg_op, feed_dict={x_ph: x0}), decimal=13)
-        np.testing.assert_array_almost_equal(test_grads, sess.run(ref_grad, feed_dict={x_ph: x0}), decimal=13)
-
-        td_op = derivatives.total_derivative(ref_hessians, dxdp, ref_mixed_partials)
-        total_deriv = sess.run(td_op, feed_dict={x_ph: x0})
-        np.testing.assert_array_almost_equal(total_deriv, test_totals)
-
-
-
-class TestBondedForce(unittest.TestCase):
+class TestPeriodicTorsions(unittest.TestCase):
 
     def setUp(self):
         self.conformers = np.array([

--- a/tests/test_nonbonded_force.py
+++ b/tests/test_nonbonded_force.py
@@ -40,10 +40,66 @@ class ReferenceLJEnergy():
 
         return ref_nrg
 
-class TestLeonnardJones(unittest.TestCase):
+class TestLennardJones(unittest.TestCase):
 
     def tearDown(self):
         tf.reset_default_graph()
+
+    def test_lj612_cpu(self):
+
+        x0 = np.array([
+            [ 0.0637,   0.0126,   0.2203],
+            [ 1.0573,  -0.2011,   1.2864],
+            [ 2.3928,   1.2209,  -0.2230],
+            [-0.6891,   1.6983,   0.0780],
+            [-0.6312,  -1.6261,  -0.2601]
+        ], dtype=np.float64)
+
+        x_ph = tf.placeholder(shape=(5, 3), dtype=np.float64)
+
+        params_np = np.array([3.0, 2.0, 1.0, 1.4], dtype=np.float64)
+        params_tf = tf.convert_to_tensor(params_np)
+        param_idxs = np.array([
+            [0, 3],
+            [1, 2],
+            [1, 2],
+            [1, 2],
+            [1, 2]], dtype=np.int32)
+
+        scale_matrix = np.array([
+            [  0,  0,  1,0.5,  0],
+            [  0,  0,  0,  1,  1],
+            [  1,  0,  0,  0,0.2],
+            [0.5,  1,  0,  0,  1],
+            [  0,  1,0.2,  1,  0],
+        ], dtype=np.float64)
+
+        sess = tf.Session()
+        sess.run(tf.initializers.global_variables())
+
+        cutoff = None
+
+        ref_nrg = LeonnardJones(params_tf, param_idxs, scale_matrix, cutoff=cutoff)
+        nrg_op = ref_nrg.energy(x_ph)
+
+        test_nrg = energy.LennardJones_double(
+            params_np.reshape(-1).tolist(),
+            param_idxs.reshape(-1).tolist(),
+            scale_matrix.reshape(-1).tolist()
+        )
+
+        dxdp = np.random.rand(params_np.shape[0], x0.shape[0], 3)
+
+        ref_grad, ref_hessians, ref_mixed_partials = derivatives.compute_ghm(nrg_op, x_ph, [params_tf])
+        test_nrg, test_grads, test_totals = test_nrg.total_derivative(x0, dxdp)
+
+        sess = tf.Session()
+        np.testing.assert_array_almost_equal(test_nrg, sess.run(nrg_op, feed_dict={x_ph: x0}), decimal=13)
+        np.testing.assert_array_almost_equal(test_grads, sess.run(ref_grad, feed_dict={x_ph: x0}), decimal=12)
+
+        td_op = derivatives.total_derivative(ref_hessians, dxdp, ref_mixed_partials)
+        total_deriv = sess.run(td_op, feed_dict={x_ph: x0})
+        np.testing.assert_array_almost_equal(total_deriv, test_totals)
 
     def test_lj612(self):
         """

--- a/timemachine/cpu_functionals/bonded_cpu.cpp
+++ b/timemachine/cpu_functionals/bonded_cpu.cpp
@@ -1,0 +1,63 @@
+#include "bonded_cpu.hpp"
+
+
+int main() {
+    std::vector<double> params({5.0, 1.0, 2.2, 3.0});
+    std::vector<size_t> param_idxs({
+        1, 3,
+        0, 2,
+        0, 1,
+        1, 2
+    });
+    std::vector<size_t> bond_idxs({
+        0, 1,
+        0, 2,
+        0, 3,
+        0, 4
+    });
+    
+    timemachine::HarmonicBond<double> hb(
+        params,
+        param_idxs,
+        bond_idxs
+    );
+    std::vector<double> geometry({
+         0.0637,   0.0126,   0.2203,
+         1.0573,  -0.2011,   1.2864,
+         2.3928,   1.2209,  -0.2230,
+        -0.6891,   1.6983,   0.0780,
+        -0.6312,  -1.6261,  -0.2601
+    });
+    std::vector<double> dxdp({
+        0.10422066, 0.17122579, 0.72177294,
+        0.08101986, 0.95524382, 0.77068016,
+        0.3582338 , 0.70634414, 0.29395797,
+        0.89439972, 0.23706983, 0.01236061,
+        0.95828988, 0.49409002, 0.72811251,
+
+        0.6789271 , 0.84382456, 0.4675572,
+        0.12289735, 0.01340453, 0.99346565,
+        0.41574403, 0.89688291, 0.02852552,
+        0.83768939, 0.99084417, 0.87983468,
+        0.15627564, 0.18022404, 0.4307694
+    });
+
+    std::vector<double> grad_out(5*3, 0.0);
+    std::vector<double> total_out(2*5*3, 0.0);
+    double energy = 0;
+
+    hb.total_derivative(
+        5,
+        2,
+        &geometry[0],
+        &dxdp[0],
+        &energy,
+        &grad_out[0],
+        &total_out[0]
+    );
+
+    for(auto i=0; i < 2*5*3; i++) {
+        std::cout << total_out[i] << std::endl;
+    }
+
+}

--- a/timemachine/cpu_functionals/bonded_cpu.hpp
+++ b/timemachine/cpu_functionals/bonded_cpu.hpp
@@ -64,10 +64,10 @@ public:
         ParamType kb = params[0];
         ParamType b0 = params[1];
 
-        auto dx = x0-x1;
-        auto dy = y0-y1;
-        auto dz = z0-z1;
-        auto dij = sqrt(dx*dx+dy*dy+dz*dz);
+        CoordType dx = x0-x1;
+        CoordType dy = y0-y1;
+        CoordType dz = z0-z1;
+        CoordType dij = sqrt(dx*dx+dy*dy+dz*dz);
         auto db = dij-b0;
         dxs[0] = kb*db*dx/dij;
         dxs[1] = kb*db*dy/dij;

--- a/timemachine/cpu_functionals/bonded_cpu.hpp
+++ b/timemachine/cpu_functionals/bonded_cpu.hpp
@@ -5,9 +5,367 @@
 #include <vector>
 #include "utils.hpp"
 
-
-
 namespace timemachine {
+
+template<typename RealType>
+std::complex<RealType> sign(std::complex<RealType> arg) {
+    if(arg.real() == 0 && arg.imag() == 0) {
+        return std::complex<RealType>(0.0, 0.0);
+    } else {
+        auto res = arg/analytic_abs(arg);
+        std::cout << "RES: " << arg << " " << analytic_abs(arg) << " | " << res << std::endl;
+        return res;
+    }
+}
+
+float complex_atan2(float z1, float z2) {
+    return std::atan2(z1, z2);
+}
+
+
+double complex_atan2(double z1, double z2) {
+    return std::atan2(z1, z2);
+}
+
+std::complex<double> complex_atan2(std::complex<double> z1, std::complex<double> z2) {
+    double real_part = std::atan2(z1.real(),z2.real());
+    double imag_part = (z2.real()*z1.imag()-z1.real()*z2.imag())/(z1.real()*z1.real()+z2.real()*z2.real());
+    return std::complex<double>(real_part, imag_part);
+}
+
+std::complex<float> complex_atan2(std::complex<float> z1, std::complex<float> z2) {
+    float real_part = std::atan2(z1.real(),z2.real());
+    float imag_part = (z2.real()*z1.imag()-z1.real()*z2.imag())/(z1.real()*z1.real()+z2.real()*z2.real());
+    return std::complex<float>(real_part, imag_part);
+}
+
+
+// template<typename RealType>
+// RealType sign(std::complex<RealType> arg) {
+//     if(arg.real() < 0.0) {
+//         return -1;
+//     } else {
+//         return 1;
+//     }
+// }
+
+template <typename NumericType>
+class PeriodicTorsion {
+
+private:
+
+    const std::vector<NumericType> params_;
+    const std::vector<size_t> param_idxs_;
+    const std::vector<size_t> tors_idxs_;
+
+
+public:
+
+    PeriodicTorsion(
+        std::vector<NumericType> params,
+        std::vector<size_t> param_idxs,
+        std::vector<size_t> tors_idxs
+    ) : params_(params), 
+        param_idxs_(param_idxs),
+        tors_idxs_(tors_idxs) {};
+
+    size_t numTorsions() const {
+        return tors_idxs_.size()/4;
+    }
+
+    NumericType ixn_energy(
+        const std::array<NumericType, 12> &xs,
+        const std::array<NumericType, 3> &params) const {
+        NumericType x0 = xs[0];
+        NumericType y0 = xs[1];
+        NumericType z0 = xs[2];
+        NumericType x1 = xs[3];
+        NumericType y1 = xs[4];
+        NumericType z1 = xs[5];
+        NumericType x2 = xs[6];
+        NumericType y2 = xs[7];
+        NumericType z2 = xs[8];
+        NumericType x3 = xs[9];
+        NumericType y3 = xs[10];
+        NumericType z3 = xs[11];
+        NumericType k = params[0];
+        NumericType phase = params[1];
+        NumericType period = params[2];
+
+        NumericType rij_x = x0 - x1;
+        NumericType rij_y = y0 - y1;
+        NumericType rij_z = z0 - z1;
+
+        NumericType rkj_x = x2 - x1;
+        NumericType rkj_y = y2 - y1;
+        NumericType rkj_z = z2 - z1;
+
+        NumericType rkl_x = x2 - x3;
+        NumericType rkl_y = y2 - y3;
+        NumericType rkl_z = z2 - z3;
+
+        NumericType n1_x, n1_y, n1_z, n2_x, n2_y, n2_z;
+
+        timemachine::cross_product(rij_x, rij_y, rij_z, rkj_x, rkj_y, rkj_z, n1_x, n1_y, n1_z);
+        timemachine::cross_product(rkj_x, rkj_y, rkj_z, rkl_x, rkl_y, rkl_z, n2_x, n2_y, n2_z);
+
+        // NumericType lhs = timemachine::norm(n1_x, n1_y, n1_z);
+        // NumericType rhs = timemachine::norm(n2_x, n2_y, n2_z);
+        // NumericType bot = lhs * rhs;
+
+        NumericType n3_x, n3_y, n3_z;
+
+        timemachine::cross_product(n1_x, n1_y, n1_z, n2_x, n2_y, n2_z, n3_x, n3_y, n3_z);
+
+        NumericType rkj_n = timemachine::norm(rkj_x, rkj_y, rkj_z);
+        rkj_x /= rkj_n;
+        rkj_y /= rkj_n;
+        rkj_z /= rkj_n;
+
+        NumericType y = timemachine::dot_product(n3_x, n3_y, n3_z, rkj_x, rkj_y, rkj_z);
+        NumericType x = timemachine::dot_product(n1_x, n1_y, n1_z, n2_x, n2_y, n2_z);
+        NumericType angle = std::atan2(y, x);
+
+        // (ytz): The sign version is commented out due to yutong not being able to figure out
+        // the correct complex step derivative.
+        // NumericType sign_angle = sign(timemachine::dot_product(rkj_x, rkj_y, rkj_z, n3_x, n3_y, n3_z));
+        // NumericType angle = sign_angle*acos(timemachine::dot_product(n1_x, n1_y, n1_z, n2_x, n2_y, n2_z)/bot);
+        return k*(1+cos(period*angle - phase));
+
+    }
+
+
+    template<
+        typename CoordType,
+        typename ParamType,
+        typename OutType>
+    std::array<OutType, 12> ixn_gradient(
+        const std::array<CoordType, 12> &xs,
+        const std::array<ParamType, 3> &params) const {
+        CoordType x0 = xs[0];
+        CoordType y0 = xs[1];
+        CoordType z0 = xs[2];
+        CoordType x1 = xs[3];
+        CoordType y1 = xs[4];
+        CoordType z1 = xs[5];
+        CoordType x2 = xs[6];
+        CoordType y2 = xs[7];
+        CoordType z2 = xs[8];
+        CoordType x3 = xs[9];
+        CoordType y3 = xs[10];
+        CoordType z3 = xs[11];
+        ParamType k = params[0];
+        ParamType phase = params[1];
+        ParamType period = params[2];
+
+        CoordType rij_x = x0 - x1;
+        CoordType rij_y = y0 - y1;
+        CoordType rij_z = z0 - z1;
+
+        CoordType rkj_x = x2 - x1;
+        CoordType rkj_y = y2 - y1;
+        CoordType rkj_z = z2 - z1;
+
+        CoordType rkj_norm = timemachine::norm(rkj_x, rkj_y, rkj_z);
+        CoordType rkj_norm_square = timemachine::dot_product(rkj_x, rkj_y, rkj_z, rkj_x, rkj_y, rkj_z);
+
+        CoordType rkl_x = x2 - x3;
+        CoordType rkl_y = y2 - y3;
+        CoordType rkl_z = z2 - z3;
+
+        CoordType n1_x, n1_y, n1_z, n2_x, n2_y, n2_z;
+
+        timemachine::cross_product(rij_x, rij_y, rij_z, rkj_x, rkj_y, rkj_z, n1_x, n1_y, n1_z);
+        timemachine::cross_product(rkj_x, rkj_y, rkj_z, rkl_x, rkl_y, rkl_z, n2_x, n2_y, n2_z);
+
+        // CoordType n1_norm = timemachine::norm(n1_x, n1_y, n1_z);
+        CoordType n1_norm_square = timemachine::dot_product(n1_x, n1_y, n1_z, n1_x, n1_y, n1_z);
+        // CoordType n2_norm = timemachine::norm(n2_x, n2_y, n2_z);
+        CoordType n2_norm_square = timemachine::dot_product(n2_x, n2_y, n2_z, n2_x, n2_y, n2_z);
+        // CoordType bot = n1_norm * n2_norm;
+
+        CoordType n3_x, n3_y, n3_z;
+
+        timemachine::cross_product(n1_x, n1_y, n1_z, n2_x, n2_y, n2_z, n3_x, n3_y, n3_z);
+
+        CoordType dangle_dR0_x = rkj_norm/(n1_norm_square) * n1_x;
+        CoordType dangle_dR0_y = rkj_norm/(n1_norm_square) * n1_y;
+        CoordType dangle_dR0_z = rkj_norm/(n1_norm_square) * n1_z; 
+
+        CoordType dangle_dR3_x = -rkj_norm/(n2_norm_square) * n2_x;
+        CoordType dangle_dR3_y = -rkj_norm/(n2_norm_square) * n2_y;
+        CoordType dangle_dR3_z = -rkj_norm/(n2_norm_square) * n2_z; 
+
+        CoordType dangle_dR1_x = (timemachine::dot_product(rij_x, rij_y, rij_z, rkj_x, rkj_y, rkj_z)/(rkj_norm_square) - 1) * dangle_dR0_x - dangle_dR3_x*timemachine::dot_product(rkl_x, rkl_y, rkl_z, rkj_x, rkj_y, rkj_z)/(rkj_norm_square);
+        CoordType dangle_dR1_y = (timemachine::dot_product(rij_x, rij_y, rij_z, rkj_x, rkj_y, rkj_z)/(rkj_norm_square) - 1) * dangle_dR0_y - dangle_dR3_y*timemachine::dot_product(rkl_x, rkl_y, rkl_z, rkj_x, rkj_y, rkj_z)/(rkj_norm_square);
+        CoordType dangle_dR1_z = (timemachine::dot_product(rij_x, rij_y, rij_z, rkj_x, rkj_y, rkj_z)/(rkj_norm_square) - 1) * dangle_dR0_z - dangle_dR3_z*timemachine::dot_product(rkl_x, rkl_y, rkl_z, rkj_x, rkj_y, rkj_z)/(rkj_norm_square);
+
+        CoordType dangle_dR2_x = (timemachine::dot_product(rkl_x, rkl_y, rkl_z, rkj_x, rkj_y, rkj_z)/(rkj_norm_square) - 1) * dangle_dR3_x - dangle_dR0_x*timemachine::dot_product(rij_x, rij_y, rij_z, rkj_x, rkj_y, rkj_z)/(rkj_norm_square);
+        CoordType dangle_dR2_y = (timemachine::dot_product(rkl_x, rkl_y, rkl_z, rkj_x, rkj_y, rkj_z)/(rkj_norm_square) - 1) * dangle_dR3_y - dangle_dR0_y*timemachine::dot_product(rij_x, rij_y, rij_z, rkj_x, rkj_y, rkj_z)/(rkj_norm_square);
+        CoordType dangle_dR2_z = (timemachine::dot_product(rkl_x, rkl_y, rkl_z, rkj_x, rkj_y, rkj_z)/(rkj_norm_square) - 1) * dangle_dR3_z - dangle_dR0_z*timemachine::dot_product(rij_x, rij_y, rij_z, rkj_x, rkj_y, rkj_z)/(rkj_norm_square);
+
+        CoordType rkj_n = timemachine::norm(rkj_x, rkj_y, rkj_z);
+        rkj_x /= rkj_n;
+        rkj_y /= rkj_n;
+        rkj_z /= rkj_n;
+
+        CoordType y = timemachine::dot_product(n3_x, n3_y, n3_z, rkj_x, rkj_y, rkj_z);
+        CoordType x = timemachine::dot_product(n1_x, n1_y, n1_z, n2_x, n2_y, n2_z);
+        CoordType angle = complex_atan2(y, x);
+
+        // CoordType sign_angle = sign(timemachine::dot_product(rkj_x, rkj_y, rkj_z, n3_x, n3_y, n3_z));
+        // CoordType angle = sign_angle*acos(timemachine::dot_product(n1_x, n1_y, n1_z, n2_x, n2_y, n2_z)/(bot));
+        OutType prefactor = -k*sin(period*angle - phase)*period;
+
+        std::array<OutType, 12> grads;
+
+        grads[0*3+0] = dangle_dR0_x * prefactor;
+        grads[0*3+1] = dangle_dR0_y * prefactor;
+        grads[0*3+2] = dangle_dR0_z * prefactor;
+
+        grads[1*3+0] = dangle_dR1_x * prefactor;
+        grads[1*3+1] = dangle_dR1_y * prefactor;
+        grads[1*3+2] = dangle_dR1_z * prefactor;
+
+        grads[2*3+0] = dangle_dR2_x * prefactor;
+        grads[2*3+1] = dangle_dR2_y * prefactor;
+        grads[2*3+2] = dangle_dR2_z * prefactor;
+
+        grads[3*3+0] = dangle_dR3_x * prefactor;
+        grads[3*3+1] = dangle_dR3_y * prefactor;
+        grads[3*3+2] = dangle_dR3_z * prefactor;
+
+        return grads;
+    }
+
+    /*
+    Implements the total derivative of the gradient at a point in time. We
+declare_harmonic_bond<float>(m, "float");
+    use raw pointers to make it easier to interface with the wrapper layers and
+    to maintain some level of consistency with the C++ code.
+    */
+    void total_derivative(
+        const size_t n_atoms,
+        const size_t n_params,
+        const NumericType* coords, // [N, 3]
+        const NumericType* dxdp, // [P, N, 3]
+        NumericType* energy_out, // []
+        NumericType* grad_out, // [N,3]
+        NumericType* total_out // [P, N, 3]
+    ) const {
+
+        for(size_t i=0; i < numTorsions(); i++) {
+            size_t atom_0_idx = tors_idxs_[i*4+0];
+            size_t atom_1_idx = tors_idxs_[i*4+1];
+            size_t atom_2_idx = tors_idxs_[i*4+2];
+            size_t atom_3_idx = tors_idxs_[i*4+3];
+
+            size_t p_k_idx = param_idxs_[i*3+0];
+            size_t p_phase_idx = param_idxs_[i*3+1];
+            size_t p_period_idx = param_idxs_[i*3+2];
+            NumericType k = params_[p_k_idx];
+            NumericType period = params_[p_period_idx];
+            NumericType phase = params_[p_phase_idx];
+
+            const NumericType x0 = coords[atom_0_idx*3+0];
+            const NumericType y0 = coords[atom_0_idx*3+1];
+            const NumericType z0 = coords[atom_0_idx*3+2];
+            const NumericType x1 = coords[atom_1_idx*3+0];
+            const NumericType y1 = coords[atom_1_idx*3+1];
+            const NumericType z1 = coords[atom_1_idx*3+2];
+            const NumericType x2 = coords[atom_2_idx*3+0];
+            const NumericType y2 = coords[atom_2_idx*3+1];
+            const NumericType z2 = coords[atom_2_idx*3+2];
+            const NumericType x3 = coords[atom_3_idx*3+0];
+            const NumericType y3 = coords[atom_3_idx*3+1];
+            const NumericType z3 = coords[atom_3_idx*3+2];
+
+            std::array<NumericType, 12> xs({x0, y0, z0, x1, y1, z1, x2, y2, z2, x3, y3, z3});
+            std::array<NumericType, 3> params({k, phase, period});
+            *energy_out += ixn_energy(xs, params);
+
+            std::array<NumericType, 12> grads = ixn_gradient<NumericType, NumericType, NumericType>(xs, params);
+
+            grad_out[atom_0_idx*3 + 0] += grads[0];
+            grad_out[atom_0_idx*3 + 1] += grads[1];
+            grad_out[atom_0_idx*3 + 2] += grads[2];
+            grad_out[atom_1_idx*3 + 0] += grads[3];
+            grad_out[atom_1_idx*3 + 1] += grads[4];
+            grad_out[atom_1_idx*3 + 2] += grads[5];
+            grad_out[atom_2_idx*3 + 0] += grads[6];
+            grad_out[atom_2_idx*3 + 1] += grads[7];
+            grad_out[atom_2_idx*3 + 2] += grads[8];
+            grad_out[atom_3_idx*3 + 0] += grads[9];
+            grad_out[atom_3_idx*3 + 1] += grads[10];
+            grad_out[atom_3_idx*3 + 2] += grads[11];
+
+            NumericType step = 1e-50;
+
+            // compute mixed partials, loop over all the parameters
+            // (ytz) TODO: unroll this
+            for(size_t j=0; j < 3; j++) {
+                std::array<std::complex<NumericType>, 3> cparams = timemachine::convert_to_complex(params);
+                cparams[j] = std::complex<NumericType>(cparams[j].real(), step);
+
+                std::array<std::complex<NumericType>, 12> dcxs = ixn_gradient<NumericType, std::complex<NumericType>, std::complex<NumericType> >(xs, cparams);
+
+                std::array<NumericType, 12> ddxs;
+                for(int k=0; k < 12; k++) {
+                    ddxs[k] = dcxs[k].imag() / step;
+                }
+                size_t p_idx = param_idxs_[i*3+j];
+                total_out[p_idx*n_atoms*3 + atom_0_idx*3 + 0] += ddxs[0];
+                total_out[p_idx*n_atoms*3 + atom_0_idx*3 + 1] += ddxs[1];
+                total_out[p_idx*n_atoms*3 + atom_0_idx*3 + 2] += ddxs[2];
+                total_out[p_idx*n_atoms*3 + atom_1_idx*3 + 0] += ddxs[3];
+                total_out[p_idx*n_atoms*3 + atom_1_idx*3 + 1] += ddxs[4];
+                total_out[p_idx*n_atoms*3 + atom_1_idx*3 + 2] += ddxs[5];
+                total_out[p_idx*n_atoms*3 + atom_2_idx*3 + 0] += ddxs[6];
+                total_out[p_idx*n_atoms*3 + atom_2_idx*3 + 1] += ddxs[7];
+                total_out[p_idx*n_atoms*3 + atom_2_idx*3 + 2] += ddxs[8];
+                total_out[p_idx*n_atoms*3 + atom_3_idx*3 + 0] += ddxs[9];
+                total_out[p_idx*n_atoms*3 + atom_3_idx*3 + 1] += ddxs[10];
+                total_out[p_idx*n_atoms*3 + atom_3_idx*3 + 2] += ddxs[11];
+            }
+
+            // compute hessian vector product, looping over all atoms and parameters
+            std::array<size_t, 12> indices({
+                atom_0_idx*3+0,
+                atom_0_idx*3+1,
+                atom_0_idx*3+2,
+                atom_1_idx*3+0,
+                atom_1_idx*3+1,
+                atom_1_idx*3+2,
+                atom_2_idx*3+0,
+                atom_2_idx*3+1,
+                atom_2_idx*3+2,
+                atom_3_idx*3+0,
+                atom_3_idx*3+1,
+                atom_3_idx*3+2
+            });
+
+            for(size_t j=0; j < 12; j++) {
+
+                std::array<std::complex<NumericType>, 12> cxs = timemachine::convert_to_complex(xs);
+                cxs[j] = std::complex<NumericType>(cxs[j].real(), step);
+                std::array<std::complex<NumericType>, 12> dcxs = ixn_gradient<std::complex<NumericType>, NumericType, std::complex<NumericType> >(cxs, params);
+                std::array<NumericType, 12> ddxs;
+                for(int k=0; k < 12; k++) {
+                    ddxs[k] = dcxs[k].imag() / step;
+                }
+
+                // this loops over *all* params, not just the two params specific to an angle.     
+                for(size_t p=0; p < n_params; p++) {
+                    auto dx0 = ddxs[0] * dxdp[p*n_atoms*3 + atom_0_idx*3 + 0] + ddxs[3] * dxdp[p*n_atoms*3 + atom_1_idx*3 + 0] + ddxs[6] * dxdp[p*n_atoms*3 + atom_2_idx*3 + 0] + ddxs[9] * dxdp[p*n_atoms*3 + atom_3_idx*3 + 0];
+                    auto dx1 = ddxs[1] * dxdp[p*n_atoms*3 + atom_0_idx*3 + 1] + ddxs[4] * dxdp[p*n_atoms*3 + atom_1_idx*3 + 1] + ddxs[7] * dxdp[p*n_atoms*3 + atom_2_idx*3 + 1] + ddxs[10] * dxdp[p*n_atoms*3 + atom_3_idx*3 + 1];
+                    auto dx2 = ddxs[2] * dxdp[p*n_atoms*3 + atom_0_idx*3 + 2] + ddxs[5] * dxdp[p*n_atoms*3 + atom_1_idx*3 + 2] + ddxs[8] * dxdp[p*n_atoms*3 + atom_2_idx*3 + 2] + ddxs[11] * dxdp[p*n_atoms*3 + atom_3_idx*3 + 2];
+                    total_out[p*n_atoms*3 + indices[j]] += dx0+dx1+dx2;
+                }
+            }
+        }
+    }
+};
+
 
 template <typename NumericType>
 class HarmonicAngle {
@@ -127,7 +485,6 @@ public:
 
     /*
     Implements the total derivative of the gradient at a point in time. We
-declare_harmonic_bond<float>(m, "float");
     use raw pointers to make it easier to interface with the wrapper layers and
     to maintain some level of consistency with the C++ code.
     */

--- a/timemachine/cpu_functionals/bonded_cpu.hpp
+++ b/timemachine/cpu_functionals/bonded_cpu.hpp
@@ -7,17 +7,6 @@
 
 namespace timemachine {
 
-template<typename RealType>
-std::complex<RealType> sign(std::complex<RealType> arg) {
-    if(arg.real() == 0 && arg.imag() == 0) {
-        return std::complex<RealType>(0.0, 0.0);
-    } else {
-        auto res = arg/analytic_abs(arg);
-        std::cout << "RES: " << arg << " " << analytic_abs(arg) << " | " << res << std::endl;
-        return res;
-    }
-}
-
 float complex_atan2(float z1, float z2) {
     return std::atan2(z1, z2);
 }
@@ -38,16 +27,6 @@ std::complex<float> complex_atan2(std::complex<float> z1, std::complex<float> z2
     float imag_part = (z2.real()*z1.imag()-z1.real()*z2.imag())/(z1.real()*z1.real()+z2.real()*z2.real());
     return std::complex<float>(real_part, imag_part);
 }
-
-
-// template<typename RealType>
-// RealType sign(std::complex<RealType> arg) {
-//     if(arg.real() < 0.0) {
-//         return -1;
-//     } else {
-//         return 1;
-//     }
-// }
 
 template <typename NumericType>
 class PeriodicTorsion {

--- a/timemachine/cpu_functionals/bonded_cpu.hpp
+++ b/timemachine/cpu_functionals/bonded_cpu.hpp
@@ -1,0 +1,190 @@
+#pragma once
+#include <array>
+#include <iostream>
+#include <complex>
+#include <vector>
+#include "utils.hpp"
+
+namespace timemachine {
+
+template <typename NumericType>
+class HarmonicBond {
+
+public:
+
+    const std::vector<NumericType> params_;
+    const std::vector<size_t> param_idxs_;
+    const std::vector<size_t> bond_idxs_;
+
+public:
+
+    HarmonicBond(
+        std::vector<NumericType> params,
+        std::vector<size_t> param_idxs,
+        std::vector<size_t> bond_idxs
+    ) : params_(params), 
+        param_idxs_(param_idxs),
+        bond_idxs_(bond_idxs) {};
+
+
+    NumericType energy(
+        const std::array<NumericType, 6> &xs,
+        const std::array<NumericType, 2> &params) const {
+        NumericType x0 = xs[0];
+        NumericType y0 = xs[1];
+        NumericType z0 = xs[2];
+        NumericType x1 = xs[3];
+        NumericType y1 = xs[4];
+        NumericType z1 = xs[5];
+        NumericType kb = params[0];
+        NumericType b0 = params[1];
+
+        auto dx = x0-x1;
+        auto dy = y0-y1;
+        auto dz = z0-z1;
+        auto db = sqrt(dx*dx+dy*dy+dz*dz)-b0;
+        return kb/2.0*db*db;
+    }
+
+    // gradient of a single interaction.
+    template<
+        typename CoordType,
+        typename ParamType,
+        typename OutType>
+    void ixn_grad(
+        const std::array<CoordType, 6> &xs,
+        const std::array<ParamType, 2> &params,
+        std::array<OutType, 6> &dxs) const {
+        CoordType x0 = xs[0];
+        CoordType y0 = xs[1];
+        CoordType z0 = xs[2];
+        CoordType x1 = xs[3];
+        CoordType y1 = xs[4];
+        CoordType z1 = xs[5];
+        ParamType kb = params[0];
+        ParamType b0 = params[1];
+
+        auto dx = x0-x1;
+        auto dy = y0-y1;
+        auto dz = z0-z1;
+        auto dij = sqrt(dx*dx+dy*dy+dz*dz);
+        auto db = dij-b0;
+        dxs[0] = kb*db*dx/dij;
+        dxs[1] = kb*db*dy/dij;
+        dxs[2] = kb*db*dz/dij;
+        dxs[3] = -dxs[0];
+        dxs[4] = -dxs[1];
+        dxs[5] = -dxs[2];
+    }
+
+    size_t numBonds() const {
+        return bond_idxs_.size()/2;
+    }
+
+    /*
+    Implements the total derivative of the gradient at a point in time. We
+    use raw pointers to make it easier to interface with the wrapper layers and
+    to maintain some level of consistency with the C++ code.
+    */
+    void total_derivative(
+        const size_t n_atoms,
+        const size_t n_params,
+        const NumericType* coords, // [N, 3]
+        const NumericType* dxdp, // [P, N, 3]
+        NumericType* energy_out, // []
+        NumericType* grad_out, // [N,3]
+        NumericType* total_out // [P, N, 3]
+    ) const {
+
+        for(size_t i=0; i < numBonds(); i++) {
+
+            size_t s_atom_idx = bond_idxs_[i*2+0];
+            size_t e_atom_idx = bond_idxs_[i*2+1];
+            size_t p_k_idx = param_idxs_[i*2+0];
+            size_t p_b_idx = param_idxs_[i*2+1];
+            NumericType kb = params_[p_k_idx];
+            NumericType b0 = params_[p_b_idx];
+
+            if(s_atom_idx == e_atom_idx) {
+                throw std::runtime_error("self-bond detected.");
+            }
+
+            const NumericType x0 = coords[s_atom_idx*3+0];
+            const NumericType y0 = coords[s_atom_idx*3+1];
+            const NumericType z0 = coords[s_atom_idx*3+2];
+            const NumericType x1 = coords[e_atom_idx*3+0];
+            const NumericType y1 = coords[e_atom_idx*3+1];
+            const NumericType z1 = coords[e_atom_idx*3+2];
+
+            std::array<NumericType, 6> xs({x0, y0, z0, x1, y1, z1});
+            std::array<NumericType, 2> params({kb, b0});
+
+            *energy_out += energy(xs, params);
+
+            std::array<NumericType, 6> dxs;
+            ixn_grad<NumericType, NumericType>(xs, params, dxs);
+            grad_out[s_atom_idx*3 + 0] += dxs[0];
+            grad_out[s_atom_idx*3 + 1] += dxs[1];
+            grad_out[s_atom_idx*3 + 2] += dxs[2];
+            grad_out[e_atom_idx*3 + 0] += dxs[3];
+            grad_out[e_atom_idx*3 + 1] += dxs[4];
+            grad_out[e_atom_idx*3 + 2] += dxs[5];
+
+            NumericType step = 1e-100;
+
+            // compute mixed partials, loop over all the parameters
+            // (ytz) TODO: unroll this
+            for(size_t j=0; j < 2; j++) {
+                std::array<std::complex<NumericType>, 2> cparams = timemachine::convert_to_complex(params);
+                cparams[j] = std::complex<NumericType>(cparams[j].real(), step);
+
+                std::array<std::complex<NumericType>, 6> dcxs;
+                ixn_grad<NumericType, std::complex<NumericType> >(xs, cparams, dcxs);
+
+                std::array<NumericType, 6> ddxs;
+                for(int k=0; k < 6; k++) {
+                    ddxs[k] = dcxs[k].imag() / step;
+                }
+                size_t p_idx = param_idxs_[i*2+j];
+                total_out[p_idx*n_atoms*3 + s_atom_idx*3 + 0] += ddxs[0];
+                total_out[p_idx*n_atoms*3 + s_atom_idx*3 + 1] += ddxs[1];
+                total_out[p_idx*n_atoms*3 + s_atom_idx*3 + 2] += ddxs[2];
+                total_out[p_idx*n_atoms*3 + e_atom_idx*3 + 0] += ddxs[3];
+                total_out[p_idx*n_atoms*3 + e_atom_idx*3 + 1] += ddxs[4];
+                total_out[p_idx*n_atoms*3 + e_atom_idx*3 + 2] += ddxs[5];
+            }
+
+            // compute hessian vector product, looping over all atoms and parameters
+            std::array<size_t, 6> indices({
+                s_atom_idx*3+0,
+                s_atom_idx*3+1,
+                s_atom_idx*3+2,
+                e_atom_idx*3+0,
+                e_atom_idx*3+1,
+                e_atom_idx*3+2,
+            });
+
+            for(size_t j=0; j < 6; j++) {
+                std::array<std::complex<NumericType>, 6> cxs = timemachine::convert_to_complex(xs);
+                cxs[j] = std::complex<NumericType>(cxs[j].real(), step);
+
+                std::array<std::complex<NumericType>, 6> dcxs;
+                ixn_grad<std::complex<NumericType>, NumericType >(cxs, params, dcxs);
+
+                std::array<NumericType, 6> ddxs;
+                for(int k=0; k < 6; k++) {
+                    ddxs[k] = dcxs[k].imag() / step;
+                }
+                for(size_t p=0; p < 2; p++) {
+                    size_t p_idx = param_idxs_[i*2+p];
+                    auto dx0 = ddxs[0] * dxdp[p_idx*n_atoms*3 + s_atom_idx*3 + 0] + ddxs[3] * dxdp[p_idx*n_atoms*3 + e_atom_idx*3 + 0];
+                    auto dx1 = ddxs[1] * dxdp[p_idx*n_atoms*3 + s_atom_idx*3 + 1] + ddxs[4] * dxdp[p_idx*n_atoms*3 + e_atom_idx*3 + 1];
+                    auto dx2 = ddxs[2] * dxdp[p_idx*n_atoms*3 + s_atom_idx*3 + 2] + ddxs[5] * dxdp[p_idx*n_atoms*3 + e_atom_idx*3 + 2];
+                    total_out[p_idx*n_atoms*3 + indices[j]] += dx0+dx1+dx2;
+                }
+            }
+        }
+    }
+};
+
+}

--- a/timemachine/cpu_functionals/bonded_cpu.hpp
+++ b/timemachine/cpu_functionals/bonded_cpu.hpp
@@ -5,12 +5,249 @@
 #include <vector>
 #include "utils.hpp"
 
+
+
 namespace timemachine {
+
+template <typename NumericType>
+class HarmonicAngle {
+
+private:
+
+    const std::vector<NumericType> params_;
+    const std::vector<size_t> param_idxs_;
+    const std::vector<size_t> angle_idxs_;
+    bool cos_angles_;
+
+
+public:
+
+    HarmonicAngle(
+        std::vector<NumericType> params,
+        std::vector<size_t> param_idxs,
+        std::vector<size_t> angle_idxs,
+        bool cos_angles=true
+    ) : params_(params), 
+        param_idxs_(param_idxs),
+        angle_idxs_(angle_idxs),
+        cos_angles_(cos_angles) {};
+
+    size_t numAngles() const {
+        return angle_idxs_.size()/3;
+    }
+
+    NumericType ixn_energy(
+        const std::array<NumericType, 9> &xs,
+        const std::array<NumericType, 2> &params) const {
+        NumericType x0 = xs[0];
+        NumericType y0 = xs[1];
+        NumericType z0 = xs[2];
+        NumericType x1 = xs[3];
+        NumericType y1 = xs[4];
+        NumericType z1 = xs[5];
+        NumericType x2 = xs[6];
+        NumericType y2 = xs[7];
+        NumericType z2 = xs[8];
+        NumericType ka = params[0];
+        NumericType a0 = params[1];
+
+        NumericType vij_x = x1 - x0;
+        NumericType vij_y = y1 - y0;
+        NumericType vij_z = z1 - z0;
+
+        NumericType vjk_x = x1 - x2;
+        NumericType vjk_y = y1 - y2;
+        NumericType vjk_z = z1 - z2;
+
+        NumericType nij = timemachine::norm(vij_x, vij_y, vij_z);
+        NumericType njk = timemachine::norm(vjk_x, vjk_y, vjk_z);
+        NumericType top = timemachine::dot_product(vij_x, vij_y, vij_z, vjk_x, vjk_y, vjk_z);
+        NumericType ca = top/(nij*njk);
+
+        NumericType delta;
+        if(!cos_angles_) {  
+            delta = acos(ca) - a0;
+        } else {
+            delta = ca - cos(a0);
+        }
+        return ka/2*(delta*delta);
+
+    }
+
+    template<
+        typename CoordType,
+        typename ParamType,
+        typename OutType>
+    std::array<OutType, 9> ixn_gradient(
+        const std::array<CoordType, 9> &xs,
+        const std::array<ParamType, 2> &params) const {
+        CoordType x0 = xs[0];
+        CoordType y0 = xs[1];
+        CoordType z0 = xs[2];
+        CoordType x1 = xs[3];
+        CoordType y1 = xs[4];
+        CoordType z1 = xs[5];
+        CoordType x2 = xs[6];
+        CoordType y2 = xs[7];
+        CoordType z2 = xs[8];
+        ParamType ka = params[0];
+        ParamType a0 = params[1];
+
+        CoordType vij_x = x1 - x0;
+        CoordType vij_y = y1 - y0;
+        CoordType vij_z = z1 - z0;
+
+        CoordType vjk_x = x1 - x2;
+        CoordType vjk_y = y1 - y2;
+        CoordType vjk_z = z1 - z2;
+
+        CoordType nij = timemachine::norm(vij_x, vij_y, vij_z);
+        CoordType njk = timemachine::norm(vjk_x, vjk_y, vjk_z);
+
+        // can be optimized
+        CoordType n3ij = nij*nij*nij;
+        CoordType n3jk = njk*njk*njk;
+        CoordType top = timemachine::dot_product(vij_x, vij_y, vij_z, vjk_x, vjk_y, vjk_z);
+
+
+        std::array<OutType, 9> grads; // uninitialized
+
+        grads[0*3+0] = 0.5*ka*((top)/(nij*njk) - cos(a0))*(2.0*(-x0 + x1)*(top)/(n3ij*njk) + 2.0*(-x1 + x2)/(nij*njk)) ;
+        grads[1*3+0] = 0.5*ka*((top)/(nij*njk) - cos(a0))*(2.0*(x0 - x1)*(top)/(n3ij*njk) + 2.0*(-x1 + x2)*(top)/(nij*n3jk) + 2.0*(-x0 + 2.0*x1 - x2)/(nij*njk)) ;
+        grads[2*3+0] = 0.5*ka*(2.0*(x0 - x1)/(nij*njk) + 2.0*(x1 - x2)*(top)/(nij*n3jk))*((top)/(nij*njk) - cos(a0)) ;
+        grads[0*3+1] = 0.5*ka*((top)/(nij*njk) - cos(a0))*(2.0*(-y0 + y1)*(top)/(n3ij*njk) + 2.0*(-y1 + y2)/(nij*njk)) ;
+        grads[1*3+1] = 0.5*ka*((top)/(nij*njk) - cos(a0))*(2.0*(y0 - y1)*(top)/(n3ij*njk) + 2.0*(-y1 + y2)*(top)/(nij*n3jk) + 2.0*(-y0 + 2.0*y1 - y2)/(nij*njk)) ;
+        grads[2*3+1] = 0.5*ka*(2.0*(y0 - y1)/(nij*njk) + 2.0*(y1 - y2)*(top)/(nij*n3jk))*((top)/(nij*njk) - cos(a0)) ;
+        grads[0*3+2] = 0.5*ka*((top)/(nij*njk) - cos(a0))*(2.0*(-z0 + z1)*(top)/(n3ij*njk) + 2.0*(-z1 + z2)/(nij*njk)) ;
+        grads[1*3+2] = 0.5*ka*((top)/(nij*njk) - cos(a0))*(2.0*(z0 - z1)*(top)/(n3ij*njk) + 2.0*(-z1 + z2)*(top)/(nij*n3jk) + 2.0*(-z0 + 2.0*z1 - z2)/(nij*njk)) ;
+        grads[2*3+2] = 0.5*ka*(2.0*(z0 - z1)/(nij*njk) + 2.0*(z1 - z2)*(top)/(nij*n3jk))*((top)/(nij*njk) - cos(a0)) ;
+
+        return grads;
+    }
+
+    /*
+    Implements the total derivative of the gradient at a point in time. We
+declare_harmonic_bond<float>(m, "float");
+    use raw pointers to make it easier to interface with the wrapper layers and
+    to maintain some level of consistency with the C++ code.
+    */
+    void total_derivative(
+        const size_t n_atoms,
+        const size_t n_params,
+        const NumericType* coords, // [N, 3]
+        const NumericType* dxdp, // [P, N, 3]
+        NumericType* energy_out, // []
+        NumericType* grad_out, // [N,3]
+        NumericType* total_out // [P, N, 3]
+    ) const {
+
+        for(size_t i=0; i < numAngles(); i++) {
+
+            size_t atom_0_idx = angle_idxs_[i*3+0];
+            size_t atom_1_idx = angle_idxs_[i*3+1];
+            size_t atom_2_idx = angle_idxs_[i*3+2];
+            size_t p_k_idx = param_idxs_[i*2+0];
+            size_t p_a_idx = param_idxs_[i*2+1];
+            NumericType kb = params_[p_k_idx];
+            NumericType a0 = params_[p_a_idx];
+
+            if(atom_0_idx == atom_1_idx) {
+                throw std::runtime_error("self-bond detected.");
+            }
+
+            const NumericType x0 = coords[atom_0_idx*3+0];
+            const NumericType y0 = coords[atom_0_idx*3+1];
+            const NumericType z0 = coords[atom_0_idx*3+2];
+            const NumericType x1 = coords[atom_1_idx*3+0];
+            const NumericType y1 = coords[atom_1_idx*3+1];
+            const NumericType z1 = coords[atom_1_idx*3+2];
+            const NumericType x2 = coords[atom_2_idx*3+0];
+            const NumericType y2 = coords[atom_2_idx*3+1];
+            const NumericType z2 = coords[atom_2_idx*3+2];
+
+            std::array<NumericType, 9> xs({x0, y0, z0, x1, y1, z1, x2, y2, z2});
+            std::array<NumericType, 2> params({kb, a0});
+
+            *energy_out += ixn_energy(xs, params);
+
+            // (ytz): very important that we initialize the array to zero.
+            std::array<NumericType, 9> grads = ixn_gradient<NumericType, NumericType, NumericType>(xs, params);
+
+            grad_out[atom_0_idx*3 + 0] += grads[0];
+            grad_out[atom_0_idx*3 + 1] += grads[1];
+            grad_out[atom_0_idx*3 + 2] += grads[2];
+            grad_out[atom_1_idx*3 + 0] += grads[3];
+            grad_out[atom_1_idx*3 + 1] += grads[4];
+            grad_out[atom_1_idx*3 + 2] += grads[5];
+            grad_out[atom_2_idx*3 + 0] += grads[6];
+            grad_out[atom_2_idx*3 + 1] += grads[7];
+            grad_out[atom_2_idx*3 + 2] += grads[8];
+
+            NumericType step = 1e-100;
+
+            // compute mixed partials, loop over all the parameters
+            // (ytz) TODO: unroll this
+            for(size_t j=0; j < 2; j++) {
+                std::array<std::complex<NumericType>, 2> cparams = timemachine::convert_to_complex(params);
+                cparams[j] = std::complex<NumericType>(cparams[j].real(), step);
+
+                std::array<std::complex<NumericType>, 9> dcxs = ixn_gradient<NumericType, std::complex<NumericType>, std::complex<NumericType> >(xs, cparams);
+
+                std::array<NumericType, 9> ddxs;
+                for(int k=0; k < 9; k++) {
+                    ddxs[k] = dcxs[k].imag() / step;
+                }
+                size_t p_idx = param_idxs_[i*2+j];
+                total_out[p_idx*n_atoms*3 + atom_0_idx*3 + 0] += ddxs[0];
+                total_out[p_idx*n_atoms*3 + atom_0_idx*3 + 1] += ddxs[1];
+                total_out[p_idx*n_atoms*3 + atom_0_idx*3 + 2] += ddxs[2];
+                total_out[p_idx*n_atoms*3 + atom_1_idx*3 + 0] += ddxs[3];
+                total_out[p_idx*n_atoms*3 + atom_1_idx*3 + 1] += ddxs[4];
+                total_out[p_idx*n_atoms*3 + atom_1_idx*3 + 2] += ddxs[5];
+                total_out[p_idx*n_atoms*3 + atom_2_idx*3 + 0] += ddxs[6];
+                total_out[p_idx*n_atoms*3 + atom_2_idx*3 + 1] += ddxs[7];
+                total_out[p_idx*n_atoms*3 + atom_2_idx*3 + 2] += ddxs[8];
+            }
+
+            // compute hessian vector product, looping over all atoms and parameters
+            std::array<size_t, 9> indices({
+                atom_0_idx*3+0,
+                atom_0_idx*3+1,
+                atom_0_idx*3+2,
+                atom_1_idx*3+0,
+                atom_1_idx*3+1,
+                atom_1_idx*3+2,
+                atom_2_idx*3+0,
+                atom_2_idx*3+1,
+                atom_2_idx*3+2
+            });
+
+            for(size_t j=0; j < 9; j++) {
+
+                std::array<std::complex<NumericType>, 9> cxs = timemachine::convert_to_complex(xs);
+                cxs[j] = std::complex<NumericType>(cxs[j].real(), step);
+                std::array<std::complex<NumericType>, 9> dcxs = ixn_gradient<std::complex<NumericType>, NumericType, std::complex<NumericType> >(cxs, params);
+                std::array<NumericType, 9> ddxs;
+                for(int k=0; k < 9; k++) {
+                    ddxs[k] = dcxs[k].imag() / step;
+                }
+
+                // this loops over *all* params, not just the two params specific to an angle.     
+                for(size_t p=0; p < n_params; p++) {
+                    auto dx0 = ddxs[0] * dxdp[p*n_atoms*3 + atom_0_idx*3 + 0] + ddxs[3] * dxdp[p*n_atoms*3 + atom_1_idx*3 + 0] + ddxs[6] * dxdp[p*n_atoms*3 + atom_2_idx*3 + 0];
+                    auto dx1 = ddxs[1] * dxdp[p*n_atoms*3 + atom_0_idx*3 + 1] + ddxs[4] * dxdp[p*n_atoms*3 + atom_1_idx*3 + 1] + ddxs[7] * dxdp[p*n_atoms*3 + atom_2_idx*3 + 1];
+                    auto dx2 = ddxs[2] * dxdp[p*n_atoms*3 + atom_0_idx*3 + 2] + ddxs[5] * dxdp[p*n_atoms*3 + atom_1_idx*3 + 2] + ddxs[8] * dxdp[p*n_atoms*3 + atom_2_idx*3 + 2];
+                    total_out[p*n_atoms*3 + indices[j]] += dx0+dx1+dx2;
+                }
+            }
+        }
+    }
+};
 
 template <typename NumericType>
 class HarmonicBond {
 
-public:
+private:
 
     const std::vector<NumericType> params_;
     const std::vector<size_t> param_idxs_;
@@ -27,7 +264,7 @@ public:
         bond_idxs_(bond_idxs) {};
 
 
-    NumericType energy(
+    NumericType ixn_energy(
         const std::array<NumericType, 6> &xs,
         const std::array<NumericType, 2> &params) const {
         NumericType x0 = xs[0];
@@ -51,10 +288,9 @@ public:
         typename CoordType,
         typename ParamType,
         typename OutType>
-    void ixn_grad(
+    std::array<OutType, 6> ixn_gradient(
         const std::array<CoordType, 6> &xs,
-        const std::array<ParamType, 2> &params,
-        std::array<OutType, 6> &dxs) const {
+        const std::array<ParamType, 2> &params) const {
         CoordType x0 = xs[0];
         CoordType y0 = xs[1];
         CoordType z0 = xs[2];
@@ -69,12 +305,17 @@ public:
         CoordType dz = z0-z1;
         CoordType dij = sqrt(dx*dx+dy*dy+dz*dz);
         auto db = dij-b0;
-        dxs[0] = kb*db*dx/dij;
-        dxs[1] = kb*db*dy/dij;
-        dxs[2] = kb*db*dz/dij;
-        dxs[3] = -dxs[0];
-        dxs[4] = -dxs[1];
-        dxs[5] = -dxs[2];
+
+        std::array<OutType, 6> grads; 
+
+        grads[0] = kb*db*dx/dij;
+        grads[1] = kb*db*dy/dij;
+        grads[2] = kb*db*dz/dij;
+        grads[3] = -grads[0];
+        grads[4] = -grads[1];
+        grads[5] = -grads[2];
+
+        return grads;
     }
 
     size_t numBonds() const {
@@ -96,10 +337,13 @@ public:
         NumericType* total_out // [P, N, 3]
     ) const {
 
+        std::vector<NumericType> hessians(n_atoms*3*n_atoms*3, 0.0);
+
         for(size_t i=0; i < numBonds(); i++) {
 
             size_t s_atom_idx = bond_idxs_[i*2+0];
             size_t e_atom_idx = bond_idxs_[i*2+1];
+
             size_t p_k_idx = param_idxs_[i*2+0];
             size_t p_b_idx = param_idxs_[i*2+1];
             NumericType kb = params_[p_k_idx];
@@ -119,10 +363,10 @@ public:
             std::array<NumericType, 6> xs({x0, y0, z0, x1, y1, z1});
             std::array<NumericType, 2> params({kb, b0});
 
-            *energy_out += energy(xs, params);
+            *energy_out += ixn_energy(xs, params);
 
-            std::array<NumericType, 6> dxs;
-            ixn_grad<NumericType, NumericType>(xs, params, dxs);
+            // (ytz): very important that we initialize the array to zero.
+            std::array<NumericType, 6> dxs = ixn_gradient<NumericType, NumericType, NumericType>(xs, params);
             grad_out[s_atom_idx*3 + 0] += dxs[0];
             grad_out[s_atom_idx*3 + 1] += dxs[1];
             grad_out[s_atom_idx*3 + 2] += dxs[2];
@@ -130,7 +374,7 @@ public:
             grad_out[e_atom_idx*3 + 1] += dxs[4];
             grad_out[e_atom_idx*3 + 2] += dxs[5];
 
-            NumericType step = 1e-100;
+            NumericType step = 1e-50;
 
             // compute mixed partials, loop over all the parameters
             // (ytz) TODO: unroll this
@@ -138,8 +382,8 @@ public:
                 std::array<std::complex<NumericType>, 2> cparams = timemachine::convert_to_complex(params);
                 cparams[j] = std::complex<NumericType>(cparams[j].real(), step);
 
-                std::array<std::complex<NumericType>, 6> dcxs;
-                ixn_grad<NumericType, std::complex<NumericType> >(xs, cparams, dcxs);
+                // (ytz): very important that we initialize the array to zero.
+                std::array<std::complex<NumericType>, 6> dcxs = ixn_gradient<NumericType, std::complex<NumericType>, std::complex<NumericType> >(xs, cparams);
 
                 std::array<NumericType, 6> ddxs;
                 for(int k=0; k < 6; k++) {
@@ -168,22 +412,25 @@ public:
                 std::array<std::complex<NumericType>, 6> cxs = timemachine::convert_to_complex(xs);
                 cxs[j] = std::complex<NumericType>(cxs[j].real(), step);
 
-                std::array<std::complex<NumericType>, 6> dcxs;
-                ixn_grad<std::complex<NumericType>, NumericType >(cxs, params, dcxs);
+                std::array<std::complex<NumericType>, 6> dcxs = ixn_gradient<std::complex<NumericType>, NumericType, std::complex<NumericType> >(cxs, params);
 
                 std::array<NumericType, 6> ddxs;
                 for(int k=0; k < 6; k++) {
                     ddxs[k] = dcxs[k].imag() / step;
+                    hessians[indices[j]*n_atoms*3 + indices[k]] += dcxs[k].imag() / step;
                 }
-                for(size_t p=0; p < 2; p++) {
-                    size_t p_idx = param_idxs_[i*2+p];
-                    auto dx0 = ddxs[0] * dxdp[p_idx*n_atoms*3 + s_atom_idx*3 + 0] + ddxs[3] * dxdp[p_idx*n_atoms*3 + e_atom_idx*3 + 0];
-                    auto dx1 = ddxs[1] * dxdp[p_idx*n_atoms*3 + s_atom_idx*3 + 1] + ddxs[4] * dxdp[p_idx*n_atoms*3 + e_atom_idx*3 + 1];
-                    auto dx2 = ddxs[2] * dxdp[p_idx*n_atoms*3 + s_atom_idx*3 + 2] + ddxs[5] * dxdp[p_idx*n_atoms*3 + e_atom_idx*3 + 2];
-                    total_out[p_idx*n_atoms*3 + indices[j]] += dx0+dx1+dx2;
+
+                // this loops over *all* params, not just the two params specific to a bond.
+                for(size_t p=0; p < n_params; p++) {
+                    auto dx0 = ddxs[0] * dxdp[p*n_atoms*3 + s_atom_idx*3 + 0] + ddxs[3] * dxdp[p*n_atoms*3 + e_atom_idx*3 + 0];
+                    auto dx1 = ddxs[1] * dxdp[p*n_atoms*3 + s_atom_idx*3 + 1] + ddxs[4] * dxdp[p*n_atoms*3 + e_atom_idx*3 + 1];
+                    auto dx2 = ddxs[2] * dxdp[p*n_atoms*3 + s_atom_idx*3 + 2] + ddxs[5] * dxdp[p*n_atoms*3 + e_atom_idx*3 + 2];
+                    total_out[p*n_atoms*3 + indices[j]] += dx0+dx1+dx2;
                 }
+
             }
         }
+
     }
 };
 

--- a/timemachine/cpu_functionals/constants.hpp
+++ b/timemachine/cpu_functionals/constants.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace timemachine {
+
+const double BOLTZMANN = 1.380658e-23;
+const double AVOGADRO = 6.0221367e23;
+const double RGAS = BOLTZMANN*AVOGADRO;
+const double BOLTZ = RGAS/1000;
+const double ONE_4PI_EPS0 = 138.935456;
+const double VIBRATIONAL_CONSTANT = 1302.79; // http://openmopac.net/manual/Hessian_Matrix.html
+
+}

--- a/timemachine/cpu_functionals/gbsa_cpu.cpp
+++ b/timemachine/cpu_functionals/gbsa_cpu.cpp
@@ -1,0 +1,97 @@
+#include <vector>
+#include <iostream>
+#include <cmath>
+#include "utils.hpp"
+
+std::vector<double> r_i_real(5, 0);
+std::vector<bool> r_i_flag(5, 0);
+
+std::vector<std::complex<double> > r_i_complex(5, 0);
+std::vector<bool> r_i_flag_complex(5, 0);
+
+template<typename NumericType>
+NumericType radii(NumericType x_i, std::vector<NumericType> xs) {
+    NumericType sum = 0;
+    for(auto j=0; j < xs.size(); j++) {
+        NumericType dx = x_i - xs[j];
+        sum += dx*dx;
+    }
+    return sum;
+}
+
+template<typename NumericType>
+NumericType energy(
+    size_t idx,
+    size_t jdx,
+    std::vector<NumericType> all_xs) {
+    
+    if(!r_i_flag[idx]) {
+        r_i_real[idx] = radii(all_xs[idx], all_xs);
+    }
+    if(!r_i_flag[jdx]) {
+        r_i_real[jdx] = radii(all_xs[jdx], all_xs);
+    }
+    NumericType r_i = r_i_real[idx];
+    NumericType r_j = r_i_real[jdx];
+
+    NumericType dx = r_i - r_j;
+    NumericType dij = sqrt(dx*dx);
+
+    return r_i * r_j * dij;
+}
+
+template<typename NumericType>
+NumericType energy_complex(
+    size_t idx,
+    size_t jdx,
+    std::vector<NumericType> all_xs) {
+    
+    if(!r_i_flag_complex[idx]) {
+        r_i_complex[idx] = radii(all_xs[idx], all_xs);
+    }
+    if(!r_i_flag_complex[jdx]) {
+        r_i_complex[jdx] = radii(all_xs[jdx], all_xs);
+    }
+    NumericType r_i = r_i_complex[idx];
+    NumericType r_j = r_i_complex[jdx];
+
+    NumericType dx = r_i - r_j;
+    NumericType dij = sqrt(dx*dx);
+
+    return r_i * r_j * dij;
+}
+
+template<typename NumericType>
+NumericType outer_loop(std::vector<NumericType> xs) {
+    NumericType nrg_sum = 0;
+    std::vector<std::complex<NumericType> > cxs = timemachine::convert_to_complex<NumericType>(xs);
+    NumericType step = 1e-100;
+    for(size_t i=0; i < xs.size(); i++) {
+        for(size_t j=0; j < xs.size(); j++) {
+            if(i == j) {
+                continue;
+            }
+            
+            // energy
+            nrg_sum += energy(i, j, xs);
+
+            // dE/dxi
+            cxs[i] = std::complex<NumericType>(xs[i], step);
+            std::complex<NumericType> dE_dxi = energy_complex(i, j, cxs);
+
+            std::cout << dE_dxi.imag()/step << std::endl;
+            // dE/dxj
+
+
+
+
+        }
+    }
+    return nrg_sum;
+}
+
+
+int main() {
+    std::vector<double> input({1.0, 2.0, 5.5, 1.0, 5.0});
+    std::cout << outer_loop(input) << std::endl;
+}

--- a/timemachine/cpu_functionals/gbsa_ref.py
+++ b/timemachine/cpu_functionals/gbsa_ref.py
@@ -1,0 +1,34 @@
+import tensorflow as tf
+
+
+def compute_radii(xs):
+    xi = tf.expand_dims(xs, 1)
+    xj = tf.expand_dims(xs, 0)
+    return tf.reduce_sum(tf.pow(xi - 0.5*xj, 2), axis=-1)
+
+
+def outer_loop(xs):
+    rs = compute_radii(xs)
+    ri = tf.expand_dims(rs, axis=1)
+    rj = tf.expand_dims(rs, axis=0)
+    d2ij = tf.pow(ri - 1.5*rj, 2)
+    nrg = tf.reduce_sum(d2ij)
+    return nrg, tf.gradients(nrg, rs)
+
+
+if __name__ == "__main__":
+    sess = tf.Session()
+    # xs = tf.convert_to_tensor([1.0, 2.3, 0.4, -0.3, 1.2])
+    xs = tf.convert_to_tensor([1.0, 2.3, 0.4], dtype=tf.float64)
+    # xs = tf.convert_to_tensor([1.0, 2.3], dtype=tf.float64)
+    radii_op = compute_radii(xs)
+    nrg_op, dE_drs = outer_loop(xs)
+
+    grad_op = tf.gradients(nrg_op, xs)
+    
+    dRdxi = tf.gradients(radii_op[0], xs)
+    dRdxj = tf.gradients(radii_op[1], xs)
+
+    # print(sess.run([radii_op, dE_drs, dRdxi, dRdxj]))
+
+    print(sess.run([grad_op]))

--- a/timemachine/cpu_functionals/gbsa_ref.py
+++ b/timemachine/cpu_functionals/gbsa_ref.py
@@ -1,6 +1,5 @@
 import tensorflow as tf
 
-
 def compute_radii(xs):
     xi = tf.expand_dims(xs, 1)
     xj = tf.expand_dims(xs, 0)
@@ -19,7 +18,7 @@ def outer_loop(xs):
 if __name__ == "__main__":
     sess = tf.Session()
     # xs = tf.convert_to_tensor([1.0, 2.3, 0.4, -0.3, 1.2])
-    xs = tf.convert_to_tensor([1.0, 2.3, 0.4], dtype=tf.float64)
+    xs = tf.convert_to_tensor([1.0, 2.3, 0.4 ], dtype=tf.float64)
     # xs = tf.convert_to_tensor([1.0, 2.3], dtype=tf.float64)
     radii_op = compute_radii(xs)
     nrg_op, dE_drs = outer_loop(xs)
@@ -28,6 +27,8 @@ if __name__ == "__main__":
     
     dRdxi = tf.gradients(radii_op[0], xs)
     dRdxj = tf.gradients(radii_op[1], xs)
+
+    tf.jacobiantf.gradients(radii_op, xs)
 
     # print(sess.run([radii_op, dE_drs, dRdxi, dRdxj]))
 

--- a/timemachine/cpu_functionals/make.sh
+++ b/timemachine/cpu_functionals/make.sh
@@ -4,4 +4,4 @@ if [ "$(uname)" == "Darwin" ]; then
     # Do something under Mac OS X platform        
 fi
 
-g++ -g -O0 -march=native -Wall -shared -std=c++17 -fPIC $PLATFORM_FLAGS `python3 -m pybind11 --includes` wrappers.cpp -o energy`python3-config --extension-suffix`
+g++ -g -O0 -march=native -Wall -shared -std=c++11 -fPIC $PLATFORM_FLAGS `python3 -m pybind11 --includes` wrappers.cpp -o energy`python3-config --extension-suffix`

--- a/timemachine/cpu_functionals/make.sh
+++ b/timemachine/cpu_functionals/make.sh
@@ -4,4 +4,4 @@ if [ "$(uname)" == "Darwin" ]; then
     # Do something under Mac OS X platform        
 fi
 
-g++ -g -O0 -march=native -Wall -shared -std=c++11 -fPIC $PLATFORM_FLAGS `python3 -m pybind11 --includes` wrappers.cpp -o energy`python3-config --extension-suffix`
+g++ -g -O0 -march=native -Wall -shared -std=c++17 -fPIC $PLATFORM_FLAGS `python3 -m pybind11 --includes` wrappers.cpp -o energy`python3-config --extension-suffix`

--- a/timemachine/cpu_functionals/make.sh
+++ b/timemachine/cpu_functionals/make.sh
@@ -1,0 +1,7 @@
+PLATFORM_FLAGS="";
+if [ "$(uname)" == "Darwin" ]; then
+	PLATFORM_FLAGS="-undefined dynamic_lookup";
+    # Do something under Mac OS X platform        
+fi
+
+g++ -g -O0 -march=native -Wall -shared -std=c++11 -fPIC $PLATFORM_FLAGS `python3 -m pybind11 --includes` wrappers.cpp -o energy`python3-config --extension-suffix`

--- a/timemachine/cpu_functionals/nonbonded_cpu.hpp
+++ b/timemachine/cpu_functionals/nonbonded_cpu.hpp
@@ -198,4 +198,234 @@ public:
     }
 };
 
+template <typename NumericType>
+class LennardJones {
+
+private:
+
+    const std::vector<NumericType> params_;
+    const std::vector<size_t> param_idxs_; // [N, 2] for sig eps
+    const std::vector<NumericType> scale_matrix_;
+
+
+public:
+
+    LennardJones(
+        std::vector<NumericType> params,
+        std::vector<size_t> param_idxs,
+        std::vector<NumericType> scale_matrix
+    ) : params_(params), 
+        param_idxs_(param_idxs),
+        scale_matrix_(scale_matrix) {};
+
+    // unscaled interaction energies
+    NumericType ixn_energy(
+        const std::array<NumericType, 6> &xs,
+        const std::array<NumericType, 4> &params) const {
+        NumericType x0 = xs[0];
+        NumericType y0 = xs[1];
+        NumericType z0 = xs[2];
+
+        NumericType x1 = xs[3];
+        NumericType y1 = xs[4];
+        NumericType z1 = xs[5];
+
+        NumericType sig0 = params[0];
+        NumericType eps0 = params[1];
+        NumericType sig1 = params[2];
+        NumericType eps1 = params[3];
+
+        NumericType dx = x0 - x1;
+        NumericType dy = y0 - y1;
+        NumericType dz = z0 - z1;
+
+        NumericType dij = timemachine::norm(dx, dy, dz);
+
+        NumericType eps = sqrt(eps0 * eps1);
+        NumericType sig = (sig0 + sig1)/2;
+
+        NumericType sig2 = sig/dij;
+        sig2 *= sig2;
+        NumericType sig6 = sig2*sig2*sig2;
+
+        NumericType energy = 4*eps*(sig6-1.0)*sig6;
+
+        return energy;
+    }
+
+    template<
+        typename CoordType,
+        typename ParamType,
+        typename OutType>
+    std::array<OutType, 6> ixn_gradient(
+        const std::array<CoordType, 6> &xs,
+        const std::array<ParamType, 4> &params) const {
+        CoordType x0 = xs[0];
+        CoordType y0 = xs[1];
+        CoordType z0 = xs[2];
+
+        CoordType x1 = xs[3];
+        CoordType y1 = xs[4];
+        CoordType z1 = xs[5];
+
+        CoordType dx = x0 - x1;
+        CoordType dy = y0 - y1;
+        CoordType dz = z0 - z1;
+
+        ParamType sig0 = params[0];
+        ParamType eps0 = params[1];
+        ParamType sig1 = params[2];
+        ParamType eps1 = params[3];
+
+        ParamType eps = sqrt(eps0 * eps1);
+        ParamType sig = (sig0 + sig1)/2;
+
+        ParamType sig2 = sig*sig;
+        ParamType sig3 = sig2*sig;
+        ParamType sig5 = sig3*sig2;
+        ParamType sig6 = sig5*sig;
+        ParamType sig12 = sig6*sig6;
+
+        // rij = d2ij, avoids a square root.
+        CoordType rij = dx*dx + dy*dy + dz*dz;
+        CoordType rij3 = rij * rij * rij;
+        CoordType rij4 = rij3 * rij;
+        CoordType rij7 = rij4 * rij3;
+
+        // (ytz): 99 % sure this loses precision so we need to refactor
+        OutType sig12rij7 = sig12/rij7;
+        OutType sig6rij4 = sig6/rij4;
+
+        OutType dEdx = 4*eps*(sig12rij7*12*dx - sig6rij4*6*dx);
+        OutType dEdy = 4*eps*(sig12rij7*12*dy - sig6rij4*6*dy);
+        OutType dEdz = 4*eps*(sig12rij7*12*dz - sig6rij4*6*dz);
+
+        std::array<OutType, 6> grads;
+
+        grads[0*3+0] = -dEdx;
+        grads[0*3+1] = -dEdy;
+        grads[0*3+2] = -dEdz;
+
+        grads[1*3+0] = dEdx;
+        grads[1*3+1] = dEdy;
+        grads[1*3+2] = dEdz;
+
+        return grads;
+    }
+
+    /*
+    Implements the total derivative of the gradient at a point in time. We
+    use raw pointers to make it easier to interface with the wrapper layers and
+    to maintain some level of consistency with the C++ code.
+    */
+    void total_derivative(
+        const size_t n_atoms,
+        const size_t n_params,
+        const NumericType* coords, // [N, 3]
+        const NumericType* dxdp, // [P, N, 3]
+        NumericType* energy_out, // []
+        NumericType* grad_out, // [N,3]
+        NumericType* total_out // [P, N, 3]
+    ) const {
+
+        // use upper right symmetric later
+        for(size_t atom_0_idx=0; atom_0_idx < n_atoms; atom_0_idx++) {
+
+            const NumericType x0 = coords[atom_0_idx*3+0];
+            const NumericType y0 = coords[atom_0_idx*3+1];
+            const NumericType z0 = coords[atom_0_idx*3+2];
+            const NumericType sig0 = params_[param_idxs_[atom_0_idx*2+0]];
+            const NumericType eps0 = params_[param_idxs_[atom_0_idx*2+1]];
+
+            for(size_t atom_1_idx=atom_0_idx+1; atom_1_idx < n_atoms; atom_1_idx++ ) {
+
+                NumericType scale = scale_matrix_[atom_0_idx*n_atoms + atom_1_idx];
+                if(scale == 0) {
+                    continue;
+                }
+
+                const NumericType x1 = coords[atom_1_idx*3+0];
+                const NumericType y1 = coords[atom_1_idx*3+1];
+                const NumericType z1 = coords[atom_1_idx*3+2];
+                const NumericType sig1 = params_[param_idxs_[atom_1_idx*2+0]];
+                const NumericType eps1 = params_[param_idxs_[atom_1_idx*2+1]];
+
+                std::array<NumericType, 6> xs({x0, y0, z0, x1, y1, z1});
+                std::array<NumericType, 4> params({sig0, eps0, sig1, eps1});
+
+                *energy_out += scale*ixn_energy(xs, params);
+
+                std::array<NumericType, 6> grads = ixn_gradient<NumericType, NumericType, NumericType>(xs, params);
+
+                grad_out[atom_0_idx*3 + 0] += scale*grads[0];
+                grad_out[atom_0_idx*3 + 1] += scale*grads[1];
+                grad_out[atom_0_idx*3 + 2] += scale*grads[2];
+
+                grad_out[atom_1_idx*3 + 0] += scale*grads[3];
+                grad_out[atom_1_idx*3 + 1] += scale*grads[4];
+                grad_out[atom_1_idx*3 + 2] += scale*grads[5];
+
+                NumericType step = 1e-50;
+
+                // compute mixed partials, loop over all the parameters
+                // (ytz) TODO: unroll this
+                std::array<size_t, 4> pidx({
+                    param_idxs_[atom_0_idx*2+0],
+                    param_idxs_[atom_0_idx*2+1],
+                    param_idxs_[atom_1_idx*2+0],
+                    param_idxs_[atom_1_idx*2+1]
+                });
+
+                for(size_t j=0; j < 4; j++) {
+                    std::array<std::complex<NumericType>, 4> cparams = timemachine::convert_to_complex(params);
+                    cparams[j] = std::complex<NumericType>(cparams[j].real(), step);
+                    std::array<std::complex<NumericType>, 6> dcxs = ixn_gradient<NumericType, std::complex<NumericType>, std::complex<NumericType> >(xs, cparams);
+
+                    std::array<NumericType, 6> ddxs;
+                    for(int k=0; k < 6; k++) {
+                        ddxs[k] = dcxs[k].imag() / step;
+                    }
+
+                    size_t p_idx = pidx[j];
+
+                    total_out[p_idx*n_atoms*3 + atom_0_idx*3 + 0] += scale*ddxs[0];
+                    total_out[p_idx*n_atoms*3 + atom_0_idx*3 + 1] += scale*ddxs[1];
+                    total_out[p_idx*n_atoms*3 + atom_0_idx*3 + 2] += scale*ddxs[2];
+                    total_out[p_idx*n_atoms*3 + atom_1_idx*3 + 0] += scale*ddxs[3];
+                    total_out[p_idx*n_atoms*3 + atom_1_idx*3 + 1] += scale*ddxs[4];
+                    total_out[p_idx*n_atoms*3 + atom_1_idx*3 + 2] += scale*ddxs[5];
+                }
+
+                std::array<size_t, 6> indices({
+                    atom_0_idx*3+0,
+                    atom_0_idx*3+1,
+                    atom_0_idx*3+2,
+                    atom_1_idx*3+0,
+                    atom_1_idx*3+1,
+                    atom_1_idx*3+2
+                });
+
+                for(size_t j=0; j < 6; j++) {
+
+                    std::array<std::complex<NumericType>, 6> cxs = timemachine::convert_to_complex(xs);
+                    cxs[j] = std::complex<NumericType>(cxs[j].real(), step);
+                    std::array<std::complex<NumericType>, 6> dcxs = ixn_gradient<std::complex<NumericType>, NumericType, std::complex<NumericType> >(cxs, params);
+                    std::array<NumericType, 6> ddxs;
+                    for(int k=0; k < 6; k++) {
+                        ddxs[k] = scale*dcxs[k].imag() / step;
+                    }
+
+                    for(size_t p=0; p < n_params; p++) {
+                        auto dx0 = ddxs[0] * dxdp[p*n_atoms*3 + atom_0_idx*3 + 0] + ddxs[3] * dxdp[p*n_atoms*3 + atom_1_idx*3 + 0];
+                        auto dx1 = ddxs[1] * dxdp[p*n_atoms*3 + atom_0_idx*3 + 1] + ddxs[4] * dxdp[p*n_atoms*3 + atom_1_idx*3 + 1];
+                        auto dx2 = ddxs[2] * dxdp[p*n_atoms*3 + atom_0_idx*3 + 2] + ddxs[5] * dxdp[p*n_atoms*3 + atom_1_idx*3 + 2];
+                        total_out[p*n_atoms*3 + indices[j]] += dx0+dx1+dx2;
+                    }
+                }
+
+            }
+        }
+    }
+};
+
 } // namespace timemachine

--- a/timemachine/cpu_functionals/nonbonded_cpu.hpp
+++ b/timemachine/cpu_functionals/nonbonded_cpu.hpp
@@ -1,0 +1,201 @@
+#pragma once
+#include <array>
+#include <iostream>
+#include <complex>
+#include <vector>
+#include "utils.hpp"
+#include "constants.hpp"
+namespace timemachine {
+
+template <typename NumericType>
+class Electrostatics {
+
+private:
+
+    const std::vector<NumericType> params_;
+    const std::vector<size_t> param_idxs_;
+    const std::vector<NumericType> scale_matrix_;
+
+
+public:
+
+    Electrostatics(
+        std::vector<NumericType> params,
+        std::vector<size_t> param_idxs,
+        std::vector<NumericType> scale_matrix
+    ) : params_(params), 
+        param_idxs_(param_idxs),
+        scale_matrix_(scale_matrix) {};
+
+
+    NumericType ixn_energy(
+        const std::array<NumericType, 6> &xs,
+        const std::array<NumericType, 2> &params) const {
+        NumericType x0 = xs[0];
+        NumericType y0 = xs[1];
+        NumericType z0 = xs[2];
+
+        NumericType x1 = xs[3];
+        NumericType y1 = xs[4];
+        NumericType z1 = xs[5];
+
+        NumericType q0 = params[0];
+        NumericType q1 = params[1];
+
+        NumericType dx = x0 - x1;
+        NumericType dy = y0 - y1;
+        NumericType dz = z0 - z1;
+
+        NumericType dij = timemachine::norm(dx, dy, dz);
+
+        return (ONE_4PI_EPS0*q0*q1)/dij;
+    }
+
+    template<
+        typename CoordType,
+        typename ParamType,
+        typename OutType>
+    std::array<OutType, 6> ixn_gradient(
+        const std::array<CoordType, 6> &xs,
+        const std::array<ParamType, 2> &params) const {
+        CoordType x0 = xs[0];
+        CoordType y0 = xs[1];
+        CoordType z0 = xs[2];
+
+        CoordType x1 = xs[3];
+        CoordType y1 = xs[4];
+        CoordType z1 = xs[5];
+
+        ParamType q0 = params[0];
+        ParamType q1 = params[1];
+
+        CoordType dx = x0 - x1;
+        CoordType dy = y0 - y1;
+        CoordType dz = z0 - z1;
+
+        CoordType dij = timemachine::norm(dx, dy, dz);
+        CoordType d3ij = dij*dij*dij;
+
+        OutType PREFACTOR = ONE_4PI_EPS0*q0*q1/d3ij;
+
+        std::array<OutType, 6> grads;
+
+        grads[0*3 + 0] = PREFACTOR*(-dx);
+        grads[0*3 + 1] = PREFACTOR*(-dy);
+        grads[0*3 + 2] = PREFACTOR*(-dz);
+
+        grads[1*3 + 0] = PREFACTOR*(dx);
+        grads[1*3 + 1] = PREFACTOR*(dy);
+        grads[1*3 + 2] = PREFACTOR*(dz);
+
+        return grads;
+    }
+
+    /*
+    Implements the total derivative of the gradient at a point in time. We
+    use raw pointers to make it easier to interface with the wrapper layers and
+    to maintain some level of consistency with the C++ code.
+    */
+    void total_derivative(
+        const size_t n_atoms,
+        const size_t n_params,
+        const NumericType* coords, // [N, 3]
+        const NumericType* dxdp, // [P, N, 3]
+        NumericType* energy_out, // []
+        NumericType* grad_out, // [N,3]
+        NumericType* total_out // [P, N, 3]
+    ) const {
+
+        // use upper right symmetric later
+        for(size_t atom_0_idx=0; atom_0_idx < n_atoms; atom_0_idx++) {
+
+            const NumericType x0 = coords[atom_0_idx*3+0];
+            const NumericType y0 = coords[atom_0_idx*3+1];
+            const NumericType z0 = coords[atom_0_idx*3+2];
+            const NumericType q0 = params_[param_idxs_[atom_0_idx]];
+
+            for(size_t atom_1_idx=atom_0_idx+1; atom_1_idx < n_atoms; atom_1_idx++ ) {
+
+                NumericType scale = scale_matrix_[atom_0_idx*n_atoms + atom_1_idx];
+                if(scale == 0) {
+                    continue;
+                }
+
+                const NumericType x1 = coords[atom_1_idx*3+0];
+                const NumericType y1 = coords[atom_1_idx*3+1];
+                const NumericType z1 = coords[atom_1_idx*3+2];
+                const NumericType q1 = params_[param_idxs_[atom_1_idx]];
+
+                std::array<NumericType, 6> xs({x0, y0, z0, x1, y1, z1});
+                std::array<NumericType, 2> params({q0, q1});
+
+                *energy_out += scale*ixn_energy(xs, params);
+
+                std::array<NumericType, 6> grads = ixn_gradient<NumericType, NumericType, NumericType>(xs, params);
+
+                grad_out[atom_0_idx*3 + 0] += scale*grads[0];
+                grad_out[atom_0_idx*3 + 1] += scale*grads[1];
+                grad_out[atom_0_idx*3 + 2] += scale*grads[2];
+
+                grad_out[atom_1_idx*3 + 0] += scale*grads[3];
+                grad_out[atom_1_idx*3 + 1] += scale*grads[4];
+                grad_out[atom_1_idx*3 + 2] += scale*grads[5];
+
+                NumericType step = 1e-50;
+
+                // compute mixed partials, loop over all the parameters
+                // (ytz) TODO: unroll this
+                std::array<size_t, 2> pidx({param_idxs_[atom_0_idx], param_idxs_[atom_1_idx]});
+                for(size_t j=0; j < 2; j++) {
+                    std::array<std::complex<NumericType>, 2> cparams = timemachine::convert_to_complex(params);
+                    cparams[j] = std::complex<NumericType>(cparams[j].real(), step);
+                    std::array<std::complex<NumericType>, 6> dcxs = ixn_gradient<NumericType, std::complex<NumericType>, std::complex<NumericType> >(xs, cparams);
+
+                    std::array<NumericType, 6> ddxs;
+                    for(int k=0; k < 6; k++) {
+                        ddxs[k] = dcxs[k].imag() / step;
+                    }
+
+                    size_t p_idx = pidx[j];
+
+                    total_out[p_idx*n_atoms*3 + atom_0_idx*3 + 0] += scale*ddxs[0];
+                    total_out[p_idx*n_atoms*3 + atom_0_idx*3 + 1] += scale*ddxs[1];
+                    total_out[p_idx*n_atoms*3 + atom_0_idx*3 + 2] += scale*ddxs[2];
+                    total_out[p_idx*n_atoms*3 + atom_1_idx*3 + 0] += scale*ddxs[3];
+                    total_out[p_idx*n_atoms*3 + atom_1_idx*3 + 1] += scale*ddxs[4];
+                    total_out[p_idx*n_atoms*3 + atom_1_idx*3 + 2] += scale*ddxs[5];
+                }
+
+                std::array<size_t, 6> indices({
+                    atom_0_idx*3+0,
+                    atom_0_idx*3+1,
+                    atom_0_idx*3+2,
+                    atom_1_idx*3+0,
+                    atom_1_idx*3+1,
+                    atom_1_idx*3+2
+                });
+
+                for(size_t j=0; j < 6; j++) {
+
+                    std::array<std::complex<NumericType>, 6> cxs = timemachine::convert_to_complex(xs);
+                    cxs[j] = std::complex<NumericType>(cxs[j].real(), step);
+                    std::array<std::complex<NumericType>, 6> dcxs = ixn_gradient<std::complex<NumericType>, NumericType, std::complex<NumericType> >(cxs, params);
+                    std::array<NumericType, 6> ddxs;
+                    for(int k=0; k < 6; k++) {
+                        ddxs[k] = scale*dcxs[k].imag() / step;
+                    }
+
+                    for(size_t p=0; p < n_params; p++) {
+                        auto dx0 = ddxs[0] * dxdp[p*n_atoms*3 + atom_0_idx*3 + 0] + ddxs[3] * dxdp[p*n_atoms*3 + atom_1_idx*3 + 0];
+                        auto dx1 = ddxs[1] * dxdp[p*n_atoms*3 + atom_0_idx*3 + 1] + ddxs[4] * dxdp[p*n_atoms*3 + atom_1_idx*3 + 1];
+                        auto dx2 = ddxs[2] * dxdp[p*n_atoms*3 + atom_0_idx*3 + 2] + ddxs[5] * dxdp[p*n_atoms*3 + atom_1_idx*3 + 2];
+                        total_out[p*n_atoms*3 + indices[j]] += dx0+dx1+dx2;
+                    }
+                }
+
+            }
+        }
+    }
+};
+
+} // namespace timemachine

--- a/timemachine/cpu_functionals/utils.hpp
+++ b/timemachine/cpu_functionals/utils.hpp
@@ -4,6 +4,32 @@
 
 namespace timemachine {
 
+// Trick to allow type promotion below
+// https://stackoverflow.com/questions/2647858/multiplying-complex-with-constant-in-c
+template <typename T>
+struct identity_t { typedef T type; };
+
+/// Make working with std::complex<> nubmers suck less... allow promotion.
+#define COMPLEX_OPS(OP)                                                 \
+  template <typename _Tp>                                               \
+  std::complex<_Tp>                                                     \
+  operator OP(std::complex<_Tp> lhs, const typename identity_t<_Tp>::type & rhs) \
+  {                                                                     \
+    return lhs OP rhs;                                                  \
+  }                                                                     \
+  template <typename _Tp>                                               \
+  std::complex<_Tp>                                                     \
+  operator OP(const typename identity_t<_Tp>::type & lhs, const std::complex<_Tp> & rhs) \
+  {                                                                     \
+    return lhs OP rhs;                                                  \
+  }
+COMPLEX_OPS(+)
+COMPLEX_OPS(-)
+COMPLEX_OPS(*)
+COMPLEX_OPS(/)
+#undef COMPLEX_OPS
+
+
 template<typename RealType, size_t N>
 std::array<std::complex<RealType>, N> convert_to_complex(const std::array<RealType, N> &input) {
     std::array<std::complex<RealType>, N> result;
@@ -11,6 +37,27 @@ std::array<std::complex<RealType>, N> convert_to_complex(const std::array<RealTy
         result[i] = std::complex<RealType>(input[i], 0);
     }
     return result;
+}
+
+template<typename RealType>
+std::vector<std::complex<RealType> > convert_to_complex(const std::vector<RealType> &input) {
+    std::vector<std::complex<RealType> > result(input.size());
+    for(size_t i=0; i < input.size(); i++) {
+        result[i] = std::complex<RealType>(input[i], 0);
+    }
+    return result;
+}
+
+template<typename RealType>
+RealType dot_product(
+    RealType x0, RealType y0, RealType z0,
+    RealType x1, RealType y1, RealType z1) {
+    return x0*x1 + y0*y1 + z0*z1;
+}
+
+template<typename RealType>
+RealType norm(RealType x, RealType y, RealType z) {
+    return sqrt(x*x + y*y + z*z);
 }
 
 }

--- a/timemachine/cpu_functionals/utils.hpp
+++ b/timemachine/cpu_functionals/utils.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include <array>
+#include <complex>
+
+namespace timemachine {
+
+template<typename RealType, size_t N>
+std::array<std::complex<RealType>, N> convert_to_complex(const std::array<RealType, N> &input) {
+    std::array<std::complex<RealType>, N> result;
+    for(size_t i=0; i < input.size(); i++) {
+        result[i] = std::complex<RealType>(input[i], 0);
+    }
+    return result;
+}
+
+}

--- a/timemachine/cpu_functionals/utils.hpp
+++ b/timemachine/cpu_functionals/utils.hpp
@@ -11,18 +11,18 @@ struct identity_t { typedef T type; };
 
 /// Make working with std::complex<> nubmers suck less... allow promotion.
 #define COMPLEX_OPS(OP)                                                 \
-  template <typename _Tp>                                               \
-  std::complex<_Tp>                                                     \
-  operator OP(std::complex<_Tp> lhs, const typename identity_t<_Tp>::type & rhs) \
-  {                                                                     \
+    template <typename _Tp>                                               \
+    std::complex<_Tp>                                                     \
+    operator OP(std::complex<_Tp> lhs, const typename identity_t<_Tp>::type & rhs) \
+    {                                                                     \
     return lhs OP rhs;                                                  \
-  }                                                                     \
-  template <typename _Tp>                                               \
-  std::complex<_Tp>                                                     \
-  operator OP(const typename identity_t<_Tp>::type & lhs, const std::complex<_Tp> & rhs) \
-  {                                                                     \
+    }                                                                     \
+    template <typename _Tp>                                               \
+    std::complex<_Tp>                                                     \
+    operator OP(const typename identity_t<_Tp>::type & lhs, const std::complex<_Tp> & rhs) \
+    {                                                                     \
     return lhs OP rhs;                                                  \
-  }
+    }
 COMPLEX_OPS(+)
 COMPLEX_OPS(-)
 COMPLEX_OPS(*)
@@ -53,6 +53,18 @@ RealType dot_product(
     RealType x0, RealType y0, RealType z0,
     RealType x1, RealType y1, RealType z1) {
     return x0*x1 + y0*y1 + z0*z1;
+}
+
+template<typename RealType>
+void cross_product(
+    RealType a1, RealType a2, RealType a3,
+    RealType b1, RealType b2, RealType b3,
+    RealType &s1, RealType &s2, RealType &s3) {
+
+    s1 = a2*b3 - a3*b2;
+    s2 = a3*b1 - a1*b3;
+    s3 = a1*b2 - a2*b1;
+
 }
 
 template<typename RealType>

--- a/timemachine/cpu_functionals/wrappers.cpp
+++ b/timemachine/cpu_functionals/wrappers.cpp
@@ -7,7 +7,6 @@
 
 namespace py = pybind11;
 
-
 template<typename NumericType>
 void declare_harmonic_bond(py::module &m, const char *typestr) {
 
@@ -42,6 +41,47 @@ void declare_harmonic_bond(py::module &m, const char *typestr) {
             py_grads.mutable_data(),
             py_totals.mutable_data()
         );
+
+        return py::make_tuple(energy, py_grads, py_totals);
+    });
+
+}
+
+template<typename NumericType>
+void declare_harmonic_angle(py::module &m, const char *typestr) {
+
+    using Class = timemachine::HarmonicAngle<NumericType>;
+    std::string pyclass_name = std::string("HarmonicAngle_") + typestr;
+    py::class_<Class>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+    .def(py::init<
+        std::vector<NumericType>, // params
+        std::vector<size_t>, // param_idxs
+        std::vector<size_t>, // angle_idxs
+        bool // whether or not we use cosine angles
+    >())
+    .def("total_derivative", [](timemachine::HarmonicAngle<NumericType> &ha,
+        const py::array_t<NumericType, py::array::c_style> coords,
+        const py::array_t<NumericType, py::array::c_style> dxdp) -> py::tuple {
+
+        const auto num_params = dxdp.shape()[0];
+        const auto num_atoms = coords.shape()[0];
+        const auto num_dims = coords.shape()[1];
+
+        NumericType energy = 0;
+        py::array_t<NumericType, py::array::c_style> py_totals({num_params, num_atoms, num_dims});
+        py::array_t<NumericType, py::array::c_style> py_grads({num_atoms, num_dims});
+        memset(py_totals.mutable_data(), 0.0, sizeof(NumericType)*num_params*num_atoms*num_dims);
+        memset(py_grads.mutable_data(), 0.0, sizeof(NumericType)*num_atoms*num_dims);
+
+        ha.total_derivative(
+            num_atoms,
+            num_params,
+            coords.data(),
+            dxdp.data(),
+            &energy,
+            py_grads.mutable_data(),
+            py_totals.mutable_data()
+        );
         return py::make_tuple(energy, py_grads, py_totals);
     });
 
@@ -51,5 +91,8 @@ PYBIND11_MODULE(energy, m) {
 
 declare_harmonic_bond<double>(m, "double");
 declare_harmonic_bond<float>(m, "float");
+
+declare_harmonic_angle<double>(m, "double");
+declare_harmonic_angle<float>(m, "float");
 
 }

--- a/timemachine/cpu_functionals/wrappers.cpp
+++ b/timemachine/cpu_functionals/wrappers.cpp
@@ -87,6 +87,47 @@ void declare_harmonic_angle(py::module &m, const char *typestr) {
 
 }
 
+
+template<typename NumericType>
+void declare_periodic_torsion(py::module &m, const char *typestr) {
+
+    using Class = timemachine::PeriodicTorsion<NumericType>;
+    std::string pyclass_name = std::string("PeriodicTorsion_") + typestr;
+    py::class_<Class>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+    .def(py::init<
+        std::vector<NumericType>, // params
+        std::vector<size_t>, // param_idxs
+        std::vector<size_t>  // torsion_idxs
+    >())
+    .def("total_derivative", [](timemachine::PeriodicTorsion<NumericType> &ha,
+        const py::array_t<NumericType, py::array::c_style> coords,
+        const py::array_t<NumericType, py::array::c_style> dxdp) -> py::tuple {
+
+        const auto num_params = dxdp.shape()[0];
+        const auto num_atoms = coords.shape()[0];
+        const auto num_dims = coords.shape()[1];
+
+        NumericType energy = 0;
+        py::array_t<NumericType, py::array::c_style> py_totals({num_params, num_atoms, num_dims});
+        py::array_t<NumericType, py::array::c_style> py_grads({num_atoms, num_dims});
+        memset(py_totals.mutable_data(), 0.0, sizeof(NumericType)*num_params*num_atoms*num_dims);
+        memset(py_grads.mutable_data(), 0.0, sizeof(NumericType)*num_atoms*num_dims);
+
+        ha.total_derivative(
+            num_atoms,
+            num_params,
+            coords.data(),
+            dxdp.data(),
+            &energy,
+            py_grads.mutable_data(),
+            py_totals.mutable_data()
+        );
+        return py::make_tuple(energy, py_grads, py_totals);
+    });
+
+}
+
+
 PYBIND11_MODULE(energy, m) {
 
 declare_harmonic_bond<double>(m, "double");
@@ -94,5 +135,8 @@ declare_harmonic_bond<float>(m, "float");
 
 declare_harmonic_angle<double>(m, "double");
 declare_harmonic_angle<float>(m, "float");
+
+declare_periodic_torsion<double>(m, "double");
+declare_periodic_torsion<float>(m, "float");
 
 }

--- a/timemachine/cpu_functionals/wrappers.cpp
+++ b/timemachine/cpu_functionals/wrappers.cpp
@@ -2,6 +2,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
 
+#include "nonbonded_cpu.hpp"
 #include "bonded_cpu.hpp"
 #include <iostream>
 
@@ -99,7 +100,7 @@ void declare_periodic_torsion(py::module &m, const char *typestr) {
         std::vector<size_t>, // param_idxs
         std::vector<size_t>  // torsion_idxs
     >())
-    .def("total_derivative", [](timemachine::PeriodicTorsion<NumericType> &ha,
+    .def("total_derivative", [](timemachine::PeriodicTorsion<NumericType> &nrg,
         const py::array_t<NumericType, py::array::c_style> coords,
         const py::array_t<NumericType, py::array::c_style> dxdp) -> py::tuple {
 
@@ -113,7 +114,7 @@ void declare_periodic_torsion(py::module &m, const char *typestr) {
         memset(py_totals.mutable_data(), 0.0, sizeof(NumericType)*num_params*num_atoms*num_dims);
         memset(py_grads.mutable_data(), 0.0, sizeof(NumericType)*num_atoms*num_dims);
 
-        ha.total_derivative(
+        nrg.total_derivative(
             num_atoms,
             num_params,
             coords.data(),
@@ -128,6 +129,45 @@ void declare_periodic_torsion(py::module &m, const char *typestr) {
 }
 
 
+template<typename NumericType>
+void declare_electrostatics(py::module &m, const char *typestr) {
+
+    using Class = timemachine::Electrostatics<NumericType>;
+    std::string pyclass_name = std::string("Electrostatics_") + typestr;
+    py::class_<Class>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+    .def(py::init<
+        std::vector<NumericType>, // params
+        std::vector<size_t>, // param_idxs
+        std::vector<NumericType>  // NxN scale_matrix
+    >())
+    .def("total_derivative", [](timemachine::Electrostatics<NumericType> &nrg,
+        const py::array_t<NumericType, py::array::c_style> coords,
+        const py::array_t<NumericType, py::array::c_style> dxdp) -> py::tuple {
+
+        const auto num_params = dxdp.shape()[0];
+        const auto num_atoms = coords.shape()[0];
+        const auto num_dims = coords.shape()[1];
+
+        NumericType energy = 0;
+        py::array_t<NumericType, py::array::c_style> py_totals({num_params, num_atoms, num_dims});
+        py::array_t<NumericType, py::array::c_style> py_grads({num_atoms, num_dims});
+        memset(py_totals.mutable_data(), 0.0, sizeof(NumericType)*num_params*num_atoms*num_dims);
+        memset(py_grads.mutable_data(), 0.0, sizeof(NumericType)*num_atoms*num_dims);
+
+        nrg.total_derivative(
+            num_atoms,
+            num_params,
+            coords.data(),
+            dxdp.data(),
+            &energy,
+            py_grads.mutable_data(),
+            py_totals.mutable_data()
+        );
+        return py::make_tuple(energy, py_grads, py_totals);
+    });
+
+}
+
 PYBIND11_MODULE(energy, m) {
 
 declare_harmonic_bond<double>(m, "double");
@@ -138,5 +178,8 @@ declare_harmonic_angle<float>(m, "float");
 
 declare_periodic_torsion<double>(m, "double");
 declare_periodic_torsion<float>(m, "float");
+
+declare_electrostatics<double>(m, "double");
+declare_electrostatics<float>(m, "float");
 
 }

--- a/timemachine/cpu_functionals/wrappers.cpp
+++ b/timemachine/cpu_functionals/wrappers.cpp
@@ -168,6 +168,46 @@ void declare_electrostatics(py::module &m, const char *typestr) {
 
 }
 
+
+template<typename NumericType>
+void declare_lennard_jones(py::module &m, const char *typestr) {
+
+    using Class = timemachine::LennardJones<NumericType>;
+    std::string pyclass_name = std::string("LennardJones_") + typestr;
+    py::class_<Class>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+    .def(py::init<
+        std::vector<NumericType>, // params
+        std::vector<size_t>, // param_idxs
+        std::vector<NumericType>  // NxN scale_matrix
+    >())
+    .def("total_derivative", [](timemachine::LennardJones<NumericType> &nrg,
+        const py::array_t<NumericType, py::array::c_style> coords,
+        const py::array_t<NumericType, py::array::c_style> dxdp) -> py::tuple {
+
+        const auto num_params = dxdp.shape()[0];
+        const auto num_atoms = coords.shape()[0];
+        const auto num_dims = coords.shape()[1];
+
+        NumericType energy = 0;
+        py::array_t<NumericType, py::array::c_style> py_totals({num_params, num_atoms, num_dims});
+        py::array_t<NumericType, py::array::c_style> py_grads({num_atoms, num_dims});
+        memset(py_totals.mutable_data(), 0.0, sizeof(NumericType)*num_params*num_atoms*num_dims);
+        memset(py_grads.mutable_data(), 0.0, sizeof(NumericType)*num_atoms*num_dims);
+
+        nrg.total_derivative(
+            num_atoms,
+            num_params,
+            coords.data(),
+            dxdp.data(),
+            &energy,
+            py_grads.mutable_data(),
+            py_totals.mutable_data()
+        );
+        return py::make_tuple(energy, py_grads, py_totals);
+    });
+
+}
+
 PYBIND11_MODULE(energy, m) {
 
 declare_harmonic_bond<double>(m, "double");
@@ -181,5 +221,8 @@ declare_periodic_torsion<float>(m, "float");
 
 declare_electrostatics<double>(m, "double");
 declare_electrostatics<float>(m, "float");
+
+declare_lennard_jones<double>(m, "double");
+declare_lennard_jones<float>(m, "float");
 
 }

--- a/timemachine/cpu_functionals/wrappers.cpp
+++ b/timemachine/cpu_functionals/wrappers.cpp
@@ -1,0 +1,57 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+
+#include "bonded_cpu.hpp"
+#include <iostream>
+
+namespace py = pybind11;
+
+
+template<typename NumericType>
+void declare_harmonic_bond(py::module &m, const char *typestr) {
+
+    using Class = timemachine::HarmonicBond<NumericType>;
+    std::string pyclass_name = std::string("HarmonicBond_") + typestr;
+    py::class_<Class>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+    .def(py::init<
+        std::vector<NumericType>, // params
+        std::vector<size_t>, // param_idxs
+        std::vector<size_t> // bond_idxs
+    >())
+    .def("total_derivative", [](timemachine::HarmonicBond<NumericType> &hb,
+        const py::array_t<NumericType, py::array::c_style> coords,
+        const py::array_t<NumericType, py::array::c_style> dxdp) -> py::tuple {
+
+        const auto num_params = dxdp.shape()[0];
+        const auto num_atoms = coords.shape()[0];
+        const auto num_dims = coords.shape()[1];
+
+        NumericType energy = 0;
+        py::array_t<NumericType, py::array::c_style> py_totals({num_params, num_atoms, num_dims});
+        py::array_t<NumericType, py::array::c_style> py_grads({num_atoms, num_dims});
+        memset(py_totals.mutable_data(), 0.0, sizeof(NumericType)*num_params*num_atoms*num_dims);
+        memset(py_grads.mutable_data(), 0.0, sizeof(NumericType)*num_atoms*num_dims);
+
+        hb.total_derivative(
+            num_atoms,
+            num_params,
+            coords.data(),
+            dxdp.data(),
+            &energy,
+            py_grads.mutable_data(),
+            py_totals.mutable_data()
+        );
+        // std::cout << "done" << std::endl;
+        // std::memcpy(py_hessians.mutable_data(), &hessians[0], hessian_size);
+        return py::make_tuple(energy, py_grads, py_totals);
+    });
+
+}
+
+PYBIND11_MODULE(energy, m) {
+
+declare_harmonic_bond<double>(m, "double");
+declare_harmonic_bond<float>(m, "float");
+
+}

--- a/timemachine/cpu_functionals/wrappers.cpp
+++ b/timemachine/cpu_functionals/wrappers.cpp
@@ -42,8 +42,6 @@ void declare_harmonic_bond(py::module &m, const char *typestr) {
             py_grads.mutable_data(),
             py_totals.mutable_data()
         );
-        // std::cout << "done" << std::endl;
-        // std::memcpy(py_hessians.mutable_data(), &hessians[0], hessian_size);
         return py::make_tuple(energy, py_grads, py_totals);
     });
 

--- a/timemachine/derivatives.py
+++ b/timemachine/derivatives.py
@@ -59,3 +59,6 @@ def compute_ghm(energy_op, x, params):
     hess = densify(tf.hessians(energy_op, x)[0])
     mp = list_jacobian(grads, params)
     return grads, hess, mp
+
+def total_derivative(hessian, dxdp, mixed_partials):
+    return tf.einsum('ijkl,mkl->mij', hessian, tf.convert_to_tensor(dxdp)) + mixed_partials[0]

--- a/timemachine/derivatives.py
+++ b/timemachine/derivatives.py
@@ -62,3 +62,4 @@ def compute_ghm(energy_op, x, params):
 
 def total_derivative(hessian, dxdp, mixed_partials):
     return tf.einsum('ijkl,mkl->mij', hessian, tf.convert_to_tensor(dxdp)) + mixed_partials[0]
+

--- a/timemachine/functionals/bonded.py
+++ b/timemachine/functionals/bonded.py
@@ -58,6 +58,18 @@ class PeriodicTorsion(Energy):
 
         return tf.atan2(y, x)
 
+    def angles(self, conf):
+        ci = tf.gather(conf, self.torsion_idxs[:, 0])
+        cj = tf.gather(conf, self.torsion_idxs[:, 1])
+        ck = tf.gather(conf, self.torsion_idxs[:, 2])
+        cl = tf.gather(conf, self.torsion_idxs[:, 3])
+
+        ks = tf.gather(self.params, self.param_idxs[:, 0])
+        phase = tf.gather(self.params, self.param_idxs[:, 1])
+        period = tf.gather(self.params, self.param_idxs[:, 2])
+        angle = self.get_signed_angle(ci, cj, ck, cl)
+        return angle
+
     def energy(self, conf):
         ci = tf.gather(conf, self.torsion_idxs[:, 0])
         cj = tf.gather(conf, self.torsion_idxs[:, 1])


### PR DESCRIPTION
This PR:

- [x] showcase how to implement an asymptotically efficient hessian vector products (hvp)
- [x] implement a custom C++ op
- [x] utilizes hessian vector products to reduce memory usage
- [x] shows how to wrap using pybind11
- [x] harmonic bond gradients, hvp O(N), mixed partials O(N)
- [x] harmonic angle gradients, hvp O(N), mixed partials O(N)
- [x] periodic torsion gradients, hvp O(N), mixed partials O(N)
- [x] lj612 gradients, hessians, mixed partials
- [x] electrostatics gradients, hessians, mixed partials
- [ ] cutoff gbsa gradients, hessians, and mixed partials