### PR TITLE
Implement Ewald summation with jax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,67 +9,20 @@ This package is designed with two goals in mind:
 
 The code is implemented against the reference OpenMM Force classes, and is rigorously tested for accuracy up to machine precision.
 
-# Example Code
-
-The following snippet shows how one can easily compute the GBSA derivatives.
-
-```python
-import numpy as np
-import tensorflow as tf
-from timemachine.functionals.gbsa import GBSAOBC
-
-masses = np.array([6.0, 1.0, 1.0, 1.0, 1.0])
-x0 = np.array([
-    [ 0.0637,   0.0126,   0.2203],
-    [ 1.0573,  -0.2011,   1.2864],
-    [ 2.3928,   1.2209,  -0.2230],
-    [-0.6891,   1.6983,   0.0780],
-    [-0.6312,  -1.6261,  -0.2601]
-], dtype=np.float64)
-
-params = np.array([
-    .1984, .115, .85, # H (q, r, s)
-    0.0221, .19, .72  # C (q, r, s)
-])
-
-param_idxs = np.array([
-    [3, 4, 5],
-    [0, 1, 2],
-    [0, 1, 2],
-    [0, 1, 2],
-    [0, 1, 2],
-])
-
-ref_radii = ref_nrg.openmm_born_radii(x0)
-nrg = GBSAOBC(params, param_idxs)
-
-x_ph = tf.placeholder(shape=(5, 3), dtype=np.float64)
-test_nrg_op = nrg.energy(x_ph)
-test_nrg_grad_op = tf.gradients(test_nrg_op, x_ph)
-test_nrg_hess_op = tf.hessians(test_nrg_op, x_ph)
-
-test_nrg, test_nrg_grad, test_nrg_hess = sess.run([test_nrg_op, test_nrg_grad_op, test_nrg_hess_op], feed_dict={x_ph: x0})
-
-# similar things can be easily done for the derivatives with respect to params
-```
-
-This is not meant to be a replacement for any production MD engine, since it's about 10-50x slower than OpenMM. For a more detailed explanation of the underlying mathematics, refer to the paper under docs for more information.
-
 # Warning
 
-This code is under heavy development. Expect everything to break every time you pull. An alpha release is anticipated for end of March.
+This code is under heavy development and barely working.  Expect everything to break every time you pull. An alpha release is anticipated for end of May.
 
 # Supported Functional Forms
 
 We currently support the following functional forms and their derivatives:
 
-- Harmonic Bonds (bonded_force.py)
-- Harmonic Angles (bonded_force.py)
-- Periodic Torsions (bonded_force.py)
-- Ewald Electrostatics (nonbonded_force.py)
-- Ewald Leonnard Jones (nonbonded_force.py)
-- Tensorfield Networks (nn_force.py)
-- GBSA OBC (gbsa.py)
+- (Periodic) Harmonic Bonds
+- (Periodic) Harmonic Angles
+- (Periodic) Periodic Torsions
+- (Periodic) Electrostatics
+- (Periodic) Leonnard Jones
+- GBSA OBC
 
 # Supported Integrators
 

--- a/tests/test_jax_nonbonded.py
+++ b/tests/test_jax_nonbonded.py
@@ -40,6 +40,7 @@ class ReferenceLJEnergy():
 
         return ref_nrg
 
+
 class TestElectrostatics(unittest.TestCase):
 
     def test_periodic_electrostatics(self):
@@ -81,6 +82,7 @@ class TestElectrostatics(unittest.TestCase):
         wrapped_nrg = functools.partial(ref_nrg.energy, box=box, cutoff=0.5, alpha=1.0, kmax=10)
         check_grads(wrapped_nrg, (conf, params), order=1, eps=1e-5)
         check_grads(wrapped_nrg, (conf, params), order=2, eps=1e-7)
+
 
 class TestLennardJones(unittest.TestCase):
 

--- a/tests/test_jax_nonbonded.py
+++ b/tests/test_jax_nonbonded.py
@@ -1,5 +1,7 @@
 import unittest
 import numpy as np
