### PR TITLE
vjp_refactor

### DIFF
--- a/examples/ahfe.py
+++ b/examples/ahfe.py
@@ -5,11 +5,18 @@ import numpy as np
 from rdkit import Chem
 from rdkit.Chem import AllChem
 from fe import pdb_writer
-from md import Recipe
+from fe import topology
 from md import builders
 
 from timemachine.lib import potentials, custom_ops
 from timemachine.lib import LangevinIntegrator
+
+import functools
+import jax
+
+from ff import Forcefield
+
+from ff.handlers import nonbonded, bonded, openmm_deserializer
 
 from ff.handlers.deserialize import deserialize_handlers
 
@@ -27,6 +34,8 @@ def get_romol_conf(mol):
 # note: not using OpenFF Molecule because want to avoid the dependency (YTZ?)
 romol = Chem.AddHs(Chem.MolFromSmiles("CC(=O)OC1=CC=CC=C1C(=O)O"))
 
+ligand_masses = [a.GetMass() for a in romol.GetAtoms()]
+
 # generate conformers
 AllChem.EmbedMolecule(romol)
 
@@ -35,14 +44,18 @@ ligand_coords = get_romol_conf(romol)
 
 # construct a 4-nanometer water box (from openmmtools approach: selecting out
 #   of a large pre-equilibrated water box snapshot)
-system, host_coords, box, topology = builders.build_water_system(4.0)
+system, host_coords, box, omm_topology = builders.build_water_system(4.0)
+
+host_bps, host_masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+
+combined_masses = np.concatenate([host_masses, ligand_masses])
 
 # write some conformations into this PDB file
-writer = pdb_writer.PDBWriter([topology, romol], "debug.pdb")
+writer = pdb_writer.PDBWriter([omm_topology, romol], "debug.pdb")
 
 # note the order in which the coordinates are concatenated in this step --
 #   in a later step we will need to combine recipes in the same order
-combined_conf = np.concatenate([host_coords, ligand_coords])
+combined_coords = np.concatenate([host_coords, ligand_coords])
 
 num_host_atoms = host_coords.shape[0]
 
@@ -50,31 +63,39 @@ num_host_atoms = host_coords.shape[0]
 # note: _ccc suffix means "correctable charge corrections"
 ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_ccc.py').read())
 
-ligand_recipe = Recipe.from_rdkit(romol, ff_handlers)
+final_potentials = []
+final_vjp_and_handles = []
 
-# note: "bound" potentials are energy functions where the parameters have been
-#   set to a constant using .bind()
-#   (contrast with "unbound" potentials, for cases where the parameters are
-#   variable and where we may be interested in dU/dparams)
-for bp in ligand_recipe.bound_potentials:
+# keep the bonded terms in the host the same.
+# but we keep the nonbonded term for a subsequent modification
+for bp in host_bps:
     if isinstance(bp, potentials.Nonbonded):
-        # note: this is something like "bp.set_lambda_offset_idxs(ones)"
-        #   (at initialization, offset_indices are all zeros)
-        array = bp.get_lambda_offset_idxs()
-        array[:] = 1 
+        host_p = bp
+    else:
+        final_potentials.append(bp)
+        final_vjp_and_handles.append(None)
 
-water_recipe = Recipe.from_openmm(system)
+ff = Forcefield(ff_handlers)
+gbt = topology.BaseTopology(romol, ff)
+hgt = topology.HostGuestTopology(gbt, host_p, num_host_atoms)
 
-# note: this step is dependent on order -- ensure consistency with the order
-#   in which coordinates were concatenated above
-# note: calling `recipe.combine(other)` will offset all of the bond indices etc.
-#   within the sub-recipe described by `other`
-combined_recipe = water_recipe.combine(ligand_recipe)
+# setup the parameter handlers for the ligand
+tuples = [
+    [hgt.parameterize_harmonic_bond, [ff.hb_handle]],
+    [hgt.parameterize_harmonic_angle, [ff.ha_handle]],
+    [hgt.parameterize_proper_torsion, [ff.pt_handle]],
+    [hgt.parameterize_improper_torsion, [ff.it_handle]],
+    [hgt.parameterize_nonbonded, [ff.q_handle, ff.lj_handle]],
+]
 
-# note: lambda goes from 0 to +infinity, where we approximate +infinity with
-#   any number of nanometers sufficiently large that the ligand has almost no
-#   interaction with the rest of the system (in this case, 1.2 nm will do)
-for final_lamb in np.linspace(0, 1.2, 8):
+# instantiate the vjps while parameterizing (forward pass)
+for fn, handles in tuples:
+    params, vjp_fn, potential = jax.vjp(fn, *[h.params for h in handles], has_aux=True)
+    final_potentials.append(potential.bind(params))
+    final_vjp_and_handles.append((vjp_fn, handles))
+
+# note: lambda goes from 0 to 1, 0 being fully-interacting and 1.0 being fully interacting.
+for final_lamb in np.linspace(0, 1, 8):
 
     seed = 2020
 
@@ -87,16 +108,16 @@ for final_lamb in np.linspace(0, 1.2, 8):
         300.0,
         1.5e-3,
         1.0,
-        combined_recipe.masses,
+        combined_masses,
         seed
     ).impl()
 
-    x0 = combined_conf
+    x0 = combined_coords
     v0 = np.zeros_like(x0)
 
     u_impls = []
 
-    for bp in combined_recipe.bound_potentials:
+    for bp in final_potentials:
         # note: YTZ recommends np.float32 here
         # note: difference between .bound_impl() and .impl()
         fn = bp.bound_impl(precision=np.float32)
@@ -121,24 +142,54 @@ for final_lamb in np.linspace(0, 1.2, 8):
         u_impls
     )
 
+    # initial insertion step to remove clashes, note that for production we probably
+    # want to adjust the box size slighty to accomodate for a uniform water density
+    # since we're doing an NVT simulation.
     for lamb_idx, lamb in enumerate(np.linspace(1.0, final_lamb, 1000)):
         # note: unlike in OpenMM, .step() accepts a float (for lambda) and does
         #   not accept an integer (for n_steps) -- .step() takes 1 step at a time
         ctxt.step(lamb)
+
+
+    print("insertion energy", ctxt.get_u_t())
 
     # note: these 5000 steps are "equilibration", before we attach a reporter /
     #   "observable" to the context and start running "production"
     for _ in range(5000):
         ctxt.step(final_lamb)
 
+    print("equilibrium energy", ctxt.get_u_t())
+
     # TODO: what was the second argument -- reporting interval in steps?
     du_dl_obs = custom_ops.AvgPartialUPartialLambda(u_impls, 5)
 
+    du_dps = []
+    for ui in u_impls:
+        du_dp_obs = custom_ops.AvgPartialUPartialParam(ui, 5)
+        ctxt.add_observable(du_dp_obs)
+        du_dps.append(du_dp_obs)
+
     ctxt.add_observable(du_dl_obs)
 
