### PR TITLE
Revert hif2a benchmark to use _sc forcefield rather than _ccc

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -6,6 +6,8 @@ import time
 import numpy as np
 
 from ff.handlers import openmm_deserializer
+from ff.handlers.deserialize import deserialize_handlers
+from ff import Forcefield
 
 from simtk.openmm import app
 
@@ -157,7 +159,11 @@ def benchmark_hif2a(verbose=False, num_batches=100, steps_per_batch=1000):
 
     from testsystems.relative import hif2a_ligand_pair as testsystem
 
-    mol_a, mol_b, core, ff = testsystem.mol_a, testsystem.mol_b, testsystem.core, testsystem.ff
+    mol_a, mol_b, core = testsystem.mol_a, testsystem.mol_b, testsystem.core
+
+    # this
+    ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_sc.py').read())
+    ff = Forcefield(ff_handlers)
 
     single_topology = SingleTopology(mol_a, mol_b, core, ff)
     rfe = free_energy.RelativeFreeEnergy(single_topology)


### PR DESCRIPTION
Reverts a change introduced in https://github.com/proteneer/timemachine/pull/348/commits/1654551f130541bcfac2b781aba781db90d4987e that inadvertently changed the force field used for hif2a benchmark from _sc to _ccc , which @proteneer reports is causing a portability issue. This should now look the same [as before](https://github.com/proteneer/timemachine/blob/12bcc2e8d590ea6eded7124aa316ce14a6bfc703/tests/benchmark.py#L193-L195).

Later, we should add a way to label when tests aren't allowed to use openeye toolkits