+import jax
+import functools
 from jax.config import config; config.update("jax_enable_x64", True)
 from timemachine.jax_functionals import jax_nonbonded
 
@@ -37,6 +39,44 @@ class ReferenceLJEnergy():
                 ref_nrg += vdwEnergy
 
         return ref_nrg
+
+class TestElectrostatics(unittest.TestCase):
+
+    def test_periodic_electrostatics(self):
+        conf = np.array([
+            [ 0.0637,   0.0126,   0.2203],
+            [ 1.0573,  -0.2011,   1.2864],
+            [ 2.3928,   1.2209,  -0.2230],
+            [-0.6891,   1.6983,   0.0780],
+            [-0.6312,  -1.6261,  -0.2601]
+        ], dtype=np.float64)
+
+        params = np.array([1.3, 0.3], dtype=np.float64)
+        param_idxs = np.array([0, 1, 1, 1, 1], dtype=np.int32)
+        scale_matrix = np.array([
+            [  0,  1,  1,  1,0.5],
+            [  1,  0,  0,  1,  1],
+            [  1,  0,  0,  0,0.2],
+            [  1,  1,  0,  0,  1],
+            [0.5,  1,0.2,  1,  0],
+        ], dtype=np.float64)
+
+        # warning: non net-neutral cell
+        ref_nrg = jax_nonbonded.Electrostatics(param_idxs, scale_matrix)
+
+        box = np.array([
+            [2.0, 0.0, 0.0],
+            [0.6, 1.6, 0.0],
+            [0.4, 0.7, 1.1]
+        ], dtype=np.float64)
+
+        wrapped_nrg = functools.partial(ref_nrg.energy, params=params, box=box, cutoff=0.5, alphaEwald=1.0, kmax=10)
+        check_grads(wrapped_nrg, (conf,), order=1, eps=1e-5)
+        check_grads(wrapped_nrg, (conf,), order=2, eps=1e-7)
+
+        wrapped_nrg = functools.partial(ref_nrg.energy, conf, box=box, cutoff=0.5, alphaEwald=1.0, kmax=10)
+        check_grads(wrapped_nrg, (params,), order=1, eps=1e-5)
+        check_grads(wrapped_nrg, (params,), order=2, eps=1e-7)
 
 class TestLennardJones(unittest.TestCase):
 

--- a/tests/test_jax_nonbonded.py
+++ b/tests/test_jax_nonbonded.py
@@ -70,13 +70,17 @@ class TestElectrostatics(unittest.TestCase):
             [0.4, 0.7, 1.1]
         ], dtype=np.float64)
 
-        wrapped_nrg = functools.partial(ref_nrg.energy, params=params, box=box, cutoff=0.5, alphaEwald=1.0, kmax=10)
+        wrapped_nrg = functools.partial(ref_nrg.energy, params=params, box=box, cutoff=0.5, alpha=1.0, kmax=10)
         check_grads(wrapped_nrg, (conf,), order=1, eps=1e-5)
         check_grads(wrapped_nrg, (conf,), order=2, eps=1e-7)
 
-        wrapped_nrg = functools.partial(ref_nrg.energy, conf, box=box, cutoff=0.5, alphaEwald=1.0, kmax=10)
+        wrapped_nrg = functools.partial(ref_nrg.energy, conf, box=box, cutoff=0.5, alpha=1.0, kmax=10)
         check_grads(wrapped_nrg, (params,), order=1, eps=1e-5)
         check_grads(wrapped_nrg, (params,), order=2, eps=1e-7)
+
+        wrapped_nrg = functools.partial(ref_nrg.energy, box=box, cutoff=0.5, alpha=1.0, kmax=10)
+        check_grads(wrapped_nrg, (conf, params), order=1, eps=1e-5)
+        check_grads(wrapped_nrg, (conf, params), order=2, eps=1e-7)
 
 class TestLennardJones(unittest.TestCase):
 


### PR DESCRIPTION
This PR implements:
- Ewald summation following that of OpenMM's convention.
- Full triclinic periodic boundary support of reduced latter basis vectors
- Uses jax's tests to ensure numerical accuracy of first and second order derivatives
