### PR TITLE
Add sign to lambda potential

### DIFF
--- a/timemachine/cpp/src/lambda_potential.cu
+++ b/timemachine/cpp/src/lambda_potential.cu
@@ -50,10 +50,11 @@ __global__ void k_reduce_add_du_dl(
     double *du_dl,
     double *u_buf,
     double *du_dl_buf,
+    int sign,
     double lambda) {
 
     if(threadIdx.x == 0) {
-        atomicAdd(du_dl, u_buf[0] + lambda*du_dl_buf[0]);
+        atomicAdd(du_dl, (u_buf[0] + lambda*du_dl_buf[0])*sign);
     }
 
 }
@@ -62,8 +63,8 @@ __global__ void k_reduce_add_du_dl(
 LambdaPotential::LambdaPotential(
     std::shared_ptr<Potential> u,
     int N,
-    int P
-) : u_(u) {
+    int P,
+    int sign) : u_(u), sign_(sign) {
 
     gpuErrchk(cudaMalloc(&d_du_dx_buffer_, N*3*sizeof(*d_du_dx_buffer_)));
     gpuErrchk(cudaMalloc(&d_du_dp_buffer_, P*sizeof(*d_du_dp_buffer_)));
@@ -133,20 +134,20 @@ void LambdaPotential::execute_device(
     if(d_du_dx) {
         int count = N*3;
         int blocks = (count + tpb - 1)/tpb;
-        k_reduce_add_force_buffer<<<blocks, tpb, 0, stream>>>(count, d_du_dx, d_du_dx_buffer_, lambda);
+        k_reduce_add_force_buffer<<<blocks, tpb, 0, stream>>>(count, d_du_dx, d_du_dx_buffer_, sign_*lambda);
     }
 
     if(d_du_dp) {
         int blocks = (P + tpb - 1)/tpb;
-        k_reduce_add_buffer<<<blocks, tpb, 0, stream>>>(P, d_du_dp, d_du_dp_buffer_, lambda);
+        k_reduce_add_buffer<<<blocks, tpb, 0, stream>>>(P, d_du_dp, d_du_dp_buffer_, sign_*lambda);
     }
 
     if(d_du_dl) {
-        k_reduce_add_du_dl<<<1, tpb, 0, stream>>>(d_du_dl, d_u_buffer_, d_du_dl_buffer_, lambda);
+        k_reduce_add_du_dl<<<1, tpb, 0, stream>>>(d_du_dl, d_u_buffer_, d_du_dl_buffer_, sign_, lambda);
     }
 
     if(d_u) {
-        k_reduce_add_buffer<<<1, tpb, 0, stream>>>(1, d_u, d_u_buffer_, lambda);
+        k_reduce_add_buffer<<<1, tpb, 0, stream>>>(1, d_u, d_u_buffer_, sign_*lambda);
     }
 
 }

--- a/timemachine/cpp/src/lambda_potential.hpp
+++ b/timemachine/cpp/src/lambda_potential.hpp
@@ -18,12 +18,15 @@ private:
     double *d_du_dl_buffer_;
     double *d_u_buffer_;
 
+    int sign_;
+
 public: 
 
     LambdaPotential(
         std::shared_ptr<Potential> u,
         int N,
-        int P
+        int P,
+        int sign
     );
 
     ~LambdaPotential();

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -643,12 +643,14 @@ void declare_lambda_potential(py::module &m) {
     .def(py::init([](
         std::shared_ptr<timemachine::Potential> potential,
         int N,
-        int P) {
+        int P,
+        int sign) {
 
         return new timemachine::LambdaPotential(
             potential,
             N,
-            P
+            P,
+            sign
         );
 
     }

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -55,11 +55,11 @@ class CustomOpWrapper():
 
 class LambdaPotential():
 
-    def __init__(self, u_fn, N, P):
+    def __init__(self, u_fn, N, P, sign):
         """
         Implements a scaled lambda potential where u_fn is transformed according to:
 
-        lambda*u_fn(lambda)
+        sign*lambda*u_fn(lambda)
 
         Parameters
         ----------
@@ -72,10 +72,14 @@ class LambdaPotential():
         P: int
             number of parameters used by u_fn
 
+        sign: int
+            which direction we compute the offset
+
         """
         self.u_fn = u_fn
         self.N = N
         self.P = P
+        self.sign = sign
         self.params = None
 
     def bind(self, params):
@@ -87,7 +91,8 @@ class LambdaPotential():
         return custom_ops.LambdaPotential(
             self.u_fn.unbound_impl(),
             self.N,
-            self.P
+            self.P,
+            self.sign
         )
 
     def bound_impl(self):


### PR DESCRIPTION
This PR was requested by @dominicrufa in order to implement a linear scaling scheme:

```
(1-lambda)*U0(lambda) + lambda*U1(lambda)
```
We can decompose this into building blocks of the form:
```
(1-lambda)*U0(lambda) + lambda*U1(lambda)
= U0(lambda) - lambda*U0(lambda) + lambda*U1(lambda)
= U0(lambda) + signed_lambda_potential(U0, lambda, -1) + signed_lambda_potential(U1, lambda, 1)
```
It is 33% more expensive but for the types of simulations that @dominicrufa is interested in it probably doesn't matter.

