### PR TITLE
Update neighborlist construction

### DIFF
--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -92,26 +92,26 @@ def benchmark_dhfr():
     lamb = 0.0
 
     start = time.time()
-    # num_steps = 50000
-    num_steps = 50000
-    # num_steps = 10
 
     writer = PDBWriter([host_pdb.topology], "dhfr.pdb")
 
-    for step in range(num_steps):
-        ctxt.step(lamb)
-        if step % 1000 == 0:
+    num_batches = 100
+    steps_per_batch = 1000
 
-            delta = time.time()-start
-            steps_per_second = step/delta
-            seconds_per_day = 86400
-            steps_per_day = steps_per_second*seconds_per_day
-            ps_per_day = dt*steps_per_day
-            ns_per_day = ps_per_day*1e-3
+    for batch in range(num_batches):
+        lambda_schedule = np.ones(steps_per_batch)*lamb
+        ctxt.multiple_steps(lambda_schedule)
 
-            print(step, "ns/day", ns_per_day)
-            # coords = recenter(ctxt.get_x_t(), box)
-            # writer.write_frame(coords*10)
+        delta = time.time()-start
+        steps_per_second = (batch+1)*steps_per_batch/delta
+        seconds_per_day = 86400
+        steps_per_day = steps_per_second*seconds_per_day
+        ps_per_day = dt*steps_per_day
+        ns_per_day = ps_per_day*1e-3
+
+        print((batch+1)*steps_per_batch, "steps @ ", ns_per_day, " ns/day")
+        # coords = recenter(ctxt.get_x_t(), box)
+        # writer.write_frame(coords*10)
 
     print("total time", time.time() - start)
 

--- a/tests/test_nonbonded.py
+++ b/tests/test_nonbonded.py
@@ -19,6 +19,7 @@ from common import prepare_nb_system, prepare_water_system, prepare_reference_no
 
 from timemachine.potentials import bonded, nonbonded, gbsa
 from timemachine.lib import potentials
+from md import builders
 
 from training import water_box
 
@@ -40,6 +41,276 @@ def hilbert_sort(conf, D):
         dists.append(dist)
     perm = np.argsort(dists)
     return perm
