### PR TITLE
Linearly rescale lambda between 0 and 1 in nonbonded ixns

### DIFF
--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -46,7 +46,7 @@ class TestContext(unittest.TestCase):
             lambda_offset_idxs,
             p_scale=3.0,
             # cutoff=0.5,
-            cutoff=100.0
+            cutoff=1.5
         )
 
         masses = np.random.rand(N)

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -572,8 +572,8 @@ void __global__ k_nonbonded_exclusions(
         gj_y += FLOAT_TO_FIXED((es_prefactor-lj_prefactor)*delta_y);
         gj_z += FLOAT_TO_FIXED((es_prefactor-lj_prefactor)*delta_z);
 
-        du_dl_i -= FLOAT_TO_FIXED((es_prefactor-lj_prefactor)*delta_w*lambda_offset_i);
-        du_dl_j += FLOAT_TO_FIXED((es_prefactor-lj_prefactor)*delta_w*lambda_offset_j);
+        du_dl_i -= FLOAT_TO_FIXED((es_prefactor-lj_prefactor)*delta_w*lambda_offset_i*cutoff);
+        du_dl_j += FLOAT_TO_FIXED((es_prefactor-lj_prefactor)*delta_w*lambda_offset_j*cutoff);
 
         // energy is size extensive so this may not be a good idea
         energy -= FLOAT_TO_FIXED(charge_scale*qij*inv_dij*ebd + lj_scale*4*eps_ij*(sig6_inv_d6ij-1)*sig6_inv_d6ij);

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -291,7 +291,7 @@ void __global__ k_nonbonded(
         delta_y -= box_y*nearbyint(delta_y*inv_box_y);
         delta_z -= box_z*nearbyint(delta_z*inv_box_z);
 
-        RealType delta_w = (lambda_plane_i - lambda_plane_j)*cutoff + (lambda_offset_i - lambda_offset_j)*real_lambda;
+        RealType delta_w = (lambda_plane_i - lambda_plane_j)*cutoff + (lambda_offset_i - lambda_offset_j)*real_lambda*cutoff;
 
         RealType d2ij = delta_x*delta_x + delta_y*delta_y + delta_z*delta_z + delta_w*delta_w;
 
@@ -339,8 +339,8 @@ void __global__ k_nonbonded(
             gj_y -= FLOAT_TO_FIXED((es_prefactor-lj_prefactor)*delta_y);
             gj_z -= FLOAT_TO_FIXED((es_prefactor-lj_prefactor)*delta_z);
 
-            du_dl_i += FLOAT_TO_FIXED((es_prefactor-lj_prefactor)*delta_w*lambda_offset_i);
-            du_dl_j -= FLOAT_TO_FIXED((es_prefactor-lj_prefactor)*delta_w*lambda_offset_j);
+            du_dl_i += FLOAT_TO_FIXED((es_prefactor-lj_prefactor)*delta_w*lambda_offset_i*cutoff);
+            du_dl_j -= FLOAT_TO_FIXED((es_prefactor-lj_prefactor)*delta_w*lambda_offset_j*cutoff);
 
             RealType u = qij*inv_dij*ebd + 4*eps_ij*(sig6_inv_d6ij-1)*sig6_inv_d6ij;
 
@@ -526,7 +526,7 @@ void __global__ k_nonbonded_exclusions(
     delta_y -= box_y*nearbyint(delta_y*inv_box_y);
     delta_z -= box_z*nearbyint(delta_z*inv_box_z);
 
-    RealType delta_w = (lambda_plane_i - lambda_plane_j)*cutoff + (lambda_offset_i - lambda_offset_j)*real_lambda;
+    RealType delta_w = (lambda_plane_i - lambda_plane_j)*cutoff + (lambda_offset_i - lambda_offset_j)*real_lambda*cutoff;
 
     RealType d2ij = delta_x*delta_x + delta_y*delta_y + delta_z*delta_z + delta_w*delta_w;
 

--- a/timemachine/potentials/jax_utils.py
+++ b/timemachine/potentials/jax_utils.py
@@ -1,13 +1,15 @@
 import jax.numpy as np
 
-
-# def lambda_to_w(lamb, plane_idxs, offset_idxs, cutoff):
-#     d4 = cutoff*plane_idxs + offset_idxs*lamb
-#     # d4 = offset_idxs*lamb
-#     return d4
-
 def convert_to_4d(x3, lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff):
-    # d4 = lambda_to_w(lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff)
+
+    # (ytz): this initializes the 4th dimension to a fixed plane adjust by an offset
+    # followed by a scaling by cutoff.
+
+    # lambda_plane_idxs are typically 0 or 1 and allows us to turn off an interaction
+    # independent of the lambda value.
+
+    # lambda_offset_idxs are typically 0 and 1, and allows us to adjust the w coordinate
+    # in a lambda-dependent way.
     d4 = cutoff*(lambda_plane_idxs + lambda_offset_idxs*lamb)
     d4 = np.expand_dims(d4, axis=-1)
     x4 = np.concatenate((x3, d4), axis=1)

--- a/timemachine/potentials/jax_utils.py
+++ b/timemachine/potentials/jax_utils.py
@@ -8,7 +8,7 @@ import jax.numpy as np
 
 def convert_to_4d(x3, lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff):
     # d4 = lambda_to_w(lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff)
-    d4 = cutoff*lambda_plane_idxs + lambda_offset_idxs*lamb
+    d4 = cutoff*(lambda_plane_idxs + lambda_offset_idxs*lamb)
     d4 = np.expand_dims(d4, axis=-1)
     x4 = np.concatenate((x3, d4), axis=1)
     return x4


### PR DESCRIPTION
This PR modifies the w (4d) coordinate in nonbonded calculations from:
```
w = lambda
```
to
```
w = cutoff*lambda
```
This is to enable a uniform treatment of lambda with alchemical terms (eg. restraint attachment etc.) as PR will now ensure lambda to be between [0, 1). This was a point of confusion for some people, and this should make the bounds less confusing and more consistent.

@schmolly This change will affect you - existing code should divide old lambda values by cutoff.