### PR TITLE
Multiplexed backwards mode done

### DIFF
--- a/launch_workers.sh
+++ b/launch_workers.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-for port in {0..1}
+for port in {0..0}
 do
     # echo $port
     python -u training/worker.py --gpu_idx 0 --port $(($port+5000)) > log_$port.txt &

--- a/training/service.proto
+++ b/training/service.proto
@@ -16,6 +16,7 @@ message ForwardRequest {
     bytes system = 2; // pickle object
     string precision = 3;
     int32 n_frames = 4;
+    string key = 5;
 }
 
 message ForwardReply {
@@ -27,6 +28,7 @@ message ForwardReply {
 // The response message containing the greetings
 message BackwardRequest {
     bytes adjoint_du_dls = 1; // pickle
+    string key = 2;
 }
 
 message BackwardReply {

--- a/training/service_pb2.py
+++ b/training/service_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\rservice.proto\"\x0e\n\x0c\x45mptyMessage\"X\n\x0e\x46orwardRequest\x12\x11\n\tinference\x18\x01 \x01(\x08\x12\x0e\n\x06system\x18\x02 \x01(\x0c\x12\x11\n\tprecision\x18\x03 \x01(\t\x12\x10\n\x08n_frames\x18\x04 \x01(\x05\"@\n\x0c\x46orwardReply\x12\x0e\n\x06\x64u_dls\x18\x01 \x01(\x0c\x12\x10\n\x08\x65nergies\x18\x02 \x01(\x0c\x12\x0e\n\x06\x66rames\x18\x03 \x01(\x0c\")\n\x0f\x42\x61\x63kwardRequest\x12\x16\n\x0e\x61\x64joint_du_dls\x18\x01 \x01(\x0c\"\x1f\n\rBackwardReply\x12\x0e\n\x06\x64l_dps\x18\x01 \x01(\x0c\x32\x9b\x01\n\x06Worker\x12/\n\x0b\x46orwardMode\x12\x0f.ForwardRequest\x1a\r.ForwardReply\"\x00\x12\x32\n\x0c\x42\x61\x63kwardMode\x12\x10.BackwardRequest\x1a\x0e.BackwardReply\"\x00\x12,\n\nResetState\x12\r.EmptyMessage\x1a\r.EmptyMessage\"\x00\x62\x06proto3'
+  serialized_pb=b'\n\rservice.proto\"\x0e\n\x0c\x45mptyMessage\"e\n\x0e\x46orwardRequest\x12\x11\n\tinference\x18\x01 \x01(\x08\x12\x0e\n\x06system\x18\x02 \x01(\x0c\x12\x11\n\tprecision\x18\x03 \x01(\t\x12\x10\n\x08n_frames\x18\x04 \x01(\x05\x12\x0b\n\x03key\x18\x05 \x01(\t\"@\n\x0c\x46orwardReply\x12\x0e\n\x06\x64u_dls\x18\x01 \x01(\x0c\x12\x10\n\x08\x65nergies\x18\x02 \x01(\x0c\x12\x0e\n\x06\x66rames\x18\x03 \x01(\x0c\"6\n\x0f\x42\x61\x63kwardRequest\x12\x16\n\x0e\x61\x64joint_du_dls\x18\x01 \x01(\x0c\x12\x0b\n\x03key\x18\x02 \x01(\t\"\x1f\n\rBackwardReply\x12\x0e\n\x06\x64l_dps\x18\x01 \x01(\x0c\x32\x9b\x01\n\x06Worker\x12/\n\x0b\x46orwardMode\x12\x0f.ForwardRequest\x1a\r.ForwardReply\"\x00\x12\x32\n\x0c\x42\x61\x63kwardMode\x12\x10.BackwardRequest\x1a\x0e.BackwardReply\"\x00\x12,\n\nResetState\x12\r.EmptyMessage\x1a\r.EmptyMessage\"\x00\x62\x06proto3'
 )
 
 
@@ -86,6 +86,13 @@ _FORWARDREQUEST = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='key', full_name='ForwardRequest.key', index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -99,7 +106,7 @@ _FORWARDREQUEST = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=33,
-  serialized_end=121,
+  serialized_end=134,
 )
 
 
@@ -144,8 +151,8 @@ _FORWARDREPLY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=123,
-  serialized_end=187,
+  serialized_start=136,
+  serialized_end=200,
 )
 
 