+
+class TestNonbondedDHFR(GradientTest):
+
+    def setUp(self):
+        # This test checks hilbert curve re-ordering gives identical results
+        pdb_path = 'tests/data/5dfr_solv_equil.pdb'
+        host_pdb = app.PDBFile(pdb_path)
+        protein_ff = app.ForceField('amber99sbildn.xml', 'tip3p.xml')
+
+        host_system = protein_ff.createSystem(
+            host_pdb.topology,
+            nonbondedMethod=app.NoCutoff,
+            constraints=None,
+            rigidWater=False
+        )
+
+        host_coords = host_pdb.positions
+        box = host_pdb.topology.getPeriodicBoxVectors()
+        self.box = np.asarray(box/box.unit)
+
+        host_fns, host_masses = openmm_deserializer.deserialize_system(
+            host_system,
+            cutoff=1.0
+        )
+
+        for f in host_fns:
+            if isinstance(f, potentials.Nonbonded):
+                self.nonbonded_fn = f
+
+        host_conf = []
+        for x,y,z in host_coords:
+            host_conf.append([to_md_units(x),to_md_units(y),to_md_units(z)])
+        self.host_conf = np.array(host_conf)
+
+        self.beta = 2.0
+        self.cutoff = 1.1
+        self.lamb = 0.1
+
+    def test_nblist_hilbert(self):
+        """
+        This test makes sure that hilbert ordering has no impact on numerical results. The
+        computed forces, energies, etc. should be bitwise identical.
+        """
+
+        np.random.seed(2021)
+
+        N = self.host_conf.shape[0]
+
+        ref_nonbonded_impl = copy.copy(self.nonbonded_fn).unbound_impl(np.float64)
+        ref_nonbonded_impl.disable_hilbert_sort()
+
+        test_nonbonded_impl = copy.copy(self.nonbonded_fn).unbound_impl(np.float64)
+
+        padding = 0.1
+        deltas = np.random.rand(N,3)-0.5 # [-0.5, +0.5]
+        divisor = 0.5*(2*np.sqrt(3))/padding
+        # if deltas are kept under +- p/(2*sqrt(3)) then no rebuild gets triggered
+        deltas = deltas/divisor # exactly within bounds, and should not trigger a rebuild
+
+        for d in deltas:
+            assert np.linalg.norm(d) < padding/2
+
+        xs = [self.host_conf, self.host_conf + deltas]
+
+        np.set_printoptions(precision=16)
+        # under pure fixed point accumulation the results should be identical.
+        for x_idx, x in enumerate(xs):
+
+            ref_du_dx, ref_du_dp, ref_du_dl, ref_u = ref_nonbonded_impl.execute(x, self.nonbonded_fn.params, self.box, 0.0)
+            test_du_dx, test_du_dp, test_du_dl, test_u = test_nonbonded_impl.execute(x, self.nonbonded_fn.params, self.box, 0.0)
+
+            np.testing.assert_array_equal(ref_du_dx, test_du_dx)
+            np.testing.assert_array_equal(ref_du_dp, test_du_dp)
+            np.testing.assert_array_equal(ref_du_dl, test_du_dl)
+            np.testing.assert_array_equal(ref_u, test_u)
+
+            ref_du_dx = ref_nonbonded_impl.execute_du_dx(x, self.nonbonded_fn.params, self.box, 0.0)
+            test_du_dx = test_nonbonded_impl.execute_du_dx(x, self.nonbonded_fn.params, self.box, 0.0)
+
+            for idx, (a, b) in enumerate(zip(ref_du_dx, test_du_dx)):
+                if np.linalg.norm(a-b) != 0:
+                    print(idx, a, b)
+                    assert 0
+                np.testing.assert_array_equal(a, b)
+
+            np.testing.assert_array_equal(ref_du_dx, test_du_dx)
+
+    def test_nblist_rebuild(self):
+        """
+        This test makes sure that periodically rebuilding the neighborlist no impact on numerical results. The
+        computed forces, energies, etc. should be bitwise identical.
+        """
+
+        N = self.host_conf.shape[0]
+
+        np.random.seed(2021)
+
+        ref_nonbonded_impl = copy.copy(self.nonbonded_fn).unbound_impl(np.float64)
+        ref_nonbonded_impl.set_nblist_padding(0.0) # rebuild with every call
+
+        padding = 0.1
+
+        test_nonbonded_impl = copy.copy(self.nonbonded_fn).unbound_impl(np.float64)
+        test_nonbonded_impl.set_nblist_padding(padding) # rebuild only when deltas have moved more than padding/2 angstroms
+
+        deltas = np.random.rand(N,3)-0.5 # [-0.5, +0.5]
+        divisor = 0.5*(2*np.sqrt(3))/padding
+        # if deltas are kept under +- p/(2*sqrt(3)) then no rebuild gets triggered
+        deltas = deltas/divisor # exactly within bounds, and should not trigger a rebuild
+
+        for d in deltas:
+            assert np.linalg.norm(d) < padding/2
+
+        xs = [self.host_conf, self.host_conf + deltas]
+
+        # under pure fixed point accumulation the results should be identical.
+        for x_idx, x in enumerate(xs):
+            ref_du_dx, ref_du_dp, ref_du_dl, ref_u = ref_nonbonded_impl.execute(x, self.nonbonded_fn.params, self.box, 0.0)
+            test_du_dx, test_du_dp, test_du_dl, test_u = test_nonbonded_impl.execute(x, self.nonbonded_fn.params, self.box, 0.0)
+
+            np.testing.assert_array_equal(ref_du_dx, test_du_dx)
+            np.testing.assert_array_equal(ref_du_dp, test_du_dp)
+            np.testing.assert_array_equal(ref_du_dl, test_du_dl)
+            np.testing.assert_array_equal(ref_u, test_u)
+
+            ref_du_dx = ref_nonbonded_impl.execute_du_dx(x, self.nonbonded_fn.params, self.box, 0.0)
+            test_du_dx = test_nonbonded_impl.execute_du_dx(x, self.nonbonded_fn.params, self.box, 0.0)
+
+            for idx, (a, b) in enumerate(zip(ref_du_dx, test_du_dx)):
+                if np.linalg.norm(a-b) != 0:
+                    print(idx, a, b)
+                    print(a)
+                    print(b)
+                    assert 0
+                np.testing.assert_array_equal(a, b)
+
+            np.testing.assert_array_equal(ref_du_dx, test_du_dx)
+
+    def test_correctness(self):
+        """
+        Test against the reference jax platform for correctness.
+        """
+        max_N = self.host_conf.shape[0]
+
+        # we can't go bigger than this due to memory limitations in the the reference platform.
+        for N in [33, 65, 231, 1050, 4080]:
+
+            test_conf = self.host_conf[:N]
+
+            # strip out parts of the system
+            test_exclusions = []
+            test_scales = []
+            for (i, j), (sa, sb) in zip(self.nonbonded_fn.get_exclusion_idxs(), self.nonbonded_fn.get_scale_factors()):
+                if i < N and j < N:
+                    test_exclusions.append((i,j))
+                    test_scales.append((sa, sb))
+            test_exclusions = np.array(test_exclusions, dtype=np.int32)
+            test_scales = np.array(test_scales, dtype=np.float64)
+            test_params = self.nonbonded_fn.params[:N, :]
+
+            test_lambda_plane_idxs = np.random.randint(low=-2, high=2, size=N, dtype=np.int32)
+            test_lambda_offset_idxs = np.random.randint(low=-2, high=2, size=N, dtype=np.int32)
+
+            test_nonbonded_fn = potentials.Nonbonded(
+                test_exclusions,
+                test_scales,
+                test_lambda_plane_idxs,
+                test_lambda_offset_idxs,
+                self.beta,
+                self.cutoff
+            )
+
+            ref_nonbonded_fn = prepare_reference_nonbonded(
+                test_params,
+                test_exclusions,
+                test_scales,
+                test_lambda_plane_idxs,
+                test_lambda_offset_idxs,
+                self.beta,
+                self.cutoff
+            )
+
+            for precision, rtol in [(np.float64, 1e-8), (np.float32, 1e-4)]:
+
+                self.compare_forces(
+                    test_conf,
+                    test_params,
+                    self.box,
+                    self.lamb,
+                    ref_nonbonded_fn,
+                    test_nonbonded_fn,
+                    rtol,
+                    precision=precision
+                )
+
+
+    @unittest.skip("benchmark-only")
+    def test_benchmark(self):
+        """
+        This is mainly for benchmarking nonbonded computations on the initial state. 
+        """
+
+        N = self.host_conf.shape[0]
+
+        host_conf = self.host_conf[:N]
+
+        precision = np.float32
+
+        impl = self.nonbonded_fn.unbound_impl(np.float32)
+
+        for _ in range(100):
+
+            impl.execute_du_dx(host_conf, self.nonbonded_fn.params, self.box, self.lamb)
+
+class TestNonbondedWater(GradientTest):
+
+    def test_nblist_box_resize(self):
+        # test that running the coordinates under two different boxes produces correct results
+        # since we should be rebuilding the nblist when the box sizes change.
+
+        host_system, host_coords, box, _ = builders.build_water_system(2.0)
+
+        host_fns, host_masses = openmm_deserializer.deserialize_system(
+            host_system,
+            cutoff=1.0
+        )
+
+        for f in host_fns:
+            if isinstance(f, potentials.Nonbonded):
+                test_nonbonded_fn = f
+
+        host_conf = []
+        for x,y,z in host_coords:
+            host_conf.append([to_md_units(x),to_md_units(y),to_md_units(z)])
+        host_conf = np.array(host_conf)
+
+        lamb = 0.1
+
+        N = host_conf.shape[0]
+
+        ref_nonbonded_fn = prepare_reference_nonbonded(
+            test_nonbonded_fn.params,
+            test_nonbonded_fn.get_exclusion_idxs(),
+            test_nonbonded_fn.get_scale_factors(),
+            test_nonbonded_fn.get_lambda_plane_idxs(),
+            test_nonbonded_fn.get_lambda_offset_idxs(),
+            test_nonbonded_fn.get_beta(),
+            test_nonbonded_fn.get_cutoff()
+        )
+
+        big_box = box + np.eye(3)*1000
+
+        # print(big_box, small_box)
+        # (ytz): note the ordering should be from large box to small box. though in the current code
+        # the rebuild is triggered as long as the box *changes*.
+        for test_box in [big_box, box]:
+
+            for precision, rtol in [(np.float64, 1e-8), (np.float32, 1e-4)]:
+
+                self.compare_forces(
+                    host_conf,
+                    test_nonbonded_fn.params,
+                    test_box,
+                    lamb,
+                    ref_nonbonded_fn,
+                    test_nonbonded_fn,
+                    rtol,
+                    precision=precision
+                )
+
 
 
 class TestNonbonded(GradientTest):
