### PR TITLE
Exclusion list changes

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -131,18 +131,13 @@ def prepare_nb_system(
 
     atom_idxs = np.arange(N)
 
-    if E == 1:
-        exclusion_idxs = np.array([[0, 1]], dtype=np.int32)
-    # exclusion_idxs = np.random.choice(atom_idxs, size=(E, 2), replace=False)
-    # exclusion_idxs = np.array(exclusion_idxs, dtype=np.int32).reshape(-1, 2)
+    exclusion_idxs = np.random.choice(atom_idxs, size=(E, 2), replace=False)
+    exclusion_idxs = np.array(exclusion_idxs, dtype=np.int32).reshape(-1, 2)
 
-
-        scales = np.array([[1, 1]], dtype=np.int32)
-
-        # scales = np.stack([
-        #     np.random.rand(E),
-        #     np.random.rand(E)
-        # ], axis=1)
+    scales = np.stack([
+            np.random.rand(E),
+            np.random.rand(E)
+    ], axis=1)
 
     beta = 2.0
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -206,8 +206,8 @@ def prepare_nb_system(
     exclusion_idxs = np.array(exclusion_idxs, dtype=np.int32).reshape(-1, 2)
 
     scales = np.stack([
-            np.random.rand(E),
-            np.random.rand(E)
+        np.random.rand(E),
+        np.random.rand(E)
     ], axis=1)
 
     beta = 2.0

--- a/tests/common.py
+++ b/tests/common.py
@@ -131,15 +131,6 @@ def prepare_water_system(
 
     atom_idxs = np.arange(N)
 
-    # exclusion_idxs = np.random.choice(atom_idxs, size=(E, 2), replace=False)
-    # exclusion_idxs = np.array(exclusion_idxs, dtype=np.int32).reshape(-1, 2)
-
-    # scales = np.stack([
-            # np.random.rand(E),
-            # np.random.rand(E)
-    # ], axis=1)
-
-
     scales = []
     exclusion_idxs = []
     for i in range(N//3):
@@ -157,7 +148,6 @@ def prepare_water_system(
     scales = np.array(scales, dtype=np.int32)
     exclusion_idxs = np.array(exclusion_idxs, dtype=np.int32)
     E = len(exclusion_idxs)
-    # scales = np.ones((E, 2), dtype=np.float64)
 
     beta = 2.0
 
@@ -472,34 +462,32 @@ class GradientTest(unittest.TestCase):
         ref_du_dx, ref_du_dp, ref_du_dl = grad_fn(x, params, box, lamb)
 
         np.testing.assert_allclose(ref_u, test_u, rtol)
+        # np.testing.assert_allclose(ref_du_dx, test_du_dx, rtol)
 
-        # print(ref_du_dx)
-        np.testing.assert_allclose(ref_du_dx, test_du_dx, rtol)
-
-        self.assert_equal_vectors(
-            np.array(ref_du_dx),
-            np.array(test_du_dx),
-            rtol
-        )
+        if precision == np.float64:
+            self.assert_equal_vectors(np.array(ref_du_dx), np.array(test_du_dx), 1e-8)
+        else:
+            self.assert_equal_vectors(np.array(ref_du_dx), np.array(test_du_dx), 1e-4)
 
         if ref_du_dl == 0:
             np.testing.assert_almost_equal(ref_du_dl, test_du_dl, 1e-5)
         else:
             np.testing.assert_allclose(ref_du_dl, test_du_dl, rtol)
 
-        # du/dp can be hard to make numerically stable sometimes
-        # print(np.amax(np.abs(ref_du_dp[:, 1])))
-        # print(np.amin(np.abs(ref_du_dp[:, 1])))
 
-        # print(ref_du_dp[:, 0])
-        # print(test_du_dp[:, 0])
+        if precision == np.float64:
+             np.testing.assert_almost_equal(ref_du_dp, test_du_dp, 1e-8)
+            # np.testing.assert_almost_equal(ref_du_dp[:, 0], test_du_dp[:, 0], 1e-8)
+            # np.testing.assert_almost_equal(ref_du_dp[:, 1], test_du_dp[:, 1], 1e-8)
+            # np.testing.assert_almost_equal(ref_du_dp[:, 2], test_du_dp[:, 2], 1e-8)
+        else:
+            np.testing.assert_almost_equal(ref_du_dp, test_du_dp, 1e-5)
+            # np.testing.assert_almost_equal(ref_du_dp[:, 0], test_du_dp[:, 0], 1e-5)
+            # np.testing.assert_almost_equal(ref_du_dp[:, 1], test_du_dp[:, 1], 1e-5)
+            # np.testing.assert_almost_equal(ref_du_dp[:, 2], test_du_dp[:, 2], 1e-5)
 
-        # np.testing.assert_allclose(ref_du_dp[:, 0], test_du_dp[:, 0], rtol*40)
-        # np.testing.assert_allclose(ref_du_dp[:, 2], test_du_dp[:, 2], rtol*40)
-        # np.testing.assert_allclose(ref_du_dp[:, 1], test_du_dp[:, 1], rtol*40)
 
-
-        np.testing.assert_allclose(ref_du_dp, test_du_dp, rtol*100)
+        # np.testing.assert_allclose(ref_du_dp, test_du_dp, rtol*100)
         # we don't need more precision than this for derivatives
         # np.testing.assert_almost_equal(ref_du_dp, test_du_dp, 1e-5)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -437,7 +437,6 @@ class GradientTest(unittest.TestCase):
         lamb,
         ref_potential,
         test_potential,
-        precision,
         rtol=None,
         benchmark=False):
 
@@ -462,32 +461,8 @@ class GradientTest(unittest.TestCase):
         ref_du_dx, ref_du_dp, ref_du_dl = grad_fn(x, params, box, lamb)
 
         np.testing.assert_allclose(ref_u, test_u, rtol)
-        # np.testing.assert_allclose(ref_du_dx, test_du_dx, rtol)
 
-        if precision == np.float64:
-            self.assert_equal_vectors(np.array(ref_du_dx), np.array(test_du_dx), 1e-8)
-        else:
-            self.assert_equal_vectors(np.array(ref_du_dx), np.array(test_du_dx), 1e-4)
+        self.assert_equal_vectors(np.array(ref_du_dx), np.array(test_du_dx), rtol)
 
-        if ref_du_dl == 0:
-            np.testing.assert_almost_equal(ref_du_dl, test_du_dl, 1e-5)
-        else:
-            np.testing.assert_allclose(ref_du_dl, test_du_dl, rtol)
-
-
-        if precision == np.float64:
-             np.testing.assert_almost_equal(ref_du_dp, test_du_dp, 1e-8)
-            # np.testing.assert_almost_equal(ref_du_dp[:, 0], test_du_dp[:, 0], 1e-8)
-            # np.testing.assert_almost_equal(ref_du_dp[:, 1], test_du_dp[:, 1], 1e-8)
-            # np.testing.assert_almost_equal(ref_du_dp[:, 2], test_du_dp[:, 2], 1e-8)
-        else:
-            np.testing.assert_almost_equal(ref_du_dp, test_du_dp, 1e-5)
-            # np.testing.assert_almost_equal(ref_du_dp[:, 0], test_du_dp[:, 0], 1e-5)
-            # np.testing.assert_almost_equal(ref_du_dp[:, 1], test_du_dp[:, 1], 1e-5)
-            # np.testing.assert_almost_equal(ref_du_dp[:, 2], test_du_dp[:, 2], 1e-5)
-
-
-        # np.testing.assert_allclose(ref_du_dp, test_du_dp, rtol*100)
-        # we don't need more precision than this for derivatives
-        # np.testing.assert_almost_equal(ref_du_dp, test_du_dp, 1e-5)
-
+        np.testing.assert_almost_equal(ref_du_dl, test_du_dl, rtol)
+        np.testing.assert_almost_equal(ref_du_dp, test_du_dp, rtol)

--- a/tests/common.py
+++ b/tests/common.py
@@ -67,7 +67,6 @@ def prepare_lj_system(
     return lj_params, ref_potential, test_potential
 
 
-
 # def prepare_es_system(
 #     x,
 #     E, # number of exclusions
@@ -110,6 +109,88 @@ def prepare_lj_system(
 #     )
 
 #     return charge_params, ref_total_energy, test_potential
+
+
+def prepare_water_system(
+    x,
+    lambda_offset_idxs,
+    p_scale,
+    cutoff,
+    precision=np.float64):
+
+    N = x.shape[0]
+    D = x.shape[1]
+
+    assert N % 3 == 0
+
+    params = np.stack([
+        (np.random.rand(N).astype(np.float64) - 0.5)*np.sqrt(138.935456), # q
+        np.random.rand(N).astype(np.float64)/5.0, # sig
+        np.random.rand(N).astype(np.float64) # eps
+    ], axis=1)
+
+    atom_idxs = np.arange(N)
+
+    # exclusion_idxs = np.random.choice(atom_idxs, size=(E, 2), replace=False)
+    # exclusion_idxs = np.array(exclusion_idxs, dtype=np.int32).reshape(-1, 2)
+
+    # scales = np.stack([
+            # np.random.rand(E),
+            # np.random.rand(E)
+    # ], axis=1)
+
+
+    scales = []
+    exclusion_idxs = []
+    for i in range(N//3):
+        O_idx = i*3+0
+        H1_idx = i*3+1
+        H2_idx = i*3+2
+        exclusion_idxs.append([O_idx, H1_idx]) # 1-2
+        exclusion_idxs.append([O_idx, H2_idx]) # 1-2
+        exclusion_idxs.append([H1_idx, H2_idx]) # 1-3
+
+        scales.append([1.0, 1.0])
+        scales.append([1.0, 1.0])
+        scales.append([np.random.rand(), np.random.rand()])
+
+    scales = np.array(scales, dtype=np.int32)
+    exclusion_idxs = np.array(exclusion_idxs, dtype=np.int32)
+    E = len(exclusion_idxs)
+    # scales = np.ones((E, 2), dtype=np.float64)
+
+    beta = 2.0
+
+    test_potential = potentials.Nonbonded(
+        exclusion_idxs,
+        scales,
+        lambda_offset_idxs,
+        beta,
+        cutoff,
+        precision=precision
+    )
+
+    charge_rescale_mask = np.ones((N, N))
+    for (i,j), exc in zip(exclusion_idxs, scales[:, 0]):
+        charge_rescale_mask[i][j] = 1 - exc
+        charge_rescale_mask[j][i] = 1 - exc
+
+    lj_rescale_mask = np.ones((N, N))
+    for (i,j), exc in zip(exclusion_idxs, scales[:, 1]):
+        lj_rescale_mask[i][j] = 1 - exc
+        lj_rescale_mask[j][i] = 1 - exc
+
+    ref_total_energy = functools.partial(
+        nonbonded.nonbonded_v3,
+        charge_rescale_mask=charge_rescale_mask,
+        lj_rescale_mask=lj_rescale_mask,
+        scales=scales,
+        beta=beta,
+        cutoff=cutoff,
+        lambda_offset_idxs=lambda_offset_idxs
+    )
+
+    return params, ref_total_energy, test_potential
 
 
 def prepare_nb_system(
@@ -390,9 +471,10 @@ class GradientTest(unittest.TestCase):
         grad_fn = jax.grad(ref_potential, argnums=(0, 1, 3))
         ref_du_dx, ref_du_dp, ref_du_dl = grad_fn(x, params, box, lamb)
 
-        # print(ref_du_dx, test_du_dx)
-
         np.testing.assert_allclose(ref_u, test_u, rtol)
+
+        # print(ref_du_dx)
+        np.testing.assert_allclose(ref_du_dx, test_du_dx, rtol)
 
         self.assert_equal_vectors(
             np.array(ref_du_dx),
@@ -406,7 +488,18 @@ class GradientTest(unittest.TestCase):
             np.testing.assert_allclose(ref_du_dl, test_du_dl, rtol)
 
         # du/dp can be hard to make numerically stable sometimes
-        # np.testing.assert_allclose(ref_du_dp, test_du_dp, rtol*10)
+        # print(np.amax(np.abs(ref_du_dp[:, 1])))
+        # print(np.amin(np.abs(ref_du_dp[:, 1])))
+
+        # print(ref_du_dp[:, 0])
+        # print(test_du_dp[:, 0])
+
+        # np.testing.assert_allclose(ref_du_dp[:, 0], test_du_dp[:, 0], rtol*40)
+        # np.testing.assert_allclose(ref_du_dp[:, 2], test_du_dp[:, 2], rtol*40)
+        # np.testing.assert_allclose(ref_du_dp[:, 1], test_du_dp[:, 1], rtol*40)
+
+
+        np.testing.assert_allclose(ref_du_dp, test_du_dp, rtol*100)
         # we don't need more precision than this for derivatives
-        np.testing.assert_almost_equal(ref_du_dp, test_du_dp, 1e-5)
+        # np.testing.assert_almost_equal(ref_du_dp, test_du_dp, 1e-5)
 

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -59,7 +59,6 @@ class TestContext(unittest.TestCase):
         cbs = -np.random.rand(len(masses))/1
         ccs = np.zeros_like(cbs)
 
-        # dt = np.random.rand()
         dt = 2e-3
         lamb = np.random.rand()
 
@@ -162,9 +161,12 @@ class TestContext(unittest.TestCase):
         ref_avg_du_dps = np.mean(ref_all_du_dps, axis=0)
         ref_avg_du_dps_f2 = np.mean(ref_all_du_dps[::2], axis=0)
 
-        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 0], ref_avg_du_dps[:, 0])
-        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 1], ref_avg_du_dps[:, 1])
-        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 2], ref_avg_du_dps[:, 2])
+        # the fixed point accumulator makes it hard to converge some of these
+        # if the derivative is super small - in which case they probably don't matter
+        # anyways
+        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 0], ref_avg_du_dps[:, 0], 1e-6)
+        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 1], ref_avg_du_dps[:, 1], 1e-6)
+        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 2], ref_avg_du_dps[:, 2], 5e-5)
 
 
 

