### PR TITLE
Optimizations Ampere

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -13,14 +13,8 @@ from timemachine.lib import custom_ops
 from timemachine.lib import LangevinIntegrator
 
 from fe.utils import to_md_units
-<<<<<<< HEAD:tests/test_benchmark.py
 from fe import free_energy
 from fe.topology import SingleTopology
-=======
-from fe import free_energy, topology
-
-from rdkit import Chem
->>>>>>> 856185f... First pass:tests/benchmark.py
 
 from md import builders, minimizer
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -13,8 +13,14 @@ from timemachine.lib import custom_ops
 from timemachine.lib import LangevinIntegrator
 
 from fe.utils import to_md_units
+<<<<<<< HEAD:tests/test_benchmark.py
 from fe import free_energy
 from fe.topology import SingleTopology
+=======
+from fe import free_energy, topology
+
+from rdkit import Chem
+>>>>>>> 856185f... First pass:tests/benchmark.py
 
 from md import builders, minimizer
 

--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -9,7 +9,8 @@ project(timemachine LANGUAGES CXX CUDA)
 find_package(PythonInterp 3.7 REQUIRED)
 find_package(PythonLibs 3.7 REQUIRED)
 
-string(APPEND CMAKE_CUDA_FLAGS "-Xptxas -v -arch=${CUDA_ARCH} -O3 -lineinfo")
+string(APPEND CMAKE_CUDA_FLAGS "-Xptxas -v -arch=${CUDA_ARCH} -O3 -line-info")
+# string(APPEND CMAKE_CUDA_FLAGS "-Xptxas -v -arch=${CUDA_ARCH} -O3")
 message(${CMAKE_CUDA_FLAGS})
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
@@ -23,12 +24,6 @@ set(PYBIND_SRC_DIR pybind11)
 
 if(NOT EXISTS ${PYBIND_SRC_DIR})
   execute_process(COMMAND git clone --branch v2.6 https://github.com/pybind/pybind11.git ${PYBIND_SRC_DIR})
-endif()
-
-set(CUB_SRC_DIR cub)
-
-if(NOT EXISTS ${CUB_SRC_DIR})
-  execute_process(COMMAND git clone --depth 1 --branch 1.10.0 https://github.com/NVIDIA/cub.git ${CUB_SRC_DIR})
 endif()
 
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/${PYBIND_SRC_DIR})

--- a/timemachine/cpp/src/fixed_point.hpp
+++ b/timemachine/cpp/src/fixed_point.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
 #define FIXED_EXPONENT             0x1000000000
-#define FIXED_BORN_PSI             0x40000000000
-#define FIXED_EXPONENT_BORN_FORCES 0x100000000
 
 template<typename RealType>
 unsigned long long __device__ __forceinline__ FLOAT_TO_FIXED(RealType v) {

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -47,7 +47,7 @@ void __global__ k_compact_trim_atoms(
             if(indexInWarp == 0) {
                 sync_start[0] = atomicAdd(interactionCount, tilesToStore);
             }
-
+            __syncwarp();
             interactingTiles[sync_start[0]] = row_block_idx; // IS THIS CORRECT? CONTESTED
             interactingAtoms[sync_start[0]*32 + threadIdx.x] = ixn_j_buffer[threadIdx.x];
 
@@ -62,6 +62,7 @@ void __global__ k_compact_trim_atoms(
         if(indexInWarp == 0) {
             sync_start[0] = atomicAdd(interactionCount, tilesToStore);
         }
+        __syncwarp();
         interactingTiles[sync_start[0]] = row_block_idx;
         interactingAtoms[sync_start[0]*32 + threadIdx.x] = ixn_j_buffer[threadIdx.x];
     }
@@ -266,6 +267,7 @@ void __global__ k_find_blocks_with_ixns(
             if(indexInWarp == 0) {
                 sync_start[0] = atomicAdd(interactionCount, tilesToStore);
             }
+            __syncwarp();
             interactingTiles[sync_start[0]] = row_block_idx;
             interactingAtoms[sync_start[0]*32 + threadIdx.x] = ixn_j_buffer[threadIdx.x];
 


### PR DESCRIPTION
The first set of optimizations of Ampere, which changed the throughput of the FP64 significantly.


- [x] Remove CUB download as CUDA 11 now provides for it.
- [x] Use single precision cutoff when doing distance calculations.
- [x] Use a faster implementation of static_cast<long long>(float) for nonbonded kernels to improve performance 
- [x] Fixes a __syncwarp() issue in the neighborlist, oddly enough this only manifested in -g and -G builds
- [x] Clean up how we do the exclusions using the new fixed point conversion script

There is still roughly an 11% FP64 utilization coming from loading the double precision coordinates. We can address this either by buffering the nonbonded kernel, or just building a 32-bit context. But this will be done in a separate PR. Note that the -rbfe test have improved by ~60% 

```
Before
dhfr-apo: N=23558 speed: 217.05ns/day dt: 1.5fs (ran 100000 steps in 59.71s)
hif2a-apo: N=8805 speed: 480.90ns/day dt: 1.5fs (ran 100000 steps in 26.95s)
hif2a-rbfe: N=8840 speed: 243.46ns/day dt: 1.5fs (ran 100000 steps in 53.24s)
solvent-apo: N=6282 speed: 623.06ns/day dt: 1.5fs (ran 100000 steps in 20.80s)
solvent-rbfe: N=6317 speed: 317.68ns/day dt: 1.5fs (ran 100000 steps in 40.80s)

After
dhfr-apo: N=23558 speed: 244.34ns/day dt: 1.5fs (ran 100000 steps in 53.04s)
hif2a-apo: N=8805 speed: 486.00ns/day dt: 1.5fs (ran 100000 steps in 26.67s)
hif2a-rbfe: N=8840 speed: 389.50ns/day dt: 1.5fs (ran 100000 steps in 33.28s)
solvent-apo: N=6282 speed: 608.51ns/day dt: 1.5fs (ran 100000 steps in 21.30s)
solvent-rbfe: N=6317 speed: 494.53ns/day dt: 1.5fs (ran 100000 steps in 26.21s)
```

