### PR TITLE
[WIP] Reference Rigid Shape Restraints

### DIFF
--- a/examples/overlap_test.py
+++ b/examples/overlap_test.py
@@ -334,7 +334,7 @@ def convergence(args):
     print("start md")
     for step in range(100000):
         # print("step", step)
-        if step % 1000 == 0:
+        if step % 10000 == 0:
             u = u_fn(x_t, lamb)
             print("lambda", lamb, "step", step, "u", u, "avg du_dl", np.mean(onp.array(du_dls)))
             mol = make_conformer(combined_mol, x_t[:ligand_a.GetNumAtoms()], x_t[ligand_a.GetNumAtoms():])
@@ -371,7 +371,7 @@ def convergence(args):
 
 if __name__ == "__main__":
 
-    pool = multiprocessing.Pool() # defaults to # of cpus
+
 
     # lambda_schedule = np.linspace(0, 1.0, os.cpu_count())
     lambda_schedule = np.linspace(0, 1.0, 24)
@@ -388,11 +388,15 @@ if __name__ == "__main__":
         for l_idx, lamb in enumerate(lambda_schedule):
             args.append((epoch, lamb, l_idx))
 
-        # convergence(args[0])
-        # assert 0
+        convergence(args[-1])
+        assert 0
+
+        pool = multiprocessing.Pool() # defaults to # of cpus
 
         avg_du_dls = pool.map(convergence, args)
         avg_du_dls = np.asarray(avg_du_dls)
+
+        pool.close()
 
         for lamb, ddl in zip(lambda_schedule, avg_du_dls):
             print("final lambda", lamb, "du_dl",  ddl)

--- a/examples/overlap_test.py
+++ b/examples/overlap_test.py
@@ -317,7 +317,7 @@ def convergence(args):
 
     for step in range(100000):
 
-        if step % 500 == 0:
+        if step % 100 == 0:
             u = combined_u_fn(x_t, lamb)
             print("lambda", lamb, "step", step, "u", u, "avg du_dl", np.mean(onp.array(du_dls)))
             mol = make_conformer(combined_mol, x_t[:ligand_a.GetNumAtoms()], x_t[ligand_a.GetNumAtoms():])
@@ -355,7 +355,10 @@ if __name__ == "__main__":
         for l_idx, lamb in enumerate(lambda_schedule):
             args.append((epoch, lamb, l_idx))
 
-        # convergence(args[0])
+        convergence(args[0])
+
+        assert 0
+
         avg_du_dls = pool.map(convergence, args)
         avg_du_dls = np.asarray(avg_du_dls)
 

--- a/tests/test_rigid_shape.py
+++ b/tests/test_rigid_shape.py
@@ -79,10 +79,10 @@ def test_vjp():
         np.zeros(ligand_b.GetNumAtoms()) + prefactor,
     ], axis=1)
 
-    coords_a = coords_a[get_heavy_atom_idxs(ligand_a)]
-    params_a = params_a[get_heavy_atom_idxs(ligand_a)]
-    coords_b = coords_b[get_heavy_atom_idxs(ligand_b)]
-    params_b = params_b[get_heavy_atom_idxs(ligand_b)]
+    # coords_a = coords_a[get_heavy_atom_idxs(ligand_a)]
+    # params_a = params_a[get_heavy_atom_idxs(ligand_a)]
+    # coords_b = coords_b[get_heavy_atom_idxs(ligand_b)]
+    # params_b = params_b[get_heavy_atom_idxs(ligand_b)]
 
     coords_a = coords_a - np.mean(coords_a, axis=0)
     coords_b = coords_b - np.mean(coords_b, axis=0)
@@ -98,6 +98,8 @@ def test_vjp():
         # print(seed)
         # qi = Rotation.random(random_state=seed).as_quat()
         qi = Rotation.from_euler('zyx', [(np.random.rand()-0.5)*90, (np.random.rand()-0.5)*90, (np.random.rand()-0.5)*90], degrees=True).as_quat()
+
+        # switch to our convention for position of real component
         qi = np.array([qi[3], qi[0], qi[1], qi[2]])
         # print(qi)
         coords_r = rigid_shape.rotate(coords_b, qi)
@@ -105,10 +107,14 @@ def test_vjp():
         # conf = make_conformer(c_mol, coords_a, coords_r)
         # writer.write(conf)
 
-        po = rigid_shape.q_opt(coords_a, coords_r, params_a, params_b)
-        q_final = rigid_shape.q_from_p(po)
+        # po = rigid_shape.q_opt(coords_a, coords_r, params_a, params_b)
+        # q_final = rigid_shape.q_from_p(po)
+        # conf = make_conformer(c_mol, coords_a, rigid_shape.rotate(coords_r, q_final))
 
-        conf = make_conformer(c_mol, coords_a, rigid_shape.rotate(coords_r, q_final))
+        rot = rigid_shape.q_opt(coords_a, coords_r, params_a, params_b)
+        # q_final = rigid_shape.q_from_p(po)
+        conf = make_conformer(c_mol, coords_a, rigid_shape.rotate_euler(coords_r, rot))
+
         writer.write(conf)
 
     writer.close()
@@ -118,6 +124,7 @@ def test_vjp():
     # print(dq_dxa, dq_dxb)
 
     # print(po)
+
 
 # def test_minimize():
 

--- a/tests/test_rigid_shape.py
+++ b/tests/test_rigid_shape.py
@@ -98,6 +98,8 @@ def test_vjp():
 
     writer = Chem.SDWriter('quat.sdf')
 
+    trip_counts = []
+
     for seed in range(100):
         # seed = 361
         # print(seed)
@@ -116,8 +118,9 @@ def test_vjp():
         # q_final = rigid_shape.q_from_p(po)
         # conf = make_conformer(c_mol, coords_a, rigid_shape.rotate(coords_r, q_final))
 
-        rot = rigid_shape.q_opt(coords_a, coords_r, params_a, params_b)
-        print("done", rot)
+        rot, count = rigid_shape.bfgs_minimize(coords_a, coords_r, params_a, params_b)
+        trip_counts.append(count)
+        print("done", rot, "count", count)
         # assert 0
         # print(rot, converged)
         # q_final = rigid_shape.q_from_p(po)
@@ -125,6 +128,8 @@ def test_vjp():
 
 
         writer.write(conf)
+
+    print("mean", np.mean(trip_counts), "std", np.std(trip_counts), "max", np.amax(trip_counts), "min", np.amin(trip_counts))
 
     writer.close()
 

