### PR TITLE
Update timer logic in benchmark.py

### DIFF
--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -91,29 +91,37 @@ def benchmark_dhfr():
 
     lamb = 0.0
 
-    start = time.time()
-
     writer = PDBWriter([host_pdb.topology], "dhfr.pdb")
 
     num_batches = 100
     steps_per_batch = 1000
+    start = time.time()
+
+    lambda_schedule = np.ones(steps_per_batch)*lamb
+
+    seconds_per_day = 86400
 
     for batch in range(num_batches):
-        lambda_schedule = np.ones(steps_per_batch)*lamb
-        ctxt.multiple_steps(lambda_schedule)
 
-        delta = time.time()-start
-        steps_per_second = (batch+1)*steps_per_batch/delta
-        seconds_per_day = 86400
+        # time the current batch
+        batch_start = time.time()
+        ctxt.multiple_steps(lambda_schedule)
+        batch_end = time.time()
+
+        delta = batch_end - batch_start
+        steps_per_second = steps_per_batch / delta
+
         steps_per_day = steps_per_second*seconds_per_day
         ps_per_day = dt*steps_per_day
         ns_per_day = ps_per_day*1e-3
 
-        print((batch+1)*steps_per_batch, "steps @ ", ns_per_day, " ns/day")
+        print(f'steps per second: {steps_per_second:.3f}')
+        print(f'ns per day: {ns_per_day:.3f}')
+
         # coords = recenter(ctxt.get_x_t(), box)
         # writer.write_frame(coords*10)
 
-    print("total time", time.time() - start)
+    print(f"total time to run {steps_per_batch * num_batches} steps: {(time.time() - start):.3f} s")
 
     writer.close()
 

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -101,6 +101,8 @@ def benchmark_dhfr():
 
     seconds_per_day = 86400
 
+    batch_times = []
+
     for batch in range(num_batches):
 
         # time the current batch
@@ -109,9 +111,12 @@ def benchmark_dhfr():
         batch_end = time.time()
 
         delta = batch_end - batch_start
-        steps_per_second = steps_per_batch / delta
 
+        batch_times.append(delta)
+
+        steps_per_second = steps_per_batch / np.mean(batch_times)
         steps_per_day = steps_per_second*seconds_per_day
+
         ps_per_day = dt*steps_per_day
         ns_per_day = ps_per_day*1e-3
 

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -95,13 +95,15 @@ def benchmark_dhfr():
 
     num_batches = 100
     steps_per_batch = 1000
-    start = time.time()
+    seconds_per_day = 86400
+    batch_times = []
 
     lambda_schedule = np.ones(steps_per_batch)*lamb
 
-    seconds_per_day = 86400
+    # run once before timer starts
+    ctxt.multiple_steps(lambda_schedule)
 
-    batch_times = []
+    start = time.time()
 
     for batch in range(num_batches):
 


### PR DESCRIPTION
The MD speed estimate reported by `tests/benchmark.py` was based on a running average that included a costly one-time setup step. This PR updates the timer to report instantaneous ("per-batch") speed estimates rather than running averages, and not start the timer until after one-time setup is complete.

An example of the difference in reported speed estimates is shown below.

![speed_estimate_comparison](https://user-images.githubusercontent.com/5759036/105089761-8a1ba480-5a6b-11eb-9847-2159afa87fcf.jpg)