--- a/tests/test_nonbonded.py
+++ b/tests/test_nonbonded.py
@@ -42,12 +42,13 @@ class TestNonbonded(GradientTest):
 
         benchmark = False
 
+        # for size in [32, 230, 1051]:
         for size in [32, 230, 1051]:
-        # for size in [32]:
 
             if not benchmark:
                 water_coords = self.get_water_coords(D, sort=False)
                 test_system = water_coords[:size]
+                test_system[1] = test_system[0]+1e-5 # very delta epsilon to trigger a singularity
                 padding = 0.2
                 diag = np.amax(test_system, axis=0) - np.amin(test_system, axis=0) + padding
                 box = np.eye(3)
@@ -59,13 +60,8 @@ class TestNonbonded(GradientTest):
 
             for coords in [test_system]:
 
-                sort = True
-                if sort:
-                    perm = hilbert_sort(coords+np.argmin(coords), D)
-                    coords = coords[perm]
-
                 N = coords.shape[0]
-                E = N//5
+                # E = N//5
 
                 lambda_offset_idxs = np.random.randint(low=0, high=2, size=N, dtype=np.int32)
 
@@ -73,7 +69,7 @@ class TestNonbonded(GradientTest):
                 # for precision, rtol in [(np.float32, 1e-4)]:
 
                     for cutoff in [1.0]:
