### PR TITLE
Lambda Potential

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -405,7 +405,6 @@ class GradientTest(unittest.TestCase):
 
         return x
 
-
     def assert_equal_vectors(self, truth, test, rtol):
         """
         OpenMM convention - errors are compared against norm of force vectors

--- a/tests/test_lambda_potential.py
+++ b/tests/test_lambda_potential.py
@@ -1,0 +1,68 @@
+from jax.config import config; config.update("jax_enable_x64", True)
+
+import functools
+import numpy as np
+
+from common import GradientTest
+from timemachine.lib import potentials
+
+from common import prepare_water_system
+
+
+def lambda_potential(conf, params, box, lamb, u_fn):
+    """
+    This would be more useful if we could also do (1-lamb)
+    """
+    return lamb * u_fn(conf, params, box, lamb)
+
+
+class TestLambdaPotential(GradientTest):
+
+    def test_nonbonded(self):
+
+        np.random.seed(4321)
+        D = 3
+
+        cutoff = 1.0
+        size = 36
+
+        water_coords = self.get_water_coords(D, sort=False)
+        coords = water_coords[:size]
+        padding = 0.2
+        diag = np.amax(coords, axis=0) - np.amin(coords, axis=0) + padding
+        box = np.eye(3)
+        np.fill_diagonal(box, diag)
+
+        N = coords.shape[0]
+
+        lambda_offset_idxs = np.random.randint(low=0, high=2, size=N, dtype=np.int32)
+
+        for precision, rtol in [(np.float64, 1e-8), (np.float32, 1e-4)]:
+
+                # E = 0 # DEBUG!
+                charge_params, ref_potential, test_potential = prepare_water_system(
+                    coords,
+                    lambda_offset_idxs,
+                    p_scale=1.0,
+                    cutoff=cutoff,
+                    precision=precision
+                )
+
+                lamb = 0.2
+
+                print("lambda", lamb, "cutoff", cutoff, "precision", precision, "xshape", coords.shape)
+
+                ref_potential = functools.partial(lambda_potential, u_fn=ref_potential)
+                test_potential = potentials.LambdaPotential(
+                    test_potential,
+                    N,charge_params.size)
+
+                self.compare_forces(
+                    coords,
+                    charge_params,
+                    box,
+                    lamb,
+                    ref_potential,
+                    test_potential,
+                    rtol
+                )

--- a/tests/test_lambda_potential.py
+++ b/tests/test_lambda_potential.py
@@ -13,6 +13,9 @@ def lambda_potential(conf, params, box, lamb, u_fn):
     """
     This would be more useful if we could also do (1-lamb)
     """
+
+    # lamb appears twice as the potential itself may be a function
+    # of lambda (eg. if we use softcores)
     return lamb * u_fn(conf, params, box, lamb)
 
 

--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -61,6 +61,7 @@ pybind11_add_module(${LIBRARY_NAME} SHARED NO_EXTRAS
   src/electrostatics.cu
   # src/stepper.cu
   src/context.cu
+  src/lambda_potential.cu
   # src/gbsa.cu
   src/centroid_restraint.cu
   src/kernels/k_neighborlist.cu

--- a/timemachine/cpp/src/lambda_potential.cu
+++ b/timemachine/cpp/src/lambda_potential.cu
@@ -1,0 +1,154 @@
+
+#include "lambda_potential.hpp"
+#include "fixed_point.hpp"
+#include "gpu_utils.cuh"
+
+namespace timemachine {
+
+__global__ void k_reduce_add_force_buffer(
+    int count,
+    unsigned long long *out,
+    unsigned long long *buffer,
+    double lambda) {
+
+    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+
+    if(idx >= count) {
+        return;
+    }
+
+    // convert fixed to double
+    double val = static_cast<double>(static_cast<long long>(buffer[idx]))/FIXED_EXPONENT;
+    val *= lambda;
+
+    unsigned long long fixed_val = static_cast<unsigned long long>((long long) (val*FIXED_EXPONENT));
+
+    atomicAdd(out + idx, fixed_val);
+
+}
+
+
+template<typename RealType>
+__global__ void k_reduce_add_buffer(
+    int count,
+    RealType *out,
+    RealType *buffer,
+    double lambda) {
+
+    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+
+    if(idx >= count) {
+        return;
+    }
+
+    // does this work if one of them is an unsigned long long?
+    atomicAdd(out + idx, lambda*buffer[idx]);
+
+}
+
+__global__ void k_reduce_add_du_dl(
+    double *du_dl,
+    double *u_buf,
+    double *du_dl_buf,
+    double lambda) {
+
+    if(threadIdx.x == 0) {
+        atomicAdd(du_dl, u_buf[0] + lambda*du_dl_buf[0]);
+    }
+
+}
+
+
+LambdaPotential::LambdaPotential(
+    std::shared_ptr<Potential> u,
+    int N,
+    int P
+) : u_(u) {
+
+    gpuErrchk(cudaMalloc(&d_du_dx_buffer_, N*3*sizeof(*d_du_dx_buffer_)));
+    gpuErrchk(cudaMalloc(&d_du_dp_buffer_, P*sizeof(*d_du_dp_buffer_)));
+    gpuErrchk(cudaMalloc(&d_du_dl_buffer_, 1*sizeof(*d_du_dl_buffer_)));
+    gpuErrchk(cudaMalloc(&d_u_buffer_, 1*sizeof(*d_u_buffer_)));
+
+}
+
+LambdaPotential::~LambdaPotential() {
+    gpuErrchk(cudaFree(d_du_dx_buffer_));
+    gpuErrchk(cudaFree(d_du_dp_buffer_));
+    gpuErrchk(cudaFree(d_du_dl_buffer_));
+    gpuErrchk(cudaFree(d_u_buffer_));
+}
+
+void LambdaPotential::execute_device(
+    const int N,
+    const int P,
+    const double *d_x,
+    const double *d_p,
+    const double *d_box,
+    const double lambda,
+    unsigned long long *d_du_dx,
+    double *d_du_dp,
+    double *d_du_dl,
+    double *d_u,
+    cudaStream_t stream) {
+
+    // initialize buffer streams
+
+    if(d_du_dx) {
+       gpuErrchk(cudaMemsetAsync(d_du_dx_buffer_, 0, N*3*sizeof(*d_du_dx_buffer_), stream))
+    }
+
+    if(d_du_dp) {
+       gpuErrchk(cudaMemsetAsync(d_du_dp_buffer_, 0, P*sizeof(*d_du_dp_buffer_), stream))
+    }
+
+    if(d_du_dl) {
+        gpuErrchk(cudaMemsetAsync(d_du_dl_buffer_, 0, 1*sizeof(*d_du_dl_buffer_)));
+    }
+
+    // extra check is due to the chain rule
+    if(d_u || d_du_dl) {
+        gpuErrchk(cudaMemsetAsync(d_u_buffer_, 0, 1*sizeof(*d_u_buffer_)));
+    }
+
+    // let the alchemical potential a(l) be:
+    // a(l) = l*u(l)
+    // da/dl = u + l*du/dl
+    u_->execute_device(
+        N,
+        P,
+        d_x,
+        d_p,
+        d_box,
+        lambda,
+        d_du_dx ? d_du_dx_buffer_ : nullptr,
+        d_du_dp ? d_du_dp_buffer_ : nullptr,
+        d_du_dl ? d_du_dl_buffer_ : nullptr,
+        (d_du_dl || d_u) ? d_u_buffer_ : nullptr,
+        stream
+    );
+
+    int tpb = 32;
+
+    if(d_du_dx) {
+        int count = N*3;
+        int blocks = (count + tpb - 1)/tpb;
+        k_reduce_add_force_buffer<<<blocks, tpb, 0, stream>>>(count, d_du_dx, d_du_dx_buffer_, lambda);
+    }
+
+    if(d_du_dp) {
+        int blocks = (P + tpb - 1)/tpb;
+        k_reduce_add_buffer<<<blocks, tpb, 0, stream>>>(P, d_du_dp, d_du_dp_buffer_, lambda);
+    }
+
+    if(d_du_dl) {
+        k_reduce_add_du_dl<<<1, tpb, 0, stream>>>(d_du_dl, d_u_buffer_, d_du_dl_buffer_, lambda);
+    }
+
+    if(d_u) {
+        k_reduce_add_buffer<<<1, tpb, 0, stream>>>(1, d_u, d_u_buffer_, lambda);
+    }
+
+}
+
+}

--- a/timemachine/cpp/src/lambda_potential.hpp
+++ b/timemachine/cpp/src/lambda_potential.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "potential.hpp"
+
+#include <memory>
+#include <typeinfo>
+
+namespace timemachine {
+
+class LambdaPotential : public Potential {
+
+private:
+
+    std::shared_ptr<Potential> u_;
+
+    unsigned long long *d_du_dx_buffer_;
+    double *d_du_dp_buffer_;
+    double *d_du_dl_buffer_;
+    double *d_u_buffer_;
+
+public: 
+
+    LambdaPotential(
+        std::shared_ptr<Potential> u,
+        int N,
+        int P
+    );
+
+    ~LambdaPotential();
+
+    virtual void execute_device(
+        const int N,
+        const int P,
+        const double *d_x,
+        const double *d_p,
+        const double *d_box,
+        const double lambda,
+        unsigned long long *d_du_dx,
+        double *d_du_dp,
+        double *d_du_dl,
+        double *d_u,
+        cudaStream_t stream
+    ) override;
+
+};
+
+}

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -8,6 +8,7 @@
 #include "bound_potential.hpp"
 #include "harmonic_bond.hpp"
 #include "harmonic_angle.hpp"
+#include "lambda_potential.hpp"
 // #include "restraint.hpp"
 #include "centroid_restraint.hpp"
 #include "periodic_torsion.hpp"
@@ -629,6 +630,31 @@ void declare_periodic_torsion(py::module &m, const char *typestr) {
 
 }
 
+void declare_lambda_potential(py::module &m) {
+
+    using Class = timemachine::LambdaPotential;
+    std::string pyclass_name = std::string("LambdaPotential");
+    py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+        m,
+        pyclass_name.c_str(),
+        py::buffer_protocol(),
+        py::dynamic_attr()
+    )
+    .def(py::init([](
+        std::shared_ptr<timemachine::Potential> potential,
+        int N,
+        int P) {
+
+        return new timemachine::LambdaPotential(
+            potential,
+            N,
+            P
+        );
+
+    }
+    ));
+
+}
 
 template <typename RealType>
 void declare_nonbonded(py::module &m, const char *typestr) {
@@ -844,6 +870,7 @@ PYBIND11_MODULE(custom_ops, m) {
 
     declare_potential(m);
     declare_bound_potential(m);
+    declare_lambda_potential(m);
 
     declare_neighborlist<double>(m, "f64");
     declare_neighborlist<float>(m, "f32");

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -56,6 +56,23 @@ class CustomOpWrapper():
 class LambdaPotential():
 
     def __init__(self, u_fn, N, P):
+        """
+        Implements a scaled lambda potential where u_fn is transformed according to:
+
+        lambda*u_fn(lambda)
+
+        Parameters
+        ----------
+        u_fn: potential energy function/class
+            one of the potentials in this file.
+
+        N: int
+            number of atoms in the system
+
+        P: int
+            number of parameters used by u_fn
+
+        """
         self.u_fn = u_fn
         self.N = N
         self.P = P

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -22,8 +22,7 @@ from timemachine.lib import custom_ops
 #             self.params
 #         )
 
-
-
+BoundPotential = custom_ops.BoundPotential
 
 class CustomOpWrapper():
 
@@ -54,6 +53,31 @@ class CustomOpWrapper():
 
         return custom_ops.BoundPotential(self.unbound_impl(), self.params)
 
+class LambdaPotential():
+
+    def __init__(self, u_fn, N, P):
+        self.u_fn = u_fn
+        self.N = N
+        self.P = P
+        self.params = None
+
+    def bind(self, params):
+        self.params = params
+        return self
+
+    def unbound_impl(self):
+
+        return custom_ops.LambdaPotential(
+            self.u_fn.unbound_impl(),
+            self.N,
+            self.P
+        )
+
+    def bound_impl(self):
+        if self.params is None:
+            raise ValueError("This op has not been bound to parameters.")
+
+        return custom_ops.BoundPotential(self.unbound_impl(), self.params)
 
 class HarmonicBond(CustomOpWrapper):
     pass


### PR DESCRIPTION
This PR adds a wrapper class called Lambda Potential that implements:

``` python
def lambda_potential(conf, params, box, lamb, u_fn):
    return lamb * u_fn(conf, params, box, lamb)
```

We can probably add a switch flag so that ```lamb*u``` becomes ```-lamb*u```, which would enable us to implement the complement:

```
(1-lambda)*u_fn
= u_fn - lambda*u_fn
```

The tests also ensure that the chain rule works properly in the event that u is a function lambda.