@@ -164,6 +171,13 @@ _BACKWARDREQUEST = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='key', full_name='BackwardRequest.key', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -176,8 +190,8 @@ _BACKWARDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=189,
-  serialized_end=230,
+  serialized_start=202,
+  serialized_end=256,
 )
 
 
@@ -208,8 +222,8 @@ _BACKWARDREPLY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=232,
-  serialized_end=263,
+  serialized_start=258,
+  serialized_end=289,
 )
 
 DESCRIPTOR.message_types_by_name['EmptyMessage'] = _EMPTYMESSAGE
@@ -263,8 +277,8 @@ _WORKER = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=266,
-  serialized_end=421,
+  serialized_start=292,
+  serialized_end=447,
   methods=[
   _descriptor.MethodDescriptor(
     name='ForwardMode',

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -407,23 +407,38 @@ class Trainer():
             charge_gradients = np.sum(charge_derivatives, axis=0) # reduce
             lj_gradients = np.sum(lj_derivatives, axis=0) # reduce
 
+            # compute a learning rate such that the max parameter changes by no more than the learning rate.
+
             for h in ff_handlers:
                 if isinstance(h, nonbonded.SimpleChargeHandler):
                     # debug for now
                     assert 0
                     h.params -= charge_gradients*self.learning_rates['charge']
                 elif isinstance(h, nonbonded.AM1CCCHandler):
-                    continue # FIX ME LATER
-                    # if np.any(np.isnan(charge_gradients)) or np.any(np.isinf(charge_gradients)):
-                    #     print("Fatal Charge Derivatives:", charge_gradients)
-                    # else:
+                    continue
+                    if np.any(np.isnan(charge_gradients)) or np.any(np.isinf(charge_gradients)) or np.any(np.amax(np.abs(charge_gradients)) > 10000.0):
+                        print("Fatal Charge Derivatives:", charge_gradients)
+                    else:
+
+                        # should we clip or rescale
+                        scale_factor = np.amax(np.abs(charge_gradients))/self.learning_rates['charge']
+                        print("Adjusting by", charge_gradients/scale_factor, "max raw elem", np.any(np.amax(np.abs(charge_gradients))))
+                        h.params -= charge_gradients/scale_factor
                         # h.params -= charge_gradients*self.learning_rates['charge']
                 elif isinstance(h, nonbonded.LennardJonesHandler):
+                    # continue
                     if np.any(np.isnan(lj_gradients)) or np.any(np.isinf(lj_gradients)):
                         print("Fatal LJ Derivatives:", lj_gradients)
                     else:
-                        print("LJ DERIVATIVES AMAX SIG", np.amax(np.abs((self.learning_rates['lj']*lj_gradients)[:, 0])))
-                        print("LJ DERIVATIVES AMAX EPS", np.amax(np.abs((self.learning_rates['lj']*lj_gradients)[:, 1])))
-                        h.params -= lj_gradients*self.learning_rates['lj']
+
+                        lj_sig_scale = np.amax(np.abs(lj_gradients[:, 0]))/self.learning_rates['lj'][0]
+                        lj_eps_scale = np.amax(np.abs(lj_gradients[:, 1]))/self.learning_rates['lj'][1]
+
+                        lj_scale_factors = np.array([lj_sig_scale, lj_eps_scale])
+                        # print("LJ DERIVATIVES AMAX SIG", np.amax(np.abs((self.learning_rates['lj']*lj_gradients)[:, 0])))
+                        # print("LJ DERIVATIVES AMAX EPS", np.amax(np.abs((self.learning_rates['lj']*lj_gradients)[:, 1])))
+                        # h.params -= lj_gradients*self.learning_rates['lj']
+                        h.params -= lj_gradients/lj_scale_factors
 
         return pred_dG, loss
+

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -186,8 +186,10 @@ class Trainer():
         """
 
         # we can only multiplex in inference mode.
-        if inference is False:
-            assert np.sum([len(x) for x in self.lambda_schedule.values()]) == len(self.stubs)
+        # enable multiplexing in backward mode as well
+
+        # if inference is False:
+            # assert np.sum([len(x) for x in self.lambda_schedule.values()]) == len(self.stubs)
 
         host_pdbfile = self.host_pdbfile
         lambda_schedule = self.lambda_schedule
@@ -199,9 +201,12 @@ class Trainer():
         combined_pdb = Chem.CombineMols(Chem.MolFromPDBFile(host_pdbfile, removeHs=False), mol)
 
         stage_forward_futures = []
+        stage_state_keys = []
+
         stub_idx = 0
 
         # step 1. Prepare the jobs
+
         for stage, ti_lambdas in self.lambda_schedule.items():
 
             # print("---Starting stage", stage, '---')
@@ -221,6 +226,7 @@ class Trainer():
             )
 
             forward_futures = []
+            state_keys = []
 
             for lamb_idx, lamb in enumerate(ti_lambdas):
 
@@ -241,12 +247,20 @@ class Trainer():
                     intg
                 )
 
+                # build a hash 
+                state_key = str(stage)+"_"+str(lamb_idx)
+
                 request = service_pb2.ForwardRequest(
                     inference=inference,
                     system=pickle.dumps(complex_system),
                     precision=self.precision,
-                    n_frames=self.n_frames
+                    n_frames=self.n_frames,
+                    key=state_key
                 )
+
+                state_keys.append(state_key)
+
+                # stage_state_keys.append(state_key)
 
                 stub = stubs[stub_idx % len(stubs)]
                 stub_idx += 1
@@ -256,6 +270,7 @@ class Trainer():
                 forward_futures.append(response_future)
 
             stage_forward_futures.append((stage, forward_futures))
+            stage_state_keys.append(state_keys)
 
         # step 2. Run forward mode on the jobs
         all_du_dls = []
@@ -347,14 +362,18 @@ class Trainer():
             stage_backward_futures = []
 
             stub_idx = 0
-            for adjoint_du_dls in all_adjoint_du_dls:
+            for a_idx, adjoint_du_dls in enumerate(all_adjoint_du_dls):
 
                 futures = []
-                for lambda_du_dls in adjoint_du_dls:
+                for l_idx, lambda_du_dls in enumerate(adjoint_du_dls):
+
+                    state_key = stage_state_keys[a_idx][l_idx]
+
                     request = service_pb2.BackwardRequest(
+                        key=state_key,
                         adjoint_du_dls=pickle.dumps(np.asarray(lambda_du_dls)),
                     )
-                    futures.append(stubs[stub_idx].BackwardMode.future(request))
+                    futures.append(stubs[stub_idx % len(stubs)].BackwardMode.future(request))
                     stub_idx += 1
 
                 stage_backward_futures.append(futures)

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -237,7 +237,8 @@ class Trainer():
                     friction=self.intg_friction,  
                     masses=combined_masses,
                     lamb=lamb,
-                    seed=np.random.randint(np.iinfo(np.int32).max)
+                    seed=1234
+                    # seed=np.random.randint(np.iinfo(np.int32).max)
                 )
 
                 complex_system = system.System(
@@ -410,6 +411,7 @@ class Trainer():
                     assert 0
                     h.params -= charge_gradients*self.learning_rates['charge']
                 elif isinstance(h, nonbonded.AM1CCCHandler):
+                    continue # FIX ME LATER
                     if np.any(np.isnan(charge_gradients)) or np.any(np.isinf(charge_gradients)):
                         print("Fatal Charge Derivatives:", charge_gradients)
                     else:
@@ -418,10 +420,8 @@ class Trainer():
                     if np.any(np.isnan(lj_gradients)) or np.any(np.isinf(lj_gradients)):
                         print("Fatal LJ Derivatives:", lj_gradients)
                     else:
-                        # print("LJ DERIVATIVES AMAX SIG", np.amax(np.abs((lj_lr*lj_gradients)[:, 0])))
-                        # print("LJ DERIVATIVES AMAX EPS", np.amax(np.abs((lj_lr*lj_gradients)[:, 1])))
-                        # print("before", h.params)
+                        print("LJ DERIVATIVES AMAX SIG", np.amax(np.abs((self.learning_rates['lj']*lj_gradients)[:, 0])))
+                        print("LJ DERIVATIVES AMAX EPS", np.amax(np.abs((self.learning_rates['lj']*lj_gradients)[:, 1])))
                         h.params -= lj_gradients*self.learning_rates['lj']
-                        # print("after", h.params)
 
         return pred_dG, loss

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -183,13 +183,12 @@ class Trainer():
         experiment_dG: float
             experimental unbinding free energy.
 
+        Returns
+        -------
+        float, float
+            Predicted unbinding free energy, and loss relative to experimental dG
+
         """
-
-        # we can only multiplex in inference mode.
-        # enable multiplexing in backward mode as well
-
-        # if inference is False:
-            # assert np.sum([len(x) for x in self.lambda_schedule.values()]) == len(self.stubs)
 
         host_pdbfile = self.host_pdbfile
         lambda_schedule = self.lambda_schedule
@@ -237,8 +236,7 @@ class Trainer():
                     friction=self.intg_friction,  
                     masses=combined_masses,
                     lamb=lamb,
-                    seed=1234
-                    # seed=np.random.randint(np.iinfo(np.int32).max)
+                    seed=np.random.randint(np.iinfo(np.int32).max)
                 )
 
                 complex_system = system.System(

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -366,13 +366,15 @@ class Trainer():
             for a_idx, adjoint_du_dls in enumerate(all_adjoint_du_dls):
 
                 futures = []
-                for l_idx, lambda_du_dls in enumerate(adjoint_du_dls):
+                for l_idx, adjoint_lambda_du_dls in enumerate(adjoint_du_dls):
 
                     state_key = stage_state_keys[a_idx][l_idx]
 
+                    print("sending", state_key, adjoint_lambda_du_dls)
+
                     request = service_pb2.BackwardRequest(
                         key=state_key,
-                        adjoint_du_dls=pickle.dumps(np.asarray(lambda_du_dls)),
+                        adjoint_du_dls=pickle.dumps(np.asarray(adjoint_lambda_du_dls)),
                     )
                     futures.append(stubs[stub_idx % len(stubs)].BackwardMode.future(request))
                     stub_idx += 1
@@ -412,10 +414,10 @@ class Trainer():
                     h.params -= charge_gradients*self.learning_rates['charge']
                 elif isinstance(h, nonbonded.AM1CCCHandler):
                     continue # FIX ME LATER
-                    if np.any(np.isnan(charge_gradients)) or np.any(np.isinf(charge_gradients)):
-                        print("Fatal Charge Derivatives:", charge_gradients)
-                    else:
-                        h.params -= charge_gradients*self.learning_rates['charge']
+                    # if np.any(np.isnan(charge_gradients)) or np.any(np.isinf(charge_gradients)):
+                    #     print("Fatal Charge Derivatives:", charge_gradients)
+                    # else:
+                        # h.params -= charge_gradients*self.learning_rates['charge']
                 elif isinstance(h, nonbonded.LennardJonesHandler):
                     if np.any(np.isnan(lj_gradients)) or np.any(np.isinf(lj_gradients)):
                         print("Fatal LJ Derivatives:", lj_gradients)

--- a/training/worker.py
+++ b/training/worker.py
@@ -31,7 +31,9 @@ class Worker(service_pb2_grpc.WorkerServicer):
         return reply
 
     def ForwardMode(self, request, context):
-        # assert self.state is None
+
+        print(request.key)
+
         if request.precision == 'single':
             precision = np.float32
         elif request.precision == 'double':
@@ -108,6 +110,8 @@ class Worker(service_pb2_grpc.WorkerServicer):
         ctxt, gradients, force_names, stepper, system = self.states[request.key]
 
         adjoint_du_dls = pickle.loads(request.adjoint_du_dls)
+
+        print(request.key, "adjoint_du_dls", adjoint_du_dls)
 
         stepper.set_du_dl_adjoint(adjoint_du_dls)
         ctxt.set_x_t_adjoint(np.zeros_like(system.x0))

--- a/training/worker.py
+++ b/training/worker.py
@@ -25,15 +25,13 @@ class Worker(service_pb2_grpc.WorkerServicer):
 
     def ResetState(self, request, context):
         self.mutex.acquire()
-        self.states = {}
+        self.states.clear()
         self.mutex.release()
         reply = service_pb2.EmptyMessage()
         return reply
 
     def ForwardMode(self, request, context):
         # assert self.state is None
-        assert request.key not in self.states
-
         if request.precision == 'single':
             precision = np.float32
         elif request.precision == 'double':
@@ -74,6 +72,7 @@ class Worker(service_pb2_grpc.WorkerServicer):
 
         # ensure only one GPU can be running at given time.
         self.mutex.acquire()
+        
         ctxt.forward_mode()
         full_du_dls = stepper.get_du_dl() # [FxT]
         energies = stepper.get_energies()
@@ -162,10 +161,7 @@ def serve(args):
     server.start()
     server.wait_for_termination()
 
-
 if __name__ == '__main__':
-
-
 
     parser = argparse.ArgumentParser(description='Worker Server')
     parser.add_argument('--gpu_idx', type=int, required=True, help='Location of all output files')

--- a/training/worker.py
+++ b/training/worker.py
@@ -24,9 +24,9 @@ class Worker(service_pb2_grpc.WorkerServicer):
         self.mutex = Lock()
 
     def ResetState(self, request, context):
-        self.mutex.acquire()
-        self.states.clear()
-        self.mutex.release()
+        with self.mutex:
+            self.states.clear()
+
         reply = service_pb2.EmptyMessage()
         return reply
 

--- a/training/worker.py
+++ b/training/worker.py
@@ -32,8 +32,6 @@ class Worker(service_pb2_grpc.WorkerServicer):
 
     def ForwardMode(self, request, context):
 
-        print(request.key)
-
         if request.precision == 'single':
             precision = np.float32
         elif request.precision == 'double':
@@ -73,37 +71,35 @@ class Worker(service_pb2_grpc.WorkerServicer):
         start = time.time()
 
         # ensure only one GPU can be running at given time.
-        self.mutex.acquire()
-        
-        ctxt.forward_mode()
-        full_du_dls = stepper.get_du_dl() # [FxT]
-        energies = stepper.get_energies()
 
-        keep_idxs = []
+        with self.mutex:
 
-        if request.n_frames > 0:
-            xs = ctxt.get_all_coords()
-            interval = max(1, xs.shape[0]//request.n_frames)
-            for frame_idx in range(xs.shape[0]):
-                if frame_idx % interval == 0:
-                    keep_idxs.append(frame_idx)
-            frames = xs[keep_idxs]
-        else:
-            frames = np.zeros((0, *system.x0.shape), dtype=system.x0.dtype)
+            ctxt.forward_mode()
+            full_du_dls = stepper.get_du_dl() # [FxT]
+            energies = stepper.get_energies()
 
-        reply = service_pb2.ForwardReply(
-            du_dls=pickle.dumps(full_du_dls), # tbd strip zeros
-            energies=pickle.dumps(energies),
-            frames=pickle.dumps(frames),
-        )
+            keep_idxs = []
 
-        # store and set state for backwards mode use.
-        if request.inference is False:
-            self.states[request.key] = (ctxt, gradients, force_names, stepper, system)
+            if request.n_frames > 0:
+                xs = ctxt.get_all_coords()
+                interval = max(1, xs.shape[0]//request.n_frames)
+                for frame_idx in range(xs.shape[0]):
+                    if frame_idx % interval == 0:
+                        keep_idxs.append(frame_idx)
+                frames = xs[keep_idxs]
+            else:
+                frames = np.zeros((0, *system.x0.shape), dtype=system.x0.dtype)
 
-        self.mutex.release()
 
-        return reply
+            # store and set state for backwards mode use.
+            if request.inference is False:
+                self.states[request.key] = (ctxt, gradients, force_names, stepper, system)
+
+            return service_pb2.ForwardReply(
+                du_dls=pickle.dumps(full_du_dls), # tbd strip zeros
+                energies=pickle.dumps(energies),
+                frames=pickle.dumps(frames),
+            )
 
     def BackwardMode(self, request, context):
 
@@ -111,48 +107,39 @@ class Worker(service_pb2_grpc.WorkerServicer):
 
         adjoint_du_dls = pickle.loads(request.adjoint_du_dls)
 
-        print(request.key, "adjoint_du_dls", np.mean(adjoint_du_dls))
-        print(request.key, "last frame", ctxt.get_last_coords())
-
         stepper.set_du_dl_adjoint(adjoint_du_dls)
         ctxt.set_x_t_adjoint(np.zeros_like(system.x0))
 
-        self.mutex.acquire()
-        ctxt.backward_mode()
+        with self.mutex:
 
-        # note that we have multiple HarmonicBonds/Angles/Torsions that correspond to different parameters
-        dl_dps = []
-        for f_name, g in zip(force_names, gradients):
-            if f_name == 'HarmonicBond':
-                dl_dps.append(g.get_du_dp_tangents())
-            elif f_name == 'HarmonicAngle':
-                dl_dps.append(g.get_du_dp_tangents())
-            elif f_name == 'PeriodicTorsion':
-                dl_dps.append(g.get_du_dp_tangents())
-            elif f_name == 'Nonbonded':
-                dl_dps.append((g.get_du_dcharge_tangents(), g.get_du_dlj_tangents()))
-            elif f_name == 'LennardJones':
-                dl_dps.append(g.get_du_dlj_tangents())
-            elif f_name == 'Electrostatics':
-                dl_dps.append(g.get_du_dcharge_tangents())
-            elif f_name == 'GBSA':
-                dl_dps.append((g.get_du_dcharge_tangents(), g.get_du_dgb_tangents()))
-            elif f_name == 'CentroidRestraint':
-                dl_dps.append(None)
-            else:
-                print("f_name")
-                raise Exception("Unknown Gradient")
+            ctxt.backward_mode()
 
-        reply = service_pb2.BackwardReply(dl_dps=pickle.dumps(dl_dps))
+            # note that we have multiple HarmonicBonds/Angles/Torsions that correspond to different parameters
+            dl_dps = []
+            for f_name, g in zip(force_names, gradients):
+                if f_name == 'HarmonicBond':
+                    dl_dps.append(g.get_du_dp_tangents())
+                elif f_name == 'HarmonicAngle':
+                    dl_dps.append(g.get_du_dp_tangents())
+                elif f_name == 'PeriodicTorsion':
+                    dl_dps.append(g.get_du_dp_tangents())
+                elif f_name == 'Nonbonded':
+                    dl_dps.append((g.get_du_dcharge_tangents(), g.get_du_dlj_tangents()))
+                elif f_name == 'LennardJones':
+                    dl_dps.append(g.get_du_dlj_tangents())
+                elif f_name == 'Electrostatics':
+                    dl_dps.append(g.get_du_dcharge_tangents())
+                elif f_name == 'GBSA':
+                    dl_dps.append((g.get_du_dcharge_tangents(), g.get_du_dgb_tangents()))
+                elif f_name == 'CentroidRestraint':
+                    dl_dps.append(None)
+                else:
+                    print("f_name")
+                    raise Exception("Unknown Gradient")
 
-        print(request.key, "DL_DPs", dl_dps)
+            del self.states[request.key]
 
-        # zero out
-        del self.states[request.key]
-
-        self.mutex.release()
-
-        return reply
+            return service_pb2.BackwardReply(dl_dps=pickle.dumps(dl_dps))
 
 
 def serve(args):

--- a/training/worker.py
+++ b/training/worker.py
@@ -111,7 +111,8 @@ class Worker(service_pb2_grpc.WorkerServicer):
 
         adjoint_du_dls = pickle.loads(request.adjoint_du_dls)
 
-        print(request.key, "adjoint_du_dls", adjoint_du_dls)
+        print(request.key, "adjoint_du_dls", np.mean(adjoint_du_dls))
+        print(request.key, "last frame", ctxt.get_last_coords())
 
         stepper.set_du_dl_adjoint(adjoint_du_dls)
         ctxt.set_x_t_adjoint(np.zeros_like(system.x0))
@@ -143,6 +144,8 @@ class Worker(service_pb2_grpc.WorkerServicer):
                 raise Exception("Unknown Gradient")
 
         reply = service_pb2.BackwardReply(dl_dps=pickle.dumps(dl_dps))
+
+        print(request.key, "DL_DPs", dl_dps)
 
         # zero out
         del self.states[request.key]


### PR DESCRIPTION
This PR:

- Stores multiple states on the workers
- Guards the self.states dictionary with mutexes to prevent most(?) type of race conditions
- Modifies the client so that backward mode jobs are distributed evenly
- We *do not* check to see if the GPUs have sufficient memory for multiple jobs. This is up to the end-user.