### PR TITLE
Rename and deprecate du_dx_t and u_t functions.

### DIFF
--- a/docking/pose_dock.py
+++ b/docking/pose_dock.py
@@ -168,7 +168,7 @@ def pose_dock(
                     f"guest_name: {guest_name}\t"
                     f"step: {str(step).zfill(len(str(n_steps)))}\t"
                     f"lambda: {lamb:.2f}\t"
-                    f"energy: {ctxt.get_u_t():.2f}"
+                    f"energy: {ctxt._get_u_t_minus_1():.2f}"
                 )
                 forces = ctxt.get_du_dx_t()
                 norm_forces = np.linalg.norm(forces, axis=-1)

--- a/docking/pose_dock.py
+++ b/docking/pose_dock.py
@@ -170,7 +170,7 @@ def pose_dock(
                     f"lambda: {lamb:.2f}\t"
                     f"energy: {ctxt._get_u_t_minus_1():.2f}"
                 )
-                forces = ctxt.get_du_dx_t()
+                forces = ctxt._get_du_dx_t_minus_1()
                 norm_forces = np.linalg.norm(forces, axis=-1)
                 if np.any(norm_forces > 10000):
                     print("Error: at least one force is too large to continue")

--- a/examples/ahfe.py
+++ b/examples/ahfe.py
@@ -151,14 +151,14 @@ for final_lamb in np.linspace(0, 1, 8):
         ctxt.step(lamb)
 
 
-    print("insertion energy", ctxt.get_u_t())
+    print("insertion energy", ctxt._get_u_t_minus_1())
 
     # note: these 5000 steps are "equilibration", before we attach a reporter /
     #   "observable" to the context and start running "production"
     for _ in range(5000):
         ctxt.step(final_lamb)
 
-    print("equilibrium energy", ctxt.get_u_t())
+    print("equilibrium energy", ctxt._get_u_t_minus_1())
 
     # TODO: what was the second argument -- reporting interval in steps?
     du_dl_obs = custom_ops.AvgPartialUPartialLambda(u_impls, 5)
@@ -174,7 +174,7 @@ for final_lamb in np.linspace(0, 1, 8):
     for _ in range(10000):
         ctxt.step(final_lamb)
 
-    print("final energy", ctxt.get_u_t())
+    print("final energy", ctxt._get_u_t_minus_1())
 
     # print vector jacobian products back into the forcefield derivative
     for du_dp_obs, vjp_and_handles in zip(du_dps, final_vjp_and_handles):

--- a/examples/rhfe_dual.py
+++ b/examples/rhfe_dual.py
@@ -164,7 +164,7 @@ for lamb_idx, final_lamb in enumerate(np.linspace(1, 0, 8)):
             writer.write_frame(ctxt.get_x_t()*10)
         ctxt.step(lamb)
 
-    print("insertion energy", ctxt.get_u_t())
+    print("insertion energy", ctxt._get_u_t_minus_1())
 
     # note: these 5000 steps are "equilibration", before we attach a reporter /
     #   "observable" to the context and start running "production"
@@ -173,7 +173,7 @@ for lamb_idx, final_lamb in enumerate(np.linspace(1, 0, 8)):
             writer.write_frame(ctxt.get_x_t()*10)
         ctxt.step(final_lamb)
 
-    print("equilibrium energy", ctxt.get_u_t())
+    print("equilibrium energy", ctxt._get_u_t_minus_1())
 
     # TODO: what was the second argument -- reporting interval in steps?
     du_dl_obs = custom_ops.AvgPartialUPartialLambda(u_impls, 5)
@@ -193,7 +193,7 @@ for lamb_idx, final_lamb in enumerate(np.linspace(1, 0, 8)):
 
     writer.close()
 
-    print("final energy", ctxt.get_u_t())
+    print("final energy", ctxt._get_u_t_minus_1())
 
     # print vector jacobian products back into the forcefield derivative
     for du_dp_obs, vjp_and_handles in zip(du_dps, final_vjp_and_handles):

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -147,8 +147,8 @@ class TestContext(unittest.TestCase):
             ctxt.step(lamb)
             test_x_t = ctxt.get_x_t()
             test_v_t = ctxt.get_v_t()
-            test_du_dx_t = ctxt.get_du_dx_t()
-            test_u_t = ctxt.get_u_t()
+            test_du_dx_t = ctxt._get_du_dx_t_minus_1()
+            test_u_t = ctxt._get_u_t_minus_1()
 
             np.testing.assert_allclose(test_u_t, ref_all_us[step])
             np.testing.assert_allclose(test_du_dx_t, ref_all_du_dxs[step])