-                        # E = 0 # DEBUG!
+                        E = 1 # DEBUG!
                         charge_params, ref_potential, test_potential = prepare_nb_system(
                             coords,
                             E,
@@ -99,6 +95,7 @@ class TestNonbonded(GradientTest):
                                 rtol=rtol,
                                 benchmark=benchmark
                             )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_nonbonded.py
+++ b/tests/test_nonbonded.py
@@ -80,8 +80,7 @@ class TestNonbonded(GradientTest):
 
         cutoff = 1.0
 
-        # for precision, rtol in [(np.float64, 1e-9), (np.float32, 1e-4)]:
-        for precision, rtol in [(np.float64, 1e-9)]:
+        for precision, rtol in [(np.float64, 1e-8), (np.float32, 1e-4)]:
 
             test_u = potentials.Nonbonded(
                 exclusion_idxs,
@@ -127,7 +126,6 @@ class TestNonbonded(GradientTest):
                 lamb,
                 ref_u,
                 test_u,
-                precision,
                 rtol=rtol,
                 benchmark=False
             )
@@ -161,8 +159,7 @@ class TestNonbonded(GradientTest):
 
                 lambda_offset_idxs = np.random.randint(low=0, high=2, size=N, dtype=np.int32)
 
-                for precision, rtol in [(np.float64, 1e-9), (np.float32, 1e-4)]:
-                # for precision, rtol in [(np.float32, 1e-4)]:
+                for precision, rtol in [(np.float64, 1e-8), (np.float32, 1e-4)]:
 
                     for cutoff in [1.0]:
                         # E = 0 # DEBUG!
