### PR TITLE
Allow plane_idxs to be set in order to make ligand non-interacting.

### DIFF
--- a/docking/dock_setup.py
+++ b/docking/dock_setup.py
@@ -131,10 +131,15 @@ def combine_potentials(guest_ff_handlers, guest_mol, host_system, precision):
 
     # allow the ligand to be alchemically decoupled
     # a value of one indicates that we allow the atom to be adjusted by the lambda value
+    guest_lambda_plane_idxs = np.zeros(len(guest_masses), dtype=np.int32)
     guest_lambda_offset_idxs = np.ones(len(guest_masses), dtype=np.int32)
 
     # use same scale factors until we modify 1-4s for electrostatics
     guest_scale_factors = np.stack([guest_scale_factors, guest_scale_factors], axis=1)
+
+    combined_lambda_plane_idxs = np.concatenate(
+        [host_nb_bp.get_lambda_plane_idxs(), guest_lambda_plane_idxs]
+    )
 
     combined_lambda_offset_idxs = np.concatenate(
         [host_nb_bp.get_lambda_offset_idxs(), guest_lambda_offset_idxs]
@@ -164,6 +169,7 @@ def combine_potentials(guest_ff_handlers, guest_mol, host_system, precision):
         potentials.Nonbonded(
             combined_exclusion_idxs,
             combined_scales,
+            combined_lambda_plane_idxs,
             combined_lambda_offset_idxs,
             combined_beta,
             combined_cutoff,

--- a/ff/handlers/openmm_deserializer.py
+++ b/ff/handlers/openmm_deserializer.py
@@ -182,6 +182,7 @@ def deserialize_system(
 
             exclusion_idxs = np.array(exclusion_idxs, dtype=np.int32)
 
+            lambda_plane_idxs = np.zeros(N, dtype=np.int32)
             lambda_offset_idxs = np.zeros(N, dtype=np.int32)
 
             # cutoff = 1000.0
@@ -203,6 +204,7 @@ def deserialize_system(
             bps.append(potentials.Nonbonded(
                 exclusion_idxs,
                 scale_factors,
+                lambda_plane_idxs,
                 lambda_offset_idxs,
                 beta,
                 cutoff,

--- a/tests/common.py
+++ b/tests/common.py
@@ -113,6 +113,7 @@ def prepare_lj_system(
 
 def prepare_water_system(
     x,
+    lambda_plane_idxs,
     lambda_offset_idxs,
     p_scale,
     cutoff,
@@ -154,6 +155,7 @@ def prepare_water_system(
     test_potential = potentials.Nonbonded(
         exclusion_idxs,
         scales,
+        lambda_plane_idxs,
         lambda_offset_idxs,
         beta,
         cutoff,
@@ -177,6 +179,7 @@ def prepare_water_system(
         scales=scales,
         beta=beta,
         cutoff=cutoff,
+        lambda_plane_idxs=lambda_plane_idxs,
         lambda_offset_idxs=lambda_offset_idxs
     )
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -189,6 +189,7 @@ def prepare_water_system(
 def prepare_nb_system(
     x,
     E, # number of exclusions
+    lambda_plane_idxs,
     lambda_offset_idxs,
     p_scale,
     cutoff,
@@ -218,6 +219,7 @@ def prepare_nb_system(
     test_potential = potentials.Nonbonded(
         exclusion_idxs,
         scales,
+        lambda_plane_idxs,
         lambda_offset_idxs,
         beta,
         cutoff,
@@ -241,6 +243,7 @@ def prepare_nb_system(
         scales=scales,
         beta=beta,
         cutoff=cutoff,
+        lambda_plane_idxs=lambda_plane_idxs,
         lambda_offset_idxs=lambda_offset_idxs
     )
 

--- a/tests/test_lambda_potential.py
+++ b/tests/test_lambda_potential.py
@@ -38,6 +38,7 @@ class TestLambdaPotential(GradientTest):
 
         N = coords.shape[0]
 
+        lambda_plane_idxs = np.random.randint(low=0, high=2, size=N, dtype=np.int32)
         lambda_offset_idxs = np.random.randint(low=0, high=2, size=N, dtype=np.int32)
 
         for sign in [2, 1, -1, 3]:
@@ -47,6 +48,7 @@ class TestLambdaPotential(GradientTest):
                     # E = 0 # DEBUG!
                     charge_params, ref_potential, test_potential = prepare_water_system(
                         coords,
+                        lambda_plane_idxs,
                         lambda_offset_idxs,
                         p_scale=1.0,
                         cutoff=cutoff,

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -36,11 +36,13 @@ class TestContext(unittest.TestCase):
 
         E = 2
 
+        lambda_plane_idxs = np.random.randint(low=0, high=2, size=N, dtype=np.int32)
         lambda_offset_idxs = np.random.randint(low=0, high=2, size=N, dtype=np.int32)
 
         params, ref_nrg_fn, test_nrg = prepare_nb_system(
             x0,
             E,
+            lambda_plane_idxs,
             lambda_offset_idxs,
             p_scale=3.0,
             # cutoff=0.5,
@@ -164,8 +166,8 @@ class TestContext(unittest.TestCase):
         # the fixed point accumulator makes it hard to converge some of these
         # if the derivative is super small - in which case they probably don't matter
         # anyways
-        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 0], ref_avg_du_dps[:, 0], 1e-6)
-        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 1], ref_avg_du_dps[:, 1], 1e-6)
+        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 0], ref_avg_du_dps[:, 0], 1.5e-6)
+        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 1], ref_avg_du_dps[:, 1], 1.5e-6)
         np.testing.assert_allclose(test_obs.avg_du_dp()[:, 2], ref_avg_du_dps[:, 2], 5e-5)
 
 

--- a/tests/test_nonbonded.py
+++ b/tests/test_nonbonded.py
@@ -76,6 +76,7 @@ class TestNonbonded(GradientTest):
 
         beta = 2.0
 
+        lambda_plane_idxs = np.random.randint(low=0, high=2, size=N, dtype=np.int32)
         lambda_offset_idxs = np.random.randint(low=0, high=2, size=N, dtype=np.int32)
 
         cutoff = 1.0
@@ -85,6 +86,7 @@ class TestNonbonded(GradientTest):
             test_u = potentials.Nonbonded(
                 exclusion_idxs,
                 scales,
+                lambda_plane_idxs,
                 lambda_offset_idxs,
                 beta,
                 cutoff,
@@ -108,6 +110,7 @@ class TestNonbonded(GradientTest):
                 scales=scales,
                 beta=beta,
                 cutoff=cutoff,
+                lambda_plane_idxs=lambda_plane_idxs,
                 lambda_offset_idxs=lambda_offset_idxs
             )
 
@@ -156,6 +159,7 @@ class TestNonbonded(GradientTest):
 
                 N = coords.shape[0]
 
+                lambda_plane_idxs = np.random.randint(low=0, high=2, size=N, dtype=np.int32)
                 lambda_offset_idxs = np.random.randint(low=0, high=2, size=N, dtype=np.int32)
 
                 for precision, rtol in [(np.float64, 1e-8), (np.float32, 1e-4)]:
@@ -164,6 +168,7 @@ class TestNonbonded(GradientTest):
                         # E = 0 # DEBUG!
                         charge_params, ref_potential, test_potential = prepare_water_system(
                             coords,
+                            lambda_plane_idxs,
                             lambda_offset_idxs,
                             p_scale=1.0,
                             cutoff=cutoff,

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -295,7 +295,9 @@ void __global__ k_nonbonded(
 
         RealType d2ij = delta_x*delta_x + delta_y*delta_y + delta_z*delta_z + delta_w*delta_w;
 
-        // remember the eps_i != 0
+        // (ytz): note that d2ij must be *strictly* less than cutoff_squared. This is because we set the
+        // non-interacting atoms to exactly cutoff*cutoff. This ensures that atoms who's 4th dimension
+        // is set to cutoff are non-interacting.
         if(d2ij < cutoff_squared  && atom_j_idx > atom_i_idx && atom_j_idx < N && atom_i_idx < N) {
 
             // electrostatics
@@ -530,6 +532,7 @@ void __global__ k_nonbonded_exclusions(
 
     unsigned long long energy = 0;
 
+    // see note: this must be strictly less than
     if(d2ij < cutoff_squared) {
 
         RealType dij = sqrt(d2ij);

--- a/timemachine/cpp/src/nonbonded.hpp
+++ b/timemachine/cpp/src/nonbonded.hpp
@@ -13,6 +13,7 @@ private:
 
     int *d_exclusion_idxs_; // [E,2]
     double *d_scales_; // [E, 2]
+    int *d_lambda_plane_idxs_;
     int *d_lambda_offset_idxs_;
     int *p_ixn_count_; // pinned memory
 
@@ -35,6 +36,7 @@ private:
 
     unsigned int *d_perm_; // hilbert curve permutation
 
+    int *d_sorted_lambda_plane_idxs_;
     int *d_sorted_lambda_offset_idxs_;
     double *d_sorted_x_; //
     double *d_sorted_p_; //
@@ -60,6 +62,7 @@ public:
     Nonbonded(
         const std::vector<int> &exclusion_idxs, // [E,2]
         const std::vector<double> &scales, // [E, 2]
+        const std::vector<int> &lambda_plane_idxs, // N
         const std::vector<int> &lambda_offset_idxs, // N
         double beta,
         double cutoff

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -672,6 +672,7 @@ void declare_nonbonded(py::module &m, const char *typestr) {
     .def(py::init([](
         const py::array_t<int, py::array::c_style> &exclusion_i,  // [E, 2] comprised of elements from N
         const py::array_t<double, py::array::c_style> &scales_i,  // [E, 2]
+        const py::array_t<int, py::array::c_style> &lambda_plane_idxs_i, //
         const py::array_t<int, py::array::c_style> &lambda_offset_idxs_i, //
         double beta,
         double cutoff) {
@@ -682,12 +683,16 @@ void declare_nonbonded(py::module &m, const char *typestr) {
         std::vector<double> scales(scales_i.size());
         std::memcpy(scales.data(), scales_i.data(), scales_i.size()*sizeof(double));
 
+        std::vector<int> lambda_plane_idxs(lambda_plane_idxs_i.size());
+        std::memcpy(lambda_plane_idxs.data(), lambda_plane_idxs_i.data(), lambda_plane_idxs_i.size()*sizeof(int));
+
         std::vector<int> lambda_offset_idxs(lambda_offset_idxs_i.size());
         std::memcpy(lambda_offset_idxs.data(), lambda_offset_idxs_i.data(), lambda_offset_idxs_i.size()*sizeof(int));
 
         return new timemachine::Nonbonded<RealType>(
             exclusion_idxs,
             scales,
+            lambda_plane_idxs,
             lambda_offset_idxs,
             beta,
             cutoff

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -136,11 +136,11 @@ class NonbondedCustomOpWrapper(CustomOpWrapper):
     def get_scale_factors(self):
         return self.args[1]
 
-    # def get_lambda_plane_idxs(self):
-    #     return self.args[2]
+    def get_lambda_plane_idxs(self):
+        return self.args[2]
 
     def get_lambda_offset_idxs(self):
-        return self.args[2]
+        return self.args[3]
 
     def get_cutoff(self):
         return self.args[-1]

--- a/timemachine/potentials/gbsa.py
+++ b/timemachine/potentials/gbsa.py
@@ -3,7 +3,7 @@
 
 import jax.numpy as np
 from jax import grad, jit
-from timemachine.potentials.jax_utils import delta_r, distance, lambda_to_w, convert_to_4d
+from timemachine.potentials.jax_utils import delta_r, distance, convert_to_4d
 
 def step(x):
     # return (x > 0)

--- a/timemachine/potentials/jax_utils.py
+++ b/timemachine/potentials/jax_utils.py
@@ -1,13 +1,14 @@
 import jax.numpy as np
 
 
-def lambda_to_w(lamb, offset_idxs):
-    # d4 = cutoff*(plane_idxs + offset_idxs*lamb)
-    d4 = offset_idxs*lamb
-    return d4
+# def lambda_to_w(lamb, plane_idxs, offset_idxs, cutoff):
+#     d4 = cutoff*plane_idxs + offset_idxs*lamb
+#     # d4 = offset_idxs*lamb
+#     return d4
 
-def convert_to_4d(x3, lamb, lambda_offset_idxs):
-    d4 = lambda_to_w(lamb, lambda_offset_idxs)
+def convert_to_4d(x3, lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff):
+    # d4 = lambda_to_w(lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff)
+    d4 = cutoff*lambda_plane_idxs + lambda_offset_idxs*lamb
     d4 = np.expand_dims(d4, axis=-1)
     x4 = np.concatenate((x3, d4), axis=1)
     return x4

--- a/timemachine/potentials/nonbonded.py
+++ b/timemachine/potentials/nonbonded.py
@@ -4,7 +4,9 @@ from jax.scipy.special import erf, erfc
 from jax.ops import index_update, index
 
 from timemachine.constants import ONE_4PI_EPS0
-from timemachine.potentials.jax_utils import delta_r, distance, lambda_to_w, convert_to_4d
+from timemachine.potentials.jax_utils import delta_r, distance, convert_to_4d
+
+
 
 
 def switch_fn(dij, cutoff):
@@ -123,11 +125,12 @@ def nonbonded_v3(
     scales,
     beta,
     cutoff,
+    lambda_plane_idxs,
     lambda_offset_idxs):
     
     N = conf.shape[0]
 
-    conf = convert_to_4d(conf, lamb, lambda_offset_idxs)
+    conf = convert_to_4d(conf, lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff)
 
     # make 4th dimension of box large enough so its roughly aperiodic
     if box is not None:


### PR DESCRIPTION
This PR modifies nonbonded interaction to allow setting atom i's 4th dimensional coordinate to cutoff*lambda_plane_idxs[i]

Before, the 4th dimension is computed as:

``` python
d4 = lambda_offset_idxs[i]*lamb
```
It is now modified to:

```
d4 = cutoff*lambda_plane_idxs[i] + lambda_offset_idxs[i]*lamb
```
pose_dock.py has also been modified - though the behavior is identical to that of before.

The use case for this is being able to be able to implement an alchemical restraint stage where a ligand with K atoms that is non-interacting with the rest of the system *without* having to introduce exclusions via K against (N-K) pairlist. 