--- a/tests/test_rigid_shape.py
+++ b/tests/test_rigid_shape.py
@@ -1,0 +1,269 @@
+from jax.config import config; config.update("jax_enable_x64", True)
+import jax
+import functools
+
+from timemachine.potentials import rigid_shape
+from scipy.spatial.transform import Rotation
+import rmsd
+import numpy as np
+import time
+
+from rdkit import Chem
+
+def recenter(conf):
+    """Return copy of conf with mean coordinates subtracted"""
+    return conf - np.mean(conf, axis=0)
+
+def get_conf(romol, idx):
+    """Get the idx'th conformer of romol, in nanometers"""
+    conformer = romol.GetConformer(idx)
+    guest_conf = np.array(conformer.GetPositions(), dtype=np.float64)/10
+    return recenter(guest_conf)
+
+def test_rotation():
+    x = np.random.rand(10, 3)
+    q = Rotation.random(random_state=2020).as_quat()
+    x_r = rigid_shape.rotate(x, q)
+    assert rmsd.kabsch_rmsd(x_r, x) < 1e-8
+
+
+def make_conformer(mol, conf_a, conf_b):
+    mol.RemoveAllConformers()
+    mol = Chem.CombineMols(mol, mol)
+    cc = Chem.Conformer(mol.GetNumAtoms())
+    conf = np.concatenate([conf_a, conf_b])
+    conf *= 10
+    for idx, pos in enumerate(np.asarray(conf)):
+        cc.SetAtomPosition(idx, (float(pos[0]), float(pos[1]), float(pos[2])))
+    mol.AddConformer(cc)
+
+    return mol
+
+
+def get_heavy_atom_idxs(mol):
+
+    idxs = []
+    for a_idx, a in enumerate(mol.GetAtoms()):
+        if a.GetAtomicNum() > 1:
+            idxs.append(a_idx)
+    return np.array(idxs, dtype=np.int32)
+
+
+def test_vjp():
+
+    prefactor = 2.7  # unitless
+    lamb = (4 * np.pi) / (3 * prefactor)  # unitless
+    kappa = np.pi / (np.power(lamb, 2 / 3))  # unitless
+    sigma = 0.15 # nanometers
+    alpha = kappa / (sigma * sigma)
+    # TODO: extract the preceding setup block and share between test_custom_op and test_volume_range?
+
+    suppl = Chem.SDMolSupplier("tests/data/ligands_40.sdf", removeHs=False)
+    mols = []
+    for mol in suppl:
+        mols.append(mol)
+
+    ligand_a = mols[0]
+    ligand_b = mols[1]
+
+
+    coords_a = get_conf(ligand_a, idx=0)
+    params_a = np.stack([
+        np.zeros(ligand_a.GetNumAtoms()) + alpha,
+        np.zeros(ligand_a.GetNumAtoms()) + prefactor,
+    ], axis=1)
+
+    coords_b = get_conf(ligand_b, idx=0)
+    params_b = np.stack([
+        np.zeros(ligand_b.GetNumAtoms()) + alpha,
+        np.zeros(ligand_b.GetNumAtoms()) + prefactor,
+    ], axis=1)
+
+    coords_a = coords_a[get_heavy_atom_idxs(ligand_a)]
+    params_a = params_a[get_heavy_atom_idxs(ligand_a)]
+    coords_b = coords_b[get_heavy_atom_idxs(ligand_b)]
+    params_b = params_b[get_heavy_atom_idxs(ligand_b)]
+
+    coords_a = coords_a - np.mean(coords_a, axis=0)
+    coords_b = coords_b - np.mean(coords_b, axis=0)
+
+    # TEST HESSIAN
+    # qi = Rotation.from_euler('z',25,degrees=True).as_quat() # needs to be transposed
+    # qi = Rotation.from_euler('z',0,degrees=True).as_quat() # needs to be transposed
+
+    writer = Chem.SDWriter('quat.sdf')
+
+    for seed in range(100):
+        # seed = 361
+        # print(seed)
+        # qi = Rotation.random(random_state=seed).as_quat()
+        qi = Rotation.from_euler('zyx', [(np.random.rand()-0.5)*90, (np.random.rand()-0.5)*90, (np.random.rand()-0.5)*90], degrees=True).as_quat()
+        qi = np.array([qi[3], qi[0], qi[1], qi[2]])
+        # print(qi)
+        coords_r = rigid_shape.rotate(coords_b, qi)
+        c_mol = Chem.CombineMols(ligand_a, ligand_b)
+        # conf = make_conformer(c_mol, coords_a, coords_r)
+        # writer.write(conf)
+
+        po = rigid_shape.q_opt(coords_a, coords_r, params_a, params_b)
+        q_final = rigid_shape.q_from_p(po)
+
+        conf = make_conformer(c_mol, coords_a, rigid_shape.rotate(coords_r, q_final))
+        writer.write(conf)
+
+    writer.close()
+
+    # grad_fn = jax.jacrev(rigid_shape.q_opt, argnums=(0,1))
+    # dq_dxa, dq_dxb = grad_fn(coords_a, coords_b, params_a, params_b)
+    # print(dq_dxa, dq_dxb)
+
+    # print(po)
+
+# def test_minimize():
+
+#     prefactor = 2.7  # unitless
+#     lamb = (4 * np.pi) / (3 * prefactor)  # unitless
+#     kappa = np.pi / (np.power(lamb, 2 / 3))  # unitless
+#     sigma = 1.6  # angstroms or nm # TODO: check unit?
+#     alpha = kappa / (sigma * sigma)
+#     # TODO: extract the preceding setup block and share between test_custom_op and test_volume_range?
+
+#     suppl = Chem.SDMolSupplier("tests/data/ligands_40.sdf", removeHs=False)
+#     mols = []
+#     for mol in suppl:
+#         mols.append(mol)
+
+#     ligand_a = mols[0]
+#     ligand_b = mols[3]
+
+#     coords_a = get_conf(ligand_a, idx=0)
+#     params_a = np.stack([
+#         np.zeros(ligand_a.GetNumAtoms()) + alpha,
+#         np.zeros(ligand_a.GetNumAtoms()) + prefactor,
+#     ], axis=1)
+
+#     coords_b = get_conf(ligand_b, idx=0)
+#     params_b = np.stack([
+#         np.zeros(ligand_b.GetNumAtoms()) + alpha,
+#         np.zeros(ligand_b.GetNumAtoms()) + prefactor,
+#     ], axis=1)
+
+#     coords_a = coords_a - np.mean(coords_a, axis=0)
+#     coords_b = coords_b - np.mean(coords_b, axis=0)
+
+#     # TEST HESSIAN
+#     qi = Rotation.from_euler('z',25,degrees=True).as_quat() # needs to be transposed
+#     qi = np.array([qi[3], qi[0], qi[1], qi[2]])
+#     # qi = Rotation.random(random_state=2021).as_quat()
+#     coords_b = rigid_shape.rotate(coords_b, qi)
+
+#     po = rigid_shape.q_opt(coords_a, coords_b, params_a, params_b)
+#     # print(po)
+
+#     # assert 0
+#     dg_dq_fn = jax.jacrev(rigid_shape.rotated_normalized_overlap_3)
+#     grad = dg_dq_fn(po, coords_a, params_a, coords_b, params_b)
+#     print("grad", grad)
+
+#     q_hess_fn = jax.hessian(rigid_shape.rotated_normalized_overlap_3, argnums=(0,))
+#     q_mp_fn = jax.jacfwd(jax.grad(rigid_shape.rotated_normalized_overlap_3, argnums=(1,)), argnums=(0,))
+
+#     # positive semi definite matrix!
+#     M = q_mp_fn(po, coords_a, params_a, coords_b, params_b)[0][0]
+#     H = q_hess_fn(po, coords_a, params_a, coords_b, params_b)[0][0]
+#     H_inv = np.linalg.inv(H)
+#     print("H:", H)
+#     print("H_inv:", H_inv)
+#     print("M:", M)
+#     print("-M.H_inv", np.transpose(-np.matmul(M, H_inv), axes=(2,0,1)))
+
+#     q_opt_jac_fn = jax.jit(jax.jacrev(rigid_shape.q_opt, argnums=(0,)))
+#     q_J = q_opt_jac_fn(coords_a, coords_b, params_a, params_b)
+
+#     print("q_J", q_J[0])
+
+#     # holy shit q_J[0] == -M.H_inv! cuz math (which means we don't have to back prop through derivatives etc.)
+#     assert 0
+
+
+#     # print("dummy angle", np.pi/25)
+
+#     # qi = Rotation.from_matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]]).as_quat()
+
+
+#     # grad_fn = jax.jit(jax.grad(rigid_shape.q_loss, argnums=(0, 1)))
+#     loss_fn = jax.jit(rigid_shape.q_loss)
+
+
+#     c_mol = Chem.CombineMols(ligand_a, ligand_b)
+#     writer = Chem.SDWriter('quat.sdf')
+
+#     for angle in np.linspace(0, 180, 100):
+
+
+#         # qi = Rotation.from_quat([np.cos(np.pi/2), 0, 0, np.sin(np.pi/2)]).as_quat()
+
+
+#         # q_opt = rigid_shape.q_opt(coords_a, coords_b, params_a, params_b)
+#         loss, q_final = loss_fn(coords_a, coords_b, params_a, params_b)
+#         print("loss", loss, "angle", angle, "q_final", q_final)
+
+
+#         # conf = make_conformer(c_mol, coords_a, rigid_shape.rotate(coords_b, q_final))
+#         # writer.write(conf)
+#         # assert 0
+
+
+#         # dqopt_dx = grad_fn(coords_a, coords_b, params_a, params_b)
+
+#         # print("force", dqopt_dx)
+#     writer.close()
+
+#     assert 0
+
+
+#     # start = time.time()
+#     # dqopt_dx = opt_fn(coords_a, coords_b, params_a, params_b)
+#     # print(time.time() - start)
+
+#     # print(q_opt)
+
+#     # a_idxs = get_heavy_atom_idxs(ligand_a)
+#     # b_idxs = get_heavy_atom_idxs(ligand_b)
+
+#     a_idxs = np.arange(ligand_a.GetNumAtoms())
+#     b_idxs = np.arange(ligand_b.GetNumAtoms())
+
+#     u_fn = functools.partial(
+#         rigid_shape.partial_normalized_overlap,
+#         x_a=coords_a,
+#         params_a=params_a,
+#         x_b=coords_b,
+#         params_b=params_b,
+#         a_idxs=a_idxs,
+#         b_idxs=b_idxs
+#     )
+
+#     grad_fn = jax.grad(u_fn, argnums=(0,))
+#     u_fn = jax.jit(u_fn)
+#     grad_fn = jax.jit(grad_fn)
+
+#     lr = 3e-5
+#     c_mol = Chem.CombineMols(ligand_a, ligand_b)
+#     writer = Chem.SDWriter('quat.sdf')
+    
+#     # different random rotation
+#     # qi = Rotation.random(random_state=2021).as_quat()
+#     qi = np.array([1.0, 0.0, 0.0, 0.0])
+
+#     for step in range(150):
+#         u = u_fn(qi)
+#         print(step, "nrg", u, "Q", qi)
+#         du_dq = grad_fn(qi)[0]
+#         qi = qi - lr*du_dq
+#         qi = qi/np.linalg.norm(qi)
+#         # print(qi)
+#         conf = make_conformer(c_mol, coords_a, rigid_shape.rotate(coords_b, qi))
+#         writer.write(conf)
+
+#     writer.close()

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -50,9 +50,26 @@ def get_heavy_atom_idxs(mol):
             idxs.append(a_idx)
     return np.array(idxs, dtype=np.int32)
 