@@ -140,167 +411,6 @@ class TestNonbonded(GradientTest):
                 rtol,
                 precision=precision
             )
-
-
-    def test_dhfr(self):
-
-        pdb_path = 'tests/data/5dfr_solv_equil.pdb'
-        host_pdb = app.PDBFile(pdb_path)
-        protein_ff = app.ForceField('amber99sbildn.xml', 'tip3p.xml')
-
-        host_system = protein_ff.createSystem(
-                host_pdb.topology,
-                nonbondedMethod=app.NoCutoff,
-                constraints=None,
-                rigidWater=False
-            )
-
-        host_coords = host_pdb.positions
-        box = host_pdb.topology.getPeriodicBoxVectors()
-        box = np.asarray(box/box.unit)
-
-        host_fns, host_masses = openmm_deserializer.deserialize_system(
-            host_system,
-            cutoff=1.0
-        )
-
-        for f in host_fns:
-            if isinstance(f, potentials.Nonbonded):
-                nonbonded_fn = f
-
-        host_conf = []
-        for x,y,z in host_coords:
-            host_conf.append([to_md_units(x),to_md_units(y),to_md_units(z)])
-        host_conf = np.array(host_conf)
-
-        beta = 2.0
-        cutoff = 1.1
-        lamb = 0.1
-
-        max_N = host_conf.shape[0]
-
-        for N in [33, 65, 231, 1050, 4080]:
-
-            print("N", N)
-
-            test_conf = host_conf[:N]
-
-           # process exclusions
-            test_exclusions = []
-            test_scales = []
-            for (i, j), (sa, sb) in zip(nonbonded_fn.get_exclusion_idxs(), nonbonded_fn.get_scale_factors()):
-                if i < N and j < N:
-                    test_exclusions.append((i,j))
-                    test_scales.append((sa, sb))
-            test_exclusions = np.array(test_exclusions, dtype=np.int32)
-            test_scales = np.array(test_scales, dtype=np.float64)
-            test_params = nonbonded_fn.params[:N, :]
-
-            test_lambda_plane_idxs = np.random.randint(low=-2, high=2, size=N, dtype=np.int32)
-            test_lambda_offset_idxs = np.random.randint(low=-2, high=2, size=N, dtype=np.int32)
-
-            test_nonbonded_fn = potentials.Nonbonded(
-                test_exclusions,
-                test_scales,
-                test_lambda_plane_idxs,
-                test_lambda_offset_idxs,
-                beta,
-                cutoff
-            )
-
-            ref_nonbonded_fn = prepare_reference_nonbonded(
-                test_params,
-                test_exclusions,
-                test_scales,
-                test_lambda_plane_idxs,
-                test_lambda_offset_idxs,
-                beta,
-                cutoff
-            )
-
-            for precision, rtol in [(np.float64, 1e-8), (np.float32, 1e-4)]:
-
-                self.compare_forces(
-                    test_conf,
-                    test_params,
-                    box,
-                    lamb,
-                    ref_nonbonded_fn,
-                    test_nonbonded_fn,
-                    rtol,
-                    precision=precision
-                )
-
-    # @unittest.skip("slow")
-    def test_benchmark(self):
-
-        pdb_path = 'tests/data/5dfr_solv_equil.pdb'
-        host_pdb = app.PDBFile(pdb_path)
-        protein_ff = app.ForceField('amber99sbildn.xml', 'tip3p.xml')
-
-        host_system = protein_ff.createSystem(
-                host_pdb.topology,
-                nonbondedMethod=app.NoCutoff,
-                constraints=None,
-                rigidWater=False
-            )
-
-        host_coords = host_pdb.positions
-        box = host_pdb.topology.getPeriodicBoxVectors()
-        box = np.asarray(box/box.unit)
-
-        host_fns, host_masses = openmm_deserializer.deserialize_system(
-            host_system,
-            cutoff=1.0
-        )
-
-        for f in host_fns:
-            if isinstance(f, potentials.Nonbonded):
-                nonbonded_fn = f
-
-        host_conf = []
-        for x,y,z in host_coords:
-            host_conf.append([to_md_units(x),to_md_units(y),to_md_units(z)])
-        host_conf = np.array(host_conf)
-
-        beta = 2.0
-        cutoff = 1.1
-        lamb = 0.0
-
-        N = host_conf.shape[0]
-
-        test_conf = host_conf[:N]
-
-       # process exclusions
-        test_exclusions = []
-        test_scales = []
-        for (i, j), (sa, sb) in zip(nonbonded_fn.get_exclusion_idxs(), nonbonded_fn.get_scale_factors()):
-            if i < N and j < N:
-                test_exclusions.append((i,j))
-                test_scales.append((sa, sb))
-        test_exclusions = np.array(test_exclusions, dtype=np.int32)
-        test_scales = np.array(test_scales, dtype=np.float64)
-        test_params = nonbonded_fn.params[:N, :]
-
-        test_lambda_plane_idxs = np.zeros(N, dtype=np.int32)
-        test_lambda_offset_idxs = np.zeros(N, dtype=np.int32)
-
-        test_nonbonded_fn = potentials.Nonbonded(
-            test_exclusions,
-            test_scales,
-            test_lambda_plane_idxs,
-            test_lambda_offset_idxs,
-            beta,
-            cutoff
-        )
-
-        precision = np.float32
-
-        impl = test_nonbonded_fn.unbound_impl(precision)
-
-        for _ in range(100):
-
-            impl.execute_du_dx(test_conf, test_params, box, lamb)
 
     def test_nonbonded(self):
 

