### PR TITLE
Easy speed up using reciprocals.

### DIFF
--- a/timemachine/cpp/src/kernels/surreal.cuh
+++ b/timemachine/cpp/src/kernels/surreal.cuh
@@ -77,14 +77,6 @@ DECL Surreal<RealType> __shfl_sync(unsigned mask, Surreal<RealType> &var, int sr
     return var;
 }
 
-template <typename RealType>
-__device__ inline void atomicAddOffset(Surreal<RealType> *base_ptr, const unsigned offset, const Surreal<RealType> &val) {
-    RealType* real_ptr = reinterpret_cast<RealType*>(base_ptr) + offset*2;
-    RealType* imag_ptr = real_ptr + 1;
-    atomicAdd(real_ptr, val.real);
-    atomicAdd(imag_ptr, val.imag);
-}
-
 #endif
 
 template <typename RealType>
@@ -106,33 +98,6 @@ template <typename RealType>
 DECL bool operator<(const Surreal<RealType> &l, const double &r) {
     return l.real < r;
 }
-
-// template <typename RealType>
-// __host__ __device__ inline RealType real_part(const Surreal<RealType> &a) {
-//     return a.real;
-// }
-
-// template <typename RealType>
-// DECL bool operator>(const Surreal<RealType> &l, const float& r) {
-//     return l.real > r;
-// }
-
-// template <typename RealType>
-// DECL bool operator<(const Surreal<RealType> &l, const double& r) {
-//     return l.real < r;
-// }
-
-
-template <typename RealType>
-DECL void add_square(Surreal<RealType> &a, const Surreal<RealType> &b) {
-    // (ytz): do *not* change the order of operations here.
-
-    a.imag += 2*b.real*b.imag;
-    a.real += b.real*b.real;
-    // return a;
-}
-
-
 
 template <typename RealType>
 DECL Surreal<RealType> Surreal<RealType>::operator+(const Surreal<RealType>& z) const {


### PR DESCRIPTION
This optimizes the norm calculation for both real and complex distance functions to use rnorm variants (which have only 1/2 ULPS of precision loss in double and single precision respectively). 