### PR TITLE
Use absolute path to examples path

### DIFF
--- a/examples/hif2a/fit_to_multiple_rbfes.py
+++ b/examples/hif2a/fit_to_multiple_rbfes.py
@@ -67,7 +67,7 @@ testing_configuration = Configuration(
 from pathlib import Path
 
 # locations relative to project root
-root = Path(__file__).parent.parent.parent
+root = Path(__file__).absolute().parent.parent.parent
 path_to_protein = str(root.joinpath('tests/data/hif2a_nowater_min.pdb'))
 path_to_ff = str(root.joinpath('ff/params/smirnoff_1_1_0_ccc.py'))
 

--- a/examples/hif2a/generate_star_map.py
+++ b/examples/hif2a/generate_star_map.py
@@ -10,9 +10,10 @@ import matplotlib.pyplot as plt
 from fe import topology
 from fe.utils import convert_uIC50_to_kJ_per_mole
 
-root = Path(__file__).parent.parent.parent
+root = Path(__file__).absolute().parent.parent.parent
 
 # 0. Get force field
+
 from ff import Forcefield
 from ff.handlers.deserialize import deserialize_handlers
 


### PR DESCRIPTION
* Ensures that users can run the script from where ever
  they want