### PR TITLE
Unify nonbonded kernels with templates

### DIFF
--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -9,7 +9,7 @@ project(timemachine LANGUAGES CXX CUDA)
 find_package(PythonInterp 3.7 REQUIRED)
 find_package(PythonLibs 3.7 REQUIRED)
 
-string(APPEND CMAKE_CUDA_FLAGS "-Xptxas -v -arch=${CUDA_ARCH} -O3 -line-info")
+string(APPEND CMAKE_CUDA_FLAGS "-Xptxas -v -arch=${CUDA_ARCH} -O3 -lineinfo")
 # string(APPEND CMAKE_CUDA_FLAGS "-Xptxas -v -arch=${CUDA_ARCH} -O3")
 message(${CMAKE_CUDA_FLAGS})
 

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -74,7 +74,7 @@ unsigned long long __device__ __forceinline__ FLOAT_TO_FIXED_NONBONDED(RealType 
     return static_cast<unsigned long long>(real_to_int64(v*FIXED_EXPONENT));
 }
 
-// generate kv values from coordinates to be radix sorted 
+// generate kv values from coordinates to be radix sorted
 void __global__ k_coords_to_kv(
     const int N,
     const double *coords,
@@ -310,191 +310,8 @@ float __device__ __forceinline__ real_es_factor(float real_beta, float dij, floa
     return -inv_d2ij*(static_cast<float>(TWO_OVER_SQRT_PI)*beta_dij*exp_beta_dij_2 + erfc_beta_dij);
 }
 
-
-template <typename RealType, bool COMPUTE_4D>
-void __global__ k_nonbonded_du_dx(
-    const int N,
-    const double * __restrict__ coords,
-    const double * __restrict__ params, // [N]
-    const double * __restrict__ box,
-    const double lambda,
-    const int * __restrict__ lambda_plane_idxs, // 0 or 1, shift
-    const int * __restrict__ lambda_offset_idxs, // 0 or 1, how much we offset from the plane by cutoff
-    const double beta,
-    const double cutoff,
-    const int * __restrict__ ixn_tiles,
-    const unsigned int * __restrict__ ixn_atoms,
-    unsigned long long * __restrict__ du_dx) {
-
-    int tile_idx = blockIdx.x;
-
-    RealType box_x = box[0*3+0];
-    RealType box_y = box[1*3+1];
-    RealType box_z = box[2*3+2];
-
-    RealType inv_box_x = 1/box_x;
-    RealType inv_box_y = 1/box_y;
-    RealType inv_box_z = 1/box_z;
-
-    int row_block_idx = ixn_tiles[tile_idx];
-
-    int atom_i_idx = row_block_idx*32 + threadIdx.x;
-
-    RealType ci_x = atom_i_idx < N ? coords[atom_i_idx*3+0] : 0;
-    RealType ci_y = atom_i_idx < N ? coords[atom_i_idx*3+1] : 0;
-    RealType ci_z = atom_i_idx < N ? coords[atom_i_idx*3+2] : 0;
-
-    unsigned long long gi_x = 0;
-    unsigned long long gi_y = 0;
-    unsigned long long gi_z = 0;
-
-    int charge_param_idx_i = atom_i_idx*3 + 0;
-    int lj_param_idx_sig_i = atom_i_idx*3 + 1;
-    int lj_param_idx_eps_i = atom_i_idx*3 + 2;
-
-    RealType qi = atom_i_idx < N ? params[charge_param_idx_i] : 0;
-    RealType sig_i = atom_i_idx < N ? params[lj_param_idx_sig_i] : 0;
-    RealType eps_i = atom_i_idx < N ? params[lj_param_idx_eps_i] : 0;
-
-    // i idx is contiguous but j is not, so we should swap them to avoid having to shuffle atom_j_idx
-    int atom_j_idx = ixn_atoms[tile_idx*32 + threadIdx.x];
-
-    RealType cj_x = atom_j_idx < N ? coords[atom_j_idx*3+0] : 0;
-    RealType cj_y = atom_j_idx < N ? coords[atom_j_idx*3+1] : 0;
-    RealType cj_z = atom_j_idx < N ? coords[atom_j_idx*3+2] : 0;
-    unsigned long long gj_x = 0;
-    unsigned long long gj_y = 0;
-    unsigned long long gj_z = 0;
-
-    int charge_param_idx_j = atom_j_idx*3 + 0;
-    int lj_param_idx_sig_j = atom_j_idx*3 + 1;
-    int lj_param_idx_eps_j = atom_j_idx*3 + 2;
-
-    RealType qj = atom_j_idx < N ? params[charge_param_idx_j] : 0;
-    RealType sig_j = atom_j_idx < N ? params[lj_param_idx_sig_j] : 0;
-    RealType eps_j = atom_j_idx < N ? params[lj_param_idx_eps_j] : 0;
-
-    RealType real_cutoff = static_cast<RealType>(cutoff);
-    RealType cutoff_squared = real_cutoff*real_cutoff;
-
-    RealType real_lambda = static_cast<RealType>(lambda);
-    RealType real_beta = static_cast<RealType>(beta);
-
-    // templatized parameter
-
-    int lambda_offset_i = (COMPUTE_4D && atom_i_idx < N) ? lambda_offset_idxs[atom_i_idx] : 0;
-    int lambda_plane_i = (COMPUTE_4D && atom_i_idx < N) ? lambda_plane_idxs[atom_i_idx] : 0;
-    int lambda_offset_j = (COMPUTE_4D && atom_j_idx < N) ? lambda_offset_idxs[atom_j_idx] : 0;
-    int lambda_plane_j = (COMPUTE_4D && atom_j_idx < N) ? lambda_plane_idxs[atom_j_idx] : 0;
-    // see if this entire tile can be computed in 3D.
-    // bool compute_4d = __any_sync(0xffffffff, lambda_plane_i != 0)  ||
-                      // __any_sync(0xffffffff, lambda_plane_j != 0)  ||
-                      // __any_sync(0xffffffff, lambda_offset_i != 0) ||
-                      // __any_sync(0xffffffff, lambda_offset_j != 0);
-
-    const int srcLane = (threadIdx.x + 1) % WARPSIZE; // fixed
-    // #pragma unroll
-    for(int round = 0; round < 32; round++) {
-
-        RealType delta_x = ci_x - cj_x;
-        RealType delta_y = ci_y - cj_y;
-        RealType delta_z = ci_z - cj_z;
-
-        delta_x -= box_x*nearbyint(delta_x*inv_box_x);
-        delta_y -= box_y*nearbyint(delta_y*inv_box_y);
-        delta_z -= box_z*nearbyint(delta_z*inv_box_z);
-
-        // (ytz): it seems more expensive todo this extra computation on the inside loop but it helps preserves
-        // precision. If we computed the 4D distance first, then delta_w = (Large_X + small_X) - (Large_Y + small_Y).
-        // However, computing via (Large_X - Large_Y) + (small_X - small_Y) would result in a smaller error. In the worst case
-        // d would be zero for Large_X = Large_Y , small_X != small_Y, Large_X >> small_X , Large_Y >> small_Y.
-        // RealType delta_w = 0;
-        RealType d2ij = delta_x*delta_x + delta_y*delta_y + delta_z*delta_z;
-
-        // compile time evaluates to either 0 or 1
-        if(COMPUTE_4D) {
-            RealType delta_w = (lambda_plane_i - lambda_plane_j)*real_cutoff + (lambda_offset_i - lambda_offset_j)*real_lambda*real_cutoff;
-            d2ij += delta_w*delta_w;
-        }
-
-        // (ytz): note that d2ij must be *strictly* less than cutoff_squared. This is because we set the
-        // non-interacting atoms to exactly real_cutoff*real_cutoff. This ensures that atoms who's 4th dimension
-        // is set to cutoff are non-interacting.
-        if(d2ij < cutoff_squared  && atom_j_idx > atom_i_idx && atom_j_idx < N && atom_i_idx < N) {
-
-
-            // electrostatics
-            RealType inv_dij = rsqrt(d2ij);
-            RealType dij = d2ij*inv_dij;
-
-            RealType inv_d2ij = inv_dij*inv_dij;
-            RealType qij = qi*qj;
-            RealType es_prefactor = qij*inv_dij*real_es_factor(real_beta, dij, inv_d2ij);
-
-            // lennard jones force
-            RealType delta_prefactor = es_prefactor;
-            if(eps_i != 0 && eps_j != 0) {
-                RealType eps_ij = eps_i * eps_j;
-                RealType sig_ij = sig_i + sig_j;
-                RealType sig_inv_dij = sig_ij*inv_dij;
-                RealType sig2_inv_d2ij = sig_inv_dij*sig_inv_dij;
-                RealType sig6_inv_d6ij = sig2_inv_d2ij*sig2_inv_d2ij*sig2_inv_d2ij;
-                RealType sig6_inv_d8ij = sig6_inv_d6ij*inv_d2ij;
-                delta_prefactor -= eps_ij*sig6_inv_d8ij*(sig6_inv_d6ij*48 - 24);
-            }
-
-            gi_x += FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_x);
-            gi_y += FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_y);
-            gi_z += FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_z);
-
-            // (ytz): the cast relies on undefined behavior since the exclusion terms will overflow.
-            // Thus far, the current gen GPUs are deterministic in the resulting value. So long
-            // as the UB stays deterministic then this should be fine. There's no guarantee though that
-            // NVIDIA will keep the behavior consistent. Furthermore, do *not* attempt to swap signs via:
-            // gj_* -= FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_*); // this is incorrect and has been shown
-            // to introduce subtle bugs!
-            gj_x += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_x);
-            gj_y += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_y);
-            gj_z += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_z);
-
-        }
-
-        atom_j_idx = __shfl_sync(0xffffffff, atom_j_idx, srcLane); // we can pre-compute this probably, but shuffling may be faster
-        qj = __shfl_sync(0xffffffff, qj, srcLane);
-        eps_j = __shfl_sync(0xffffffff, eps_j, srcLane);
-        sig_j = __shfl_sync(0xffffffff, sig_j, srcLane);
-        cj_x = __shfl_sync(0xffffffff, cj_x, srcLane);
-        cj_y = __shfl_sync(0xffffffff, cj_y, srcLane);
-        cj_z = __shfl_sync(0xffffffff, cj_z, srcLane);
-        gj_x = __shfl_sync(0xffffffff, gj_x, srcLane);
-        gj_y = __shfl_sync(0xffffffff, gj_y, srcLane);
-        gj_z = __shfl_sync(0xffffffff, gj_z, srcLane);
-
-        if(COMPUTE_4D) {
-            lambda_offset_j = __shfl_sync(0xffffffff, lambda_offset_j, srcLane); // this also can be optimized away
-            lambda_plane_j = __shfl_sync(0xffffffff, lambda_plane_j, srcLane);
-        }
-    }
-
-    // these reduction buffers are really tricky
-    if(du_dx) {
-        if(atom_i_idx < N) {
-            atomicAdd(du_dx + atom_i_idx*3 + 0, gi_x);
-            atomicAdd(du_dx + atom_i_idx*3 + 1, gi_y);
-            atomicAdd(du_dx + atom_i_idx*3 + 2, gi_z);
-        }
-        if(atom_j_idx < N) {
-            atomicAdd(du_dx + atom_j_idx*3 + 0, gj_x);
-            atomicAdd(du_dx + atom_j_idx*3 + 1, gj_y);
-            atomicAdd(du_dx + atom_j_idx*3 + 2, gj_z);
-        }
-    }
-
-}
-
-
-template <typename RealType>
-void __global__ k_nonbonded(
+template <typename RealType, bool COMPUTE_U, bool COMPUTE_DU_DX, bool COMPUTE_DU_DL, bool COMPUTE_DU_DP>
+void __global__ k_nonbonded_unified(
     const int N,
     const double * __restrict__ coords,
     const double * __restrict__ params, // [N]
@@ -556,6 +373,7 @@ void __global__ k_nonbonded(
     RealType cj_x = atom_j_idx < N ? coords[atom_j_idx*3+0] : 0;
     RealType cj_y = atom_j_idx < N ? coords[atom_j_idx*3+1] : 0;
     RealType cj_z = atom_j_idx < N ? coords[atom_j_idx*3+2] : 0;
+
     unsigned long long gj_x = 0;
     unsigned long long gj_y = 0;
     unsigned long long gj_z = 0;
@@ -600,7 +418,7 @@ void __global__ k_nonbonded(
         // (ytz): note that d2ij must be *strictly* less than cutoff_squared. This is because we set the
         // non-interacting atoms to exactly real_cutoff*real_cutoff. This ensures that atoms who's 4th dimension
         // is set to cutoff are non-interacting.
-        if(d2ij < cutoff_squared  && atom_j_idx > atom_i_idx && atom_j_idx < N && atom_i_idx < N) {
+        if(d2ij < cutoff_squared && atom_j_idx > atom_i_idx && atom_j_idx < N && atom_i_idx < N) {
 
             // electrostatics
             RealType inv_dij = rsqrt(d2ij);
@@ -636,30 +454,43 @@ void __global__ k_nonbonded(
 
                 RealType lj_prefactor = eps_ij*sig6_inv_d8ij*(sig6_inv_d6ij*48 - 24);
                 u += 4*eps_ij*(sig6_inv_d6ij-1)*sig6_inv_d6ij;
+
                 delta_prefactor -= lj_prefactor;
 
-                RealType sig_grad = 24*eps_ij*sig5*inv_d6ij*(2*sig6_inv_d6ij-1);
-                g_sigi += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DSIG>(sig_grad);
-                g_sigj += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DSIG>(sig_grad);
-                RealType eps_grad = 4*(sig6_inv_d6ij-1)*sig6_inv_d6ij;
-                g_epsi += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DEPS>(eps_grad*eps_j);
-                g_epsj += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DEPS>(eps_grad*eps_i);
+                if(COMPUTE_DU_DP) {
+                    RealType sig_grad = 24*eps_ij*sig5*inv_d6ij*(2*sig6_inv_d6ij-1);
+                    g_sigi += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DSIG>(sig_grad);
+                    g_sigj += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DSIG>(sig_grad);
+                    RealType eps_grad = 4*(sig6_inv_d6ij-1)*sig6_inv_d6ij;
+                    g_epsi += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DEPS>(eps_grad*eps_j);
+                    g_epsj += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DEPS>(eps_grad*eps_i);
+                }
+
             }
-         
-            gi_x += FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_x);
-            gi_y += FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_y);
-            gi_z += FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_z);
 
-            gj_x += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_x);
-            gj_y += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_y);
-            gj_z += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_z);
+            if(COMPUTE_DU_DX) {
+                gi_x += FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_x);
+                gi_y += FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_y);
+                gi_z += FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_z);
 
