### PR TITLE
Coerce into numpy array

### DIFF
--- a/fe/parameterize_batch.py
+++ b/fe/parameterize_batch.py
@@ -306,7 +306,7 @@ if __name__ == "__main__":
                     fpath = os.path.join(args.out_dir, fname)
                     epoch_train_ff_params.save(fpath)
 
-                sim.system.params = epoch_train_params
+                sim.system.params = np.asarray(epoch_train_params)
 
                 all_args = []
 

--- a/fe/parameterize_simple.py
+++ b/fe/parameterize_simple.py
@@ -277,7 +277,7 @@ if __name__ == "__main__":
         fpath = os.path.join(args.out_dir, fname)
         epoch_ff_params.save(fpath)
 
-        sim.system.params = epoch_params
+        sim.system.params = np.asarray(epoch_params)
 
         all_args = []
 

--- a/ff/forcefield.py
+++ b/ff/forcefield.py
@@ -132,6 +132,9 @@ class Forcefield():
                 param_idxs = v[1:]
                 # print(smirks, param_idxs)
                 param_vals = recursive_lookup(param_idxs)
+
+                # coerce into numpy array as new_params may be a jax array
+                param_vals = np.asarray(param_vals)
                 new_params.append([smirks, *param_vals])
 
             raw_ff[force_type]["params"] = new_params


### PR DESCRIPTION
When we update the ff parameters using jax optimizers, the ff.params gets overwritten sometimes into a DeviceArray. We need to coerce it into numpy arrays.

@chuantian 