@@ -185,7 +182,6 @@ class TestNonbonded(GradientTest):
                                 lamb,
                                 ref_potential,
                                 test_potential,
-                                precision,
                                 rtol=rtol,
                                 benchmark=benchmark
                             )

--- a/tests/test_nonbonded.py
+++ b/tests/test_nonbonded.py
@@ -35,7 +35,6 @@ def hilbert_sort(conf, D):
 
 class TestNonbonded(GradientTest):
 
-    @unittest.skip("boo")
     def test_exclusion(self):
 
         # This test verifies behavior when two particles are arbitrarily
@@ -45,8 +44,6 @@ class TestNonbonded(GradientTest):
         np.random.seed(2020)
 
         # water_coords = self.get_water_coords(3, sort=False)
-
-
         water_coords = self.get_water_coords(3, sort=False)
         test_system = water_coords[:126] # multiple of 3
         padding = 0.2
@@ -56,43 +53,26 @@ class TestNonbonded(GradientTest):
 
         N = test_system.shape[0]
 
-        EA = 0
+        EA = 10
 
         atom_idxs = np.arange(test_system.shape[0])
 
         # pick a set of atoms that will be mutually excluded from each other.
         # we will need to set their exclusions manually
-        # exclusion_atoms = np.random.choice(atom_idxs, size=(EA), replace=False)
-        # exclusion_idxs = []
+        exclusion_atoms = np.random.choice(atom_idxs, size=(EA), replace=False)
+        exclusion_idxs = []
 