-            du_dl_i += FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_w*lambda_offset_i*cutoff);
-            du_dl_j += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_w*lambda_offset_j*cutoff);
+                gj_x += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_x);
+                gj_y += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_y);
+                gj_z += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_z);
+            }
 
-            energy += FLOAT_TO_FIXED_NONBONDED(u);
-            g_qi += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DCHARGE>(qj*inv_dij*ebd);
-            g_qj += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DCHARGE>(qi*inv_dij*ebd);
+            if(COMPUTE_DU_DL) {
+                du_dl_i += FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_w*lambda_offset_i*cutoff);
+                du_dl_j += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_w*lambda_offset_j*cutoff);
+            }
+
+            if(COMPUTE_U) {
+                energy += FLOAT_TO_FIXED_NONBONDED(u);
+            }
+
+            if(COMPUTE_DU_DP) {
+                g_qi += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DCHARGE>(qj*inv_dij*ebd);
+                g_qj += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DCHARGE>(qi*inv_dij*ebd);
+            }
 
         }
 
@@ -670,19 +501,30 @@ void __global__ k_nonbonded(
         cj_x = __shfl_sync(0xffffffff, cj_x, srcLane); // needs to support real
         cj_y = __shfl_sync(0xffffffff, cj_y, srcLane); // needs to support real
         cj_z = __shfl_sync(0xffffffff, cj_z, srcLane); // needs to support real
-        gj_x = __shfl_sync(0xffffffff, gj_x, srcLane);
-        gj_y = __shfl_sync(0xffffffff, gj_y, srcLane);
-        gj_z = __shfl_sync(0xffffffff, gj_z, srcLane);
-        g_qj = __shfl_sync(0xffffffff, g_qj, srcLane);
-        g_sigj = __shfl_sync(0xffffffff, g_sigj, srcLane);
-        g_epsj = __shfl_sync(0xffffffff, g_epsj, srcLane);
+
         lambda_offset_j = __shfl_sync(0xffffffff, lambda_offset_j, srcLane); // this also can be optimized away
         lambda_plane_j = __shfl_sync(0xffffffff, lambda_plane_j, srcLane);
-        du_dl_j = __shfl_sync(0xffffffff, du_dl_j, srcLane);
+
+        if(COMPUTE_DU_DX) {
+            gj_x = __shfl_sync(0xffffffff, gj_x, srcLane);
+            gj_y = __shfl_sync(0xffffffff, gj_y, srcLane);
+            gj_z = __shfl_sync(0xffffffff, gj_z, srcLane);
+        }
+
+        if(COMPUTE_DU_DP) {
+            g_qj = __shfl_sync(0xffffffff, g_qj, srcLane);
+            g_sigj = __shfl_sync(0xffffffff, g_sigj, srcLane);
+            g_epsj = __shfl_sync(0xffffffff, g_epsj, srcLane);
+        }
+
+        if(COMPUTE_DU_DL) {
+            du_dl_j = __shfl_sync(0xffffffff, du_dl_j, srcLane);
+        }
+
     }
 
     // these reduction buffers are really tricky