-    for _ in range(100000):
+    for _ in range(10000):
         ctxt.step(final_lamb)
+
+    print("final energy", ctxt.get_u_t())
+
+    # print vector jacobian products back into the forcefield derivative
+    for du_dp_obs, vjp_and_handles in zip(du_dps, final_vjp_and_handles):
+        du_dp = du_dp_obs.avg_du_dp()
+
+        if vjp_and_handles:
+            vjp_fn, handles = vjp_and_handles
+            du_df = vjp_fn(du_dp) # vjp into forcefield derivatives
+            for f_grad, h in zip(du_df, handles):
+                print("handle:", type(h).__name__)
+                for s, vv in zip(h.smirks, f_grad):
+                    if np.any(vv) != 0:
+                        print(s, vv)
+                print("\n")
 
     du_dl = du_dl_obs.avg_du_dl()
 
-    print(final_lamb, du_dl)
+    print("lambda", final_lamb, "du_dl", du_dl)

--- a/examples/ahfe.py
+++ b/examples/ahfe.py
@@ -77,7 +77,7 @@ for bp in host_bps:
 
 ff = Forcefield(ff_handlers)
 gbt = topology.BaseTopology(romol, ff)
-hgt = topology.HostGuestTopology(gbt, host_p, num_host_atoms)
+hgt = topology.HostGuestTopology(host_p, gbt)
 
 # setup the parameter handlers for the ligand
 tuples = [

--- a/examples/rhfe.py
+++ b/examples/rhfe.py
@@ -6,7 +6,6 @@ from rdkit import Chem
 from rdkit.Chem import AllChem
 from fe import pdb_writer
 from fe import topology
-from md import recipe
 from md import builders
 from md import minimizer
 

--- a/examples/rhfe.py
+++ b/examples/rhfe.py
@@ -87,7 +87,7 @@ for bp in host_bps:
         final_vjp_and_handles.append(None)
 
 gdt = topology.DualTopology(romol_a, romol_b, ff)
-hgt = topology.HostGuestTopology(gdt, host_p, num_host_atoms)
+hgt = topology.HostGuestTopology(host_p, gdt)
 
 # setup the parameter handlers for the ligand
 tuples = [

--- a/examples/rhfe.py
+++ b/examples/rhfe.py
@@ -1,4 +1,4 @@
-# absolute hydration free energy
+# relative hydration free energy
 
 import numpy as np
 

--- a/examples/rhfe.py
+++ b/examples/rhfe.py
@@ -1,133 +1,157 @@
-# relative hydration free energy
+# absolute hydration free energy
 
 import numpy as np
 
 from rdkit import Chem
 from rdkit.Chem import AllChem
 from fe import pdb_writer
-from md import Recipe
+from fe import topology
+from md import recipe
 from md import builders
+from md import minimizer
 
 from timemachine.lib import potentials, custom_ops
 from timemachine.lib import LangevinIntegrator
 
+import functools
+import jax
+
+from ff import Forcefield
+
+from ff.handlers import nonbonded, bonded, openmm_deserializer
+
 from ff.handlers.deserialize import deserialize_handlers
 
 
-# 1. build water box
-# 2. build pair of ligands
-# 3. convert to recipe
-
 def get_romol_conf(mol):
+    """Coordinates of mol's 0th conformer, in nanometers"""
     conformer = mol.GetConformer(0)
     guest_conf = np.array(conformer.GetPositions(), dtype=np.float64)
-    return guest_conf / 10  # from angstroms to nm
+    return guest_conf/10 # from angstroms to nm
 
-
-# convert an oxygen to a fluorine
+# construct an RDKit molecule of aspirin
+# note: not using OpenFF Molecule because want to avoid the dependency (YTZ?)
 romol_a = Chem.AddHs(Chem.MolFromSmiles("CC(=O)OC1=CC=CC=C1C(=O)O"))
-romol_b = Chem.AddHs(Chem.MolFromSmiles("CC(=O)OC1=CC=CC=C1C(=O)F"))
+romol_b = Chem.AddHs(Chem.MolFromSmiles("CC(=O)OC1=CC=CC=C1C(=O)OC"))
+
+ligand_masses_a = [a.GetMass() for a in romol_a.GetAtoms()]
+ligand_masses_b = [a.GetMass() for a in romol_b.GetAtoms()]
 
 # generate conformers
 AllChem.EmbedMolecule(romol_a)
 AllChem.EmbedMolecule(romol_b)
 
-# write in order: waterbox, ligand_a, ligand_b
-ligand_a_coords = get_romol_conf(romol_a)
-ligand_b_coords = get_romol_conf(romol_b)
-system, host_coords, box, topology = builders.build_water_system(4.0)
+# extract the 0th conformer
+ligand_coords_a = get_romol_conf(romol_a)
+ligand_coords_b = get_romol_conf(romol_b)
 
-writer = pdb_writer.PDBWriter([topology, romol_a, romol_b], "debug.pdb")
+# construct a 4-nanometer water box (from openmmtools approach: selecting out
+#   of a large pre-equilibrated water box snapshot)
+system, host_coords, box, omm_topology = builders.build_water_system(4.0)
 
-# concatenate in order
-combined_conf = np.concatenate([host_coords, ligand_a_coords, ligand_b_coords])
+# padding to avoid jank
+box = box + np.eye(3)*0.1
 
-# "host" in this case = "waterbox"
+host_bps, host_masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+
+combined_masses = np.concatenate([host_masses, ligand_masses_a, ligand_masses_b])
+
+
+# minimize coordinates
+
+# note: .py file rather than .offxml file
+# note: _ccc suffix means "correctable charge corrections"
+ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_ccc.py').read())
+ff = Forcefield(ff_handlers)
+
+# for RHFE we need to insert the reference ligand first, before inserting the
+# decoupling ligand
+minimized_coords = minimizer.minimize_4d(romol_a, system, host_coords, ff, box)
+
+# note the order in which the coordinates are concatenated in this step --
+#   in a later step we will need to combine recipes in the same order
+# combined_coords = np.concatenate([host_coords, ligand_coords_a, ligand_coords_b])
+combined_coords = np.concatenate([minimized_coords, ligand_coords_b])
+
 num_host_atoms = host_coords.shape[0]
 
-ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_ccc.py').read())
+final_potentials = []
+final_vjp_and_handles = []
 
-ligand_a_recipe = Recipe.from_rdkit(romol_a, ff_handlers)
-ligand_b_recipe = Recipe.from_rdkit(romol_b, ff_handlers)
-
-for bp in ligand_a_recipe.bound_potentials:
+# keep the bonded terms in the host the same.
+# but we keep the nonbonded term for a subsequent modification
+for bp in host_bps:
     if isinstance(bp, potentials.Nonbonded):
-        array = bp.get_lambda_offset_idxs()
-        array[:] = 1
+        host_p = bp
+    else:
+        final_potentials.append(bp)
+        final_vjp_and_handles.append(None)
 
-for bp in ligand_b_recipe.bound_potentials:
-    if isinstance(bp, potentials.Nonbonded):
-        array = bp.get_lambda_offset_idxs()
-        array[:] = 1
+gdt = topology.DualTopology(romol_a, romol_b, ff)
+hgt = topology.HostGuestTopology(gdt, host_p, num_host_atoms)
 
-water_recipe = Recipe.from_openmm(system)
+# setup the parameter handlers for the ligand
+tuples = [
+    [hgt.parameterize_harmonic_bond, [ff.hb_handle]],
+    [hgt.parameterize_harmonic_angle, [ff.ha_handle]],
+    [hgt.parameterize_proper_torsion, [ff.pt_handle]],
+    [hgt.parameterize_improper_torsion, [ff.it_handle]],
+    [hgt.parameterize_nonbonded, [ff.q_handle, ff.lj_handle]],
+]
 
-ligand_ab_recipe = ligand_a_recipe.combine(ligand_b_recipe)
+# instantiate the vjps while parameterizing (forward pass)
+for fn, handles in tuples:
+    params, vjp_fn, potential = jax.vjp(fn, *[h.params for h in handles], has_aux=True)
+    final_potentials.append(potential.bind(params))
+    final_vjp_and_handles.append((vjp_fn, handles))
 
-num_a_atoms = ligand_a_coords.shape[0]
-num_b_atoms = ligand_b_coords.shape[0]
+# add centroid restraint
 
-#
-for bp in ligand_ab_recipe.bound_potentials:
-    if isinstance(bp, potentials.Nonbonded):
-        exclusion_idxs = bp.get_exclusion_idxs()
-        scale_factors = bp.get_scale_factors()
-        new_exclusions = []
-        new_scale_factors = []
-        for i in range(num_a_atoms):
-            for j in range(num_b_atoms):
-                new_exclusions.append((i, j + num_a_atoms))
+restraint_a_idxs = np.arange(romol_a.GetNumAtoms()) + num_host_atoms
+restraint_b_idxs = np.arange(romol_b.GetNumAtoms()) + num_host_atoms + romol_a.GetNumAtoms()
 
-                # an exclusion scale factor of 1.0 means "subtract 1.0 times
-                #   the contribution of this pair" -- and this is done in a NaN-
-                #   safe way using some wizardry that lets you add Nan and
-                #   subtract NaN from the accumulator, using some wizardry
-                new_scale_factors.append((1.0, 1.0))
-        new_exclusions = np.concatenate([exclusion_idxs, new_exclusions])
-        new_scale_factors = np.concatenate([scale_factors, new_scale_factors])
-
-        # note: np.int32 is important here!
-        bp.set_exclusion_idxs(new_exclusions.astype(np.int32))
-        bp.set_scale_factors(new_scale_factors.astype(np.float64))
-
-# note: np.int32 is important here! may encounter type error with np.int64
-restr = potentials.CentroidRestraint(
-    np.arange(num_a_atoms, dtype=np.int32),
-    np.arange(num_b_atoms, dtype=np.int32),
-    ligand_ab_recipe.masses,
-    200,
+restraint = potentials.CentroidRestraint(
+    restraint_a_idxs.astype(np.int32),
+    restraint_b_idxs.astype(np.int32),
+    combined_masses,
+    100.0,
     0.0
 ).bind([])
 
-ligand_ab_recipe.bound_potentials.append(restr)
-ligand_ab_recipe.vjp_fns.append([])  # TODO: is this append command important?
+final_potentials.append(restraint)
+final_vjp_and_handles.append(None)
 
-combined_recipe = water_recipe.combine(ligand_ab_recipe)
+# note: lambda goes from 0 to 1, 0 being fully-interacting and 1.0 being fully interacting.
+for lamb_idx, final_lamb in enumerate(np.linspace(1, 0, 8)):
 
-for final_lamb in np.linspace(0, 1.2, 8):
+
+    # write some conformations into this PDB file
+    writer = pdb_writer.PDBWriter([omm_topology, romol_a, romol_b], "debug_"+str(lamb_idx)+".pdb")
 
     seed = 2020
 
+    # note: the .impl() call at the end returns a pickle-able version of the
+    #   wrapper function -- since contexts are not pickle-able -- which will
+    #   be useful later in timemachine's multi-device parallelization strategy)
+    # note: OpenMM unit system used throughout
+    #   (temperature: kelvin, timestep: picosecond, collision_rate: picosecond^-1)
     intg = LangevinIntegrator(
         300.0,
         1.5e-3,
         1.0,
-        combined_recipe.masses,
+        combined_masses,
         seed
     ).impl()
 
-    x0 = combined_conf
+    x0 = combined_coords
     v0 = np.zeros_like(x0)
 
     u_impls = []
 
-    for bp in combined_recipe.bound_potentials:
-        fn = bp.bound_impl(precision=np.float32)
-        du_dx, du_dl, u = fn.execute(x0, box, 100.0)
-        max_norm_water = np.amax(np.linalg.norm(du_dx[:num_host_atoms], axis=0))
-        max_norm_ligand = np.amax(np.linalg.norm(du_dx[num_host_atoms:], axis=0))
-        u_impls.append(fn)
+    for bp in final_potentials:
+        u_impls.append(bp.bound_impl(np.float32))
 
+    # context components: positions, velocities, box, integrator, energy fxns
     ctxt = custom_ops.Context(
         x0,
         v0,
@@ -136,30 +160,57 @@ for final_lamb in np.linspace(0, 1.2, 8):
         u_impls
     )
 
-    for lamb_idx, lamb in enumerate(np.linspace(1.0, final_lamb, 1000)):
-        if lamb_idx % 1000 == 0:
-            writer.write_frame(ctxt.get_x_t() * 10)  # note angstroms/nm conversion
-            print(lamb_idx, ctxt.get_u_t())
+    for step, lamb in enumerate(np.linspace(1.0, final_lamb, 1000)):
+        if step % 500 == 0:
+            writer.write_frame(ctxt.get_x_t()*10)
         ctxt.step(lamb)
 
+    print("insertion energy", ctxt.get_u_t())
+
+    # note: these 5000 steps are "equilibration", before we attach a reporter /
+    #   "observable" to the context and start running "production"
     for step in range(5000):
-        if step % 1000 == 0:
-            writer.write_frame(ctxt.get_x_t() * 10)  # note angstroms/nm conversion
+        if step % 500 == 0:
+            writer.write_frame(ctxt.get_x_t()*10)
         ctxt.step(final_lamb)
 
+    print("equilibrium energy", ctxt.get_u_t())
+
+    # TODO: what was the second argument -- reporting interval in steps?
     du_dl_obs = custom_ops.AvgPartialUPartialLambda(u_impls, 5)
+
+    du_dps = []
+    for ui in u_impls:
+        du_dp_obs = custom_ops.AvgPartialUPartialParam(ui, 5)
+        ctxt.add_observable(du_dp_obs)
+        du_dps.append(du_dp_obs)
 
     ctxt.add_observable(du_dl_obs)
 
-    for step in range(20000):
-
-        if step % 1000 == 0:
-            writer.write_frame(ctxt.get_x_t() * 10)
-
+    for _ in range(20000):
+        if step % 500 == 0:
+            writer.write_frame(ctxt.get_x_t()*10)
+        print("FINAL LAMB", final_lamb)
         ctxt.step(final_lamb)
 
     writer.close()
 
+    print("final energy", ctxt.get_u_t())
+
+    # print vector jacobian products back into the forcefield derivative
+    for du_dp_obs, vjp_and_handles in zip(du_dps, final_vjp_and_handles):
+        du_dp = du_dp_obs.avg_du_dp()
+
+        if vjp_and_handles:
+            vjp_fn, handles = vjp_and_handles
+            du_df = vjp_fn(du_dp) # vjp into forcefield derivatives
+            for f_grad, h in zip(du_df, handles):
+                print("handle:", type(h).__name__)
+                for s, vv in zip(h.smirks, f_grad):
+                    if np.any(vv) != 0:
+                        print(s, vv)
+                print("\n")
+
     du_dl = du_dl_obs.avg_du_dl()
 
-    print(final_lamb, du_dl)
+    print("lambda", final_lamb, "du_dl", du_dl)

--- a/examples/rhfe.py
+++ b/examples/rhfe.py
@@ -190,7 +190,6 @@ for lamb_idx, final_lamb in enumerate(np.linspace(1, 0, 8)):
     for _ in range(20000):
         if step % 500 == 0:
             writer.write_frame(ctxt.get_x_t()*10)
-        print("FINAL LAMB", final_lamb)
         ctxt.step(final_lamb)
 
     writer.close()

--- a/fe/rbfe.py
+++ b/fe/rbfe.py
@@ -148,9 +148,6 @@ def stage_0(recipe, b_idxs, core_pairs, centroid_k, core_k):
     recipe.bound_potentials.append(lhs)
     recipe.bound_potentials.append(rhs)
 
-    recipe.vjp_fns.append([])
-    recipe.vjp_fns.append([])
-
     set_nonbonded_lambda_idxs(recipe, b_idxs, 1, 0)
 
 def stage_1(recipe, a_idxs, b_idxs, core_pairs, core_k):
@@ -183,7 +180,6 @@ def stage_1(recipe, a_idxs, b_idxs, core_pairs, core_k):
     core_restraints = create_core_restraints(core_pairs, core_k)
 
     recipe.bound_potentials.append(core_restraints)
-    recipe.vjp_fns.append([])
 
     add_nonbonded_exclusions(recipe, a_idxs, b_idxs)
     set_nonbonded_lambda_idxs(recipe, b_idxs, 0, 1)

--- a/fe/topology.py
+++ b/fe/topology.py
@@ -1,0 +1,305 @@
+import numpy as np
+import jax.numpy as jnp
+
+from timemachine.lib import potentials
+from ff.handlers import nonbonded, bonded
+
+_SCALE_12 = 1.0
+_SCALE_13 = 1.0
+_SCALE_14 = 0.5
+_BETA = 2.0
+_CUTOFF = 1.2
+
+class HostGuestTopology():
+
+    def __init__(self, guest_topology, host_p, num_host_atoms):
+        """
+        Utility tool for combining host with a guest, in that order.
+
+        Parameters
+        ----------
+        guest_topology:
+            Guest's Topology {Base, Dual, Single}Topology.
+
+        host_p:
+            Nonbonded potential for the host.
+
+        num_host_atoms:
+            Number of atoms in the host.
+    
+        """
+        self.guest_topology = guest_topology
+        self.host_p = host_p
+        self.num_host_atoms = num_host_atoms
+
+    def parameterize_harmonic_bond(self, ff_params):
+        params, potential = self.guest_topology.parameterize_harmonic_bond(ff_params)
+        potential.set_bond_idxs(potential.get_bond_idxs() + self.num_host_atoms)
+        return params, potential
+
+    def parameterize_harmonic_angle(self, ff_params):
+        params, potential = self.guest_topology.parameterize_harmonic_angle(ff_params)
+        potential.set_angle_idxs(potential.get_angle_idxs() + self.num_host_atoms)
+        return params, potential
+
+    def parameterize_proper_torsion(self, ff_params):
+        params, potential = self.guest_topology.parameterize_proper_torsion(ff_params)
+        potential.set_torsion_idxs(potential.get_torsion_idxs() + self.num_host_atoms)
+        return params, potential
+
+    def parameterize_improper_torsion(self, ff_params):
+        params, potential = self.guest_topology.parameterize_improper_torsion(ff_params)
+        potential.set_torsion_idxs(potential.get_torsion_idxs() + self.num_host_atoms)
+        return params, potential
+
+    def parameterize_nonbonded(self, ff_q_params, ff_lj_params):
+        # this needs to take care of the case when there's parameter interpolation.
+        num_guest_atoms = self.guest_topology.get_num_atoms()
+        guest_qlj, guest_p = self.guest_topology.parameterize_nonbonded(ff_q_params, ff_lj_params)
+        
+        # see if we're doing parameter interpolation
+        assert guest_qlj.shape[1] == 3
+
+        assert guest_p.get_beta() == self.host_p.get_beta()
+        assert guest_p.get_cutoff() == self.host_p.get_cutoff()
+
+        if guest_qlj.shape[0] == num_guest_atoms:
+            # no parameter interpolation
+            hg_nb_params = jnp.concatenate([self.host_p.params, guest_qlj])
+        elif guest_qlj.shape[0] == num_guest_atoms*2:
+            # with parameter interpolation
+            hg_nb_params_src = jnp.concatenate([self.host_p.params, guest_qlj[:num_guest_atoms]])
+            hg_nb_params_dst = jnp.concatenate([self.host_p.params, guest_qlj[num_guest_atoms:]])
+            hg_nb_params = jnp.concatenate([hg_nb_params_src, hg_nb_params_dst])
+        else:
+            # you dun' goofed and consequences will never be the same
+            assert 0
+
+        hg_exclusion_idxs = np.concatenate([self.host_p.get_exclusion_idxs(), guest_p.get_exclusion_idxs() + self.num_host_atoms])
+        hg_scale_factors = np.concatenate([self.host_p.get_scale_factors(), guest_p.get_scale_factors()])
+        hg_lambda_offset_idxs = np.concatenate([self.host_p.get_lambda_offset_idxs(), guest_p.get_lambda_offset_idxs()])
+        hg_lambda_plane_idxs = np.concatenate([self.host_p.get_lambda_plane_idxs(), guest_p.get_lambda_plane_idxs()])
+
+        return hg_nb_params, potentials.Nonbonded(
+            hg_exclusion_idxs,
+            hg_scale_factors,
+            hg_lambda_plane_idxs,
+            hg_lambda_offset_idxs,
+            guest_p.get_beta(),
+            guest_p.get_cutoff()
+        )
+
+
+class BaseTopology():
+
+    def __init__(self, mol, forcefield):
+        """
+        Utility for working with a single ligand.
+
+        Parameter
+        ---------
+        mol: ROMol
+            Ligand to be parameterized
+
+        forcefield: ff.Forcefield
+            A convenience wrapper for forcefield lists.
+
+        """
+        self.mol = mol
+        self.ff = forcefield
+
+    def get_num_atoms(self):
+        return self.mol.GetNumAtoms()
+
+    def parameterize_nonbonded(self, ff_q_params, ff_lj_params):
+        q_params = self.ff.q_handle.partial_parameterize(ff_q_params, self.mol)
+        lj_params = self.ff.lj_handle.partial_parameterize(ff_lj_params, self.mol)
+
+        exclusion_idxs, scale_factors = nonbonded.generate_exclusion_idxs(
+            self.mol,
+            scale12=_SCALE_12,
+            scale13=_SCALE_13,
+            scale14=_SCALE_14
+        )
+
+        scale_factors = np.stack([scale_factors, scale_factors], axis=1)
+
+        N = len(q_params)
+
+        lambda_plane_idxs = np.zeros(N, dtype=np.int32)
+        lambda_offset_idxs = np.ones(N, dtype=np.int32)
+
+        beta = _BETA
+        cutoff = _CUTOFF # solve for this analytically later
+
+        nb = potentials.Nonbonded(
+            exclusion_idxs,
+            scale_factors,
+            lambda_plane_idxs,
+            lambda_offset_idxs,
+            beta,
+            cutoff
+        ) 
+
+        params = jnp.concatenate([
+            jnp.reshape(q_params, (-1, 1)),
+            jnp.reshape(lj_params, (-1, 2))
+        ], axis=1)
+
+        return params, nb
+
+    def parameterize_harmonic_bond(self, ff_params):
+        params, idxs = self.ff.hb_handle.partial_parameterize(ff_params, self.mol)
+        return params, potentials.HarmonicBond(idxs)
+
+
+    def parameterize_harmonic_angle(self, ff_params):
+        params, idxs = self.ff.ha_handle.partial_parameterize(ff_params, self.mol)
+        return params, potentials.HarmonicAngle(idxs)
+
+
+    def parameterize_proper_torsion(self, ff_params):
+        params, idxs = self.ff.pt_handle.partial_parameterize(ff_params, self.mol)
+        return params, potentials.PeriodicTorsion(idxs)
+
+
+    def parameterize_improper_torsion(self, ff_params):
+        params, idxs = self.ff.it_handle.partial_parameterize(ff_params, self.mol)
+        return params, potentials.PeriodicTorsion(idxs)
+
+
+
+class DualTopology():
+
+    def __init__(self, mol_a, mol_b, forcefield):
+        """
+        Utility for working with two ligands via dual topology. Both copies of the ligand
+        will be present after merging.
+
+        Parameter
+        ---------
+        mol_a: ROMol
+            First ligand to be parameterized
+
+        mol_b: ROMol
+            Second ligand to be parameterized
+
+        forcefield: ff.Forcefield
+            A convenience wrapper for forcefield lists.
+
+        """
+        self.mol_a = mol_a
+        self.mol_b = mol_b
+        self.ff = forcefield
+
+    def get_num_atoms(self):
+        return self.mol_a.GetNumAtoms() + self.mol_b.GetNumAtoms()
+
+    def parameterize_nonbonded(self, ff_q_params, ff_lj_params):
+        q_params_a = self.ff.q_handle.partial_parameterize(ff_q_params, self.mol_a)
+        q_params_b = self.ff.q_handle.partial_parameterize(ff_q_params, self.mol_b) # HARD TYPO
+        lj_params_a = self.ff.lj_handle.partial_parameterize(ff_lj_params, self.mol_a)
+        lj_params_b = self.ff.lj_handle.partial_parameterize(ff_lj_params, self.mol_b)
+
+        q_params = jnp.concatenate([q_params_a, q_params_b])
+        lj_params = jnp.concatenate([lj_params_a, lj_params_b])
+
+        exclusion_idxs_a, scale_factors_a = nonbonded.generate_exclusion_idxs(
+            self.mol_a,
+            scale12=_SCALE_12,
+            scale13=_SCALE_13,
+            scale14=_SCALE_14
+        )
+
+        exclusion_idxs_b, scale_factors_b = nonbonded.generate_exclusion_idxs(
+            self.mol_b,
+            scale12=_SCALE_12,
+            scale13=_SCALE_13,
+            scale14=_SCALE_14
+        )
+
+        mutual_exclusions = []
+        mutual_scale_factors = []
+
+        NA = self.mol_a.GetNumAtoms()
+        NB = self.mol_b.GetNumAtoms()
+
+        for i in range(NA):
+            for j in range(NB):
+                mutual_exclusions.append([i, j + NA])
+                mutual_scale_factors.append([1.0, 1.0])
+
+        mutual_exclusions = np.array(mutual_exclusions)
+        mutual_scale_factors = np.array(mutual_scale_factors)
+
+        combined_exclusion_idxs = np.concatenate([
+            exclusion_idxs_a,
+            exclusion_idxs_b + NA,
+            mutual_exclusions
+        ]).astype(np.int32)
+
+        combined_scale_factors = np.concatenate([
+            np.stack([scale_factors_a, scale_factors_a], axis=1),
+            np.stack([scale_factors_b, scale_factors_b], axis=1),
+            mutual_scale_factors
+        ]).astype(np.float64)
+
+        combined_lambda_plane_idxs = np.zeros(NA+NB, dtype=np.int32)
+        combined_lambda_offset_idxs = np.concatenate([
+            np.ones(NA, dtype=np.int32),
+            np.ones(NB, dtype=np.int32)
+        ])
+
+        beta = _BETA
+        cutoff = _CUTOFF # solve for this analytically later
+
+        nb = potentials.Nonbonded(
+            combined_exclusion_idxs,
+            combined_scale_factors,
+            combined_lambda_plane_idxs,
+            combined_lambda_offset_idxs,
+            beta,
+            cutoff
+        ) 
+
+        params = jnp.concatenate([
+            jnp.reshape(q_params, (-1, 1)),
+            jnp.reshape(lj_params, (-1, 2))
+        ], axis=1)
+
+        return params, nb
+
+    def parameterize_harmonic_bond(self, ff_params):
+        offset = self.mol_a.GetNumAtoms()
+        params_a, idxs_a = self.ff.hb_handle.partial_parameterize(ff_params, self.mol_a)
+        params_b, idxs_b = self.ff.hb_handle.partial_parameterize(ff_params, self.mol_b)
+        params_c = jnp.concatenate([params_a, params_b])
+        idxs_c = jnp.concatenate([idxs_a, idxs_b + offset])
+        return params_c, potentials.HarmonicBond(idxs_c)
+
+
+    def parameterize_harmonic_angle(self, ff_params):
+        offset = self.mol_a.GetNumAtoms()
+        params_a, idxs_a = self.ff.ha_handle.partial_parameterize(ff_params, self.mol_a)
+        params_b, idxs_b = self.ff.ha_handle.partial_parameterize(ff_params, self.mol_b)
+        params_c = jnp.concatenate([params_a, params_b])
+        idxs_c = jnp.concatenate([idxs_a, idxs_b + offset])
+        return params_c, potentials.HarmonicAngle(idxs_c)
+
+
+    def parameterize_proper_torsion(self, ff_params):
+        offset = self.mol_a.GetNumAtoms()
+        params_a, idxs_a = self.ff.pt_handle.partial_parameterize(ff_params, self.mol_a)
+        params_b, idxs_b = self.ff.pt_handle.partial_parameterize(ff_params, self.mol_b)
+        params_c = jnp.concatenate([params_a, params_b])
+        idxs_c = jnp.concatenate([idxs_a, idxs_b + offset])
+        return params_c, potentials.PeriodicTorsion(idxs_c)
+
+    def parameterize_improper_torsion(self, ff_params):
+        offset = self.mol_a.GetNumAtoms()
+        params_a, idxs_a = self.ff.it_handle.partial_parameterize(ff_params, self.mol_a)
+        params_b, idxs_b = self.ff.it_handle.partial_parameterize(ff_params, self.mol_b)
+        params_c = jnp.concatenate([params_a, params_b])
+        idxs_c = jnp.concatenate([idxs_a, idxs_b + offset])
+        return params_c, potentials.PeriodicTorsion(idxs_c)
+

--- a/ff/__init__.py
+++ b/ff/__init__.py
@@ -1,0 +1,41 @@
+from ff.handlers import nonbonded, bonded
+
+class Forcefield():
+    """
+    A forcefield supports generation of parameters of a standard
+    molecular system.
+    """
+
+
+    def __init__(self, ff_handlers):
+        self.hb_handle = None
+        self.ha_handle = None
+        self.pt_handle = None
+        self.it_handle = None
+        self.lj_handle = None
+        self.q_handle = None
+        for handle in ff_handlers:
+            if isinstance(handle, bonded.HarmonicBondHandler):
+                self.hb_handle = handle
+            if isinstance(handle, bonded.HarmonicAngleHandler):
+                self.ha_handle = handle
+            if isinstance(handle, bonded.ProperTorsionHandler):
+                self.pt_handle = handle
+            if isinstance(handle, bonded.ImproperTorsionHandler):
+                self.it_handle = handle
+            if isinstance(handle, nonbonded.LennardJonesHandler):
+                self.lj_handle = handle
+            if isinstance(handle, nonbonded.AM1CCCHandler):
+                assert self.q_handle is None
+                self.q_handle = handle
+            if isinstance(handle, nonbonded.AM1BCCHandler):
+                assert self.q_handle is None
+                self.q_handle = handle
+            if isinstance(handle, nonbonded.SimpleChargeHandler):
+                assert self.q_handle is None
+                self.q_handle = handle
+
+    # def serialize(self):
+
+
+    # def deserialize(self):

--- a/ff/__init__.py
+++ b/ff/__init__.py
@@ -2,11 +2,8 @@ from ff.handlers import nonbonded, bonded
 
 class Forcefield():
     """
-    A forcefield supports generation of parameters of a standard
-    molecular system.
+    Utility class for wrapping around a list of ff_handlers
     """
-
-
     def __init__(self, ff_handlers):
         self.hb_handle = None
         self.ha_handle = None
@@ -16,14 +13,19 @@ class Forcefield():
         self.q_handle = None
         for handle in ff_handlers:
             if isinstance(handle, bonded.HarmonicBondHandler):
+                assert self.hb_handle is None
                 self.hb_handle = handle
             if isinstance(handle, bonded.HarmonicAngleHandler):
+                assert self.ha_handle is None
                 self.ha_handle = handle
             if isinstance(handle, bonded.ProperTorsionHandler):
+                assert self.pt_handle is None
                 self.pt_handle = handle
             if isinstance(handle, bonded.ImproperTorsionHandler):
+                assert self.it_handle is None
                 self.it_handle = handle
             if isinstance(handle, nonbonded.LennardJonesHandler):
+                assert self.lj_handle is None
                 self.lj_handle = handle
             if isinstance(handle, nonbonded.AM1CCCHandler):
                 assert self.q_handle is None
@@ -34,8 +36,3 @@ class Forcefield():
             if isinstance(handle, nonbonded.SimpleChargeHandler):
                 assert self.q_handle is None
                 self.q_handle = handle
-
-    # def serialize(self):
-
-
-    # def deserialize(self):

--- a/ff/handlers/bonded.py
+++ b/ff/handlers/bonded.py
@@ -40,6 +40,11 @@ class ReversibleBondHandler(SerializableMixIn):
         self.props = props
         assert len(self.smirks) == len(self.params)
 
+    def lookup_smirks(self, query):
+        for s_idx, s in enumerate(self.smirks):
+            if s == query:
+                return self.params[s_idx]
+
     def partial_parameterize(self, params, mol):
         return self.static_parameterize(params, self.smirks, mol)
 

--- a/ff/handlers/bonded.py
+++ b/ff/handlers/bonded.py
@@ -40,7 +40,14 @@ class ReversibleBondHandler(SerializableMixIn):
         self.props = props
         assert len(self.smirks) == len(self.params)
 
+    def partial_parameterize(self, params, mol):
+        return self.static_parameterize(params, self.smirks, mol)
+
     def parameterize(self, mol):
+        return self.static_parameterize(self.params, self.smirks, mol)
+
+    @staticmethod
+    def static_parameterize(params, smirks, mol):
         """
         Parameterize given molecule
 
@@ -56,11 +63,8 @@ class ReversibleBondHandler(SerializableMixIn):
 
         """
 
-        bond_idxs, param_idxs = generate_vd_idxs(mol, self.smirks)
-        param_fn = functools.partial(parameterize_ligand, param_idxs=param_idxs)
-        sys_params, vjp_fn = jax.vjp(param_fn, self.params)
-
-        return np.array(bond_idxs, dtype=np.int32), (np.array(sys_params, dtype=np.float64), vjp_fn)
+        bond_idxs, param_idxs = generate_vd_idxs(mol, smirks)
+        return params[param_idxs], bond_idxs
 
 # we need to subclass to get the names backout
 class HarmonicBondHandler(ReversibleBondHandler):
@@ -95,31 +99,36 @@ class ProperTorsionHandler():
                 self.params.append(term)
         
         self.counts = np.array(self.counts, dtype=np.int32)
-        # prefix sum of size + 1
-        self.pfxsum = np.concatenate([[0], np.cumsum(self.counts)]) 
+ 
         self.params = np.array(self.params, dtype=np.float64)
         self.props = props
 
     def parameterize(self, mol):
-        torsion_idxs, param_idxs = generate_vd_idxs(mol, self.smirks)
+        return self.static_parameterize(self.params, self.smirks, self.counts, mol)
+
+    def partial_parameterize(self, params, mol):
+        return self.static_parameterize(params, self.smirks, self.counts, mol)
+
+
+    @staticmethod
+    def static_parameterize(params, smirks, counts, mol):
+        torsion_idxs, param_idxs = generate_vd_idxs(mol, smirks)
 
         assert len(torsion_idxs) == len(param_idxs)
 
         scatter_idxs = []
-        n_smirks = len(self.counts) # number of patterns
-
+        n_smirks = len(counts) # number of patterns
         repeats = []
+
+        # prefix sum of size + 1
+        pfxsum = np.concatenate([[0], np.cumsum(counts)]) 
         for p_idx in param_idxs:
-            start = self.pfxsum[p_idx]
-            end = self.pfxsum[p_idx+1]
+            start = pfxsum[p_idx]
+            end = pfxsum[p_idx+1]
             scatter_idxs.extend((range(start, end)))
-            repeats.append(self.counts[p_idx])
+            repeats.append(counts[p_idx])
 
-        scatter_idxs = np.array(scatter_idxs, dtype=np.int32).flatten()
-        param_fn = functools.partial(parameterize_ligand, param_idxs=scatter_idxs)
-        sys_params, vjp_fn = jax.vjp(param_fn, self.params)
-
-        return np.repeat(torsion_idxs, repeats, axis=0).astype(np.int32), (np.array(sys_params, dtype=np.float64), vjp_fn)
+        return params[scatter_idxs], np.repeat(torsion_idxs, repeats, axis=0).astype(np.int32)
 
     def serialize(self):
         list_params = []
@@ -150,7 +159,15 @@ class ImproperTorsionHandler(SerializableMixIn):
         assert self.params.shape[1] == 3
         assert len(self.smirks) == len(self.params)
 
+    def partial_parameterize(self, params, mol):
+        return self.static_parameterize(params, self.smirks, mol)
+
     def parameterize(self, mol):
+        return self.static_parameterize(self.params, self.smirks, mol)
+
+
+    @staticmethod
+    def static_parameterize(params, smirks, mol):
 
         # improper torsions do not use a valence dict as
         # we cannot sort based on b_idxs[0] and b_idxs[-1]
@@ -167,7 +184,7 @@ class ImproperTorsionHandler(SerializableMixIn):
             nbs = sorted(nbs)
             return nbs[0], ctr, nbs[1], nbs[2]
 
-        for p_idx, patt in enumerate(self.smirks):
+        for p_idx, patt in enumerate(smirks):
             matches = match_smirks(mol, patt)
 
             for m in matches:
@@ -184,8 +201,4 @@ class ImproperTorsionHandler(SerializableMixIn):
                 improper_idxs.append((center, p[0], p[1], p[2]))
                 param_idxs.append(p_idx)
 
-
-        param_fn = functools.partial(parameterize_ligand, param_idxs=param_idxs)
-        sys_params, vjp_fn = jax.vjp(param_fn, self.params)
-
-        return np.array(improper_idxs, dtype=np.int32), (np.array(sys_params, dtype=np.float64), vjp_fn)
+        return params[param_idxs], np.array(improper_idxs, dtype=np.int32)

--- a/md/minimizer.py
+++ b/md/minimizer.py
@@ -17,7 +17,7 @@ def get_romol_conf(mol):
 
 def minimize_4d(romol, host_system, host_coords, ff, box):
     """
-    Insert romol into a ligand via 4D decoupling under a Langevin thermostat.
+    Insert romol into a host system via 4D decoupling under a Langevin thermostat.
 
     Parameters
     ----------

--- a/md/minimizer.py
+++ b/md/minimizer.py
@@ -1,0 +1,82 @@
+import numpy as np
+
+from fe import topology
+
+from timemachine.lib import potentials
+from timemachine.lib import LangevinIntegrator, custom_ops
+
+from ff.handlers import openmm_deserializer
+from ff import Forcefield
+
+def get_romol_conf(mol):
+    """Coordinates of mol's 0th conformer, in nanometers"""
+    conformer = mol.GetConformer(0)
+    guest_conf = np.array(conformer.GetPositions(), dtype=np.float64)
+    return guest_conf/10 # from angstroms to nm
+
+
+def minimize_4d(romol, host_system, host_coords, ff, box):
+
+    host_bps, host_masses = openmm_deserializer.deserialize_system(host_system, cutoff=1.2)
+
+    ligand_masses = [a.GetMass() for a in romol.GetAtoms()]
+    combined_masses = np.concatenate([host_masses, ligand_masses])
+    ligand_coords = get_romol_conf(romol)
+    combined_coords = np.concatenate([host_coords, ligand_coords])
+    num_host_atoms = host_coords.shape[0]
+
+    final_potentials = []
+    for bp in host_bps:
+        if isinstance(bp, potentials.Nonbonded):
+            host_p = bp
+        else:
+            final_potentials.append(bp)
+
+    gbt = topology.BaseTopology(romol, ff)
+    hgt = topology.HostGuestTopology(gbt, host_p, num_host_atoms)
+
+    # setup the parameter handlers for the ligand
+    tuples = [
+        [hgt.parameterize_harmonic_bond, [ff.hb_handle]],
+        [hgt.parameterize_harmonic_angle, [ff.ha_handle]],
+        [hgt.parameterize_proper_torsion, [ff.pt_handle]],
+        [hgt.parameterize_improper_torsion, [ff.it_handle]],
+        [hgt.parameterize_nonbonded, [ff.q_handle, ff.lj_handle]],
+    ]
+
+    for fn, handles in tuples:
+        params, potential = fn(*[h.params for h in handles])
+        final_potentials.append(potential.bind(params))
+
+    seed = 2020
+
+    intg = LangevinIntegrator(
+        300.0,
+        1.5e-3,
+        1.0,
+        combined_masses,
+        seed
+    ).impl()
+
+    x0 = combined_coords
+    v0 = np.zeros_like(x0)
+
+    u_impls = []
+
+    for bp in final_potentials:
+        fn = bp.bound_impl(precision=np.float32)
+        u_impls.append(fn)
+
+    # context components: positions, velocities, box, integrator, energy fxns
+    ctxt = custom_ops.Context(
+        x0,
+        v0,
+        box,
+        intg,
+        u_impls
+    )
+
+    for lamb in np.linspace(1.0, 0, 1000):
+        ctxt.step(lamb)
+
+    return ctxt.get_x_t()

--- a/md/minimizer.py
+++ b/md/minimizer.py
@@ -16,6 +16,27 @@ def get_romol_conf(mol):
 
 
 def minimize_4d(romol, host_system, host_coords, ff, box):
+    """
+    Insert romol into a ligand via 4D decoupling under a Langevin thermostat.
+
+    Parameters
+    ----------
+    romol: ROMol
+        Ligand to be inserted. It must be embedded.
+
+    host_system: openmm.System
+        OpenMM System representing the host
+
+    host_coords: np.ndarray
+        N x 3 coordinates of the host. units of nanometers.
+
+    ff: ff.Forcefield
+        Wrapper class around a list of handlers
+
+    box: np.ndarray [3,3]
+        Box matrix for periodic boundary conditions. units of nanometers.
+
+    """
 
     host_bps, host_masses = openmm_deserializer.deserialize_system(host_system, cutoff=1.2)
 
@@ -33,7 +54,7 @@ def minimize_4d(romol, host_system, host_coords, ff, box):
             final_potentials.append(bp)
 
     gbt = topology.BaseTopology(romol, ff)
-    hgt = topology.HostGuestTopology(gbt, host_p, num_host_atoms)
+    hgt = topology.HostGuestTopology(host_p, gbt)
 
     # setup the parameter handlers for the ligand
     tuples = [

--- a/tests/test_rbfe.py
+++ b/tests/test_rbfe.py
@@ -83,7 +83,6 @@ def get_romol_conf(mol):
     guest_conf = guest_conf/10 # from angstroms to nm
     return np.array(guest_conf, dtype=np.float64)
 
-
 def test_stage_0():
 
     benzene = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1"))

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -11,19 +11,19 @@ from ff.handlers.deserialize import deserialize_handlers
 from md import Recipe
 from md import builders
 
-# def test_recipe_from_rdkit():
-#     ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_ccc.py').read())
-#     suppl = Chem.SDMolSupplier('tests/data/ligands_40.sdf', removeHs=False)
-#     for mol_idx, mol in enumerate(suppl):
-#         print(mol_idx, Chem.MolToSmiles(mol))
-#         system = md.Recipe.from_rdkit(mol, ff_handlers, np.float32)
-#         if mol_idx > 2:
-#             break
+def test_recipe_from_rdkit():
+    ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_ccc.py').read())
+    suppl = Chem.SDMolSupplier('tests/data/ligands_40.sdf', removeHs=False)
+    for mol_idx, mol in enumerate(suppl):
+        print(mol_idx, Chem.MolToSmiles(mol))
+        system = md.Recipe.from_rdkit(mol, ff_handlers)
+        if mol_idx > 2:
+            break
 
-# def test_recipe_from_openmm():
-#     fname = 'tests/data/hif2a_nowater_min.pdb'
-#     openmm_system, _, _, _, _ = builders.build_protein_system(fname)
-#     md.Recipe.from_openmm(openmm_system, np.float32)
+def test_recipe_from_openmm():
+    fname = 'tests/data/hif2a_nowater_min.pdb'
+    openmm_system, _, _, _, _ = builders.build_protein_system(fname)
+    md.Recipe.from_openmm(openmm_system)
 
 
 def test_combine_recipe():
@@ -36,7 +36,6 @@ def test_combine_recipe():
     openmm_system, openmm_conf, _, _, _ = builders.build_protein_system('tests/data/hif2a_nowater_min.pdb')
     protein_recipe = md.Recipe.from_openmm(openmm_system)
 
-    # for exclude in [True, False]:
     for left_recipe, right_recipe in [[protein_recipe, ligand_recipe], [ligand_recipe, protein_recipe]]:
 
         combined_recipe = left_recipe.combine(right_recipe)
@@ -53,23 +52,7 @@ def test_combine_recipe():
         n_left = len(left_recipe.masses)
         n_right = len(right_recipe.masses)
 
-        # if exclude:
-        #     assert (len(left_idxs) + len(right_idxs) + n_left * n_right) == len(combined_idxs)
-        #     test_set = np.sort(combined_idxs[len(left_idxs) + len(right_idxs):])
-
-        #     ref_set = []
-        #     for i in range(n_left):
-        #         for j in range(n_right):
-        #             ref_set.append((i, j+n_left))
-        #     ref_set = np.sort(np.array(ref_set, dtype=np.int32))
-
-        #     np.testing.assert_array_equal(test_set, ref_set)
-        # else:
-        # assert (len(left_idxs) + len(right_idxs)) == len(combined_idxs)
         np.testing.assert_array_equal(np.concatenate([left_idxs, right_idxs + n_left]), combined_idxs)
-
-        for handle, vjp_fn in combined_recipe.vjp_fns[-1]:
-            assert handle.params.shape == vjp_fn(qlj)[0].shape
 
         for bp in combined_recipe.bound_potentials:
             bp.bound_impl(precision=np.float32)

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -102,6 +102,9 @@ class HarmonicBond(CustomOpWrapper):
     def get_bond_idxs(self):
         return self.args[0]
 
+    def set_bond_idxs(self, new_idxs):
+        self.args[0] = new_idxs
+
 # this is an alias to make type checking easier
 class CoreRestraint(HarmonicBond):
 
@@ -121,10 +124,16 @@ class HarmonicAngle(CustomOpWrapper):
     def get_angle_idxs(self):
         return self.args[0]
 
+    def set_angle_idxs(self, new_idxs):
+        self.args[0] = new_idxs
+
 class PeriodicTorsion(CustomOpWrapper):
 
     def get_torsion_idxs(self):
         return self.args[0]
+
+    def set_torsion_idxs(self, new_idxs):
+        self.args[0] = new_idxs
 
 class InertialRestraint(CustomOpWrapper):
 


### PR DESCRIPTION
This PR cleans up one of the ugliest warts in the code, manual chaining of vjp_fns when computing jacobians. SingleTopology methods involve extensive interpolation, splicing, and chaining of forcefield parameters, which will be error-prone if we still did the vjps manually.

This PR doe the following:

- Base forcefield handlers no longer return vjp_fns in parameterize(). Instead a partial_parameterization function exposes a params field that allows one to call jax.vjp on it directly. The older .parameterize class suffered in that its signature does not include an explicit "params" field.
- Adds the new {Base,Dual}Topology classes are intended to replace the Recipe classes. The harder, SingleTopology class will come in a separate PR.
- Recipe is still working but its vjp_fn functionality have been removed, but it will be removed in a later commit.
- ahfe.py and rhfe.py have been cleaned up to use this new system, and the vjp_fns are tested and included for both.
- Adds a 4D minimizer code to do the **initial** insertion in relative hydration free energy calculations.