--- a/timemachine/cpp/src/context.cu
+++ b/timemachine/cpp/src/context.cu
@@ -119,13 +119,13 @@ int Context::num_atoms() const {
     return N_;
 }
 
-double Context::get_u_t() const {
+double Context::get_u_t_minus_1() const {
     double u;
     gpuErrchk(cudaMemcpy(&u, d_u_t_, 1*sizeof(*d_u_t_), cudaMemcpyDeviceToHost));
     return u;
 }
 
-void Context::get_du_dx_t(unsigned long long *out_buffer) const {
+void Context::get_du_dx_t_minus_1(unsigned long long *out_buffer) const {
     gpuErrchk(cudaMemcpy(out_buffer, d_du_dx_t_, N_*3*sizeof(*out_buffer), cudaMemcpyDeviceToHost));
 }
 

--- a/timemachine/cpp/src/context.hpp
+++ b/timemachine/cpp/src/context.hpp
@@ -30,9 +30,9 @@ public:
 
     int num_atoms() const;
 
-    double get_u_t() const;
+    double get_u_t_minus_1() const;
 
-    void get_du_dx_t(unsigned long long *out_buffer) const;
+    void get_du_dx_t_minus_1(unsigned long long *out_buffer) const;
 
     void get_x_t(double *out_buffer) const;
 

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -209,17 +209,6 @@ void declare_context(py::module &m) {
     }))
     .def("add_observable", &timemachine::Context::add_observable)
     .def("step", &timemachine::Context::step)
-    .def("get_du_dx_t", [](timemachine::Context &ctxt) -> py::array_t<double, py::array::c_style> {
-        unsigned int N = ctxt.num_atoms();
-        unsigned int D = 3;
-        std::vector<unsigned long long> du_dx(N*D);
-        ctxt.get_du_dx_t(&du_dx[0]);
-        py::array_t<double, py::array::c_style> py_du_dx({N, D});
-        for(int i=0; i < du_dx.size(); i++) {
-            py_du_dx.mutable_data()[i] = static_cast<double>(static_cast<long long>(du_dx[i]))/FIXED_EXPONENT;
-        }
-        return py_du_dx;
-    })
     .def("get_x_t", [](timemachine::Context &ctxt) -> py::array_t<double, py::array::c_style> {
         unsigned int N = ctxt.num_atoms();
         unsigned int D = 3;
@@ -234,8 +223,25 @@ void declare_context(py::module &m) {
         ctxt.get_v_t(buffer.mutable_data());
         return buffer;
     })
-    .def("get_u_t", [](timemachine::Context &ctxt) -> double {
-        return ctxt.get_u_t();
+    .def("_get_du_dx_t_minus_1", [](timemachine::Context &ctxt) -> py::array_t<double, py::array::c_style> {
+        PyErr_WarnEx(PyExc_DeprecationWarning, 
+            "_get_du_dx_t_minus_1() should only be used for testing. It will be removed in a future release.", 
+            1);
+        unsigned int N = ctxt.num_atoms();
+        unsigned int D = 3;
+        std::vector<unsigned long long> du_dx(N*D);
+        ctxt.get_du_dx_t_minus_1(&du_dx[0]);
+        py::array_t<double, py::array::c_style> py_du_dx({N, D});
+        for(int i=0; i < du_dx.size(); i++) {
+            py_du_dx.mutable_data()[i] = static_cast<double>(static_cast<long long>(du_dx[i]))/FIXED_EXPONENT;
+        }
+        return py_du_dx;
+    })
+    .def("_get_u_t_minus_1", [](timemachine::Context &ctxt) -> double {
+        PyErr_WarnEx(PyExc_DeprecationWarning, 
+            "_get_u_t_minus_1() should only be used for testing. It will be removed in a future release.", 
+            1);
+        return ctxt.get_u_t_minus_1();
     });
 }
 

--- a/training/worker.py
+++ b/training/worker.py
@@ -70,7 +70,7 @@ class Worker(service_pb2_grpc.WorkerServicer):
         # dynamics
         for step in range(request.prod_steps):
             if step % 100 == 0:
-                u = ctxt.get_u_t()
+                u = ctxt._get_u_t_minus_1()
                 energies.append(u)
 
             if request.n_frames > 0:


### PR DESCRIPTION
Addresses #306 based on offline comments with @maxentile 

I think this is explicit enough. We will remove these functions entirely when we re-work the integrator system.