### PR TITLE
Fix gte sign for k_check_rebuild_box

### DIFF
--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -83,7 +83,7 @@ void __global__ k_check_rebuild_box(
 
     const int idx = blockIdx.x*blockDim.x + threadIdx.x;
 
-    if(idx > 9) {
+    if(idx >= 9) {
         return;
     }
 


### PR DESCRIPTION
This PR fixes an off by one error. It will not affect the correctness of previous results, only the speed, as the worst case behavior is triggering and extra nblist rebuild. 