### PR TITLE
Restore CoM restraints

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -437,7 +437,7 @@ class GradientTest(unittest.TestCase):
         lamb,
         ref_potential,
         test_potential,
-        rtol=None,
+        rtol,
         benchmark=False):
 
         test_potential = test_potential.unbound_impl()
@@ -463,6 +463,8 @@ class GradientTest(unittest.TestCase):
         np.testing.assert_allclose(ref_u, test_u, rtol)
 
         self.assert_equal_vectors(np.array(ref_du_dx), np.array(test_du_dx), rtol)
+
+        print("????", ref_du_dl, test_du_dl)
 
         np.testing.assert_almost_equal(ref_du_dl, test_du_dl, rtol)
         np.testing.assert_almost_equal(ref_du_dp, test_du_dp, rtol)

--- a/tests/common.py
+++ b/tests/common.py
@@ -464,7 +464,5 @@ class GradientTest(unittest.TestCase):
 
         self.assert_equal_vectors(np.array(ref_du_dx), np.array(test_du_dx), rtol)
 
-        print("????", ref_du_dl, test_du_dl)
-
         np.testing.assert_almost_equal(ref_du_dl, test_du_dl, rtol)
         np.testing.assert_almost_equal(ref_du_dp, test_du_dp, rtol)

--- a/tests/test_nonbonded.py
+++ b/tests/test_nonbonded.py
@@ -126,8 +126,7 @@ class TestNonbonded(GradientTest):
                 lamb,
                 ref_u,
                 test_u,
-                rtol=rtol,
-                benchmark=False
+                rtol
             )
 
     def test_nonbonded(self):
@@ -182,7 +181,7 @@ class TestNonbonded(GradientTest):
                                 lamb,
                                 ref_potential,
                                 test_potential,
-                                rtol=rtol,
+                                rtol,
                                 benchmark=benchmark
                             )
 

--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -62,7 +62,7 @@ pybind11_add_module(${LIBRARY_NAME} SHARED NO_EXTRAS
   # src/stepper.cu
   src/context.cu
   # src/gbsa.cu
-  # src/centroid_restraint.cu
+  src/centroid_restraint.cu
   src/kernels/k_neighborlist.cu
 )
 

