### PR TITLE
restrict to c_alpha

### DIFF
--- a/training/setup_system.py
+++ b/training/setup_system.py
@@ -328,7 +328,7 @@ def create_system(
     backbone_atoms = []
     for r_idx, residue in enumerate(host_pdb.getTopology().residues()):
         for a in residue.atoms():
-            if a.name == 'C' or a.name == 'CA' or a.name == 'N' or a.name == 'O':
+            if a.name == 'CA':
                 backbone_atoms.append(a.index)
 
     final_gradients.append(setup_core_restraints(


### PR DESCRIPTION
After some offline discussion with @chuantian it makes more sense to restrain to c-alphas, as:

1) We don't want to perturb the hydrogen-bonding network too much on the N and the O
2) We can spread out the restraint to multiple residues as opposed to localizing them to 1 or 2 residues.