### PR TITLE
Minimize host against both molecules

### DIFF
--- a/fe/model.py
+++ b/fe/model.py
@@ -76,6 +76,7 @@ class RBFEModel():
 
             print("Minimizing the host structure to remove clashes.")
             min_host_coords = minimizer.minimize_host_4d(mol_a, host_system, host_coords, self.ff, host_box)
+            min_host_coords = minimizer.minimize_host_4d(mol_b, host_system, min_host_coords, self.ff, host_box)
 
             rfe = free_energy.RelativeFreeEnergy(mol_a, mol_b, core, self.ff)
 

--- a/fe/model.py
+++ b/fe/model.py
@@ -75,6 +75,9 @@ class RBFEModel():
             ("solvent", self.solvent_system, self.solvent_coords, self.solvent_box, self.solvent_schedule)]:
 
             print("Minimizing the host structure to remove clashes.")
+            # (ytz): this isn't strictly symmetric, and we should modify minimize later on remove
+            # the hysteresis by jointly minimizing against a and b at the same time. We may also want
+            # to remove the randomness completely from the minimization.
             min_host_coords = minimizer.minimize_host_4d(mol_a, host_system, host_coords, self.ff, host_box)
             min_host_coords = minimizer.minimize_host_4d(mol_b, host_system, min_host_coords, self.ff, host_box)
 


### PR DESCRIPTION
This PR should fix some of the implosions that @maxentile was seeing. The issue was that minimizing the host w.r.t. to only ligand A doesn't resolve clashes in ligand B. This is why we were mainly seeing implosions at lambda=1.0 but not at lambda=0.0

The question is, does minimizing w.r.t. A then B result in the same host conf as minimizing w.r.t. B then A? If not, we should probably use  joint minimization approach where A and B are minimized simultaneously with exclusions between A and B.