### PR TITLE
Move precision arg to impl calls

### DIFF
--- a/docking/dock_setup.py
+++ b/docking/dock_setup.py
@@ -14,7 +14,7 @@ def combine_parameters(guest_q, guest_lj, host_qlj):
     return np.concatenate([host_qlj, guest_qlj])
 
 
-def combine_potentials(guest_ff_handlers, guest_mol, host_system, precision):
+def combine_potentials(guest_ff_handlers, guest_mol, host_system):
     """
     This function is responsible for figuring out how to take two separate hamiltonians
     and combining them into one sensible alchemical system.
@@ -31,9 +31,6 @@ def combine_potentials(guest_ff_handlers, guest_mol, host_system, precision):
     host_system: openmm.System
         Host system to be deserialized
 
-    precision: np.float32 or np.float64
-        Numerical precision of the functional form
-
     Returns
     -------
     tuple
@@ -43,7 +40,7 @@ def combine_potentials(guest_ff_handlers, guest_mol, host_system, precision):
     """
 
     host_potentials, host_masses = openmm_deserializer.deserialize_system(
-        host_system, precision, cutoff=1.0
+        host_system, cutoff=1.0
     )
     host_nb_bp = None
 
@@ -72,7 +69,7 @@ def combine_potentials(guest_ff_handlers, guest_mol, host_system, precision):
             bond_idxs, (bond_params, vjp_fn) = results
             bond_idxs += num_host_atoms
             combined_potentials.append(
-                potentials.HarmonicBond(bond_idxs, precision=precision).bind(
+                potentials.HarmonicBond(bond_idxs).bind(
                     bond_params
                 )
             )
@@ -81,7 +78,7 @@ def combine_potentials(guest_ff_handlers, guest_mol, host_system, precision):
             angle_idxs, (angle_params, vjp_fn) = results
             angle_idxs += num_host_atoms
             combined_potentials.append(
-                potentials.HarmonicAngle(angle_idxs, precision=precision).bind(
+                potentials.HarmonicAngle(angle_idxs).bind(
                     angle_params
                 )
             )
@@ -90,7 +87,7 @@ def combine_potentials(guest_ff_handlers, guest_mol, host_system, precision):
             torsion_idxs, (torsion_params, vjp_fn) = results
             torsion_idxs += num_host_atoms
             combined_potentials.append(
-                potentials.PeriodicTorsion(torsion_idxs, precision=precision).bind(
+                potentials.PeriodicTorsion(torsion_idxs).bind(
                     torsion_params
                 )
             )
@@ -99,7 +96,7 @@ def combine_potentials(guest_ff_handlers, guest_mol, host_system, precision):
             torsion_idxs, (torsion_params, vjp_fn) = results
             torsion_idxs += num_host_atoms
             combined_potentials.append(
-                potentials.PeriodicTorsion(torsion_idxs, precision=precision).bind(
+                potentials.PeriodicTorsion(torsion_idxs).bind(
                     torsion_params
                 )
             )
@@ -172,8 +169,7 @@ def combine_potentials(guest_ff_handlers, guest_mol, host_system, precision):
             combined_lambda_plane_idxs,
             combined_lambda_offset_idxs,
             combined_beta,
-            combined_cutoff,
-            precision=precision,
+            combined_cutoff
         ).bind(combined_nb_params)
     )
 

--- a/docking/pose_dock.py
+++ b/docking/pose_dock.py
@@ -81,7 +81,7 @@ def pose_dock(
         )
 
         bps, masses = dock_setup.combine_potentials(
-            guest_ff_handlers, guest_mol, host_system, np.float32
+            guest_ff_handlers, guest_mol, host_system
         )
         for atom_num in constant_atoms:
             masses[atom_num - 1] += 50000
@@ -112,8 +112,9 @@ def pose_dock(
         v0 = np.zeros_like(x0)
 
         impls = []
+        precision = np.float32
         for b in bps:
-            p_impl = b.bound_impl()
+            p_impl = b.bound_impl(precision)
             impls.append(p_impl)
 
         ctxt = custom_ops.Context(x0, v0, box, intg, impls)

--- a/ff/handlers/openmm_deserializer.py
+++ b/ff/handlers/openmm_deserializer.py
@@ -15,7 +15,6 @@ def value(quantity):
 
 def deserialize_system(
     system,
-    precision,
     cutoff):
     """
     Deserialize an OpenMM XML file
@@ -61,7 +60,7 @@ def deserialize_system(
 
             bond_idxs = np.array(bond_idxs, dtype=np.int32)
             bond_params = np.array(bond_params, dtype=np.float64)
-            bps.append(potentials.HarmonicBond(bond_idxs, precision=precision).bind(bond_params))
+            bps.append(potentials.HarmonicBond(bond_idxs).bind(bond_params))
 
         if isinstance(force, mm.HarmonicAngleForce):
 
@@ -80,7 +79,7 @@ def deserialize_system(
             angle_idxs = np.array(angle_idxs, dtype=np.int32)
             angle_params = np.array(angle_params, dtype=np.float64)
 
-            bps.append(potentials.HarmonicAngle(angle_idxs, precision=precision).bind(angle_params))
+            bps.append(potentials.HarmonicAngle(angle_idxs).bind(angle_params))
 
         if isinstance(force, mm.PeriodicTorsionForce):
 
@@ -98,7 +97,7 @@ def deserialize_system(
 
             torsion_idxs = np.array(torsion_idxs, dtype=np.int32)
             torsion_params = np.array(torsion_params, dtype=np.float64)
-            bps.append(potentials.PeriodicTorsion(torsion_idxs, precision=precision).bind(torsion_params))
+            bps.append(potentials.PeriodicTorsion(torsion_idxs).bind(torsion_params))
 
         if isinstance(force, mm.NonbondedForce):
 
@@ -207,8 +206,7 @@ def deserialize_system(
                 lambda_plane_idxs,
                 lambda_offset_idxs,
                 beta,
-                cutoff,
-                precision=precision).bind(nb_params)
+                cutoff).bind(nb_params)
             )
 
             # nrg_fns.append(('Exclusions', (exclusion_idxs, scale_factors, es_scale_factors)))

--- a/tests/common.py
+++ b/tests/common.py
@@ -116,8 +116,7 @@ def prepare_water_system(
     lambda_plane_idxs,
     lambda_offset_idxs,
     p_scale,
-    cutoff,
-    precision=np.float64):
+    cutoff):
 
     N = x.shape[0]
     D = x.shape[1]
@@ -158,8 +157,7 @@ def prepare_water_system(
         lambda_plane_idxs,
         lambda_offset_idxs,
         beta,
-        cutoff,
-        precision=precision
+        cutoff
     )
 
     charge_rescale_mask = np.ones((N, N))
@@ -192,8 +190,7 @@ def prepare_nb_system(
     lambda_plane_idxs,
     lambda_offset_idxs,
     p_scale,
-    cutoff,
-    precision=np.float64):
+    cutoff):
 
     N = x.shape[0]
     D = x.shape[1]
@@ -222,8 +219,7 @@ def prepare_nb_system(
         lambda_plane_idxs,
         lambda_offset_idxs,
         beta,
-        cutoff,
-        precision=precision
+        cutoff
     )
 
     charge_rescale_mask = np.ones((N, N))
@@ -443,9 +439,10 @@ class GradientTest(unittest.TestCase):
         ref_potential,
         test_potential,
         rtol,
+        precision,
         benchmark=False):
 
-        test_potential = test_potential.unbound_impl()
+        test_potential = test_potential.unbound_impl(precision)
 
         x = (x.astype(np.float32)).astype(np.float64)
         params = (params.astype(np.float32)).astype(np.float64)

--- a/tests/test_bonded.py
+++ b/tests/test_bonded.py
@@ -51,8 +51,7 @@ class TestBonded(GradientTest):
                 gbi,
                 masses,
                 kb,
-                b0,
-                precision=precision
+                b0
             )
 
             params = np.array([], dtype=np.float64)
@@ -65,7 +64,8 @@ class TestBonded(GradientTest):
                 lamb,
                 ref_nrg,
                 test_nrg,
-                rtol
+                rtol,
+                precision=precision
             )
 
 
@@ -88,11 +88,7 @@ class TestBonded(GradientTest):
         lamb = 0.0
 
         for precision, rtol in [(np.float32, 4e-5), (np.float64, 1e-9)]:
-            test_potential = potentials.HarmonicBond(
-                bond_idxs,
-                precision=precision
-            )
-
+            test_potential = potentials.HarmonicBond(bond_idxs)
             ref_potential = functools.partial(
                 bonded.harmonic_bond,
                 bond_idxs=bond_idxs
@@ -110,7 +106,8 @@ class TestBonded(GradientTest):
                 lamb,
                 ref_potential,
                 test_potential,
-                rtol
+                rtol,
+                precision=precision
             )
 
     def test_harmonic_angle(self):
@@ -133,11 +130,7 @@ class TestBonded(GradientTest):
 
         for precision, rtol in [(np.float64, 1e-9), (np.float32, 2e-5)]:
             # print(precision, rtol)
-            test_potential = potentials.HarmonicAngle(
-                angle_idxs,
-                precision=precision
-            )
-
+            test_potential = potentials.HarmonicAngle(angle_idxs)
             ref_potential = functools.partial(bonded.harmonic_angle, angle_idxs=angle_idxs)
 
 
@@ -153,7 +146,8 @@ class TestBonded(GradientTest):
                 lamb,
                 ref_potential,
                 test_potential,
-                rtol
+                rtol,
+                precision=precision
             )
 
 
@@ -178,10 +172,7 @@ class TestBonded(GradientTest):
 
         for precision, rtol in [(np.float32, 2e-5), (np.float64, 1e-9)]:
 
-            test_potential = potentials.PeriodicTorsion(
-                torsion_idxs,
-                precision=precision
-            )
+            test_potential = potentials.PeriodicTorsion(torsion_idxs)
 
             # test the parameter derivatives for correctness.
             ref_potential = functools.partial(bonded.periodic_torsion, torsion_idxs=torsion_idxs)
@@ -195,5 +186,6 @@ class TestBonded(GradientTest):
                 lamb,
                 ref_potential,
                 test_potential,
-                rtol
+                rtol,
+                precision=precision
             )

--- a/tests/test_lambda_potential.py
+++ b/tests/test_lambda_potential.py
@@ -59,8 +59,7 @@ class TestLambdaPotential(GradientTest):
                                 lambda_plane_idxs,
                                 lambda_offset_idxs,
                                 p_scale=1.0,
-                                cutoff=cutoff,
-                                precision=precision
+                                cutoff=cutoff
                             )
 
                             print("lambda", lamb, "cutoff", cutoff, "precision", precision, "xshape", coords.shape)
@@ -85,5 +84,6 @@ class TestLambdaPotential(GradientTest):
                                 lamb,
                                 ref_potential,
                                 test_potential,
-                                rtol
+                                rtol,
+                                precision=precision
                             )

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -46,8 +46,7 @@ class TestContext(unittest.TestCase):
             lambda_offset_idxs,
             p_scale=3.0,
             # cutoff=0.5,
-            cutoff=100.0,
-            precision=np.float64
+            cutoff=100.0
         )
 
         masses = np.random.rand(N)
@@ -120,7 +119,7 @@ class TestContext(unittest.TestCase):
             1234
         )
 
-        bp = test_nrg.bind(params).bound_impl()
+        bp = test_nrg.bind(params).bound_impl(precision=np.float64)
         bps = [bp]
 
         ctxt = custom_ops.Context(

--- a/tests/test_nonbonded.py
+++ b/tests/test_nonbonded.py
@@ -89,8 +89,7 @@ class TestNonbonded(GradientTest):
                 lambda_plane_idxs,
                 lambda_offset_idxs,
                 beta,
-                cutoff,
-                precision=precision
+                cutoff
             )
 
             charge_rescale_mask = np.ones((N, N))
@@ -129,7 +128,8 @@ class TestNonbonded(GradientTest):
                 lamb,
                 ref_u,
                 test_u,
-                rtol
+                rtol,
+                precision=precision
             )
 
     def test_nonbonded(self):
@@ -171,8 +171,7 @@ class TestNonbonded(GradientTest):
                             lambda_plane_idxs,
                             lambda_offset_idxs,
                             p_scale=1.0,
-                            cutoff=cutoff,
-                            precision=precision
+                            cutoff=cutoff
                         )
 
                         for lamb in [0.0, 0.1, 0.2]:
@@ -187,6 +186,7 @@ class TestNonbonded(GradientTest):
                                 ref_potential,
                                 test_potential,
                                 rtol,
+                                precision=precision,
                                 benchmark=benchmark
                             )
 


### PR DESCRIPTION
This PR cleans up one of the warts with how we handle the precision argument in our custom ops. Previously the constructor arg in the python wrappers requires passing in precision. However, the precision of the calculation is really an implementation detail and should go into the unbound_impl() and bound_impl() calls instead. This simplifies the downstream logic of combining hamiltonians without having to worry about precision mismatch etc. 