### PR TITLE
Fix restraints and add a repeatability test

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -468,3 +468,12 @@ class GradientTest(unittest.TestCase):
 
         np.testing.assert_almost_equal(ref_du_dl, test_du_dl, rtol)
         np.testing.assert_almost_equal(ref_du_dp, test_du_dp, rtol)
+
+        # we should obtain the same result after calling the function twice.
+        # this checks to make sure that buffers etc are being cleaned properly in GPU code.
+        test_du_dx_2, test_du_dp_2, test_du_dl_2, test_u_2 = test_potential.execute(x, params, box, lamb)
+
+        np.testing.assert_array_equal(test_du_dx, test_du_dx_2)
+        np.testing.assert_array_equal(test_du_dp, test_du_dp_2)
+        np.testing.assert_array_equal(test_du_dl, test_du_dl_2)
+        np.testing.assert_array_equal(test_u, test_u_2)

--- a/timemachine/cpp/src/inertial_restraint.cu
+++ b/timemachine/cpp/src/inertial_restraint.cu
@@ -400,6 +400,12 @@ void InertialRestraint<RealType>::execute_device(
     grad_eigh(a_w, a_v, dl_da_v, dl_da_tensor);
     grad_eigh(b_w, b_v, dl_db_v, dl_db_tensor);
 
+    for(int i=0; i < h_c_idxs_.size(); i++) {
+        for(int d=0; d < 3; d++) {
+            h_conf_adjoint_[h_c_idxs_[i]*3+d] = 0;
+        }
+    }
+
     grad_inertia_tensor(N_A_, &h_a_idxs[0], &h_masses[0], &h_x_in[0], dl_da_tensor, &h_conf_adjoint_[0]);
     grad_inertia_tensor(N_B_, &h_b_idxs[0], &h_masses[0], &h_x_in[0], dl_db_tensor, &h_conf_adjoint_[0]);
 

--- a/timemachine/cpp/src/inertial_restraint.cu
+++ b/timemachine/cpp/src/inertial_restraint.cu
@@ -23,7 +23,7 @@ InertialRestraint<RealType>::InertialRestraint(
     h_b_idxs_(group_b_idxs),
     h_masses_(masses),
     h_x_buffer_(N_*3),
-    h_conf_adjoint_(N_*3, 0) {
+    h_conf_adjoint_(N_*3) {
 
     for(int i=0; i < group_a_idxs.size(); i++) {
         if(group_a_idxs[i] >= N_ || group_a_idxs[i] < 0) {


### PR DESCRIPTION
This PR fixes a bug in the restraints code not clearing the buffer after each invocation, resulting in bad things happening. It also adds a test to catch this sort of bad behavior in the future.

