### PR TITLE
Improve memory usage by computing velocity derivatives

### DIFF
--- a/tests/test_integrator_gpu.py
+++ b/tests/test_integrator_gpu.py
@@ -13,8 +13,6 @@ class TestGPUIntegrator(unittest.TestCase):
         # (ytz): needed to clear variables
         tf.reset_default_graph()
 
-
-
     def test_gpu_electrostatic_analytic_integration(self):
         """
         Testing that lower triangular hessians are working as intended. This is because for the
@@ -87,19 +85,12 @@ class TestGPUIntegrator(unittest.TestCase):
 
         # verify correctness of jacobians through time
         ref_dxdp_es_op = jacobian(ref_x_final_op, ref_nrg.get_params(), use_pfor=False) # (N, 3, P)
-        # ref_dxdp_ha_op = jacobian(ref_x_final_op, ha.get_params(), use_pfor=False) # (N, 3, P)
         ref_dxdp_es_op = tf.transpose(ref_dxdp_es_op, perm=[2,0,1])
-        # ref_dxdp_ha_op = tf.transpose(ref_dxdp_ha_op, perm=[2,0,1])
-
-        buffer_size = 100 # just make something large
 
         total_params = params_np.shape[0]
-        # global_angle_param_idxs = np.arange(angle_params_np.shape[0], dtype=np.int32) + global_bond_param_idxs.shape[0]
-        # total_params = bond_params_np.shape[0] + angle_params_np.shape[0]
 
         gpu_intg = custom_ops.Integrator_double(
             dt,
-            buffer_size,
             num_atoms,
             total_params,
             ref_intg.coeff_a,
@@ -209,15 +200,12 @@ class TestGPUIntegrator(unittest.TestCase):
         ref_dxdp_hb_op = tf.transpose(ref_dxdp_hb_op, perm=[2,0,1])
         ref_dxdp_ha_op = tf.transpose(ref_dxdp_ha_op, perm=[2,0,1])
 
-        buffer_size = 100 # just make something large
-
         global_bond_param_idxs = np.arange(bond_params_np.shape[0], dtype=np.int32)
         global_angle_param_idxs = np.arange(angle_params_np.shape[0], dtype=np.int32) + global_bond_param_idxs.shape[0]
         total_params = bond_params_np.shape[0] + angle_params_np.shape[0]
 
         gpu_intg = custom_ops.Integrator_double(
             dt,
-            buffer_size,
             num_atoms,
             total_params,
             ref_intg.coeff_a,
@@ -358,15 +346,12 @@ class TestGPUIntegrator(unittest.TestCase):
         ref_dxdp_hb_op = tf.transpose(ref_dxdp_hb_op, perm=[2,0,1])
         ref_dxdp_ha_op = tf.transpose(ref_dxdp_ha_op, perm=[2,0,1])
 
-        buffer_size = 100 # just make something large
-
         global_bond_param_idxs = np.arange(bond_params_np.shape[0], dtype=np.int32)
         global_angle_param_idxs = np.arange(angle_params_np.shape[0], dtype=np.int32) + global_bond_param_idxs.shape[0]
         total_params = bond_params_np.shape[0] + angle_params_np.shape[0]
 
         gpu_intg = custom_ops.Integrator_double(
             dt,
-            buffer_size,
             num_atoms,
             total_params,
             ref_intg.coeff_a,

--- a/tests/test_integrator_gpu.py
+++ b/tests/test_integrator_gpu.py
@@ -7,94 +7,6 @@ from timemachine.functionals import bonded, nonbonded
 from timemachine.cpu_functionals import custom_ops
 from tests.test_integrator import ReferenceLangevinIntegrator
 
-class ReferenceIntegrator():
-
-    def __init__(self,
-        x_t,
-        v_t,
-        noise,
-        grads,
-        hessians,
-        mixed_partials,
-        dt,
-        coeff_a,
-        coeff_bs,
-        coeff_cs,
-        buffer_size,
-        precision=tf.float64):
-
-        self.x_t = x_t
-        self.v_t = v_t
-        self.dt = dt
-
-        self.num_params = mixed_partials.shape[0]
-        self.num_atoms = mixed_partials.shape[1]
-        self.dE_dx = grads
-        self.d2E_dx2 = hessians
-        self.d2E_dxdp = mixed_partials
-        self.ca = coeff_a
-        self.cbs = coeff_bs
-        self.ccs = coeff_cs
-
-        self.scale = (1-tf.pow(self.ca, tf.range(buffer_size, dtype=precision)+1))/(1-self.ca)
-        self.scale = tf.reverse(self.scale, [0])
-        self.scale = tf.reshape(self.scale, (-1, 1, 1, 1))
-
-        self.initializers = []
-    
-        # buffer for current step's dxdp
-        self.dxdp_t = tf.get_variable(
-            "buffer_dxdp",
-            shape=(self.num_params, self.num_atoms, 3),
-            dtype=precision,
-            initializer=tf.initializers.zeros)
-        self.initializers.append(self.dxdp_t.initializer)
-
-        # buffer for unconverged Dps
-        self.buffer_Dx = tf.get_variable(
-            "buffer_Dx",
-            shape=(buffer_size, self.num_params, self.num_atoms, 3),
-            dtype=precision,
-            initializer=tf.initializers.zeros)
-        self.initializers.append(self.buffer_Dx.initializer)
-
-        # buffer for converged Dps
-        self.converged_Dps = tf.get_variable(
-            "converged_Dps",
-            shape=(self.num_params, self.num_atoms, 3),
-            dtype=precision,
-            initializer=tf.initializers.zeros)
-
-        self.initializers.append(self.converged_Dps.initializer)
-
-        num_dims = 3
-        num_atoms = self.num_atoms
-
-        Dx_t = tf.einsum('ijkl,mkl->mij', self.d2E_dx2, self.dxdp_t)
-        Dx_t += self.d2E_dxdp
-        self.Dx_t = Dx_t
-
-        all_ops = []
-
-        converged_Dx_assign = tf.assign_add(self.converged_Dps, self.buffer_Dx[0])
-        override = self.buffer_Dx[0].assign(Dx_t)
-        buffer_Dx_assign = tf.assign(
-            self.buffer_Dx,
-            tf.roll(override, shift=-1, axis=0)
-        )
-
-        # compute dxdp_{t+1} using unconverged Dp and converged Dps
-        new_dxdp_t = buffer_Dx_assign * self.scale
-        new_dxdp_t = tf.reduce_sum(new_dxdp_t, axis=0)
-        new_dxdp_t += converged_Dx_assign * self.scale[0][0][0][0]
-        new_dxdp_t *= -self.cbs * self.dt
-
-        self.dxdp_t_assign = tf.assign(self.dxdp_t, new_dxdp_t)
-
-        self.new_v_t = self.ca*self.v_t - self.cbs*self.dE_dx + self.ccs*noise
-        self.new_x_t = self.x_t + self.new_v_t * self.dt
-
-
 class TestGPUIntegrator(unittest.TestCase):
 
     def tearDown(self):
@@ -149,7 +61,7 @@ class TestGPUIntegrator(unittest.TestCase):
 
         masses = np.array([6.0, 1.0, 1.0, 1.0, 1.0], dtype=np.float64)
 
-        friction = 10.0
+        friction = 100.0
         dt = 0.01
         temp = 0.0
         num_atoms = len(masses)
@@ -157,7 +69,7 @@ class TestGPUIntegrator(unittest.TestCase):
 
         ref_intg = ReferenceLangevinIntegrator(masses, dt, friction, temp)
 
-        num_steps = 5
+        num_steps = 10
 
         x = x_ph
 
@@ -508,101 +420,6 @@ class TestGPUIntegrator(unittest.TestCase):
 
         np.testing.assert_array_almost_equal(cpu_dxdp[:2], ref_dxdp_bonds)
         np.testing.assert_array_almost_equal(cpu_dxdp[2:], ref_dxdp_angles)
-
-
-    def test_gpu_integrator(self):
-        """
-        Testing convergence of zetas.
-        """
-
-        masses = np.array([1.0, 12.0, 4.0, 2.0], dtype=np.float64)
-
-        num_atoms = masses.shape[0]
-
-        x_ph = tf.placeholder(shape=(num_atoms, 3), dtype=np.float64)
-        v_ph = tf.placeholder(shape=(num_atoms, 3), dtype=np.float64)
-        noise_ph = tf.placeholder(shape=(num_atoms, 3), dtype=np.float64)
-        grad_ph = tf.placeholder(shape=(num_atoms, 3), dtype=np.float64)
-        hessian_ph = tf.placeholder(shape=(num_atoms, 3, num_atoms, 3), dtype=np.float64)
-        mixed_partial_ph = tf.placeholder(shape=(5, num_atoms, 3), dtype=np.float64)
-
-        num_params = mixed_partial_ph.shape[0]
-
-        coeff_a = np.float64(0.5)
-        coeff_bs = np.expand_dims(np.array(masses), axis=1)
-        coeff_cs = np.expand_dims(1/np.array(masses), axis=1)
-        buffer_size = 3
-        dt = 0.03
-
-        ref_intg = ReferenceIntegrator(
-            x_ph,
-            v_ph,
-            noise_ph,
-            grad_ph,
-            hessian_ph,
-            mixed_partial_ph,
-            dt,
-            coeff_a,
-            coeff_bs,
-            coeff_cs,
-            buffer_size,
-            precision=tf.float64)
-
-        gpu_intg = custom_ops.Integrator_double(
-            dt,
-            buffer_size,
-            num_atoms,
-            num_params,
-            coeff_a,
-            coeff_bs.reshape(-1).tolist(),
-            coeff_cs.reshape(-1).tolist()
-        )
-
-        sess = tf.Session()
-        sess.run(tf.initializers.global_variables())
-
-        num_steps = 10
-
-        x_t = np.random.rand(num_atoms,3).astype(dtype=np.float64)-0.5
-        v_t = np.random.rand(num_atoms,3).astype(dtype=np.float64)-0.5
-
-        gpu_intg.set_coordinates(x_t.reshape(-1).tolist());
-        gpu_intg.set_velocities(v_t.reshape(-1).tolist());
-
-        for step in range(num_steps):
-            # -0.5 is to avoid exccess accumulation
-            grad = np.random.rand(num_atoms,3).astype(dtype=np.float64)-0.5
-            # this absolutely needs to be symmetric for things to work to avoid a transposition
-            hessian = np.random.rand(num_atoms*3,num_atoms*3).astype(dtype=np.float64)-0.5
-            hessian = (hessian + hessian.T)/2
-            hessian = hessian.reshape((num_atoms, 3, num_atoms, 3))
-            mixed_partial = np.random.rand(num_params,num_atoms,3).astype(dtype=np.float64)-0.5
-
-            gpu_intg.step(grad, hessian, mixed_partial)
-            test_dxdp_val = gpu_intg.get_dxdp()
-            test_x_t_val = gpu_intg.get_coordinates()
-            test_v_t_val = gpu_intg.get_velocities()
-            test_noise = gpu_intg.get_noise()
-
-            new_x, new_v, ref_dxdp_val = sess.run([ref_intg.new_x_t, ref_intg.new_v_t, ref_intg.dxdp_t_assign], feed_dict={
-                x_ph: x_t,
-                v_ph: v_t,
-                noise_ph: np.array(test_noise).reshape(num_atoms, 3),
-                grad_ph: grad,
-                hessian_ph: hessian,
-                mixed_partial_ph: mixed_partial
-            })
-
-            np.testing.assert_allclose(test_v_t_val, new_v.reshape(-1))
-            np.testing.assert_allclose(test_x_t_val, new_x.reshape(-1))
-
-            x_t = new_x
-            v_t = new_v
-
-            np.testing.assert_allclose(
-                test_dxdp_val,
-                ref_dxdp_val.reshape(-1)
-            )
 
 
 if __name__ == "__main__":

--- a/timemachine/cpu_functionals/integrator.cu
+++ b/timemachine/cpu_functionals/integrator.cu
@@ -60,14 +60,12 @@ namespace timemachine {
 template<typename NumericType> 
 Integrator<NumericType>::Integrator(
     NumericType dt,
-    int W,
     int N,
     int P,
     const NumericType coeff_a,
     const std::vector<NumericType> &coeff_bs,
     const std::vector<NumericType> &coeff_cs) :
     dt_(dt),
-    W_(W),
     N_(N),
     P_(P),
     step_(0),

--- a/timemachine/cpu_functionals/integrator.hpp
+++ b/timemachine/cpu_functionals/integrator.hpp
@@ -21,7 +21,6 @@ private:
     cublasHandle_t cb_handle_;
     curandGenerator_t  cr_rng_;
 
-    const int W_;
     const int N_;
     const int P_;
 
@@ -108,7 +107,6 @@ public:
 
     Integrator(
         NumericType dt,
-        int W,
         int N,
         int P,
         const NumericType coeff_a,

--- a/timemachine/cpu_functionals/integrator.hpp
+++ b/timemachine/cpu_functionals/integrator.hpp
@@ -34,8 +34,9 @@ private:
     NumericType *d_x_t_; // geometries
     NumericType *d_v_t_; // velocities
     NumericType *d_dxdp_t_; // derivatives of geometry wrt parameters
-    NumericType *d_total_buffer_; // total derivatives
-    NumericType *d_converged_buffer_;
+    NumericType *d_dvdp_t_; // derivatives of geometry wrt parameters
+    // NumericType *d_total_buffer_; // total derivatives
+    // NumericType *d_converged_buffer_;
 
 
     // should these be owned by the context instead? we want them to be explicit

--- a/timemachine/cpu_functionals/make.sh
+++ b/timemachine/cpu_functionals/make.sh
@@ -13,4 +13,4 @@ fi
 
 nvcc --use_fast_math --ptxas-options=-v -lineinfo -arch=sm_61 -O3 -Xcompiler="-fPIC" -std=c++11 integrator.cu nonbonded_gpu.cu bonded_gpu.cu gpu_utils.cu context.cu -c
 
-g++ -O3 -march=native -Wall -shared -std=c++11 -fPIC $PLATFORM_FLAGS `python3 -m pybind11 --includes` -L/usr/local/cuda-9.0/lib64/ -I/usr/local/cuda-9.0/include/ wrappers.cpp integrator.o nonbonded_gpu.o bonded_gpu.o gpu_utils.o context.o -o custom_ops`python3-config --extension-suffix` -lcurand -lcublas -lcudart
+g++ -O3 -march=native -Wall -shared -std=c++11 -fPIC $PLATFORM_FLAGS `python3 -m pybind11 --includes` -L/usr/local/cuda-10.0/lib64/ -I/usr/local/cuda-10.0/include/ wrappers.cpp integrator.o nonbonded_gpu.o bonded_gpu.o gpu_utils.o context.o -o custom_ops`python3-config --extension-suffix` -lcurand -lcublas -lcudart

--- a/timemachine/cpu_functionals/wrappers.cpp
+++ b/timemachine/cpu_functionals/wrappers.cpp
@@ -529,7 +529,6 @@ void declare_integrator(py::module &m, const char *typestr) {
     py::class_<Class>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
     .def(py::init<
         NumericType, // dt
-        int, // W,
         int, // N,
         int, // P,
         NumericType, // coeff_a, 

--- a/train_charges.py
+++ b/train_charges.py
@@ -124,13 +124,10 @@ def initialize_system(
 
     a,b,c = get_abc_coefficents(masses, dt, friction, temperature)
 
-    buf_size = estimate_buffer_size(1e-10, a)
-    # print("BUFFER_SIZE", buf_size)
     x0 = mol_coords_to_numpy_array(mol)/10
 
     intg = custom_ops.Integrator_double(
         dt,
-        buf_size,
         num_atoms,
         total_params,
         a,


### PR DESCRIPTION
As part of the thinking behind doing complex-step derivatives all the way - I sort of realized that we can actually store derivatives of the velocity with respect to parameters and get an easy speedup. This PR:

1. Decreases memory usage by 100x (by not having to store the buffer windows). Note that the hessians are still an issue depending on the size of the system (requiring O(N^2) to store). When we go full complex-step we should be able to get rid of this as well.
2. Allows use of arbitrary frictions for thermostats.
3. Vastly simplifies and clears the way for other types of integrators (leap-frog/verlet etc.) 

I should've realized this much, much earlier.