-        # for idx, i in enumerate(exclusion_atoms):
-        #     for jdx, j in enumerate(exclusion_atoms):
-        #         if jdx > idx:
-        #             exclusion_idxs.append((i,j))
+        for idx, i in enumerate(exclusion_atoms):
+            for jdx, j in enumerate(exclusion_atoms):
+                if jdx > idx:
+                    exclusion_idxs.append((i,j))
 
-        # E = len(exclusion_idxs)
-
-        # print(exclusion_idxs)
-
-        # exclusion_idxs = np.array(exclusion_idxs, dtype=np.int32)
-        # scales = np.ones((E, 2), dtype=np.float64)
+        E = len(exclusion_idxs)
+        exclusion_idxs = np.array(exclusion_idxs, dtype=np.int32)
+        scales = np.ones((E, 2), dtype=np.float64)
         # perturb the system
-        # for idx in exclusion_atoms:
-            # test_system[idx] = np.zeros(3) + np.random.rand()/1000+2
-
-        # water exclusions
-
-        # exclusion_idxs = []
-        # for i in range(N//3):
-        #     O_idx = i*3+0
-        #     H1_idx = i*3+1
-        #     H2_idx = i*3+2
-        #     exclusion_idxs.append([O_idx, H1_idx]) # 1-2
-        #     exclusion_idxs.append([O_idx, H2_idx]) # 1-2
-        #     exclusion_idxs.append([H1_idx, H2_idx]) # 1-3
-        # exclusion_idxs = np.array(exclusion_idxs, dtype=np.int32)
-        # E = len(exclusion_idxs)
-        # scales = np.ones((E, 2), dtype=np.float64)
+        for idx in exclusion_atoms:
+            test_system[idx] = np.zeros(3) + np.random.rand()/1000+2
 
         beta = 2.0
 
@@ -136,7 +116,7 @@ class TestNonbonded(GradientTest):
 
             params = np.stack([
                 (np.random.rand(N).astype(np.float64) - 0.5)*np.sqrt(138.935456), # q
-                np.random.rand(N).astype(np.float64)/3.0, # sig
+                np.random.rand(N).astype(np.float64)/10.0, # sig
                 np.random.rand(N).astype(np.float64) # eps
             ], axis=1)
 
@@ -181,7 +161,7 @@ class TestNonbonded(GradientTest):
 
                 lambda_offset_idxs = np.random.randint(low=0, high=2, size=N, dtype=np.int32)
 
-                for precision, rtol in [(np.float64, 1e-9), (np.float32, 3e-4)]:
+                for precision, rtol in [(np.float64, 1e-9), (np.float32, 1e-4)]:
                 # for precision, rtol in [(np.float32, 1e-4)]:
 
                     for cutoff in [1.0]:

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -20,8 +20,6 @@ RealType __device__ __forceinline__ FIXED_TO_FLOAT_DU_DP(unsigned long long v) {
     return static_cast<RealType>(static_cast<long long>(v))/EXPONENT;
 }
 
-// forces energies du/dl use the same
-
 template<typename RealType>
 unsigned long long __device__ __forceinline__ FLOAT_TO_FIXED(RealType v) {
     return static_cast<unsigned long long>((long long)(v*FIXED_EXPONENT));
@@ -152,7 +150,6 @@ void __global__ k_add_ull_to_real(
     } else if(stride_idx == 2) {
         real_array[idx*stride+stride_idx] += FIXED_TO_FLOAT_DU_DP<RealType, FIXED_EXPONENT_DU_DEPS>(ull_array[idx*stride+stride_idx]);
     }
-
 
 
 }

