### PR TITLE
Bugfixes for BAR

### DIFF
--- a/fe/parameterize_simple.py
+++ b/fe/parameterize_simple.py
@@ -91,11 +91,11 @@ def error_fn(all_du_dls, T, schedule, true_dG):
     fwd_sched = schedule[:T//2]
     bkwd = all_du_dls[:, T//2:]
     bkwd_sched = schedule[T//2:]
-    dG_fwd = math_utils.trapz(fwd, fwd_sched)
-    dG_bkwd = math_utils.trapz(bkwd, bkwd_sched)
-
-    print("fwd", dG_fwd)
-    print("bkwd", dG_bkwd)
+    dG_fwd = math_utils.trapz(fwd, fwd_sched) # integral from inf to 0
+    dG_bkwd = math_utils.trapz(bkwd, bkwd_sched) # integral from 0 to inf
+    # dG_fwd and dG_bkwd have the same sign, so we need to flip dG_bkwd so the
+    # direction of integral is the same (requirement for pymbar.BAR)
+    dG_bkwd = -dG_bkwd # this is needed for BAR to be correct
     pred_dG = loss.mybar(jnp.stack([dG_fwd, dG_bkwd]))
 
     return jnp.abs(pred_dG - true_dG)
@@ -242,7 +242,7 @@ if __name__ == "__main__":
             plt.plot(np.log(lambda_schedule[:T//2]), fwd)
             plt.plot(np.log(lambda_schedule[T//2:]), bkwd)
 
-        plt.show()
+        # plt.show() # enable on desktop (non servers if you want to see what's going on)
 
         error = error_fn(all_du_dls, T, lambda_schedule, 100)
 
@@ -272,7 +272,7 @@ if __name__ == "__main__":
                 pf = allowed_groups[gp]
                 filtered_grad.append(g*pf)
                 if g != 0:
-                    print("derivs", g_idx, '\t', g, '\t adjusted to', g*pf)
+                    print("derivs", g_idx, '\t', g, '\t adjusted to', g*pf, '\t old val', sim.combined_params[g_idx])
             else:
                 filtered_grad.append(0)
 

--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -6,7 +6,7 @@ project(timemachine LANGUAGES CXX CUDA)
 find_package(PythonInterp 3.6 REQUIRED)
 find_package(PythonLibs 3.6 REQUIRED)
 
-string(APPEND CMAKE_CUDA_FLAGS "-Xptxas='-v' -arch=sm_60 -O2 -lineinfo")
+string(APPEND CMAKE_CUDA_FLAGS "-Xptxas='-v' -arch=sm_70 -O2 -lineinfo")
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)

--- a/timemachine/cpp/tests/test_reverse_mode.py
+++ b/timemachine/cpp/tests/test_reverse_mode.py
@@ -50,8 +50,6 @@ class TestContext(unittest.TestCase):
 
         if lamb_flags is not None:
 
-            assert exponent is not None
-
             params, ref_nrgs, test_nrgs = prepare_nonbonded_system(
                 x0,
                 E,
@@ -108,12 +106,11 @@ class TestContext(unittest.TestCase):
         """
         np.random.seed(4321)
         N = 32
+
         lambda_flags = np.random.randint(0, 2, size=N) - 1
-        exponent = 2
         ref_total_nrg_fn, x0, params, masses, test_energies = self.setup_charge_system(
             N=N,
-            lamb_flags=lambda_flags,
-            exponent=exponent
+            lamb_flags=lambda_flags
         )
         v0 = np.random.rand(x0.shape[0], x0.shape[1])
         N = len(masses)


### PR DESCRIPTION
Hot fix for this incredibly stupid bug on my end.

Suppose we were computing fwd_dG by integrating from [a,b] and bkwd_dG by integrating from [b,a], we need to flip the sign of bkwd_dG so that it's equivalent to integrating from [a,b] before passing it in to BAR.

This resolves the issue of not being able to train on a single conformer, as well as maintaining the ability to train on multiple conformers.