### PR TITLE
Clean up the config file a little more

### DIFF
--- a/launch_workers.sh
+++ b/launch_workers.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-for port in {0..2}
+for port in {0..5}
 do
     # echo $port
     python -u training/worker.py --gpu_idx 0 --port $(($port+5000)) > log_$port.txt &

--- a/training/config.ini
+++ b/training/config.ini
@@ -7,6 +7,10 @@ forcefield=params/smirnoff_1_1_0.py
 out_dir=frames
 n_frames=25
 du_dl_cutoff=10000
+train_frac=0.6
+
+[learning_rates]
+charge=0.004
 
 [integrator]
 steps=25000

--- a/training/worker.py
+++ b/training/worker.py
@@ -72,13 +72,15 @@ class Worker(service_pb2_grpc.WorkerServicer):
         energies = stepper.get_energies()
 
         keep_idxs = []
-        xs = ctxt.get_all_coords()
-        interval = max(1, xs.shape[0]//request.n_frames)
-        for frame_idx in range(xs.shape[0]):
-            if frame_idx % interval == 0:
-                keep_idxs.append(frame_idx)
 
-        frames = xs[keep_idxs]
+        if request.n_frames > 0:
+            xs = ctxt.get_all_coords()
+            interval = max(1, xs.shape[0]//request.n_frames)
+            for frame_idx in range(xs.shape[0]):
+                if frame_idx % interval == 0:
+                    keep_idxs.append(frame_idx)
+
+        frames = np.zeros((0, *system.x0.shape), dtype=system.x0.dtype)
 
         reply = service_pb2.ForwardReply(
             du_dls=pickle.dumps(full_du_dls),


### PR DESCRIPTION
1. Skip writing frames if n_frames is zero (saves time on the parameter server and worker)
2. Allow % of dataset to be used as training set to be configurable
3. Temporarily disable gb derivatives