### PR TITLE
Specialize casting for 86

### DIFF
--- a/timemachine/cpp/src/kernels/k_fixed_point.cuh
+++ b/timemachine/cpp/src/kernels/k_fixed_point.cuh
@@ -11,6 +11,7 @@ RealType __device__ __forceinline__ FIXED_TO_FLOAT_DU_DP(unsigned long long v) {
 // (ytz): courtesy of @scottlegrand/NVIDIA, even faster conversion
 // This was original a hack to improve perf on Maxwell, that is now needed for Ampere
 long long __device__ __forceinline__ real_to_int64(float x) {
+#if __CUDA_ARCH__ == 860
   float z = x * (float)0x1.00000p-32;
   int hi = __float2int_rz( z );                         // First convert high bits
   float delta = x - ((float)0x1.00000p32*((float)hi));  // Check remainder sign
@@ -20,6 +21,9 @@ long long __device__ __forceinline__ real_to_int64(float x) {
   hi -= test;                                           // Two's complement correction
   long long res = __double_as_longlong(__hiloint2double(hi,lo)); // Return 64-bit result
   return res;
+#else
+    return static_cast<long long>(x);
+#endif
 }
 
 // (ytz): reference version, left here for pedagogical reasons, do not remove.


### PR DESCRIPTION
Per @dmclark17 this PR specializes the static_cast convention only for CUDA_ARCH=sm_86. Roughly a 23% speed-up.

Before

```
dhfr-apo: N=23558 speed: 254.43ns/day dt: 1.5fs (ran 100000 steps in 50.95s)
building a protein system with 1758 protein atoms and 7047 water atoms
hif2a-apo: N=8805 speed: 482.40ns/day dt: 1.5fs (ran 100000 steps in 26.87s)
WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
hif2a-rbfe-with-du-dp: N=8840 speed: 402.42ns/day dt: 1.5fs (ran 100000 steps in 32.21s)
hif2a-rbfe-du-dl-freq-0: N=8840 speed: 402.28ns/day dt: 1.5fs (ran 100000 steps in 32.22s)
hif2a-rbfe-du-dl-freq-1: N=8840 speed: 382.35ns/day dt: 1.5fs (ran 100000 steps in 33.90s)
hif2a-rbfe-du-dl-freq-5: N=8840 speed: 396.94ns/day dt: 1.5fs (ran 100000 steps in 32.66s)
solvent-apo: N=6282 speed: 612.97ns/day dt: 1.5fs (ran 100000 steps in 21.15s)
solvent-rbfe-with-du-dp: N=6317 speed: 496.21ns/day dt: 1.5fs (ran 100000 steps in 26.12s)
solvent-rbfe-du-dl-freq-0: N=6317 speed: 498.67ns/day dt: 1.5fs (ran 100000 steps in 25.99s)
solvent-rbfe-du-dl-freq-1: N=6317 speed: 474.17ns/day dt: 1.5fs (ran 100000 steps in 27.34s)
solvent-rbfe-du-dl-freq-5: N=6317 speed: 483.54ns/day dt: 1.5fs (ran 100000 steps in 26.81s)
```

after

```
dhfr-apo: N=23558 speed: 313.43ns/day dt: 1.5fs (ran 100000 steps in 41.36s)
building a protein system with 1758 protein atoms and 7047 water atoms
hif2a-apo: N=8805 speed: 561.24ns/day dt: 1.5fs (ran 100000 steps in 23.10s)
WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
hif2a-rbfe-with-du-dp: N=8840 speed: 475.31ns/day dt: 1.5fs (ran 100000 steps in 27.27s)
hif2a-rbfe-du-dl-freq-0: N=8840 speed: 477.97ns/day dt: 1.5fs (ran 100000 steps in 27.12s)
hif2a-rbfe-du-dl-freq-1: N=8840 speed: 449.90ns/day dt: 1.5fs (ran 100000 steps in 28.81s)
hif2a-rbfe-du-dl-freq-5: N=8840 speed: 472.18ns/day dt: 1.5fs (ran 100000 steps in 27.45s)
solvent-apo: N=6282 speed: 702.95ns/day dt: 1.5fs (ran 100000 steps in 18.44s)
solvent-rbfe-with-du-dp: N=6317 speed: 585.09ns/day dt: 1.5fs (ran 100000 steps in 22.16s)
solvent-rbfe-du-dl-freq-0: N=6317 speed: 586.78ns/day dt: 1.5fs (ran 100000 steps in 22.09s)
solvent-rbfe-du-dl-freq-1: N=6317 speed: 526.48ns/day dt: 1.5fs (ran 100000 steps in 24.62s)
solvent-rbfe-du-dl-freq-5: N=6317 speed: 578.94ns/day dt: 1.5fs (ran 100000 steps in 22.39s)
```