### PR TITLE
Changes to lambda potential

### DIFF
--- a/timemachine/cpp/src/lambda_potential.hpp
+++ b/timemachine/cpp/src/lambda_potential.hpp
@@ -18,7 +18,8 @@ private:
     double *d_du_dl_buffer_;
     double *d_u_buffer_;
 
-    int sign_;
+    double multiplier_;
+    double offset_;
 
 public: 
 
@@ -26,7 +27,8 @@ public:
         std::shared_ptr<Potential> u,
         int N,
         int P,
-        int sign
+        double multiplier,
+        double offset
     );
 
     ~LambdaPotential();

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -644,13 +644,15 @@ void declare_lambda_potential(py::module &m) {
         std::shared_ptr<timemachine::Potential> potential,
         int N,
         int P,
-        int sign) {
+        double multiplier,
+        double offset) {
 
         return new timemachine::LambdaPotential(
             potential,
             N,
             P,
-            sign
+            multiplier,
+            offset
         );
 
     }

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -55,11 +55,11 @@ class CustomOpWrapper():
 
 class LambdaPotential():
 
-    def __init__(self, u_fn, N, P, sign):
+    def __init__(self, u_fn, N, P, multiplier, offset):
         """
         Implements a scaled lambda potential where u_fn is transformed according to:
 
-        sign*lambda*u_fn(lambda)
+        (multiplier*lambda + offset)*u_fn(lambda)
 
         Parameters
         ----------
@@ -72,14 +72,15 @@ class LambdaPotential():
         P: int
             number of parameters used by u_fn
 
-        sign: int
+        sign: mul
             which direction we compute the offset
 
         """
         self.u_fn = u_fn
         self.N = N
         self.P = P
-        self.sign = sign
+        self.multiplier = multiplier
+        self.offset = offset
         self.params = None
 
     def bind(self, params):
@@ -92,7 +93,8 @@ class LambdaPotential():
             self.u_fn.unbound_impl(),
             self.N,
             self.P,
-            self.sign
+            self.multiplier,
+            self.offset
         )
 
     def bound_impl(self):


### PR DESCRIPTION
This PR changes the LambdaPotential to be more general, it used to be

```
u = sign*lambda*u_fn(lambda)
```

Where sign is an int.

For sake of flexibility it is now more general:

```
u = (multiplier*lambda+offset)*u_fn(lambda)
```

To implement (1-lambda)*u_fn + lambda*u_fn one would implement 2 lambda potentials:

```
LHS has multiplier=-1, offset =1
RHS has multiplier=1, offset=0
```