-
 class TestShape(GradientTest):
 
+
+    def test_rigid_shape(self):
+
+        suppl = Chem.SDMolSupplier("tests/data/ligands_40.sdf", removeHs=False)
+        prefactor = 2.7  # unitless
+        lamb = (4 * np.pi) / (3 * prefactor)  # unitless
+        kappa = np.pi / (np.power(lamb, 2 / 3))  # unitless
+        sigma = 1.6  # angstroms or nm # TODO: check unit?
+        alpha = kappa / (sigma * sigma)
+
+        mols = []
+        for a in suppl:
+            mols.append(a)
+
+        print(mols[0], mols[1])
+
+
+    @unittest.skip("debug")
     def test_volume_range(self):
         """Assert that:
         * normalized overlap for identical configurations = 1
@@ -101,6 +118,7 @@ class TestShape(GradientTest):
                 assert v <= 1
                 assert v >= 0.5
 
+    @unittest.skip("debug1")
     def test_custom_op(self):
         """Construct a Shape potential and validate it using compare_forces"""
         suppl = Chem.SDMolSupplier("tests/data/ligands_40.sdf", removeHs=False)

--- a/timemachine/potentials/rigid_shape.py
+++ b/timemachine/potentials/rigid_shape.py
@@ -1,0 +1,401 @@
+# a rigid version of the shape potential
+
+# our goal is to compute an optimized quaternion q_opt such that
+# the derivative of shape overlap w.r.t. q_i is close to zero. the
+# final loss function is then defined on q_opt. The rotation
+# quaternion must be of unit length
+
+import functools
+import jax
+import numpy as onp
+import jax.numpy as np
+import scipy.optimize
+
+from timemachine.potentials import shape
+
+def quat_mul(q1, q2):
+    """
+    Multiply two quaternions
+    """
+    w1, x1, y1, z1 = q1
+    w2, x2, y2, z2 = q2
+    w = w1*w2 - x1*x2 - y1*y2 - z1*z2
+    x = w1*x2 + x1*w2 + y1*z2 - z1*y2
+    y = w1*y2 + y1*w2 + z1*x2 - x1*z2
+    z = w1*z2 + z1*w2 + x1*y2 - y1*x2
+    return np.array([w, x, y, z])
+
+def qmv_rhs(q1, q2):
+    """
+    Multiply two quaternions
+    """
+    # w1, x1, y1, z1 = q1
+    w1 = q1[:, 0]
+    x1 = q1[:, 1]
+    y1 = q1[:, 2]
+    z1 = q1[:, 3]
+    w2, x2, y2, z2 = q2
+    w = w1*w2 - x1*x2 - y1*y2 - z1*z2
+    x = w1*x2 + x1*w2 + y1*z2 - z1*y2
+    y = w1*y2 + y1*w2 + z1*x2 - x1*z2
+    z = w1*z2 + z1*w2 + x1*y2 - y1*x2
+    return np.array([w, x, y, z]).T
+
+
+def qmv_lhs(q1, q2):
+    """
+    Multiply two quaternions
+    """
+    w1, x1, y1, z1 = q1
+    w2 = q2[:, 0]
+    x2 = q2[:, 1]
+    y2 = q2[:, 2]
+    z2 = q2[:, 3]
+    # w2, x2, y2, z2 = q2
+    w = w1*w2 - x1*x2 - y1*y2 - z1*z2
+    x = w1*x2 + x1*w2 + y1*z2 - z1*y2
+    y = w1*y2 + y1*w2 + z1*x2 - x1*z2
+    z = w1*z2 + z1*w2 + x1*y2 - y1*x2
+    return np.array([w, x, y, z]).T
+
+
+def rotate(x, q):
+    """
+    Rotate a set of points by the quaternion q.
+    """
+    q_T = q*np.array([1,-1,-1,-1])
+    N = x.shape[0]
+    x_q = np.zeros((N, 4))
+    x_q = jax.ops.index_update(x_q, jax.ops.index[:, 1:], x)
+    # x_q[:, 1:] = x
+    x_r = qmv_lhs(q, qmv_rhs(x_q, q_T))[:, 1:]
+    return x_r 
+
+def q_from_p(p):
+    w = np.sqrt(1-np.dot(p, p))
+    q = np.array([w, p[0], p[1], p[2]])
+    return q
+
+
+# original
+# def rotated_normalized_overlap_3(p, x_a, x_b, params_a, params_b):
+#     """
+#     Leading quaternion parameterized from p via:
+#     x, y, z = p
+#     q = (1-sqrt(x^2+y^2+z^2), x, y, z)
+#     """
+#     w = np.sqrt(1-np.dot(p, p))
+#     q = np.array([w, p[0], p[1], p[2]])
+#     x_r = rotate(x_b, q)
+#     return -shape.volume(
+#         x_a,
+#         params_a,
+#         x_r,
+#         params_b
+#     )
+
+
+def rotated_normalized_overlap_xyz(p, x_a, x_b, params_a, params_b):
+    """
+    Leading quaternion parameterized from p via:
+    x, y, z = p
+    q = (1-sqrt(x^2+y^2+z^2), x, y, z)
+    """
+    w = np.sqrt(1-np.dot(p, p))
+    q = np.array([w, p[0], p[1], p[2]])
+    x_r = rotate(x_b, q)
+    return -shape.volume(
+        x_a,
+        params_a,
+        x_r,
+        params_b
+    )
+
+def polar_to_cartesian(rpt):
+    r, phi, theta = rpt
+    x = r*np.sin(theta)*np.cos(phi)
+    y = r*np.sin(theta)*np.sin(phi)
+    z = r*np.cos(theta)
+    return np.array([x,y,z])
+
+def cartesian_to_polar(xyz):
+    x, y, z = xyz
+    r = np.sqrt(x*x+y*y+z*z)
+    phi = np.arctan(y/x)
+    theta = np.arccos(z/r)
+    return np.array([r,phi,theta])
+
+
+def rotated_normalized_overlap_polar(rpt, x_a, x_b, params_a, params_b):
+    """
+    Leading quaternion parameterized from p via:
+    x, y, z = p
+    q = (1-sqrt(x^2+y^2+z^2), x, y, z)
+    """
+    p = polar_to_cartesian(rpt)
+    w = np.sqrt(1-np.dot(p, p))
+    q = np.array([w, p[0], p[1], p[2]])
+    x_r = rotate(x_b, q)
+    return -shape.volume(
+        x_a,
+        params_a,
+        x_r,
+        params_b
+    )
+
+
+def rotated_normalized_overlap_q(q, x_a, x_b, params_a, params_b):
+    x_r = rotate(x_b, q)
+    return -shape.volume(
+        x_a,
+        params_a,
+        x_r,
+        params_b
+    )
+
+# first order
+jit_u_fn = jax.jit(rotated_normalized_overlap_xyz)
+jit_du_dq_fn = jax.jit(jax.grad(rotated_normalized_overlap_xyz, argnums=(0,)))
+
+# second order
+jit_d2u_dq2_fn = jax.jit(jax.hessian(rotated_normalized_overlap_xyz, argnums=(0,)))
+# first reverse mode differentiate w.r.t. x, then fwd differentiate w.r.t. q as it's more efficient
+jit_d2u_dxadq_fn = jax.jit(jax.jacfwd(jax.grad(rotated_normalized_overlap_xyz, argnums=(1,)), argnums=(0,)))
+jit_d2u_dxbdq_fn = jax.jit(jax.jacfwd(jax.grad(rotated_normalized_overlap_xyz, argnums=(2,)), argnums=(0,)))
+
+def bfgs_minimize(x_a, x_b, params_a, params_b):
+    """
+    Minimize the quaternion such that u_fn is a minima and grad_fn has a zero norm. Note that the returned
+    quaternion is implicitly parameterized.
+    """
+
+    # (ytz): Several attempts were made in order satisfy the unit norm requirement for rotational
+    # quaternions.
+
+    # 1) Constrained SLSQP: while this minimizes q adequately it does not generate generate a zero norm
+    # on the gradient.
+    # 2) Unconstrained BFGS: attempts to find a q that results in taking the square root of a negative
+    # number.
+    # 3) Bounded L-BFGS-B:  This is done by parameterizing q=(sqrt(1-x^2+y^2+z^2), x, y, z).
+    # this is the current implementation which bounds the individual imag components  to +/- sqrt(1/3),
+    # which guarantees a unit norm. While this would be insufficient for finding a suitable
+    # global minima, this is okay since we assume that a minimizing quaternion close to the identity
+    # rotation can be found (as the identity is where we start from!)
+
+    # 4) A polar attempt has been made, however the projected norm always seems to default to zero, which
+    # causes massive problem for lfgs
+
+    u_fn = functools.partial(jit_u_fn, x_a=x_a, x_b=x_b, params_a=params_a, params_b=params_b)
+    grad_fn = functools.partial(jit_du_dq_fn, x_a=x_a, x_b=x_b, params_a=params_a, params_b=params_b)
+    hess_fn = functools.partial(jit_d2u_dq2_fn, x_a=x_a, x_b=x_b, params_a=params_a, params_b=params_b)
+
+    # not needed
+    def sanitize_hess(v):
+        h = hess_fn(v)[0][0]
+        return onp.array(h)
+
+    def v_and_grad_fn(v):
+        # the onp casts are necessary for L-BFGS-B since it requires mutability
+        # (scipy actually gives an inaccurate warning re: fortran ordering)
+        return onp.array(u_fn(v)), onp.array(grad_fn(v)[0])
+
+    pi = np.array([0.0, 0.0, 0.0]) # x y z = 0, w is implicitly set to 1
+
+    for count in range(1000):
+
+        if np.any(pi):
+            q = pi/np.linalg.norm(pi)
+            xyz_min = -np.abs(q)
+            xyz_max = np.abs(q)
+            xyz_bounds = np.stack([xyz_min, xyz_max], axis=1)
+        else:
+            # initial round
+            delta = np.sqrt(1/3)
+            xyz_bounds = np.array([(-delta, delta), (-delta, delta), (-delta, delta)])
+
+        res = scipy.optimize.minimize(
+            v_and_grad_fn,
+            pi,
+            bounds=xyz_bounds,
+            method='L-BFGS-B',
+            jac=True,
+            options={'disp': False, 'ftol':1e-32, 'gtol':0}
+        )
+
+        pi = res.x
+
+        if np.linalg.norm(grad_fn(res.x)) < 1e-6:
+            break
+
+    if np.linalg.norm(grad_fn(pi)) >= 1e-6:
+        print("FAILED:", pi, grad_fn(pi))
+
+    return pi
+
+    # Everything below is kept for only pedagogical reasons.
+
+    # 1) Constrained SLSQP
+    # def unit_norm(v):
+    #     return np.linalg.norm(v) - 1
+
+    # unit_norm_grad = jax.grad(unit_norm, argnums=(0,))
+
+    # def g_fn(v):
+    #     return unit_norm_grad(v)[0]
+
+    # cons = [{'type':'eq', 'fun': unit_norm, 'jac': g_fn}]
+    # qi = np.array([1.0, 0.0, 0.0, 0.0])
+    # res = scipy.optimize.minimize(
+    #     v_and_grad_fn,
+    #     qi,
+    #     jac=True,
+    #     constraints=cons,
+    #     method='SLSQP',
+    #     # method='trust-constr',
+    #     options={'xtol': 1e-16}
+    # )
+
+    # print(res)
+
+    # assert np.linalg.norm(grad_fn(res.x)) < 1e-5
+    # return res.x
+
+
+    # assert 0
+
+    # return res.x
+
+    # 2) Unconstrained BFGS
+    # pi = np.array([0.0, 0.0, 0.0]) # x y z = 0, w is implicitly set to 1
+    # lr = 1e-4
+    # iterations = 100
+    # for step in range(iterations):
+    #     u = jit_u_fn(pi, x_a, x_b, params_a, params_b)
+    #     du_dp = jit_du_dq_fn(pi, x_a, x_b, params_a, params_b)[0]
+    #     qi =  q_from_p(pi)
+    #     print("u", u, "norm du_dp", np.linalg.norm(du_dp), "du_dp", du_dp, "pi", pi, "norm", np.linalg.norm(qi), "qi", qi)
+    #     pi = pi - lr*du_dp
+
+    # assert 0
+
+    # tol = 1e-8
+    # res = scipy.optimize.minimize(
+    #     v_and_grad_fn,
+    #     pi,
+    #     method='BFGS',
+    #     jac=True,
+    #     options={'disp': True, 'gtol':tol}
+    # )
+
+    # return res.x
+
+    # Newton CG
+    # pi = np.array([0.0, 0.0, 0.0]) # x y z = 0, w is implicitly set to 1
+
+
+    # res = scipy.optimize.minimize(
+    #     v_and_grad_fn,
+    #     pi,
+    #     method='Newton-CG',
+    #     # method='trust-exact',
+    #     jac=True,
+    #     hess=sanitize_hess,
+    #     options={'xtol':1e-8}
+    # )
+
+    # print(res)
+    # print(res.x)
+    # print(np.linalg.norm(grad_fn(res.x)))
+
+    # assert np.linalg.norm(grad_fn(res.x)) < 1e-5
+    # return res.x
+
+    # assert 0
+
+    # BFGS
+    # pi = np.array([0.0, 0.0, 0.0]) # x y z = 0, w is implicitly set to 1
+    # delta = np.sqrt(1/3)
+    # xyz_bounds = np.array([(-delta, delta), (-delta, delta), (-delta, delta)])
+
+    # res = scipy.optimize.minimize(
+    #     v_and_grad_fn,
+    #     pi, bounds=xyz_bounds,
+    #     method='L-BFGS-B',
+    #     jac=True,
+    #     options={'disp': False, 'ftol':1e-32, 'gtol':0}
+    # )
+
+@jax.custom_vjp
+def q_opt(x_a, x_b, params_a, params_b):
+    return bfgs_minimize(x_a, x_b, params_a, params_b)
+
+    # (ytz): old, non-converging method
+    # # this doesn't work becuase we haven't converged g_q
+    # iterations = 100
+    # lr = 3e-5
+    # def carry_fn(v, x):
+    #     du_dp = grad_fn(v)[0]
+    #     v = v - lr*du_dp
+    #     return v, None
+
+    # pi, _ = jax.lax.scan(carry_fn, pi, None, length=iterations)
+
+    # return pi
+
+def q_opt_fwd(x_a, x_b, params_a, params_b):
+    po = bfgs_minimize(x_a, x_b, params_a, params_b)
+    return bfgs_minimize(x_a, x_b, params_a, params_b), (po, x_a, x_b, params_a, params_b)
+
+def q_opt_bwd(res, dl_dq):
+    # (ytz): the reverse mode derivative basically uses an analytical form
+    # of the implicit function theorem in explicit form.
+
+    # This can probably be made more efficient as the hessian vector product combined
+    # with the mixed partial derivatives is computed in a rather inefficient way that
+    # can probably be linearized out.
+
+    po, x_a, x_b, params_a, params_b = res
+    MA = jit_d2u_dxadq_fn(po, x_a, x_b, params_a, params_b)[0][0]
+    MB = jit_d2u_dxbdq_fn(po, x_a, x_b, params_a, params_b)[0][0]
+
+    # (ytz): H is *mostly* positive semi-definite, come up with proof later
+    H = jit_d2u_dq2_fn(po, x_a, x_b, params_a, params_b)[0][0]
+    H_inv = np.linalg.inv(H)
+
+    dl_dxa = np.transpose(-np.matmul(MA, H_inv), axes=(2,0,1))
+    dl_dxb = np.transpose(-np.matmul(MB, H_inv), axes=(2,0,1))
+ 
+    dl_dxa = np.einsum('i,ijk->jk', dl_dq, dl_dxa)
+    dl_dxb = np.einsum('i,ijk->jk', dl_dq, dl_dxb)
+
+    return (dl_dxa, dl_dxb, None, None)
+
+
+q_opt.defvjp(q_opt_fwd, q_opt_bwd)
+
+
+def q_loss(x_a, x_b, params_a, params_b):
+    p_final = q_opt(x_a, x_b, params_a, params_b)
+    q_final = q_from_p(p_final)
+    q_ref = np.array([1,0,0,0], dtype=np.float64)
+    angle = np.arccos(2*np.dot(q_final, q_ref)**2 - 1)
+    return 100*angle
+
+
+def rigid_energy(conf, params, box, lamb, a_idxs, b_idxs, alphas, weights, k):
+
+    conf_a = conf[a_idxs]
+    conf_b = conf[b_idxs]
+
+    com_a = np.mean(conf_a, axis=0)
+    com_b = np.mean(conf_b, axis=0)
+
+    conf_a = conf_a - com_a
+    conf_b = conf_b - com_b
+
+    params_c = np.stack([alphas, weights], axis=1)
+
+    params_a = params_c[a_idxs]
+    params_b = params_c[b_idxs]
+
+    return q_loss(conf_a, conf_b, params_a, params_b) + k*np.linalg.norm(com_a - com_b)

