### PR TITLE
Remove callback and register a pytree node in estimator.

### DIFF
--- a/examples/hif2a/fit_to_multiple_rbfes.py
+++ b/examples/hif2a/fit_to_multiple_rbfes.py
@@ -63,13 +63,6 @@ intermediate_configuration = Configuration(
     num_prod_steps=10000,
 )
 
-intermediate_configuration = Configuration(
-    num_complex_windows=2,
-    num_solvent_windows=2,
-    num_equil_steps=1000,
-    num_prod_steps=1000,
-)
-
 testing_configuration = Configuration(
     num_complex_windows=10,
     num_solvent_windows=10,

--- a/examples/hif2a/fit_to_multiple_rbfes.py
+++ b/examples/hif2a/fit_to_multiple_rbfes.py
@@ -63,6 +63,13 @@ intermediate_configuration = Configuration(
     num_prod_steps=10000,
 )
 
+intermediate_configuration = Configuration(
+    num_complex_windows=2,
+    num_solvent_windows=2,
+    num_equil_steps=1000,
+    num_prod_steps=1000,
+)
+
 testing_configuration = Configuration(
     num_complex_windows=10,
     num_solvent_windows=10,
@@ -78,7 +85,7 @@ testing_configuration = Configuration(
 
 
 # locations relative to project root
-root = Path(timemachine.__file__).parent
+root = Path(__file__).parent.parent.parent
 path_to_protein = str(root.joinpath('tests/data/hif2a_nowater_min.pdb'))
 
 
@@ -211,11 +218,9 @@ if __name__ == "__main__":
         prod_steps=configuration.num_prod_steps,
     )
 
-
-    def loss_fxn(ff_params, mol_a, mol_b, core, label_ddG, callback=None):
-        pred_ddG = binding_model.predict(ff_params, mol_a, mol_b, core, callback)
-        return pseudo_huber_loss(pred_ddG - label_ddG)
-
+    def loss_fxn(ff_params, mol_a, mol_b, core, label_ddG):
+        pred_ddG, stage_results = binding_model.predict(ff_params, mol_a, mol_b, core)
+        return pseudo_huber_loss(pred_ddG - label_ddG), stage_results
 
     # TODO: how to get intermediate results from the computational pipeline encapsulated in binding_model.loss ?
     #   e.g. stage_results, and further diagnostic information
@@ -307,15 +312,7 @@ if __name__ == "__main__":
         # TODO: adjust this threshold a bit, move reliability calculations into fe/estimator.py or fe/model.py
         return np.isnan(du_dls).any() or (du_dls.std(1).max() > 1000)
 
-
     results_this_step = dict()  # {stage : result} pairs # TODO: proper type hint
-
-
-    def save_in_memory_callback(results, stage):
-        global results_this_step
-        results_this_step[stage] = results
-        print(f'collected {stage} results!')
-
 
     # in each optimizer step, look at one transformation from relative_transformations
     for step, rfe_ind in enumerate(step_inds):
@@ -325,8 +322,18 @@ if __name__ == "__main__":
         t0 = time()
 
         # TODO: perhaps update this to accept an rfe argument, instead of all of rfe's attributes as arguments
-        loss, loss_grads = jax.value_and_grad(loss_fxn, argnums=0)(ordered_params, rfe.mol_a, rfe.mol_b, rfe.core,
-                                                                   rfe.label, callback=save_in_memory_callback)
+        (loss, stage_results), loss_grads = jax.value_and_grad(loss_fxn, argnums=0, has_aux=True)(
+            ordered_params,
+            rfe.mol_a,
+            rfe.mol_b,
+            rfe.core,
+            rfe.label
+        )
+
+        for stage, result in stage_results:
+            results_this_step[stage] = result
+            print(f'collected {stage} results!')
+
         print(f"at optimizer step {step}, loss={loss:.3f}")
 
         # check if it's probably okay to take an optimizer step on the basis of this result

--- a/examples/hif2a/fit_to_multiple_rbfes.py
+++ b/examples/hif2a/fit_to_multiple_rbfes.py
@@ -78,7 +78,7 @@ testing_configuration = Configuration(
 
 
 # locations relative to project root
-root = Path(__file__).parent.parent.parent
+root = Path(timemachine.__file__).parent.parent
 path_to_protein = str(root.joinpath('tests/data/hif2a_nowater_min.pdb'))
 
 

--- a/examples/rbfe_single.py
+++ b/examples/rbfe_single.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
         cmd_args.num_prod_steps
     )
 
-    vg_fn = jax.value_and_grad(binding_model.loss, argnums=0)
+
 
     ordered_params = forcefield.get_ordered_params()
     ordered_handles = forcefield.get_ordered_handles()
@@ -171,8 +171,11 @@ if __name__ == "__main__":
     flat_grad_traj = []
     loss_traj = []
 
+    vg_fn = jax.value_and_grad(binding_model.loss, argnums=0, has_aux=True)
+
     for epoch in range(1000):
         epoch_params = serialize_handlers(ordered_handles)
+
         (loss, aux), loss_grad = vg_fn(ordered_params, mol_a, mol_b, core, label_ddG)
 
         print("epoch", epoch, "loss", loss)

--- a/fe/estimator.py
+++ b/fe/estimator.py
@@ -19,11 +19,11 @@ class SimulationResult:
    du_dps: np.array
 
 def flatten(v):
-  return tuple(), (v.xs, v.du_dls, v.du_dps)
+    return tuple(), (v.xs, v.du_dls, v.du_dps)
 
 def unflatten(aux_data, children):
-  xs, du_dls, du_dps = aux_data
-  return SimulationResult(xs, du_dls, du_dps)
+    xs, du_dls, du_dps = aux_data
+    return SimulationResult(xs, du_dls, du_dps)
 
 jax.tree_util.register_pytree_node(SimulationResult, flatten, unflatten)
 
@@ -109,8 +109,7 @@ def simulate(lamb, box, x0, v0, final_potentials, integrator, equil_steps, prod_
 
 FreeEnergyModel = namedtuple(
     "FreeEnergyModel",
-    ["unbound_potentials", "client", "box", "x0", "v0", "integrator", "lambda_schedule", "equil_steps", "prod_steps"],
-    defaults=[None] # note: defaults applied to rightmost parameters
+    ["unbound_potentials", "client", "box", "x0", "v0", "integrator", "lambda_schedule", "equil_steps", "prod_steps"]
 )
 
 gradient = List[Any] # TODO: make this more descriptive of dG_grad structure

--- a/fe/estimator.py
+++ b/fe/estimator.py
@@ -9,16 +9,23 @@ from timemachine.lib import potentials, custom_ops
 
 from typing import Tuple, List, Any
 
+import dataclasses
+import jax.numpy as jnp
+
+@dataclasses.dataclass
 class SimulationResult:
-    def __init__(self, xs=None, du_dls=None, du_dps=None):
-        self.xs = xs
-        self.du_dls = du_dls
-        self.du_dps = du_dps
+   xs: np.array
+   du_dls: np.array
+   du_dps: np.array
 
-    def save(self, path):
-        return np.savez(path, xs=self.xs, du_dls=self.du_dls, du_dps=self.du_dps)
+def flatten(v):
+  return tuple(), (v.xs, v.du_dls, v.du_dps)
 
+def unflatten(aux_data, children):
+  xs, du_dls, du_dps = aux_data
+  return SimulationResult(xs, du_dls, du_dps)
 
+jax.tree_util.register_pytree_node(SimulationResult, flatten, unflatten)
 
 def simulate(lamb, box, x0, v0, final_potentials, integrator, equil_steps, prod_steps, get_trajectory=False,
     x_interval=1000, du_dl_interval=5):
@@ -102,14 +109,13 @@ def simulate(lamb, box, x0, v0, final_potentials, integrator, equil_steps, prod_
 
 FreeEnergyModel = namedtuple(
     "FreeEnergyModel",
-    ["unbound_potentials", "client", "box", "x0", "v0", "integrator", "lambda_schedule", "equil_steps", "prod_steps",
-     "callback"],
+    ["unbound_potentials", "client", "box", "x0", "v0", "integrator", "lambda_schedule", "equil_steps", "prod_steps"],
     defaults=[None] # note: defaults applied to rightmost parameters
 )
 
 gradient = List[Any] # TODO: make this more descriptive of dG_grad structure
 
-def _deltaG(model, sys_params, callback=None) -> Tuple[float, gradient]:
+def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
 
     assert len(sys_params) == len(model.unbound_potentials)
 
@@ -130,10 +136,6 @@ def _deltaG(model, sys_params, callback=None) -> Tuple[float, gradient]:
 
         results = [x.result() for x in futures]
 
-    if callback is not None:
-        # TODO: what should the signature of callback be?
-        callback(results)
-
     mean_du_dls = []
     all_grads = []
 
@@ -147,24 +149,22 @@ def _deltaG(model, sys_params, callback=None) -> Tuple[float, gradient]:
     for rhs, lhs in zip(all_grads[-1], all_grads[0]):
         dG_grad.append(rhs - lhs)
 
-    return dG, dG_grad
+    return (dG, results), dG_grad
 
-@functools.partial(jax.custom_vjp, nondiff_argnums=(0,2))
-def deltaG(model, sys_params, callback=None) -> float:
-    return _deltaG(model=model, sys_params=sys_params, callback=callback)[0]
+@functools.partial(jax.custom_vjp, nondiff_argnums=(0,))
+def deltaG(model, sys_params) -> Tuple[float, List]:
+    return _deltaG(model=model, sys_params=sys_params)[0]
 
-def deltaG_fwd(model, sys_params, callback=None) -> Tuple[float, gradient]:
-    """same signature as DeltaG, but returns"""
-    return _deltaG(model=model, sys_params=sys_params, callback=callback)
+def deltaG_fwd(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
+    """same signature as DeltaG, but returns the full tuple"""
+    return _deltaG(model=model, sys_params=sys_params)
 
-def deltaG_bwd(model, callback, residual, grad) -> Tuple[gradient]:
+def deltaG_bwd(model, residual, grad) -> Tuple[np.array]:
     """Note: nondiff args must appear first here, even though one of them appears last in the original function's signature!
-
-    Ahh: https://jax.readthedocs.io/en/latest/notebooks/Custom_derivative_rules_for_Python_code.html#jax-custom-vjp-with-nondiff-argnums
-    >A similar option exists for jax.custom_vjp, and similarly the convention is that the non-differentiable arguments
-    >are passed as the first arguments to the rules, no matter where they appear in the original function’s signature.
-
     """
-    return ([grad*r for r in residual], )
+    # residual are the partial dG / partial dparams for each term
+    # grad[0] is the adjoint of dG w.r.t. loss: partial L/partial dG
+    # grad[1] is the adjoint of dG w.r.t. simulation result, which we don't use
+    return ([grad[0]*r for r in residual],)
 
 deltaG.defvjp(deltaG_fwd, deltaG_bwd)

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -70,11 +70,11 @@ def test_free_energy_estimator():
             100
         )
 
-        value_and_grad_fn = jax.value_and_grad(estimator.deltaG, argnums=1)
-        dG, sys_grad = value_and_grad_fn(mdl, sys_params) # run fwd, store result, and run bwd
+        value_and_grad_fn = jax.value_and_grad(estimator.deltaG, argnums=1, has_aux=True)
+        (dG, _), sys_grad = value_and_grad_fn(mdl, sys_params) # run fwd, store result, and run bwd
 
-        grad_fn = jax.grad(estimator.deltaG, argnums=1)
-        grad = grad_fn(mdl, sys_params)
+        grad_fn = jax.grad(estimator.deltaG, argnums=1, has_aux=True)
+        grad, _ = grad_fn(mdl, sys_params)
 
         assert len(grad) == 2
         assert grad[0].shape == sys_params[0].shape

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -81,7 +81,7 @@ def test_absolute_free_energy():
                 prod_steps
             )
 
-            dG = estimator.deltaG(model, sys_params)
+            dG, _ = estimator.deltaG(model, sys_params)
             dGs.append(dG)
 
 
@@ -189,7 +189,7 @@ def test_relative_free_energy():
             prod_steps
         )
 
-        return estimator.deltaG(model, sys_params)
+        return estimator.deltaG(model, sys_params)[0]
 
     vg_fn = jax.value_and_grad(vacuum_model)
     dG, ff_grads = vg_fn(ff_params) # dG and ff_params_grad
@@ -236,7 +236,7 @@ def test_relative_free_energy():
                 prod_steps
             )
 
-            dG = estimator.deltaG(model, sys_params)
+            dG, _ = estimator.deltaG(model, sys_params)
             dGs.append(dG)
 
         return dGs[0] - dGs[1]


### PR DESCRIPTION
This PR removes the need to chase callbacks several layers into the estimator code to keep track of results. We're not in javascript land anymore!