--- a/timemachine/cpp/src/context.hpp
+++ b/timemachine/cpp/src/context.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <vector>
-// #include "potential.hpp"
 #include "integrator.hpp"
 #include "bound_potential.hpp"
 #include "observable.hpp"
@@ -17,7 +16,6 @@ public:
         const double *x_0,
         const double *v_0,
         const double *box_0,
-        // double lambda,
         Integrator *intg,
         std::vector<BoundPotential *> bps
     );
@@ -27,6 +25,8 @@ public:
     void add_observable(Observable *obs); // tbd: shared_ptr
 
     void step(double lambda);
+
+    void multiple_steps(std::vector<double> lambda_schedule);
 
     int num_atoms() const;
 
@@ -38,7 +38,7 @@ public:
 
 private:
 
-    void compute(unsigned int flags);
+    void _step(double lambda);
 
     int step_;
     int N_; // number of particles
@@ -46,17 +46,12 @@ private:
     double *d_x_t_; // coordinates
     double *d_v_t_; // velocities
     double *d_box_t_; // box vectors
-    // double *d_u_t_; // u (energy)
-    // double lambda_; // (ytz): not a pointer!
 
     unsigned long long *d_du_dx_t_; // du/dx 
-
-    // std::vector<cudaStream_t> streams_;
 
     Integrator *intg_;
     std::vector<Observable *> observables_;
     std::vector<BoundPotential *> bps_;