--- a/timemachine/potentials/rigid_shape.py
+++ b/timemachine/potentials/rigid_shape.py
@@ -5,6 +5,7 @@
 # final loss function is then defined on q_opt. The rotation
 # quaternion must be of unit length
 
+from optimizers import ncg, trust_region
 import functools
 import jax
 import numpy as onp
@@ -12,6 +13,9 @@ import jax.numpy as np
 import scipy.optimize
 
 from timemachine.potentials import shape
+
+
+from tensorflow_probability.substrates import jax as tfp
 
 def quat_mul(q1, q2):
     """
@@ -178,6 +182,37 @@ def rotated_normalized_overlap_euler(abc, x_a, x_b, params_a, params_b):
     )
 
 
+def expm(xyz):
+    theta2 = np.dot(xyz, xyz)
+    machine_eps = np.sqrt(np.finfo(np.float64).eps)
+
+    def taylor(_):
+        real = 1-theta2/8
+        imag = (0.5+theta2/48)*xyz
+        return real, imag
+
+    def standard(_):
+        theta = np.linalg.norm(xyz)
+        real = np.cos(theta/2)
+        imag = np.sin(theta/2)*(xyz/theta)
+        return real, imag
+
+    real, imag = jax.lax.cond(theta2 < machine_eps, taylor, standard, None)
+    return np.array([real, imag[0], imag[1], imag[2]])
+
+
+def rotated_normalized_overlap_expm(xyz, x_a, x_b, params_a, params_b):
+    q = expm(xyz)
+    x_r = rotate(x_b, q)
+    return -shape.volume(
+        x_a,
+        params_a,
+        x_r,
+        params_b
+    )
+
+
+
 def rotated_normalized_overlap_q(q, x_a, x_b, params_a, params_b):
     x_r = rotate(x_b, q)
     return -shape.volume(
@@ -197,44 +232,111 @@ jit_d2u_dq2_fn = jax.jit(jax.hessian(rotated_normalized_overlap_euler, argnums=(
 jit_d2u_dxadq_fn = jax.jit(jax.jacfwd(jax.grad(rotated_normalized_overlap_euler, argnums=(1,)), argnums=(0,)))
 jit_d2u_dxbdq_fn = jax.jit(jax.jacfwd(jax.grad(rotated_normalized_overlap_euler, argnums=(2,)), argnums=(0,)))
 
+@jax.jit
 def bfgs_minimize(x_a, x_b, params_a, params_b):
     """
     Minimize the quaternion such that u_fn is a minima and grad_fn has a zero norm. Note that the returned
     quaternion is implicitly parameterized.
     """
-
-    # (ytz): Several attempts were made in order satisfy the unit norm requirement for rotational
-    # quaternions.
-
-    # 1) Constrained SLSQP: while this minimizes q adequately it does not generate generate a zero norm
-    # on the gradient.
-    # 2) Unconstrained BFGS: attempts to find a q that results in taking the square root of a negative
-    # number.
-    # 3) Bounded L-BFGS-B:  This is done by parameterizing q=(sqrt(1-x^2+y^2+z^2), x, y, z).
-    # this is the current implementation which bounds the individual imag components  to +/- sqrt(1/3),
-    # which guarantees a unit norm. While this would be insufficient for finding a suitable
-    # global minima, this is okay since we assume that a minimizing quaternion close to the identity
-    # rotation can be found (as the identity is where we start from!)
-
-    # 4) A polar attempt has been made, however the projected norm always seems to default to zero, which
-    # causes massive problem for lfgs
-
     u_fn = functools.partial(jit_u_fn, x_a=x_a, x_b=x_b, params_a=params_a, params_b=params_b)
     grad_fn = functools.partial(jit_du_dq_fn, x_a=x_a, x_b=x_b, params_a=params_a, params_b=params_b)
     hess_fn = functools.partial(jit_d2u_dq2_fn, x_a=x_a, x_b=x_b, params_a=params_a, params_b=params_b)
 
     # not needed
     def sanitize_hess(v):
-        h = hess_fn(v)[0][0]
-        return onp.array(h)
+        return hess_fn(v)[0][0]
+
+    def sanitize_grad(v):
+        return grad_fn(v)[0]
 
     def v_and_grad_fn(v):
         # the onp casts are necessary for L-BFGS-B since it requires mutability
         # (scipy actually gives an inaccurate warning re: fortran ordering)
-        return onp.array(u_fn(v)), onp.array(grad_fn(v)[0])
+        # return onp.array(u_fn(v)), onp.array(grad_fn(v)[0])
+        return u_fn(v), grad_fn(v)[0]
 
     pi = np.array([0.0, 0.0, 0.0]) # x y z = 0, w is implicitly set to 1
 
+    # trust region
+    # alpha = 0.05
+    # we actually set a max limit on the trust region based on distance from sphere
+
+    # determine max radius based on pos later.
+    # cur_radii = 0.1
+    # 
+    # for _ in range(50):
+
+    #     H = sanitize_hess(pi) # hessian
+    #     J = sanitize_grad(pi) # jacobian
+    #     U = u_fn(pi)
+
+    #     if np.linalg.norm(J) < 1e-8:
+    #         break
+
+    #     J_norm = np.linalg.norm(J)
+
+    #     K = J.T @ H @ J
+
+    #     if K <= 0:
+    #         t = 1
+    #     else:
+    #         t = min(J_norm**3/(0.1*K), 1)
+
+    #     pk = -t*(cur_radii/J_norm)*J
+
+    #     pi = pi + pk
+
+
+    def body_fun(x):
+
+        cur_radii = 0.1
+
+        H = sanitize_hess(x) # hessian
+        J = sanitize_grad(x) # jacobian
+        U = u_fn(x)
+        J_norm = np.linalg.norm(J)
+
+        K = J.T @ H @ J
+
+        t = jax.lax.cond(K <= 0, lambda _: 1.0, lambda _: np.minimum(J_norm**3/(0.1*K), 1.0), None)
+
+        pk = -t*(cur_radii/J_norm)*J
+
+        x = x + pk
+        return x
+
+    def cond_fun(x):
+        return np.linalg.norm(sanitize_grad(x)) > 1e-8
+
+    return jax.lax.while_loop(cond_fun, body_fun, pi)
+
+
+    print("\njax cauchy", "radii", np.linalg.norm(pi), "xyz", pi, "|doverlap/dangles|", np.linalg.norm(grad_fn(pi)))
+
+    pi = np.array([0.0, 0.0, 0.0]) 
+
+    res = scipy.optimize.minimize(
+        v_and_grad_fn,
+        pi,
+        method='trust-ncg',
+        jac=True,
+        hess=sanitize_hess,
+        options={'disp': False, 'gtol':1e-8}
+    )
+    print("Scipy: trust-ncg expm", "radii", np.linalg.norm(res.x), "xyz", res.x, "|doverlap/dangles|", np.linalg.norm(grad_fn(res.x)))
+
+    # res = scipy.optimize.minimize(
+    #     v_and_grad_fn,
+    #     pi,
+    #     method='trust-exact',
+    #     jac=True,
+    #     hess=sanitize_hess,
+    #     options={'disp': False, 'gtol':1e-8}
+    # )
+    # print("Scipy: trust-exact expm", "radii", np.linalg.norm(res.x), "xyz", res.x, "|doverlap/dangles|", np.linalg.norm(grad_fn(res.x)))
+
+
+    # works
     res = scipy.optimize.minimize(
         v_and_grad_fn,
         pi,
@@ -243,12 +345,365 @@ def bfgs_minimize(x_a, x_b, params_a, params_b):
         options={'disp': False, 'gtol':1e-8}
     )
 
-    if np.linalg.norm(grad_fn(res.x)) >= 1e-6:
-        print("FAILED:", res.x, grad_fn(res.x))
+    print("Scipy: BFGS expm", "radii", np.linalg.norm(res.x), "xyz", res.x,  "|doverlap/dxyz|", np.linalg.norm(grad_fn(res.x)))
+    return res.x
+
+
+
+    for _ in range(100):
+
+        for r in np.linspace(0.24, 0.5, 100):
+            for theta in np.linspace(0, 2*np.pi, 20):
+                for phi in np.linspace(0, 2*np.pi, 20):
+                    pk = np.array([
+                        np.sin(theta)*np.cos(phi),
+                        np.sin(theta)*np.sin(phi),
+                        np.cos(theta)
+                    ])
+                    h = hess_fn(pi - r*pk)[0][0]
+                    w, v = np.linalg.eigh(h)
+                    if np.all(w > 0):
+                        print("FOUND PD hessian", r, theta, phi, w)
+
+                        # newton cg time!
+
+                        x = pi - r*pk
+
+                        for _ in range(20):
+                            hh = hess_fn(x)[0][0]
+                            jj = grad_fn(x)[0]
+                            pk = np.linalg.inv(hh)@jj
+
+                            qa = np.dot(pk, pk)
+                            qb = -2*np.dot(pk, x)
+                            qc = np.dot(x, x) - 1
+
+                            max_dt = (-qb + np.sqrt(qb**2 - 4*qa*qc))/(2*qa)
+
+                            # find nearest minima
+                            for alpha in np.linspace(-max_dt, max_dt, 100):
+                                print("test with alpha", alpha, u_fn(x - alpha*pk), "w", np.linalg.eigh(sanitize_hess(x - alpha*pk))[0])
+
+                            assert 0
+                            # print("max_dt", max_dt)
+
+                            # alpha, fc, gc, new_fval, old_fval, new_slope = scipy.optimize.line_search(u_fn, sanitize_grad, x, -pk, amax=max_dt-1e-8)
+
+                            # print("fc, gc", fc, gc)
+
+                            # x = x - alpha*pk
+                            # print("minimizing, x:", x, "jac", jj, "pk", np.linalg.inv(hh)@jj, "w", np.linalg.eigh(hh)[0])
+                        # print(x, linalg.norm)
+
+                        break
+
+        assert 0
+
+    # def body_fn(val):
+
+    #     x, count = val
+    #     H = hess_fn(x)[0][0]
+    #     J = grad_fn(x)[0]
+
+    #     w, v = np.linalg.eigh(H)
+    #     w = np.where(np.abs(w) <= 0.1, 0.1*np.sign(w), w)
+    #     H_pd = v @ np.eye(3)*w @ v.T 
+    #     pk = np.linalg.inv(H_pd) @ J
+
+    #     qa = np.dot(pk, pk)
+    #     qb = -2*np.dot(pk, x)
+    #     qc = np.dot(x, x) - 1
+
+    #     max_dt = (-qb + np.sqrt(qb**2 - 4*qa*qc))/(2*qa)
+    #     dt = np.clip(max_dt-0.1, 0, 1)
+
+    #     # max_dt = np.amax(np.array([max_dt_plus, max_dt_minus]))
+
+    #     # stay away from the boundary
+    #     # dt = np.amin(np.array([max_dt-0.1, 1.0]))
+    #     x = x - dt*pk
+
+    #     return (x, count+1)
+
+    # def cond_fn(val):
+    #     x, count = val
+    #     return count < 100
+    #     return np.linalg.norm(grad_fn(x)) > 1e-6
+
+    # count = 0
+    # x = pi
+
+        # A = np.array([
+        #     [0,    J[0],    J[1],    J[2]   ],
+        #     [J[0], H[0][0], H[0][1], H[0][2]],
+        #     [J[1], H[1][0], H[1][1], H[1][2]],
+        #     [J[2], H[2][0], H[2][1], H[2][2]]
+        # ]) # augmented Hessian
+
+        # w, v = np.linalg.eigh(A)
+        # vt = v[:, 0]
+        # qk = vt[1:]/vt[0]
+
+        # pi = pi + 0.5*qk
+    # def body_fn(x):
+
+    #     H = hess_fn(x)[0][0]
+    #     J = grad_fn(x)[0]
+
+    #     # print(x, J, u_fn(x))
+    #     w, v = np.linalg.eigh(H)
+    #     w = np.abs(w)
+    #     H_pd = v @ np.eye(3)*w @ v.T 
+    #     pk = np.linalg.inv(H_pd) @ J
+    #     x = x - 0.5*pk
+    #     x = x - (2*np.pi)*np.floor(x/(2*np.pi)) # shove between 0 and 2pi
+    #     return x
+
+    # def cond_fn(x):
+    #     return np.linalg.norm(grad_fn(x)) > 1e-6
+
+    res = jax.lax.while_loop(cond_fn, body_fn, pi)
+
+    print("JAX: homebrew quaternions", res, "|doverlap/dxyz|", np.linalg.norm(grad_fn(res)), "count", count)
+
+    return res
+
+def foo():
+        # assert 0
+
+    assert 0
+
+    # def body_fun(v):
+    #     H = sanitize_hess(v)
+    #     # H_off = np.sum(np.where(np.eye(3), 0, np.abs(H)), axis=0)
+    #     # H_on = np.diag(H)
+    #     # delta = H_off - H_on
+    #     # eps = 1.0
+    #     # delta = np.where(delta > -eps, delta+eps, 0)
+    #     # H = H + np.eye(3)*delta
+    #     # J = sanitize_grad(v)
+    #     # v = v - np.linalg.inv(H) @ J
+    #     # return v
+
+
+    #     w,v = np.linalg.eigh(H)
+    #     np.where(w < 0, 0, w)
+    #     print(w)
+
+    #     assert 0
+
+    # def cond_fun(v):
+    #     return np.linalg.norm(grad_fn(v)) > 1e-6
+
+    # pi = jax.lax.while_loop(cond_fun, body_fun, pi)
+    # return pi
+    # x = pi
+
+    # for _ in range(100):
+    #     H = sanitize_hess(x)
+    #     w, v = np.linalg.eigh(H)
+    #     w = np.where(w < 0, 0, w)
+    #     H_psd = v @ np.eye(3)*w @ v.T
+    #     J = sanitize_grad(x)
+    #     x = x - np.linalg.inv(H) @ J
+    #     x = x - (2*np.pi)*np.floor(x/(2*np.pi)) # shove between 0 and 2pi
+
+    # def body_fun(x):
+    #     H = sanitize_hess(x)
+    #     # w, v = np.linalg.eigh(H)
+    #     # w = np.where(w < 0, 0, w)
+    #     # H_psd = v @ np.eye(3)*w @ v.T
+    #     J = sanitize_grad(x)
+    #     x = x - np.linalg.inv(H) @ J
+    #     x = x - (2*np.pi)*np.floor(x/(2*np.pi)) # shove between 0 and 2pi
+    #     return x
+
+    # def cond_fun(v):
+    #     return np.linalg.norm(grad_fn(v)) > 1e-6
+
+    # pi = jax.lax.while_loop(cond_fun, body_fun, pi)
+
+    # return pi
+
+    # print("Full Newton euler angles", x, "|doverlap/dangles|", np.linalg.norm(sanitize_grad(x)))
+    # return pi
+    # # # assert 0
+    # pi = np.array([0.0, 0.0, 0.0]) # x y z = 0, w is implicitly set to 1
+
+    # # assert 0
+
+
+
+    # # res = ncg.minimize(
+    # #     u_fn,
+    # #     pi,
+    # #     jac=sanitize_grad,
+    # #     hess=sanitize_hess
+    # # )
+
+    # # print("JAX Newton-CG euler angles", res, "|doverlap/dangles|", np.linalg.norm(grad_fn(res)))
+
+    # # assert 0
+
+
+
+    # res = trust_region._minimize_trustregion_exact(
+    #     u_fn,
+    #     pi,
+    #     jac=sanitize_grad,
+    #     hess=sanitize_hess
+    # )
+    # print("\n")
+
+    # print("JAX: trust-exact euler angles", res, "|doverlap/dangles|", np.linalg.norm(grad_fn(res)))
+
+    # # assert 0
+
+    # res = scipy.optimize.minimize(
+    #     v_and_grad_fn,
+    #     pi,
+    #     method='trust-exact',
+    #     jac=True,
+    #     hess=sanitize_hess,
+    #     options={'disp': False, 'gtol':1e-8}
+    # )
+    # print("Scipy: trust-exact euler angles", res.x, "|doverlap/dangles|", np.linalg.norm(grad_fn(res.x)))
+    # # assert 0
+
+    jax_trust_ncg = functools.partial(trust_region._minimize_trust_ncg, fun=u_fn, jac=sanitize_grad, hess=sanitize_hess)
+    jax_trust_ncg = jax.jit(jax_trust_ncg)
+
+    res = jax_trust_ncg(x0=pi)
+
+    print(res)
+
+    assert 0
+
+
+    res = trust_region._minimize_trust_ncg(
+        u_fn,
+        pi,
+        jac=sanitize_grad,
+        hess=sanitize_hess
+    )
+
+    print("JAX: trust-ncg euler angles", res, "|doverlap/dangles|", np.linalg.norm(grad_fn(res)))
+
+    # assert 0
+
+    res = scipy.optimize.minimize(
+        v_and_grad_fn,
+        pi,
+        method='trust-ncg',
+        jac=True,
+        hess=sanitize_hess,
+        options={'disp': False, 'gtol':1e-8}
+    )
+    print("Scipy: trust-ncg euler angles", res.x, "|doverlap/dangles|", np.linalg.norm(grad_fn(res.x)))
+    # assert 0
+
+
+
 
     return res.x
 
 
+    # works
+    res = scipy.optimize.minimize(
+        v_and_grad_fn,
+        pi,
+        method='Newton-CG',
+        jac=True,
+        hess=sanitize_hess,
+        options={'disp': False}
+    )
+    print("Newton-CG euler angles", res.x, "|doverlap/dangles|", np.linalg.norm(grad_fn(res.x)))
+    # return res.x
+
+    # works
+    res = scipy.optimize.minimize(
+        v_and_grad_fn,
+        pi,
+        method='BFGS',
+        jac=True,
+        options={'disp': False, 'gtol':1e-8}
+    )
+
+    print("Scipy-BFGS euler angles", res.x, "|doverlap/dangles|", np.linalg.norm(grad_fn(res.x)))
+    return res.x
+
+
+    res = tfp.optimizer.bfgs_minimize(
+        initial_position=pi,
+        value_and_gradients_function=v_and_grad_fn
+    )
+
+    print("TFP BFGS euler angles", res.position, "|doverlap/dangles|", np.linalg.norm(grad_fn(res.position)))
+
+    return res.position
+    assert 0
+    return res.position
+
+    for count in range(50):
+        fx, gx = v_and_grad_fn(pi)
+        hx = sanitize_hess(pi)
+        pk = np.matmul(np.linalg.inv(hx), gx)
+
+        # qa = np.dot(pk, pk)
+        # qb = -2*np.dot(pk, pi)
+        # qc = np.dot(pi, pi) - 1
+
+        # this can be solved analytically
+        # roots = np.real(np.roots(np.array([qa, qb, qc]))) # assert imag part being zero
+        # max_dt = np.amax(roots) # complement is just -max_root+2 (2 is diameter of sphere)
+
+        # for dt in np.linspace(0, max_dt, 100):
+        #     tpi = pi - dt*pk
+        #     print(dt, u_fn(tpi))
+
+        # alpha, fc, gc, new_fval, old_fval, new_slope = scipy.optimize.line_search(u_fn, grad_fn, pi, pk, amax=max_dt-1e-8)
+
+        # print("alpha bounded", alpha)
+
+        dt, fc, gc, new_fval, old_fval, new_slope = scipy.optimize.line_search(u_fn, grad_fn, pi, pk)
+
+        print("DT", dt)
+
+        # print("alpha unbounded", alpha)
+
+        # assert 0
+        # # print("DT", dt)
+
+        # # assert 0
+
+        print(pi, gx)
+
+        # dt = 1
+        pi = pi - dt*pk
+
+
+        # print("pi", pi, "gx", gx)
+
+
+        # assert max_dt > 0
+
+        # # print("max", u_fn(pi - max_dt*pk)) # maybe will nan depending on machine precision
+        # # print("max minus eps", u_fn(pi - (max_dt - 1e-4)*pk)) # should not nan
+        # # print("max plus eps", u_fn(pi - (max_dt + 1e-4)*pk)) # should nan 
+
+        # # assert 0
+
+        # for dt in np.linspace(0, max_dt, 100):
+        #     tpi = pi - dt*pk
+        #     print(dt, u_fn(tpi))
+
+        # assert 0
+
+
+    # if np.linalg.norm(grad_fn(pi)) >= 1e-6:
+    print("FAILED:", pi, grad_fn(pi))
+
+    return pi
 
 @jax.custom_vjp
 def q_opt(x_a, x_b, params_a, params_b):
@@ -290,8 +745,15 @@ def q_loss(x_a, x_b, params_a, params_b):
     p_final = q_opt(x_a, x_b, params_a, params_b)
 
     # tbd periodic distance if necessary
-    # period = 2*np.pi
+    # box = 2*np.pi
     # diff -= box[d]*np.floor(np.expand_dims(diff[...,d], axis=-1)/box[d][d]+0.5)
+    # results are between -pi and pi
+    # p_final = np.min
+    # p_final is between 0 and 2pi, so measure the circular distance
+    p_final = p_final - (2*np.pi)*np.floor(p_final/(2*np.pi))
+    p_final = np.where(p_final > (2*np.pi - p_final), (2*np.pi - p_final), p_final)
+    # print("p_final", p_final)
+
     return 100*np.dot(p_final, p_final)
 
 

--- a/timemachine/potentials/shape.py
+++ b/timemachine/potentials/shape.py
@@ -113,3 +113,36 @@ def harmonic_overlap(conf, params, box, lamb, a_idxs, b_idxs, alphas, weights, k
 
     V = normalized_overlap(conf_a, params_a, conf_b, params_b)
     return k*(V-1)**2
+
+
+def inverse_overlap(conf, params, box, lamb, a_idxs, b_idxs, alphas, weights, k):
+    """
+    Compute the shape potential. The derivative of this function
+    w.r.t. conf generates a non-rigid force.
+
+    Parameters
+    ----------
+    conf: np.array [N, 3]
+        Conformation of the system
+
+    params: np.array [N, 2]
+        Shape parameters of the system
+
+    a_idxs: np.array [A]
+        Molecule A's indices into the conformation
+
+    b_idxs: np.array [B]
+        Molecule B's indices into the conformation
+
+    """
+
+    conf_a = conf[a_idxs]
+    conf_b = conf[b_idxs]
+
+    params_c = np.stack([alphas, weights], axis=1)
+
+    params_a = params_c[a_idxs]
+    params_b = params_c[b_idxs]
+
+    V = normalized_overlap(conf_a, params_a, conf_b, params_b)
+    return k/V

--- a/timemachine/potentials/shape.py
+++ b/timemachine/potentials/shape.py
@@ -55,7 +55,8 @@ def normalized_overlap(conf_a, params_a, conf_b, params_b):
            int dr rho_A^2 + rho_B^2
 
     Guaranteeing that 0 <= S_AB <= 1. An alternative would be
-    something like the Tanimoto. 
+    something like the Tanimoto. If we only wanted to maximize the overlap
+    we do not need to compute the normalization ratios.
 
     Parameters
     ----------


### PR DESCRIPTION
This pull request implements rigid orientational restraints using the SHAPE overlap as opposed to using principal moments of inertia. PMI-based approaches have unstable eigenvector derivatives that naturally arise throughout the simulation due to symmetries in the inertia tensor (which result in degenerate eigenvalues).

The general protocol is as follows:

1. We compute a rotational quaternion q_opt(x_a, x_b) that computes the maximum overlap between two molecules x_a and x_b.
2. The rotational quaternion is typically solved using an iterative method. In order to satisfy the rotational requirement, the norm of the quaternion must be 1. This is done with a re-parameterization of q(a,b,c)=(1-a^2-b^2-c^2, a, b, c).
3. We iterate over multiple rounds of BFGS-B by optimizing the enclosing box bounds under a sphere in order to satisfy the unit norm requirement.
4. The initial quaternion is {1,0,0,0}, and is intentionally chosen to be identical to that of the reference quaternion used in the definition of the loss function.
4. Unlike other popular packages, we actually check and enforce that dOverlap/dq has a max norm of 1e-6 at q=q_opt. Most constrained optimizers (eg: SLSQP, or other renormalization techniques) do not actually generate zero norms in the derivative.
5. A zero norm derivative enables us to do an extremely cool trick: we can use the implicit function theorem to solve for dq_opt/dx_{a,b} without having to backpropagate through BFGS. dq/dx_a is just -M.H^{-1} evaluated at the optimum. This enables us to generate forces.
6. The analytical solution is done by inverting a 4x4 nearly PD hessian.

We can use this to alchemically switch between rigid shape restraints to a non-rigid shape restraint with probably maximum overlap in phase space.