--- a/timemachine/cpp/src/centroid_restraint.hpp
+++ b/timemachine/cpp/src/centroid_restraint.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "gradient.hpp"
+#include "potential.hpp"
 #include <vector>
 
 namespace timemachine {
 
 template<typename RealType>
-class CentroidRestraint : public Gradient {
+class CentroidRestraint : public Potential {
 
 private:
 
@@ -17,8 +17,6 @@ private:
     int N_;
     int N_A_;
     int N_B_;
-    int lambda_flag_;
-    int lambda_offset_;
 
     double kb_;
     double b0_;
@@ -30,31 +28,22 @@ public:
         const std::vector<int> &group_b_idxs,
         const std::vector<double> &masses,
         const double kb,
-        const double b0,
-        const int lambda_flag,
-        const int lambda_offset
+        const double b0
     );
 
     ~CentroidRestraint();
 
-    virtual void execute_lambda_inference_device(
+    virtual void execute_device(
         const int N,
-        const double *d_coords_primals,
-        const double lambda_primal,
-        unsigned long long *d_out_coords_primals,
-        double *d_out_lambda_primals,
-        double *d_out_energy_primal,
-        cudaStream_t stream
-    ) override;
-
-    virtual void execute_lambda_jvp_device(
-        const int N,
-        const double *d_coords_primals,
-        const double *d_coords_tangents,
-        const double lambda_primal,
-        const double lambda_tangent,
-        double *d_out_coords_primals,
-        double *d_out_coords_tangents,
+        const int P,
+        const double *d_x,
+        const double *d_p,
+        const double *d_box,
+        const double lambda,
+        unsigned long long *d_du_dx,
+        double *d_du_dp,
+        double *d_du_dl,
+        double *d_u,
         cudaStream_t stream
     ) override;
 

--- a/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
@@ -6,12 +6,9 @@
 __device__ const double PI = 3.14159265358979323846;
 
 template<typename RealType>
-void __global__ k_centroid_restraint_inference(
+void __global__ k_centroid_restraint(
     const int N,     // number of bonds
     const double *coords,  // [n, 3]
-    const double lambda,
-    const int lambda_flag,
-    const int lambda_offset,
     const int *group_a_idxs,
     const int *group_b_idxs,
     const int N_A,
@@ -20,7 +17,6 @@ void __global__ k_centroid_restraint_inference(
     const double kb,
     const double b0,
     unsigned long long *grad_coords,
-    double *du_dl,
     double *energy) {
 
     // (ytz): ultra shitty inefficient algorithm, optimize later
@@ -29,10 +25,6 @@ void __global__ k_centroid_restraint_inference(
     if(t_idx != 0) {
         return;
     }
-
-    // stage 0               1         0.5          0
-    // stage 1               0         3.5          1
-    double lambda_full = lambda_flag*lambda + lambda_offset;
 
     double group_a_ctr[3] = {0};
     double mass_a_sums[3] = {0};
@@ -64,12 +56,11 @@ void __global__ k_centroid_restraint_inference(
 
     double dij = sqrt(dx*dx + dy*dy + dz*dz);
 
-    double nrg = lambda_full*kb*(dij-b0)*(dij-b0);
+    double nrg = kb*(dij-b0)*(dij-b0);
 
     atomicAdd(energy, nrg);
-    atomicAdd(du_dl, lambda_flag*kb*(dij-b0)*(dij-b0));
 
-    double du_ddij = 2*lambda_full*kb*(dij-b0);
+    double du_ddij = 2*kb*(dij-b0);
 
     // grads
     for(int d=0; d < 3; d++) {
@@ -84,95 +75,6 @@ void __global__ k_centroid_restraint_inference(
             double mass_i = masses[group_b_idxs[i]];
             double dx = -du_ddij*ddij_dxi*(mass_i/mass_b_sums[d]);
             atomicAdd(grad_coords + group_b_idxs[i]*3 + d, static_cast<unsigned long long>((long long) (dx*FIXED_EXPONENT)));
-        }
-    }
-
-}
-
-
-
-template<typename RealType>
-void __global__ k_centroid_restraint_jvp(
-    const int N,     // number of bonds
-    const double *coords_primal,  // [n, 3]
-    const double *coords_tangent,
-    const double lambda_primal,
-    const double lambda_tangent,
-    const int lambda_flag,
-    const int lambda_offset,
-    const int *group_a_idxs,
-    const int *group_b_idxs,
-    const int N_A,
-    const int N_B,
-    const double *masses, // ignore masses for now
-    const double kb,
-    const double b0,
-    double *grad_coords_primals,
-    double *grad_coords_tangents) {
-
-    // (ytz): ultra shitty inefficient algorithm, optimize later
-    const auto t_idx = blockDim.x*blockIdx.x + threadIdx.x;
-
-    if(t_idx != 0) {
-        return;
-    }
-
-    // stage 0               1         0.5          0
-    // stage 1               0         3.5          1
-    Surreal<double> lambda(lambda_primal, lambda_tangent);
-    Surreal<double> lambda_full = lambda_flag*lambda + lambda_offset;
-
-
-    Surreal<double> group_a_ctr[3];
-    double mass_a_sums[3] = {0};
-    for(int d=0; d < 3; d++) {
-        group_a_ctr[d].real = 0;
-        group_a_ctr[d].imag = 0;
-        for(int i=0; i < N_A; i++) {
-            double mass_i = masses[group_a_idxs[i]];
-            group_a_ctr[d].real += mass_i*coords_primal[group_a_idxs[i]*3+d];
-            group_a_ctr[d].imag += mass_i*coords_tangent[group_a_idxs[i]*3+d];
-            mass_a_sums[d] += mass_i;
-        }
-        group_a_ctr[d] /=  mass_a_sums[d];
-    }
-
-    Surreal<double> group_b_ctr[3];
-    double mass_b_sums[3] = {0};
-    for(int d=0; d < 3; d++) {
-        group_b_ctr[d].real = 0;
-        group_b_ctr[d].imag = 0;
-        for(int i=0; i < N_B; i++) {
-            double mass_i = masses[group_b_idxs[i]];
-            group_b_ctr[d].real += mass_i*coords_primal[group_b_idxs[i]*3+d];
-            group_b_ctr[d].imag += mass_i*coords_tangent[group_b_idxs[i]*3+d];
-            mass_b_sums[d] += mass_i;
-        }
-        group_b_ctr[d] /= mass_b_sums[d];
-    }
-
-    Surreal<double> dx = group_a_ctr[0] - group_b_ctr[0];
-    Surreal<double> dy = group_a_ctr[1] - group_b_ctr[1];
-    Surreal<double> dz = group_a_ctr[2] - group_b_ctr[2];
-
-    Surreal<double> dij = sqrt(dx*dx + dy*dy + dz*dz);
-    Surreal<double> du_ddij = 2*lambda_full*kb*(dij-b0);
-
-    // grads
-    for(int d=0; d < 3; d++) {
-        Surreal<double> ddij_dxi = (group_a_ctr[d] - group_b_ctr[d])/dij;
-
-        for(int i=0; i < N_A; i++) {
-            double mass_i = masses[group_a_idxs[i]];
-            Surreal<double> dx = du_ddij*ddij_dxi*(mass_i/mass_a_sums[d]);
-            atomicAdd(grad_coords_primals + group_a_idxs[i]*3 + d, dx.real);
-            atomicAdd(grad_coords_tangents + group_a_idxs[i]*3 + d, dx.imag);
-        }
-        for(int i=0; i < N_B; i++) {
-            double mass_i = masses[group_b_idxs[i]];
-            Surreal<double> dx = -du_ddij*ddij_dxi*(mass_i/mass_b_sums[d]);
-            atomicAdd(grad_coords_primals + group_b_idxs[i]*3 + d, dx.real);
-            atomicAdd(grad_coords_tangents + group_b_idxs[i]*3 + d, dx.imag);
         }
     }
 

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -9,7 +9,7 @@
 #include "harmonic_bond.hpp"
 #include "harmonic_angle.hpp"
 // #include "restraint.hpp"
-// #include "centroid_restraint.hpp"
+#include "centroid_restraint.hpp"
 #include "periodic_torsion.hpp"
 #include "nonbonded.hpp"
 #include "lennard_jones.hpp"
@@ -552,46 +552,42 @@ void declare_harmonic_angle(py::module &m, const char *typestr) {
 // }
 
 
-// template <typename RealType>
-// void declare_centroid_restraint(py::module &m, const char *typestr) {
+template <typename RealType>
+void declare_centroid_restraint(py::module &m, const char *typestr) {
 
-//     using Class = timemachine::CentroidRestraint<RealType>;
-//     std::string pyclass_name = std::string("CentroidRestraint_") + typestr;
-//     py::class_<Class, timemachine::Gradient>(
-//         m,
-//         pyclass_name.c_str(),
-//         py::buffer_protocol(),
-//         py::dynamic_attr()
-//     )
-//     .def(py::init([](
-//         const py::array_t<int, py::array::c_style> &group_a_idxs,
-//         const py::array_t<int, py::array::c_style> &group_b_idxs,
-//         const py::array_t<double, py::array::c_style> &masses,
-//         double kb,
-//         double b0,
-//         int lambda_flag,
-//         int lambda_offset
-//     ){
-//         std::vector<int> vec_group_a_idxs(group_a_idxs.size());
-//         std::memcpy(vec_group_a_idxs.data(), group_a_idxs.data(), vec_group_a_idxs.size()*sizeof(int));
-//         std::vector<int> vec_group_b_idxs(group_b_idxs.size());
-//         std::memcpy(vec_group_b_idxs.data(), group_b_idxs.data(), vec_group_b_idxs.size()*sizeof(int));
-//         std::vector<double> vec_masses(masses.size());
-//         std::memcpy(vec_masses.data(), masses.data(), vec_masses.size()*sizeof(double));
+    using Class = timemachine::CentroidRestraint<RealType>;
+    std::string pyclass_name = std::string("CentroidRestraint_") + typestr;
+    py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+        m,
+        pyclass_name.c_str(),
+        py::buffer_protocol(),
+        py::dynamic_attr()
+    )
+    .def(py::init([](
+        const py::array_t<int, py::array::c_style> &group_a_idxs,
+        const py::array_t<int, py::array::c_style> &group_b_idxs,
+        const py::array_t<double, py::array::c_style> &masses,
+        double kb,
+        double b0
+    ) {
+        std::vector<int> vec_group_a_idxs(group_a_idxs.size());
+        std::memcpy(vec_group_a_idxs.data(), group_a_idxs.data(), vec_group_a_idxs.size()*sizeof(int));
+        std::vector<int> vec_group_b_idxs(group_b_idxs.size());
+        std::memcpy(vec_group_b_idxs.data(), group_b_idxs.data(), vec_group_b_idxs.size()*sizeof(int));
+        std::vector<double> vec_masses(masses.size());
+        std::memcpy(vec_masses.data(), masses.data(), vec_masses.size()*sizeof(double));
 
-//         return new timemachine::CentroidRestraint<RealType>(
-//             vec_group_a_idxs,
-//             vec_group_b_idxs,
-//             vec_masses,
-//             kb,
-//             b0,
-//             lambda_flag,
-//             lambda_offset
-//         );
-//     }
-//     ));
+        return new timemachine::CentroidRestraint<RealType>(
+            vec_group_a_idxs,
+            vec_group_b_idxs,
+            vec_masses,
+            kb,
+            b0
+        );
 
-// }
+    }));
+
+}
 
 
 template <typename RealType>
@@ -852,8 +848,8 @@ PYBIND11_MODULE(custom_ops, m) {
     declare_neighborlist<double>(m, "f64");
     declare_neighborlist<float>(m, "f32");
 
-    // declare_centroid_restraint<double>(m, "f64");
-    // declare_centroid_restraint<float>(m, "f32");
+    declare_centroid_restraint<double>(m, "f64");
+    declare_centroid_restraint<float>(m, "f32");
 
     // declare_restraint<double>(m, "f64");
     // declare_restraint<float>(m, "f32");

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -64,6 +64,9 @@ class HarmonicAngle(CustomOpWrapper):
 class PeriodicTorsion(CustomOpWrapper):
     pass
 
+class CentroidRestraint(CustomOpWrapper):
+    pass
+
 
 class NonbondedCustomOpWrapper(CustomOpWrapper):
 

--- a/timemachine/potentials/bonded.py
+++ b/timemachine/potentials/bonded.py
@@ -2,7 +2,7 @@ import jax.numpy as np
 
 from timemachine.potentials.jax_utils import distance, delta_r, convert_to_4d
 
-def centroid_restraint(conf, lamb, masses, lamb_flag, lamb_offset, group_a_idxs, group_b_idxs, kb, b0):
+def centroid_restraint(conf, params, box, lamb, masses, group_a_idxs, group_b_idxs, kb, b0):
 
     xi = conf[group_a_idxs]
     xj = conf[group_b_idxs]
@@ -14,9 +14,7 @@ def centroid_restraint(conf, lamb, masses, lamb_flag, lamb_offset, group_a_idxs,
     dij = np.sqrt(np.sum(dx*dx))
     delta = dij - b0
 
-    lamb_final = lamb*lamb_flag + lamb_offset
-
-    return lamb_final*kb*delta*delta
+    return kb*delta*delta
 
 def restraint(conf, lamb, params, lamb_flags, box, bond_idxs):
     """


### PR DESCRIPTION
This restores functionality for center of mass restraints, but removing the lambda parameter. The alchemical lambda parameter has been removed as it will be done property later on through an AlchemicalGradient class.