--- a/timemachine/cpp/src/nonbonded.cu
+++ b/timemachine/cpp/src/nonbonded.cu
@@ -43,6 +43,10 @@ Nonbonded<RealType>::Nonbonded(
 
     gpuErrchk(cudaMalloc(&d_du_dl_buffer_, N_*sizeof(*d_du_dl_buffer_)));
     gpuErrchk(cudaMalloc(&d_u_buffer_, N_*sizeof(*d_u_buffer_)));
+
+    gpuErrchk(cudaMalloc(&d_du_dl_reduce_sum_, 1*sizeof(*d_du_dl_reduce_sum_)));
+    gpuErrchk(cudaMalloc(&d_u_reduce_sum_, 1*sizeof(*d_u_reduce_sum_)));
+
     gpuErrchk(cudaMalloc(&d_perm_, N_*sizeof(*d_perm_)));
 
     gpuErrchk(cudaMalloc(&d_sorted_lambda_offset_idxs_, N_*sizeof(*d_sorted_lambda_offset_idxs_)));
@@ -50,6 +54,7 @@ Nonbonded<RealType>::Nonbonded(
     gpuErrchk(cudaMalloc(&d_sorted_p_, N_*3*sizeof(*d_sorted_p_)));
     gpuErrchk(cudaMalloc(&d_sorted_du_dx_, N_*3*sizeof(*d_sorted_du_dx_)));
     gpuErrchk(cudaMalloc(&d_sorted_du_dp_, N_*3*sizeof(*d_sorted_du_dp_)));
+    gpuErrchk(cudaMalloc(&d_du_dp_buffer_, N_*3*sizeof(*d_du_dp_buffer_)));
 
     gpuErrchk(cudaMalloc(&d_exclusion_idxs_, E_*2*sizeof(*d_exclusion_idxs_)));
     gpuErrchk(cudaMemcpy(d_exclusion_idxs_, &exclusion_idxs[0], E_*2*sizeof(*d_exclusion_idxs_), cudaMemcpyHostToDevice));
@@ -109,6 +114,10 @@ Nonbonded<RealType>::~Nonbonded() {
     gpuErrchk(cudaFree(d_scales_));
     gpuErrchk(cudaFree(d_lambda_offset_idxs_));
 
+    gpuErrchk(cudaFree(d_du_dl_reduce_sum_));
+    gpuErrchk(cudaFree(d_u_reduce_sum_));
+
+    gpuErrchk(cudaFree(d_du_dp_buffer_));
     gpuErrchk(cudaFree(d_du_dl_buffer_));
     gpuErrchk(cudaFree(d_u_buffer_));
     gpuErrchk(cudaFree(d_perm_)); // nullptr if we never built nblist
@@ -233,10 +242,12 @@ void Nonbonded<RealType>::execute_device(
 	   gpuErrchk(cudaMemsetAsync(d_sorted_du_dp_, 0, N*3*sizeof(*d_sorted_du_dp_), stream))
     }
     if(d_du_dl) {
-        gpuErrchk(cudaMemsetAsync(d_du_dl_buffer_, 0, N*sizeof(*d_du_dl_buffer_), stream));        
+        gpuErrchk(cudaMemsetAsync(d_du_dl_buffer_, 0, N*sizeof(*d_du_dl_buffer_), stream));
+        gpuErrchk(cudaMemsetAsync(d_du_dl_reduce_sum_, 0, 1*sizeof(*d_du_dl_reduce_sum_), stream));
     }
     if(d_u) {
-        gpuErrchk(cudaMemsetAsync(d_u_buffer_, 0, N*sizeof(*d_du_dl_buffer_), stream));        
+        gpuErrchk(cudaMemsetAsync(d_u_buffer_, 0, N*sizeof(*d_u_buffer_), stream));
+        gpuErrchk(cudaMemsetAsync(d_u_reduce_sum_, 0, 1*sizeof(*d_u_reduce_sum_), stream));
     }
 
     gpuErrchk(cudaStreamSynchronize(stream));
@@ -278,7 +289,7 @@ void Nonbonded<RealType>::execute_device(
     // params are N,3
     // this needs to be an accumlated permute
     if(d_du_dp) {
-        k_inv_permute_accum<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_sorted_du_dp_, d_du_dp);
+        k_inv_permute_assign<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_sorted_du_dp_, d_du_dp_buffer_);
         gpuErrchk(cudaPeekAtLastError());
     }
 
@@ -300,24 +311,34 @@ void Nonbonded<RealType>::execute_device(
             beta_,
             cutoff_,
             d_du_dx,
-            d_du_dp,
+            d_du_dp_buffer_,
             d_du_dl ? d_du_dl_buffer_ : nullptr, // switch to nullptr if we don't request du_dl
             d_u ? d_u_buffer_ : nullptr // switch to nullptr if we don't request energies
         );
         gpuErrchk(cudaPeekAtLastError());
     }
 
+    if(d_du_dp) {
+        k_cast_ull_to_real<<<dimGrid, tpb, 0, stream>>>(N, d_du_dp_buffer_, d_du_dp);
+        gpuErrchk(cudaPeekAtLastError());
+    }
+
+    // we must accumulate in fixed point to get the cancellation of nans
+    // otherwise if we convert prematurely floating points become messed u
+
     if(d_du_dl) {
-        k_reduce_buffer<<<B, 32, 0, stream>>>(N, d_du_dl_buffer_, d_du_dl);
+        k_reduce_buffer<<<B, 32, 0, stream>>>(N, d_du_dl_buffer_, d_du_dl_reduce_sum_);
+        gpuErrchk(cudaPeekAtLastError());
+        k_final_copy<<<1, 32, 0, stream>>>(d_du_dl_reduce_sum_, d_du_dl);
         gpuErrchk(cudaPeekAtLastError());
     }
 
     if(d_u) {
-        k_reduce_buffer<<<B, 32, 0, stream>>>(N, d_u_buffer_, d_u);
+        k_reduce_buffer<<<B, 32, 0, stream>>>(N, d_u_buffer_, d_u_reduce_sum_);
+        gpuErrchk(cudaPeekAtLastError());
+        k_final_copy<<<1, 32, 0, stream>>>(d_u_reduce_sum_, d_u);
         gpuErrchk(cudaPeekAtLastError());
     }
-
-
     
 }
 