-
 
 };
 

--- a/timemachine/cpp/src/gpu_utils.cu
+++ b/timemachine/cpp/src/gpu_utils.cu
@@ -7,11 +7,9 @@ curandStatus_t templateCurandNormal(
     return curandGenerateNormal(generator, outputPtr, n, mean, stddev);
 }
 
-// #include <iostream> 
 curandStatus_t templateCurandNormal(
     curandGenerator_t generator, 
     double *outputPtr, size_t n, 
     double mean, double stddev) {
-    // std::cout << "N DOUBLE" << n << std::endl;
     return curandGenerateNormalDouble(generator, outputPtr, n, mean, stddev);
 }

--- a/timemachine/cpp/src/integrator.cu
+++ b/timemachine/cpp/src/integrator.cu
@@ -95,7 +95,6 @@ void LangevinIntegrator::step_fwd(
         dt_
     );
 
-    cudaDeviceSynchronize();
     gpuErrchk(cudaPeekAtLastError());
 
 }

--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -212,7 +212,6 @@ void Neighborlist<RealType>::compute_block_bounds_device(
 	int D,
 	const double *d_coords,
     const double *d_box,
-    // const int *d_perm,
 	cudaStream_t stream) {
 
     assert(N == N_);

--- a/timemachine/cpp/src/nonbonded.cu
+++ b/timemachine/cpp/src/nonbonded.cu
@@ -30,7 +30,9 @@ Nonbonded<RealType>::Nonbonded(
     beta_(beta),
     d_sort_storage_(nullptr),
     d_sort_storage_bytes_(0),
-    compute_4d_(false) {
+    compute_4d_(false),
+    nblist_padding_(0.1),
+    disable_hilbert_(false) {
 
     for(auto x : lambda_plane_idxs) {
         if(x != 0) {
@@ -86,6 +88,13 @@ Nonbonded<RealType>::Nonbonded(
     
     gpuErrchk(cudaMallocHost(&p_ixn_count_, 1*sizeof(*p_ixn_count_)));
 
+    gpuErrchk(cudaMalloc(&d_nblist_x_, N_*3*sizeof(*d_nblist_x_)));
+    gpuErrchk(cudaMemset(d_nblist_x_, 0, N_*3*sizeof(*d_nblist_x_))); // set non-sensical positions
+    gpuErrchk(cudaMalloc(&d_nblist_box_, 3*3*sizeof(*d_nblist_x_)));
+    gpuErrchk(cudaMemset(d_nblist_box_, 0, 3*3*sizeof(*d_nblist_x_)));
+    gpuErrchk(cudaMalloc(&d_rebuild_nblist_, 1*sizeof(*d_rebuild_nblist_)));
+    gpuErrchk(cudaMallocHost(&p_rebuild_nblist_, 1*sizeof(*p_rebuild_nblist_)));
+
     gpuErrchk(cudaMalloc(&d_sort_keys_in_, N_*sizeof(d_sort_keys_in_)));
     gpuErrchk(cudaMalloc(&d_sort_keys_out_, N_*sizeof(d_sort_keys_out_)));
     gpuErrchk(cudaMalloc(&d_sort_vals_in_, N_*sizeof(d_sort_vals_in_)));
@@ -128,7 +137,6 @@ Nonbonded<RealType>::Nonbonded(
 
 };
 
-
 template <typename RealType>
 Nonbonded<RealType>::~Nonbonded() {
 
@@ -159,8 +167,24 @@ Nonbonded<RealType>::~Nonbonded() {
     gpuErrchk(cudaFree(d_sort_storage_));
 
     gpuErrchk(cudaFreeHost(p_ixn_count_));
+
+    gpuErrchk(cudaFree(d_nblist_x_));
+    gpuErrchk(cudaFree(d_nblist_box_));
+    gpuErrchk(cudaFree(d_rebuild_nblist_));
+    gpuErrchk(cudaFreeHost(p_rebuild_nblist_));
 };
 
+
+template<typename RealType>
+void Nonbonded<RealType>::set_nblist_padding(double val) {
+    nblist_padding_ = val;
+}
+
+
+template<typename RealType>
+void Nonbonded<RealType>::disable_hilbert_sort() {
+    disable_hilbert_ = true;
+}
 
 template <typename RealType>
 void Nonbonded<RealType>::hilbert_sort(
@@ -192,6 +216,14 @@ void Nonbonded<RealType>::hilbert_sort(
 
 }
 
+void __global__ k_arange(int N, unsigned int *arr) {
+    const int atom_idx = blockIdx.x*blockDim.x + threadIdx.x;
+    if(atom_idx >= N) {
+        return;
+    }
+    arr[atom_idx] = atom_idx;
+}
+
 template <typename RealType>
 void Nonbonded<RealType>::execute_device(
         const int N,
@@ -208,16 +240,19 @@ void Nonbonded<RealType>::execute_device(
 
     // (ytz) the nonbonded algorithm proceeds as follows:
 
-    // 0. (done in constructor), construct a hilbert curve mapping each of the 256x256x256 cells into an index.
-    // 1. look up which cell each particle belongs to, and its linear index along the hilbert curve.
-    // 2. use radix pair sort keyed on the hilbert index with values equal to the atomic index
-    // 3. resulting sorted values is the permutation array.
-    // 4. permute coords, params, lambda_offsets
-    // 5. compute the neighborlist into tiles
-    // 6. compute the nonbonded interactions using the neighborlist
-    // 7. inverse permute the forces, du/dps into the original index.
-    // 8. u and du/dl is buffered into a per-particle array, and then reduced.
-    // 9. note that du/dl is not an exact per-particle du/dl - it is only used for reduction purposes.
+    // (done in constructor), construct a hilbert curve mapping each of the 256x256x256 cells into an index.
+    // a. decide if we need to rebuild the neighborlist, if so:
+    //     - look up which cell each particle belongs to, and its linear index along the hilbert curve.
+    //     - use radix pair sort keyed on the hilbert index with values equal to the atomic index
+    //     - resulting sorted values is the permutation array.
+    //     - permute lambda plane/offsets, coords
+    // b. else:
+    //     - permute new coords
+    // c. permute parameters
+    // d. compute the nonbonded interactions using the neighborlist
+    // e. inverse permute the forces, du/dps into the original index.
+    // f. u and du/dl is buffered into a per-particle array, and then reduced.
+    // g. note that du/dl is not an exact per-particle du/dl - it is only used for reduction purposes.
 
     // assert(N == N_);
     // assert(P == N_*3);
@@ -230,34 +265,59 @@ void Nonbonded<RealType>::execute_device(
     const int B = (N+32-1)/32;
     const int tpb = 32;
 
-    // randomly re-hilbert sort
-    this->hilbert_sort(d_x, d_box, stream);
 
-	dim3 dimGrid(B, 3, 1);
+    dim3 dimGrid(B, 3, 1);
+
+    // (ytz) see if we need to rebuild the neighborlist.
+    // (ytz + jfass): note that this logic needs to change if we use NPT later on since a resize in the box
+    // can introduce new interactions.
+    k_check_rebuild_coords<RealType><<<B, tpb, 0, stream>>>(N, d_x, d_nblist_x_, nblist_padding_, d_rebuild_nblist_);
+    gpuErrchk(cudaPeekAtLastError());
+    k_check_rebuild_box<RealType><<<1, tpb, 0, stream>>>(N, d_box, d_nblist_box_, d_rebuild_nblist_);
+    gpuErrchk(cudaPeekAtLastError());
+
+    // we can optimize this away by doing the check on the GPU directly.
+    gpuErrchk(cudaMemcpyAsync(p_rebuild_nblist_, d_rebuild_nblist_, 1*sizeof(*p_rebuild_nblist_), cudaMemcpyDeviceToHost, stream));
+    gpuErrchk(cudaStreamSynchronize(stream)); // slow!
+
+    if(p_rebuild_nblist_[0] > 0) {
+
+        // (ytz): update the permutation index before building neighborlist, as the neighborlist is tied
+        // to a particular sort order
+        if(!disable_hilbert_) {
+            this->hilbert_sort(d_x, d_box, stream);            
+        } else {
+            k_arange<<<B, 32, 0, stream>>>(N, d_perm_);
+            gpuErrchk(cudaPeekAtLastError());
+        }
+
+        // compute new coordinates, new lambda_idxs, new_plane_idxs
+        k_permute<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_x, d_sorted_x_);
+        gpuErrchk(cudaPeekAtLastError());
+        k_permute<<<B, tpb, 0, stream>>>(N, d_perm_, d_lambda_plane_idxs_, d_sorted_lambda_plane_idxs_);
+        gpuErrchk(cudaPeekAtLastError());
+        k_permute<<<B, tpb, 0, stream>>>(N, d_perm_, d_lambda_offset_idxs_, d_sorted_lambda_offset_idxs_);
+        gpuErrchk(cudaPeekAtLastError());
+        nblist_.build_nblist_device(
+            N,
+            d_sorted_x_,
+            d_box,
+            cutoff_+nblist_padding_,
+            stream
+        );
+        gpuErrchk(cudaMemsetAsync(d_rebuild_nblist_, 0, sizeof(*d_rebuild_nblist_), stream));
+        gpuErrchk(cudaMemcpyAsync(p_ixn_count_, nblist_.get_ixn_count(), 1*sizeof(*p_ixn_count_), cudaMemcpyDeviceToHost, stream));
+        gpuErrchk(cudaMemcpyAsync(d_nblist_x_, d_x, N*3*sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
+        gpuErrchk(cudaMemcpyAsync(d_nblist_box_, d_box, 3*3*sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
+        gpuErrchk(cudaStreamSynchronize(stream));
+
+    } else {
+        k_permute<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_x, d_sorted_x_);
+        gpuErrchk(cudaPeekAtLastError());
+    }
 
     k_permute<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_p, d_sorted_p_);
     gpuErrchk(cudaPeekAtLastError());
-
-    k_permute<<<B, tpb, 0, stream>>>(N, d_perm_, d_lambda_plane_idxs_, d_sorted_lambda_plane_idxs_);
-    k_permute<<<B, tpb, 0, stream>>>(N, d_perm_, d_lambda_offset_idxs_, d_sorted_lambda_offset_idxs_);
-
-    gpuErrchk(cudaPeekAtLastError());
-
-    k_permute<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_x, d_sorted_x_);
-    gpuErrchk(cudaPeekAtLastError());
-
-    // cudaDeviceSynchronize();
-    // auto start = std::chrono::high_resolution_clock::now();
-
-    nblist_.build_nblist_device(
-        N,
-        d_sorted_x_,
-        d_box,
-        cutoff_,
-        stream
-    );
-
-    gpuErrchk(cudaMemcpyAsync(p_ixn_count_, nblist_.get_ixn_count(), 1*sizeof(*p_ixn_count_), cudaMemcpyDeviceToHost, stream));
 
 
     // this stream needs to be synchronized so we can be sure that p_ixn_count_ is properly set.
@@ -277,15 +337,9 @@ void Nonbonded<RealType>::execute_device(
         gpuErrchk(cudaMemsetAsync(d_u_reduce_sum_, 0, 1*sizeof(*d_u_reduce_sum_), stream));
     }
 
-    gpuErrchk(cudaStreamSynchronize(stream));
-
-    // std::cout << "get_ixn_count(): " << *p_ixn_count_ << std::endl;
-
     if(d_du_dx && !d_du_dp && !d_du_dl && !d_u) {
 
         // split tiles into 3D and 4D
-
-        // std::cout << "force only du_dx" << std::endl;
         // templatized, so we need to generate specializations at compile time. Eventually
         // this whole kernel will be replaced by a JIT'd version
         if(compute_4d_) {
@@ -341,14 +395,6 @@ void Nonbonded<RealType>::execute_device(
         );
     }
 
-    // cudaDeviceSynchronize();
-
-    // auto end = std::chrono::high_resolution_clock::now();
-
-    // std::chrono::duration<double> elapsed = end - start;
-    // std::cout << "NB Forces time: " << elapsed.count() << "ms\n";
-
-    // cudaDeviceSynchronize();
     gpuErrchk(cudaPeekAtLastError());
 
     // coords are N,3

--- a/timemachine/cpp/src/nonbonded.hpp
+++ b/timemachine/cpp/src/nonbonded.hpp
@@ -24,6 +24,12 @@ private:
     const int E_;
     const int N_;
 
+    double nblist_padding_;
+    double *d_nblist_x_; // coords which were used to compute the nblist
+    double *d_nblist_box_; // box which was used to rebuild the nblist
+    int *d_rebuild_nblist_; // whether or not we have to rebuild the nblist
+    int *p_rebuild_nblist_; // pinned
+
     // reduction buffer
     unsigned long long *d_sorted_du_dl_buffer_;
     unsigned long long *d_sorted_u_buffer_;
@@ -52,6 +58,7 @@ private:
     size_t d_sort_storage_bytes_;
 
     bool compute_4d_;
+    bool disable_hilbert_;
 
     void hilbert_sort(
         const double *d_x,
@@ -60,6 +67,10 @@ private:
     );
 
 public:
+
+    // these are marked public but really only intended for testing.
+    void set_nblist_padding(double val);
+    void disable_hilbert_sort();
 
     Nonbonded(
         const std::vector<int> &exclusion_idxs, // [E,2]

--- a/timemachine/cpp/src/periodic_torsion.cu
+++ b/timemachine/cpp/src/periodic_torsion.cu
@@ -56,7 +56,6 @@ void PeriodicTorsion<RealType>::execute_device(
 
     const int D = 3;
 
-
     if(blocks > 0) {
         k_periodic_torsion<RealType, D><<<blocks, tpb, 0, stream>>>(
             T_,
@@ -67,15 +66,8 @@ void PeriodicTorsion<RealType>::execute_device(
             d_du_dp,
             d_u
         );        
-
-
         gpuErrchk(cudaPeekAtLastError());
-
     }
-
-    // (remove me)
-    cudaDeviceSynchronize();
-
 
 };
 


### PR DESCRIPTION
This PR reconstructs the neighborlist and the hilbert ordering only when the distance of any particle has moved beyond padding/2. Matches behavior as that of OpenMM, and will soon get close to parity in terms of performance.

Main changes;

- Implements a context.multiple_steps() to save on device synchronization overhead
- Neighborlist is now padded with a 1A offset and rebuilt roughly once every 5-10 steps. However, the actual non-bonded computation is now roughly 10% more expensive.
- Hilbert reordering is done only when neighborlist is rebuilt since Radix sweeping gets expensive.
- Removed unnecessary calls to cudaDeviceSynchronize()
- Modifed the fixed pointe accumulation order in the nonbonded kernels.

The "holy grail" of implementations is an incremental/delta based neighborlist algorithm. But as far as I know, no one's figured out how to do this on the GPU yet.

```
 GPU activities:   52.41%  11.1187s     50000  222.37us  219.23us  277.54us  void k_nonbonded_du_dx<float, bool=0>(int, double const *, double const *, double const *, double, int const *, int const *, double, double, int const *, unsigned int const *, __int64*)
                    9.18%  1.94830s      8876  219.50us  199.52us  251.71us  void k_find_blocks_with_ixns<float>(int, double const *, double const *, double const *, double const *, unsigned int*, int*, unsigned int*, unsigned int*, double)
                    5.19%  1.10064s     50500  21.794us  12.640us  25.343us  void k_nonbonded_exclusions<float>(int, double const *, double const *, double const *, double, int const *, int const *, int const *, double const *, double, double, __int64*, __int64*, __int64*, __int64*)
                    4.51%  957.47ms     44380  21.574us  20.800us  42.688us  void cub::RadixSortScanBinsKernel<cub::DeviceRadixSortPolicy<unsigned int, unsigned int, int>::Policy700, int>(unsigned int*, int)
                    3.27%  693.96ms     50000  13.879us  13.408us  65.696us  void timemachine::update_forward<double>(int, int, double, timemachine::update_forward<double> const *, timemachine::update_forward<double> const , timemachine::update_forward<double> const , timemachine::update_forward<double>*, timemachine::update_forward<double> const *, __int64 const *, timemachine::update_forward<double>)
                    2.93%  622.50ms    101000  6.1630us  5.4400us  58.080us  void k_permute<double>(int, unsigned int const *, double const *, double*)
                    2.62%  554.84ms     26628  20.836us  16.448us  49.087us  void cub::DeviceRadixSortDownsweepKernel<cub::DeviceRadixSortPolicy<unsigned int, unsigned int, int>::Policy700, bool=1, bool=0, unsigned int, unsigned int, int>(cub::DeviceRadixSortPolicy<unsigned int, unsigned int, int>::Policy700 const *, cub::DeviceRadixSortDownsweepKernel<cub::DeviceRadixSortPolicy<unsigned int, unsigned int, int>::Policy700, bool=1, bool=0, unsigned int, unsigned int, int>*, bool=1 const *, cub::DeviceRadixSortDownsweepKernel<cub::DeviceRadixSortPolicy<unsigned int, unsigned int, int>::Policy700, bool=1, bool=0, unsigned int, unsigned int, int>**, bool=0*, cub::DeviceRadixSortDownsweepKernel<cub::DeviceRadixSortPolicy<unsigned int, unsigned int, int>::Policy700, bool=1, bool=0, unsigned int, unsigned int, int>**, int, int, cub::GridEvenShare<cub::DeviceRadixSortDownsweepKernel<cub::DeviceRadixSortPolicy<unsigned int, unsigned int, int>::Policy700, bool=1, bool=0, unsigned int, unsigned int, int>**>)
                    2.38%  504.88ms     50500  9.9970us  3.6160us  48.928us  void k_harmonic_angle_inference<float, int=3>(int, double const *, double const *, int const *, __int64*, double*, double*)
                    2.33%  494.80ms     50500  9.7980us  4.7360us  50.687us  void k_periodic_torsion<float, int=3>(int, double const *, double const *, int const *, __int64*, double*, double*)
                    1.96%  415.69ms     50000  8.3130us  7.6480us  44.832us  void gen_sequenced<curandStateXORWOW, double2, normal_args_double_st, __operator_&__(double2 curand_normal_scaled2_double<curandStateXORWOW>(curandStateXORWOW*, normal_args_double_st)), rng_config<curandStateXORWOW, curandOrdering=101>>(curandStateXORWOW*, double2*, unsigned long, unsigned long, normal_args_double_st)
```