-    if(du_dx) {
+    if(COMPUTE_DU_DX) {
         if(atom_i_idx < N) {
             atomicAdd(du_dx + atom_i_idx*3 + 0, gi_x);
             atomicAdd(du_dx + atom_i_idx*3 + 1, gi_y);
@@ -695,7 +537,7 @@ void __global__ k_nonbonded(
         }
     }
 
-    if(du_dp) {
+    if(COMPUTE_DU_DP) {
 
         if(atom_i_idx < N) {
             atomicAdd(du_dp + charge_param_idx_i, g_qi);
@@ -712,13 +554,13 @@ void __global__ k_nonbonded(
     }
 
     // these are buffered and then reduced to avoid massive conflicts
-    if(du_dl_buffer) {
+    if(COMPUTE_DU_DL) {
         if(atom_i_idx < N) {
             atomicAdd(du_dl_buffer + atom_i_idx, du_dl_i + du_dl_j);
         }
     }
 
-    if(u_buffer) {
+    if(COMPUTE_U) {
         if(atom_i_idx < N) {
             atomicAdd(u_buffer + atom_i_idx, energy);
         }
@@ -894,6 +736,7 @@ void __global__ k_nonbonded_exclusions(
         du_dl_j -= FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_w*lambda_offset_j*cutoff);
 
         // energy is size extensive so this may not be a good idea
+
         energy -= FLOAT_TO_FIXED_NONBONDED(u);
 
         g_qi -= FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DCHARGE>(charge_scale*qj*inv_dij*ebd);

--- a/timemachine/cpp/src/nonbonded.hpp
+++ b/timemachine/cpp/src/nonbonded.hpp
@@ -6,10 +6,28 @@
 
 namespace timemachine {
 
+typedef void (*k_nonbonded_fn)(const int N,
+    const double * __restrict__ coords,
+    const double * __restrict__ params, // [N]
+    const double * __restrict__ box,
+    const double lambda,
+    const int * __restrict__ lambda_plane_idxs, // 0 or 1, shift
+    const int * __restrict__ lambda_offset_idxs, // 0 or 1, how much we offset from the plane by cutoff
+    const double beta,
+    const double cutoff,
+    const int * __restrict__ ixn_tiles,
+    const unsigned int * __restrict__ ixn_atoms,
+    unsigned long long * __restrict__ du_dx,
+    unsigned long long * __restrict__ du_dp,
+    unsigned long long * __restrict__ du_dl_buffer,
+    unsigned long long * __restrict__ u_buffer);
+
 template<typename RealType>
 class Nonbonded : public Potential {
 
 private:
+
+    std::array<k_nonbonded_fn, 16> kernel_ptrs_;
 
     int *d_exclusion_idxs_; // [E,2]
     double *d_scales_; // [E, 2]


### PR DESCRIPTION
This is mostly a janitorial PR to unify nonbonded kernels with templates. Before we had a specialized _du_dx version. However, for non-equilibrium simulations we will need a specialized _du_dx + _du_dp + _du_dl version as we need du_dp for parameter interpolation's du_dl and du_dl for the subsequent work calculation.

This PR now introduces 4 flags which will be used to denote which of the 4 computations (U, DU_DX, DU_DL, DU_DP) we desire. The compiler will automatically elide out the intermediates. We also remove the specialized 3D distance variant as well, as me and @maxentile discussed that the focus will be on FE calculations.


The speed is not affected.

```
GTX 3080
master:
dhfr-apo: N=23558 speed: 244.34ns/day dt: 1.5fs (ran 100000 steps in 53.04s)
hif2a-apo: N=8805 speed: 486.00ns/day dt: 1.5fs (ran 100000 steps in 26.67s)
hif2a-rbfe: N=8840 speed: 389.50ns/day dt: 1.5fs (ran 100000 steps in 33.28s)
solvent-apo: N=6282 speed: 608.51ns/day dt: 1.5fs (ran 100000 steps in 21.30s)
solvent-rbfe: N=6317 speed: 494.53ns/day dt: 1.5fs (ran 100000 steps in 26.21s)

pr:
dhfr-apo: N=23558 speed: 242.57ns/day dt: 1.5fs (ran 100000 steps in 53.43s)
hif2a-apo: N=8805 speed: 485.39ns/day dt: 1.5fs (ran 100000 steps in 26.70s)
hif2a-rbfe: N=8840 speed: 396.05ns/day dt: 1.5fs (ran 100000 steps in 32.73s)
solvent-apo: N=6282 speed: 613.54ns/day dt: 1.5fs (ran 100000 steps in 21.13s)
solvent-rbfe: N=6317 speed: 501.58ns/day dt: 1.5fs (ran 100000 steps in 25.84s)
```