### PR TITLE
Minor neighborlist improvement.

### DIFF
--- a/timemachine/cpp/src/kernels/k_find_block_bounds.cu
+++ b/timemachine/cpp/src/kernels/k_find_block_bounds.cu
@@ -22,13 +22,13 @@ void __global__ k_find_block_bounds(
             int atom_i_idx = tile_idx*WARPSIZE + i;
             if(atom_i_idx < N) {
                 double ci = coords[atom_i_idx*D + d];
-                ci_min = ci < ci_min ? ci : ci_min;
-                ci_max = ci > ci_max ? ci : ci_max;                
+                ci_min = min(ci, ci_min);
+                ci_max = max(ci, ci_max);
             }
         }
      
         block_bounds_ctr[tile_idx*D+d] = (ci_max + ci_min)/2.0;
-        block_bounds_ext[tile_idx*D+d] = ci_max - ci_min;
+        block_bounds_ext[tile_idx*D+d] = (ci_max - ci_min)/2.0;
     }
 
 }


### PR DESCRIPTION
This is a minor change to the neighborlist code. The old version of the code was still correct, just slightly less efficient. It was estimating the box size to be 2 times bigger than it actually was, thereby skipping less number of blocks than is optimal.