--- a/timemachine/cpp/src/nonbonded.hpp
+++ b/timemachine/cpp/src/nonbonded.hpp
@@ -24,8 +24,14 @@ private:
     const int N_;
 
     // reduction buffer
-    double *d_du_dl_buffer_;
-    double *d_u_buffer_;
+    unsigned long long *d_sorted_du_dl_buffer_;
+    unsigned long long *d_sorted_u_buffer_;
+
+    unsigned long long *d_du_dl_buffer_;
+    unsigned long long *d_u_buffer_;
+
+    unsigned long long *d_du_dl_reduce_sum_;
+    unsigned long long *d_u_reduce_sum_;
 
     unsigned int *d_perm_; // hilbert curve permutation
 
@@ -33,7 +39,8 @@ private:
     double *d_sorted_x_; //
     double *d_sorted_p_; //
     unsigned long long *d_sorted_du_dx_; //
-    double *d_sorted_du_dp_; //
+    unsigned long long *d_sorted_du_dp_; //
+    unsigned long long *d_du_dp_buffer_; //
 
     unsigned int *d_bin_to_idx_;
     unsigned int *d_sort_keys_in_;

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -74,6 +74,8 @@ class NonbondedCustomOpWrapper(CustomOpWrapper):
         exclusion_set = set()
 
         for src, dst in exclusion_idxs:
+            # (ytz): this is very important to get proper
+            # cancellation in fixed point land
             src, dst = sorted((src, dst))
             exclusion_set.add((src, dst))
 

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -74,8 +74,6 @@ class NonbondedCustomOpWrapper(CustomOpWrapper):
         exclusion_set = set()
 
         for src, dst in exclusion_idxs:
-            # (ytz): this is very important to get proper
-            # cancellation in fixed point land
             src, dst = sorted((src, dst))
             exclusion_set.add((src, dst))
 

