### PR TITLE
Use commit-specific directory for CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
   stages {
     stage('Execute CI') {
       steps {
-        sh '/usr/local/bin/fab -f /opt/jenkins/jenkins_scripts/timemachine_ci_fab.py ci:'+env.WORKSPACE','+env.GIT_COMMIT
+        sh '/usr/local/bin/fab -f /opt/jenkins/jenkins_scripts/timemachine_ci_fab.py ci:'+env.WORKSPACE+','+env.GIT_COMMIT
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
   stages {
     stage('Execute CI') {
       steps {
-        sh '/usr/local/bin/fab -f /opt/jenkins/jenkins_scripts/timemachine_ci_fab.py ci:'+env.WORKSPACE
+        sh '/usr/local/bin/fab -f /opt/jenkins/jenkins_scripts/timemachine_ci_fab.py ci:'+env.WORKSPACE','+env.GIT_COMMIT
       }
     }
 


### PR DESCRIPTION
This updates the Jenkins file so each CI pipeline happens in a directory named for the commit hash. Fixes issue of directories classing for concurrent builds.