--- a/timemachine/potentials/nonbonded.py
+++ b/timemachine/potentials/nonbonded.py
@@ -118,7 +118,6 @@ def nonbonded_v3(
     params,
     box,
     lamb,
-    # exclusion_idxs,
     charge_rescale_mask,
     lj_rescale_mask,
     scales,
@@ -127,8 +126,6 @@ def nonbonded_v3(
     lambda_offset_idxs):
     
     N = conf.shape[0]
-    # build exclusion mask
-
 
     conf = convert_to_4d(conf, lamb, lambda_offset_idxs)
 

--- a/timemachine/potentials/nonbonded.py
+++ b/timemachine/potentials/nonbonded.py
@@ -113,6 +113,87 @@ def lennard_jones_v2(
 
     return lj - lj_exc
 
+def nonbonded_v3(
+    conf,
+    params,
+    box,
+    lamb,
+    # exclusion_idxs,
+    charge_rescale_mask,
+    lj_rescale_mask,
+    scales,
+    beta,
+    cutoff,
+    lambda_offset_idxs):
+    
+    N = conf.shape[0]
+    # build exclusion mask
+
+
+    conf = convert_to_4d(conf, lamb, lambda_offset_idxs)
+
+    # make 4th dimension of box large enough so its roughly aperiodic
+    if box is not None:
+        box_4d = np.eye(4)*1000
+        box_4d = index_update(box_4d, index[:3, :3], box)
+    else:
+        box_4d = None
+
+    box = box_4d
+
+    charges = params[:, 0]
+    sig = params[:, 1]
+    eps = params[:, 2]
+
+    sig_i = np.expand_dims(sig, 0)
+    sig_j = np.expand_dims(sig, 1)
+    sig_ij = (sig_i + sig_j)/2
+    sig_ij_raw = sig_ij
+
+    eps_i = np.expand_dims(eps, 0)
+    eps_j = np.expand_dims(eps, 1)
+
+    eps_ij = np.sqrt(eps_i * eps_j)
+
+    ri = np.expand_dims(conf, 0)
+    rj = np.expand_dims(conf, 1)
+    dij = distance(ri, rj, box)
+
+    N = conf.shape[0]
+    keep_mask = np.ones((N,N)) - np.eye(N)
+    keep_mask = np.where(eps_ij != 0, keep_mask, 0)
+
+    if cutoff is not None:
+        eps_ij = np.where(dij < cutoff, eps_ij, np.zeros_like(eps_ij))
+
+    # (ytz): this avoids a nan in the gradient in both jax and tensorflow
+    sig_ij = np.where(keep_mask, sig_ij, np.zeros_like(sig_ij))
+    eps_ij = np.where(keep_mask, eps_ij, np.zeros_like(eps_ij))
+
+    sig2 = sig_ij/dij
+    sig2 *= sig2
+    sig6 = sig2*sig2*sig2
+
+    eij_lj = 4*eps_ij*(sig6-1.0)*sig6
+    eij_lj = np.where(keep_mask, eij_lj, np.zeros_like(eij_lj))
+
+    qi = np.expand_dims(charges, 0) # (1, N)
+    qj = np.expand_dims(charges, 1) # (N, 1)
+    qij = np.multiply(qi, qj)
+
+    # (ytz): trick used to avoid nans in the diagonal due to the 1/dij term.
+    keep_mask = 1 - np.eye(conf.shape[0])
+    qij = np.where(keep_mask, qij, np.zeros_like(qij))
+    dij = np.where(keep_mask, dij, np.zeros_like(dij))
+
+    # funny enough lim_{x->0} erfc(x)/x = 0
+    eij_charge = np.where(keep_mask, qij*erfc(beta*dij)/dij, np.zeros_like(dij)) # zero out diagonals
+    if cutoff is not None:
+        eij_charge = np.where(dij > cutoff, np.zeros_like(eij_charge), eij_charge)
+
+    eij_total = (eij_lj*lj_rescale_mask + eij_charge*charge_rescale_mask)
+
+    return np.sum(eij_total/2)
 
 def lennard_jones(conf, lj_params, box, cutoff):
     """


### PR DESCRIPTION
This PR uses a trick to improve the way we compute exclusions. Previously blocks that contained exclusions will exhibit a significant loss of accuracy due to the accumulation of floating point numbers.

1. Given 4 floating point numbers, where a,c,d, are well-behaved, and b is an exclusion term, we compute (a+b+c+d)-b
2. (a+b+c+d) is casted to fixed point via unsigned long longs (ull), as well as -b
3. However, this method will result in massive loss of precision for most 1-2 exclusions and many 1-3 exclusions since calculations inside the parentheses are still accumulated using regular floating point arithmetic.
4. Instead we do every accumulation, even that of inside the parentheses, in fixed point. Meaning, we compute (a_ull + b_ull + c_ull + d_ull) - b_ull
5. ulls formally are a closed group under modular arithmetic, as any overflow will "circle back". This means we can perfectly cancel out large exclusion terms without fundamentally affecting the accuracy of the remaining operations.

This is very different from how OpenMM and AMBER handles exclusion lists, as they typically require construction of specialized neighborlists and nonbonded kernels that can handle tiles with exclusions. I'm not sure which approach is superior in the long run, but this implementation was hacked together in about 4 hours. Note that the PR still needs some cleanup and optimizations.


