### PR TITLE
Rename timemachine to jankmachine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .idea
 *.pkl
 __pycache__/
-timemachine/cpp/build/
+jankmachine/cpp/build/
 *.so
 *.DS_Store

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
   stages {
     stage('Execute CI') {
       steps {
-        sh '/usr/local/bin/fab -f /opt/jenkins/jenkins_scripts/timemachine_ci_fab.py ci:'+env.WORKSPACE+','+env.GIT_COMMIT
+        sh '/usr/local/bin/fab -f /opt/jenkins/jenkins_scripts/jankmachine_ci_fab.py ci:'+env.WORKSPACE+','+env.GIT_COMMIT
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ We currently support the following functional forms. Parameters that can be opti
 If using conda the following can be used to configure your environment
 
 ```
-conda create -n timemachine python=3.7
-conda activate timemachine
+conda create -n jankmachine python=3.7
+conda activate jankmachine
 conda install -c conda-forge -c openeye -c rdkit openmm openeye-toolkits rdkit
 ```
 
@@ -48,7 +48,7 @@ conda install -c conda-forge -c openeye -c rdkit openmm openeye-toolkits rdkit
 
 ```
 pip install -r requirements.txt
-cd timemachine/cpp
+cd jankmachine/cpp
 mkdir build
 cd build
 cmake -DCUDA_ARCH=sm_70 ../
@@ -85,13 +85,13 @@ When we have experimental measurements, the loss function and its derivative is 
 
 An example source code of how one can train the RBFE via TI is available at:
 
-- [examples/rbfe_single.py](https://github.com/proteneer/timemachine/blob/master/examples/rbfe_single.py)
+- [examples/rbfe_single.py](https://github.com/proteneer/jankmachine/blob/master/examples/rbfe_single.py)
 
-To update the forcefield parameters, the timemachine computes derivatives of the potential with respect to redundant system parameters (C++/CUDA), which are backprop'd into unique forcefield parameters using vector jacobian products (python/jax). The parameters are fitted using gradient descent with gradient clipping whose bounds are set to physically sensible and numerically stable values for each parameter type.
+To update the forcefield parameters, the jankmachine computes derivatives of the potential with respect to redundant system parameters (C++/CUDA), which are backprop'd into unique forcefield parameters using vector jacobian products (python/jax). The parameters are fitted using gradient descent with gradient clipping whose bounds are set to physically sensible and numerically stable values for each parameter type.
 
 ## Forcefield Gotchas
 
-Most of the training is using the correctable charge corrections [ccc forcefield](https://github.com/proteneer/timemachine/blob/master/ff/params/smirnoff_1_1_0_ccc.py), which is SMIRNOFF 1.1.0 augmented with BCCs ported via the [recharge](https://github.com/openforcefield/openff-recharge) project. There are some additional modifications:
+Most of the training is using the correctable charge corrections [ccc forcefield](https://github.com/proteneer/jankmachine/blob/master/ff/params/smirnoff_1_1_0_ccc.py), which is SMIRNOFF 1.1.0 augmented with BCCs ported via the [recharge](https://github.com/openforcefield/openff-recharge) project. There are some additional modifications:
 
 1. The charges have been multiplied by sqrt(ONE_4PI_EPS0) as an optimization.
 2. The eps parameter in LJ have been replaced by an alpha such that alpha^2=eps in order to avoid negative eps values during training.

--- a/barostat/barostat.py
+++ b/barostat/barostat.py
@@ -2,7 +2,7 @@ import numpy as np
 import functools
 import jax
 import jax.numpy as jnp
-from timemachine.integrator import langevin_coefficients
+from jankmachine.integrator import langevin_coefficients
 
 from jax.config import config; config.update("jax_enable_x64", True)
 

--- a/docking/dock_and_equilibrate.py
+++ b/docking/dock_and_equilibrate.py
@@ -11,7 +11,7 @@ from md import builders
 from fe import pdb_writer, free_energy
 from ff import Forcefield
 from ff.handlers.deserialize import deserialize_handlers
-from timemachine.lib import custom_ops, LangevinIntegrator
+from jankmachine.lib import custom_ops, LangevinIntegrator
 
 from docking import report
 

--- a/docking/pose_dock.py
+++ b/docking/pose_dock.py
@@ -12,8 +12,8 @@ from fe.utils import to_md_units
 from fe import free_energy
 from ff.handlers.deserialize import deserialize_handlers
 from ff import Forcefield
-from timemachine.lib import LangevinIntegrator
-from timemachine.lib import custom_ops
+from jankmachine.lib import LangevinIntegrator
+from jankmachine.lib import custom_ops
 
 from docking import report
 

--- a/docking/relative_docking.py
+++ b/docking/relative_docking.py
@@ -12,7 +12,7 @@ from md import builders, minimizer
 from fe import free_energy, topology
 from ff import Forcefield
 from ff.handlers.deserialize import deserialize_handlers
-from timemachine.lib import custom_ops, LangevinIntegrator
+from jankmachine.lib import custom_ops, LangevinIntegrator
 
 from testsystems.relative import hif2a_ligand_pair
 

--- a/docking/rigorous_work.py
+++ b/docking/rigorous_work.py
@@ -13,7 +13,7 @@ from md import builders
 from fe import pdb_writer, free_energy
 from ff import Forcefield
 from ff.handlers.deserialize import deserialize_handlers
-from timemachine.lib import custom_ops, LangevinIntegrator
+from jankmachine.lib import custom_ops, LangevinIntegrator
 
 from docking import report
 

--- a/docs/paper.tex
+++ b/docs/paper.tex
@@ -128,6 +128,6 @@ A second more practical issue deals with the computational complexity and speed.
 
 \section{Code}
 
-The code is publicly available at www.github.com/proteneer/timemachine and licensed under the Apache V2.
+The code is publicly available at www.github.com/proteneer/jankmachine and licensed under the Apache V2.
 
 \end{document}

--- a/examples/ahfe.py
+++ b/examples/ahfe.py
@@ -8,8 +8,8 @@ from fe import pdb_writer
 from fe import topology
 from md import builders
 
-from timemachine.lib import potentials, custom_ops
-from timemachine.lib import LangevinIntegrator
+from jankmachine.lib import potentials, custom_ops
+from jankmachine.lib import LangevinIntegrator
 
 import functools
 import jax
@@ -101,7 +101,7 @@ for final_lamb in np.linspace(0, 1, 8):
 
     # note: the .impl() call at the end returns a pickle-able version of the
     #   wrapper function -- since contexts are not pickle-able -- which will
-    #   be useful later in timemachine's multi-device parallelization strategy)
+    #   be useful later in jankmachine's multi-device parallelization strategy)
     # note: OpenMM unit system used throughout
     #   (temperature: kelvin, timestep: picosecond, collision_rate: picosecond^-1)
     intg = LangevinIntegrator(

--- a/examples/estimator_variance.py
+++ b/examples/estimator_variance.py
@@ -1,4 +1,4 @@
-# Adapted from https://github.com/proteneer/timemachine/blob/8f4c6d009ff27e070c19ff16901082197c54494d/examples/rbfe_single.py
+# Adapted from https://github.com/proteneer/jankmachine/blob/8f4c6d009ff27e070c19ff16901082197c54494d/examples/rbfe_single.py
 
 # without computing gradient (just computing dG_estimate), with default lambda protocol,
 # what is the bias and variance of dG_estimate as a function of computational effort?

--- a/examples/hif2a/fit_to_multiple_rbfes.py
+++ b/examples/hif2a/fit_to_multiple_rbfes.py
@@ -5,7 +5,7 @@ import jax
 from jax import numpy as jnp
 import numpy as np
 import datetime
-import timemachine
+import jankmachine
 from training.dataset import Dataset
 
 # forcefield handlers
@@ -78,7 +78,7 @@ testing_configuration = Configuration(
 
 
 # locations relative to project root
-root = Path(timemachine.__file__).parent.parent
+root = Path(jankmachine.__file__).parent.parent
 
 
 def _save_forcefield(fname, ff_params):

--- a/examples/hif2a/generate_star_map.py
+++ b/examples/hif2a/generate_star_map.py
@@ -7,8 +7,8 @@ from functools import partial
 
 from pickle import dump
 
-import timemachine
-from timemachine.parser import TimemachineConfig
+import jankmachine
+from jankmachine.parser import TimemachineConfig
 
 from fe import topology
 from fe.utils import convert_uIC50_to_kJ_per_mole
@@ -119,7 +119,7 @@ def generate_star(
             transformations.append(rfe)
         except AtomMappingError as e:
             # note: some of transformations may fail the factorizability assertion here:
-            # https://github.com/proteneer/timemachine/blob/2eb956f9f8ce62287cc531188d1d1481832c5e96/fe/topology.py#L381-L431
+            # https://github.com/proteneer/jankmachine/blob/2eb956f9f8ce62287cc531188d1d1481832c5e96/fe/topology.py#L381-L431
             error_transformations.append((hub, spoke, core))
 
     print(f'total # of edges that encountered atom mapping errors: {len(error_transformations)}')

--- a/examples/overlap_test.py
+++ b/examples/overlap_test.py
@@ -22,8 +22,8 @@ from rdkit import Chem
 from rdkit.Chem import AllChem
 
 from ff import handlers
-from timemachine.potentials import bonded, shape
-from timemachine.integrator import langevin_coefficients
+from jankmachine.potentials import bonded, shape
+from jankmachine.integrator import langevin_coefficients
 
 
 def pmi_restraints_new(conf, params, box, lamb, a_idxs, b_idxs, masses, angle_force, com_force):

--- a/examples/rhfe_dual.py
+++ b/examples/rhfe_dual.py
@@ -9,8 +9,8 @@ from fe import topology
 from md import builders
 from md import minimizer
 
-from timemachine.lib import potentials, custom_ops
-from timemachine.lib import LangevinIntegrator
+from jankmachine.lib import potentials, custom_ops
+from jankmachine.lib import LangevinIntegrator
 
 import functools
 import jax
@@ -131,7 +131,7 @@ for lamb_idx, final_lamb in enumerate(np.linspace(1, 0, 8)):
 
     # note: the .impl() call at the end returns a pickle-able version of the
     #   wrapper function -- since contexts are not pickle-able -- which will
-    #   be useful later in timemachine's multi-device parallelization strategy)
+    #   be useful later in jankmachine's multi-device parallelization strategy)
     # note: OpenMM unit system used throughout
     #   (temperature: kelvin, timestep: picosecond, collision_rate: picosecond^-1)
     intg = LangevinIntegrator(

--- a/fe/estimator.py
+++ b/fe/estimator.py
@@ -5,7 +5,7 @@ import copy
 import jax
 import numpy as np
 
-from timemachine.lib import potentials, custom_ops
+from jankmachine.lib import potentials, custom_ops
 
 from typing import Tuple, List, Any
 
@@ -49,7 +49,7 @@ def simulate(lamb, box, x0, v0, final_potentials, integrator, equil_steps, prod_
     final_potentials: list
         list of unbound potentials
 
-    integrator: timemachine.Integrator
+    integrator: jankmachine.Integrator
         integrator to be used for dynamics
 
     equil_steps: int

--- a/fe/free_energy.py
+++ b/fe/free_energy.py
@@ -5,8 +5,8 @@ import numpy as np
 
 from fe import topology
 
-from timemachine.lib import potentials, custom_ops
-from timemachine.lib import LangevinIntegrator
+from jankmachine.lib import potentials, custom_ops
+from jankmachine.lib import LangevinIntegrator
 
 from ff.handlers import openmm_deserializer
 

--- a/fe/model.py
+++ b/fe/model.py
@@ -5,7 +5,7 @@ from simtk import openmm
 from rdkit import Chem
 
 from md import minimizer
-from timemachine.lib import LangevinIntegrator
+from jankmachine.lib import LangevinIntegrator
 from fe import free_energy, topology, estimator
 from ff import Forcefield
 

--- a/fe/topology.py
+++ b/fe/topology.py
@@ -2,7 +2,7 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 
-from timemachine.lib import potentials
+from jankmachine.lib import potentials
 from ff.handlers import nonbonded, bonded
 
 _SCALE_12 = 1.0

--- a/fe/utils.py
+++ b/fe/utils.py
@@ -14,7 +14,7 @@ def write(xyz, masses, recenter=True):
     if recenter:
         xyz = xyz - np.mean(xyz, axis=0, keepdims=True)
     buf = str(len(masses)) + '\n'
-    buf += 'timemachine\n'
+    buf += 'jankmachine\n'
     for m, (x,y,z) in zip(masses, xyz):
         if int(round(m)) == 12:
             symbol = 'C'

--- a/ff/handlers/nonbonded.py
+++ b/ff/handlers/nonbonded.py
@@ -11,7 +11,7 @@ from ff.handlers.utils import match_smirks, sort_tuple
 from ff.handlers.serialize import SerializableMixIn
 from ff.handlers.bcc_aromaticity import AromaticityModel
 
-from timemachine import constants
+from jankmachine import constants
 
 from jax import ops
 

--- a/ff/handlers/openmm_deserializer.py
+++ b/ff/handlers/openmm_deserializer.py
@@ -7,8 +7,8 @@ from simtk.openmm.app import PDBFile
 from simtk.openmm.app import forcefield as ff
 from simtk import unit
 
-from timemachine import constants
-from timemachine.lib import potentials
+from jankmachine import constants
+from jankmachine.lib import potentials
 
 def value(quantity):
     return quantity.value_in_unit_system(unit.md_unit_system)

--- a/md/minimizer.py
+++ b/md/minimizer.py
@@ -2,8 +2,8 @@ import numpy as np
 
 from fe import topology
 
-from timemachine.lib import potentials
-from timemachine.lib import LangevinIntegrator, custom_ops
+from jankmachine.lib import potentials
+from jankmachine.lib import LangevinIntegrator, custom_ops
 
 from ff.handlers import openmm_deserializer
 from ff import Forcefield

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,10 +3,10 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 import functools
-from timemachine.constants import ONE_4PI_EPS0
+from jankmachine.constants import ONE_4PI_EPS0
 
-from timemachine.potentials import bonded, nonbonded, gbsa
-from timemachine.lib import potentials, custom_ops
+from jankmachine.potentials import bonded, nonbonded, gbsa
+from jankmachine.lib import potentials, custom_ops
 
 from hilbertcurve.hilbertcurve import HilbertCurve
 

--- a/tests/dual_topology.py
+++ b/tests/dual_topology.py
@@ -7,8 +7,8 @@ import numpy as np
 from rdkit import Chem
 from rdkit.Chem import AllChem
 
-from timemachine.lib import potentials, custom_ops
-from timemachine.lib import LangevinIntegrator
+from jankmachine.lib import potentials, custom_ops
+from jankmachine.lib import LangevinIntegrator
 
 from ff.handlers import openmm_deserializer
 from ff.handlers.deserialize import deserialize_handlers

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -11,8 +11,8 @@ from ff import Forcefield
 
 from simtk.openmm import app
 
-from timemachine.lib import custom_ops
-from timemachine.lib import LangevinIntegrator
+from jankmachine.lib import custom_ops
+from jankmachine.lib import LangevinIntegrator
 
 from fe.utils import to_md_units
 from fe import free_energy

--- a/tests/test_bonded.py
+++ b/tests/test_bonded.py
@@ -6,8 +6,8 @@ config.update("jax_enable_x64", True)
 import functools
 
 from common import GradientTest
-from timemachine.lib import potentials
-from timemachine.potentials import bonded
+from jankmachine.lib import potentials
+from jankmachine.potentials import bonded
 
 
 class TestBonded(GradientTest):

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -1,5 +1,5 @@
 """
-Tests for the timemachine/docking/ files
+Tests for the jankmachine/docking/ files
 """
 
 import unittest

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -4,8 +4,8 @@ import numpy as np
 
 
 from fe import estimator
-from timemachine.lib import LangevinIntegrator
-from timemachine.lib import potentials
+from jankmachine.lib import LangevinIntegrator
+from jankmachine.lib import potentials
 from parallel.client import CUDAPoolClient
 
 

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -15,7 +15,7 @@ from parallel.client import CUDAPoolClient
 
 from md import builders, minimizer
 
-from timemachine.lib import LangevinIntegrator, custom_ops
+from jankmachine.lib import LangevinIntegrator, custom_ops
 
 
 def test_absolute_free_energy():

--- a/tests/test_lambda_potential.py
+++ b/tests/test_lambda_potential.py
@@ -5,7 +5,7 @@ import functools
 import numpy as np
 
 from common import GradientTest
-from timemachine.lib import potentials
+from jankmachine.lib import potentials
 
 from common import prepare_water_system
 

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -8,9 +8,9 @@ import jax
 import jax.numpy as jnp
 
 
-from timemachine.lib import custom_ops
-# from timemachine.lib import potentials
-from timemachine.potentials import bonded, nonbonded
+from jankmachine.lib import custom_ops
+# from jankmachine.lib import potentials
+from jankmachine.potentials import bonded, nonbonded
 
 from common import GradientTest
 from common import prepare_nb_system

--- a/tests/test_nblist.py
+++ b/tests/test_nblist.py
@@ -1,5 +1,5 @@
 import numpy as np
-from timemachine.lib import custom_ops
+from jankmachine.lib import custom_ops
 
 from hilbertcurve.hilbertcurve import HilbertCurve
 

--- a/tests/test_nonbonded.py
+++ b/tests/test_nonbonded.py
@@ -17,8 +17,8 @@ import functools
 from common import GradientTest
 from common import prepare_nb_system, prepare_water_system, prepare_reference_nonbonded
 
-from timemachine.potentials import bonded, nonbonded, gbsa
-from timemachine.lib import potentials
+from jankmachine.potentials import bonded, nonbonded, gbsa
+from jankmachine.lib import potentials
 from md import builders
 
 from hilbertcurve.hilbertcurve import HilbertCurve

--- a/tests/test_parameter_interpolation.py
+++ b/tests/test_parameter_interpolation.py
@@ -4,7 +4,7 @@ import functools
 import numpy as np
 
 from common import GradientTest
-from timemachine.lib import potentials
+from jankmachine.lib import potentials
 
 from common import prepare_water_system
 

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -8,8 +8,8 @@ from rdkit import Chem
 import functools
 import numpy as np
 
-from timemachine.potentials import shape
-from timemachine.lib import potentials
+from jankmachine.potentials import shape
+from jankmachine.lib import potentials
 
 from common import GradientTest
 

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -14,7 +14,7 @@ from ff.handlers.deserialize import deserialize_handlers
 
 import jax
 
-from timemachine.lib import potentials
+from jankmachine.lib import potentials
 
 def get_romol_conf(mol):
     """Coordinates of mol's 0th conformer, in nanometers"""

--- a/thermo_deriv/analytical_derivatives.py
+++ b/thermo_deriv/analytical_derivatives.py
@@ -27,7 +27,7 @@ import numpy as np
 import functools
 
 
-from timemachine.constants import BOLTZ
+from jankmachine.constants import BOLTZ
 
 lennard_jones = jax.jit(lennard_jones)
 dU_dp = jax.jit(jax.grad(lennard_jones, argnums=(1,)))

--- a/thermo_deriv/density_fitting_2d.py
+++ b/thermo_deriv/density_fitting_2d.py
@@ -5,10 +5,10 @@ import jax.numpy as jnp
 
 from quadpy import quad
 from thermo_deriv.lj import lennard_jones
-from timemachine.integrator import langevin_coefficients
+from jankmachine.integrator import langevin_coefficients
 import numpy as np
 import functools
-from timemachine.constants import BOLTZ
+from jankmachine.constants import BOLTZ
 
 from matplotlib import pyplot as plt
 

--- a/thermo_deriv/fe_fitting.py
+++ b/thermo_deriv/fe_fitting.py
@@ -13,10 +13,10 @@ import jax.numpy as jnp
 
 from quadpy import quad
 from thermo_deriv.lj import lennard_jones
-from timemachine.integrator import langevin_coefficients
+from jankmachine.integrator import langevin_coefficients
 import numpy as np
 import functools
-from timemachine.constants import BOLTZ
+from jankmachine.constants import BOLTZ
 
 from matplotlib import pyplot as plt
 

--- a/thermo_deriv/md_grad.py
+++ b/thermo_deriv/md_grad.py
@@ -5,10 +5,10 @@ import jax.numpy as jnp
 
 from quadpy import quad
 from thermo_deriv.lj import lennard_jones
-from timemachine.integrator import langevin_coefficients
+from jankmachine.integrator import langevin_coefficients
 import numpy as np
 import functools
-from timemachine.constants import BOLTZ
+from jankmachine.constants import BOLTZ
 
 from matplotlib import pyplot as plt
 

--- a/thermo_deriv/thermo_grad.py
+++ b/thermo_deriv/thermo_grad.py
@@ -6,7 +6,7 @@ from quadpy import quad
 from thermo_deriv.lj_non_periodic import lennard_jones
 import numpy as np
 import functools
-from timemachine.constants import BOLTZ
+from jankmachine.constants import BOLTZ
 
 BOLTZ = RGAS/1000
 

--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(PYBIND11_PYTHON_VERSION 3.7 CACHE STRING "Which version of python we're building wrappers against")
 
-project(timemachine LANGUAGES CXX CUDA)
+project(jankmachine LANGUAGES CXX CUDA)
 
 find_package(PythonInterp 3.7 REQUIRED)
 find_package(PythonLibs 3.7 REQUIRED)

--- a/timemachine/cpp/src/bound_potential.cu
+++ b/timemachine/cpp/src/bound_potential.cu
@@ -1,7 +1,7 @@
 #include "bound_potential.hpp"
 #include "gpu_utils.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 BoundPotential::BoundPotential(
     std::shared_ptr<Potential> potential,

--- a/timemachine/cpp/src/bound_potential.hpp
+++ b/timemachine/cpp/src/bound_potential.hpp
@@ -5,7 +5,7 @@
 
 #include "potential.hpp"
 
-namespace timemachine {
+namespace jankmachine {
 
 // a potential bounded to a set of parameters with some shape
 struct BoundPotential {
@@ -63,4 +63,4 @@ struct BoundPotential {
 };
 
 
-} // namespace timemachine
+} // namespace jankmachine

--- a/timemachine/cpp/src/centroid_restraint.cu
+++ b/timemachine/cpp/src/centroid_restraint.cu
@@ -6,7 +6,7 @@
 #include "gpu_utils.cuh"
 #include "k_centroid_restraint.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 template <typename RealType>
 CentroidRestraint<RealType>::CentroidRestraint(
@@ -92,4 +92,4 @@ void CentroidRestraint<RealType>::execute_device(
 template class CentroidRestraint<double>;
 template class CentroidRestraint<float>;
 
-} // namespace timemachine
+} // namespace jankmachine

--- a/timemachine/cpp/src/centroid_restraint.hpp
+++ b/timemachine/cpp/src/centroid_restraint.hpp
@@ -3,7 +3,7 @@
 #include "potential.hpp"
 #include <vector>
 
-namespace timemachine {
+namespace jankmachine {
 
 template<typename RealType>
 class CentroidRestraint : public Potential {

--- a/timemachine/cpp/src/context.cu
+++ b/timemachine/cpp/src/context.cu
@@ -7,7 +7,7 @@
 #include <chrono>
 #include <cub/cub.cuh>
 
-namespace timemachine {
+namespace jankmachine {
 
 Context::Context(
     int N,

--- a/timemachine/cpp/src/context.hpp
+++ b/timemachine/cpp/src/context.hpp
@@ -6,7 +6,7 @@
 #include "bound_potential.hpp"
 #include "observable.hpp"
 
-namespace timemachine {
+namespace jankmachine {
 
 class Context {
 

--- a/timemachine/cpp/src/electrostatics.cu
+++ b/timemachine/cpp/src/electrostatics.cu
@@ -13,7 +13,7 @@
 #include "k_electrostatics.cuh"
 #include "k_electrostatics_jvp.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 template <typename RealType>
 Electrostatics<RealType>::Electrostatics(
@@ -480,4 +480,4 @@ void Electrostatics<RealType>::execute_device(
 template class Electrostatics<double>;
 template class Electrostatics<float>;
 
-} // namespace timemachine
+} // namespace jankmachine

--- a/timemachine/cpp/src/electrostatics.hpp
+++ b/timemachine/cpp/src/electrostatics.hpp
@@ -4,7 +4,7 @@
 #include "potential.hpp"
 #include <vector>
 
-namespace timemachine {
+namespace jankmachine {
 
 template<typename RealType>
 class Electrostatics : public Potential {

--- a/timemachine/cpp/src/gbsa.cu
+++ b/timemachine/cpp/src/gbsa.cu
@@ -9,7 +9,7 @@
 #include "k_gbsa.cuh"
 #include "k_gbsa_jvp.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 template <typename RealType>
 GBSA<RealType>::GBSA(

--- a/timemachine/cpp/src/gbsa.hpp
+++ b/timemachine/cpp/src/gbsa.hpp
@@ -5,7 +5,7 @@
 #include "surreal.cuh"
 #include <vector>
 
-namespace timemachine {
+namespace jankmachine {
 
 template<typename RealType>
 class GBSA : public Gradient {

--- a/timemachine/cpp/src/gbsa_jvp.cuh
+++ b/timemachine/cpp/src/gbsa_jvp.cuh
@@ -5,7 +5,7 @@
 #include "kernel_utils.cuh"
 #include "math_utils.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 
 template <int D>

--- a/timemachine/cpp/src/gradient.cu
+++ b/timemachine/cpp/src/gradient.cu
@@ -5,7 +5,7 @@
 #include "gpu_utils.cuh"
 #include "surreal.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 void Potential::execute_host(
     const int N,

--- a/timemachine/cpp/src/gradient.hpp
+++ b/timemachine/cpp/src/gradient.hpp
@@ -2,7 +2,7 @@
 
 // #include <cuda_runtime.h>
 
-// namespace timemachine {
+// namespace jankmachine {
 
 // class Params {
 

--- a/timemachine/cpp/src/harmonic_angle.cu
+++ b/timemachine/cpp/src/harmonic_angle.cu
@@ -6,7 +6,7 @@
 #include "gpu_utils.cuh"
 #include "k_harmonic_angle.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 template <typename RealType>
 HarmonicAngle<RealType>::HarmonicAngle(
@@ -104,4 +104,4 @@ void HarmonicAngle<RealType>::execute_device(
 template class HarmonicAngle<double>;
 template class HarmonicAngle<float>;
 
-} // namespace timemachine
+} // namespace jankmachine

--- a/timemachine/cpp/src/harmonic_angle.hpp
+++ b/timemachine/cpp/src/harmonic_angle.hpp
@@ -3,7 +3,7 @@
 #include "potential.hpp"
 #include <vector>
 
-namespace timemachine {
+namespace jankmachine {
 
 template<typename RealType>
 class HarmonicAngle : public Potential {

--- a/timemachine/cpp/src/harmonic_bond.cu
+++ b/timemachine/cpp/src/harmonic_bond.cu
@@ -6,7 +6,7 @@
 #include "gpu_utils.cuh"
 #include "k_harmonic_bond.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 template <typename RealType>
 HarmonicBond<RealType>::HarmonicBond(
@@ -102,4 +102,4 @@ void HarmonicBond<RealType>::execute_device(
 template class HarmonicBond<double>;
 template class HarmonicBond<float>;
 
-} // namespace timemachine
+} // namespace jankmachine

--- a/timemachine/cpp/src/harmonic_bond.hpp
+++ b/timemachine/cpp/src/harmonic_bond.hpp
@@ -3,7 +3,7 @@
 #include "potential.hpp"
 #include <vector>
 
-namespace timemachine {
+namespace jankmachine {
 
 template<typename RealType>
 class HarmonicBond : public Potential {

--- a/timemachine/cpp/src/inertial_restraint.cu
+++ b/timemachine/cpp/src/inertial_restraint.cu
@@ -8,7 +8,7 @@
 #include "solver.hpp"
 #include "../fixed_point.hpp"
 
-namespace timemachine {
+namespace jankmachine {
 
 template <typename RealType>
 InertialRestraint<RealType>::InertialRestraint(
@@ -234,7 +234,7 @@ void grad_eigh(
     double a_adjoint[3][3]   // input array adjoints
     ) {
     /*
-    (ytz): I really hate this code. See timemachine.lib.pmi.grad_eigh for a slightly more
+    (ytz): I really hate this code. See jankmachine.lib.pmi.grad_eigh for a slightly more
     readable python implementation.
 
     Reference implementation of the vector jacobian product of the derivative of column
@@ -447,4 +447,4 @@ void InertialRestraint<RealType>::execute_device(
 template class InertialRestraint<double>;
 template class InertialRestraint<float>;
 
-} // namespace timemachine
+} // namespace jankmachine

--- a/timemachine/cpp/src/inertial_restraint.hpp
+++ b/timemachine/cpp/src/inertial_restraint.hpp
@@ -3,7 +3,7 @@
 #include "potential.hpp"
 #include <vector>
 
-namespace timemachine {
+namespace jankmachine {
 
 template<typename RealType>
 class InertialRestraint : public Potential {

--- a/timemachine/cpp/src/integrator.cu
+++ b/timemachine/cpp/src/integrator.cu
@@ -4,7 +4,7 @@
 #include "fixed_point.hpp"
 #include "gpu_utils.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 int round_up_even(int count) {
     if(count % 2 == 1) {
@@ -99,7 +99,7 @@ void LangevinIntegrator::step_fwd(
 
 }
 
-} // end namespace timemachine
+} // end namespace jankmachine
 
 // template<typename RealType>
 // void step_forward(

--- a/timemachine/cpp/src/integrator.hpp
+++ b/timemachine/cpp/src/integrator.hpp
@@ -2,7 +2,7 @@
 
 #include "curand.h"
 
-namespace timemachine {
+namespace jankmachine {
 
 class Integrator {
 
@@ -69,4 +69,4 @@ public:
 //     RealType *d_x_new,
 //     RealType *d_v_new);
 
-} // end namespace timemachine
+} // end namespace jankmachine

--- a/timemachine/cpp/src/interpolated_potential.cu
+++ b/timemachine/cpp/src/interpolated_potential.cu
@@ -6,7 +6,7 @@
 
 #include <stdexcept>
 
-namespace timemachine {
+namespace jankmachine {
 
 
 __global__ void k_final_add(

--- a/timemachine/cpp/src/interpolated_potential.hpp
+++ b/timemachine/cpp/src/interpolated_potential.hpp
@@ -5,7 +5,7 @@
 #include <memory>
 #include <typeinfo>
 
-namespace timemachine {
+namespace jankmachine {
 
 class InterpolatedPotential : public Potential {
 

--- a/timemachine/cpp/src/lambda_potential.cu
+++ b/timemachine/cpp/src/lambda_potential.cu
@@ -3,7 +3,7 @@
 #include "fixed_point.hpp"
 #include "gpu_utils.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 __global__ void k_reduce_add_force_buffer(
     int count,

--- a/timemachine/cpp/src/lambda_potential.hpp
+++ b/timemachine/cpp/src/lambda_potential.hpp
@@ -5,7 +5,7 @@
 #include <memory>
 #include <typeinfo>
 
-namespace timemachine {
+namespace jankmachine {
 
 class LambdaPotential : public Potential {
 

--- a/timemachine/cpp/src/langevin.cu
+++ b/timemachine/cpp/src/langevin.cu
@@ -88,7 +88,7 @@
 // }
 
 
-// namespace timemachine {
+// namespace jankmachine {
 
 
 // template<typename RealType> 
@@ -421,5 +421,5 @@
 
 // }
 
-// template class timemachine::LangevinOptimizer<double>;
-// template class timemachine::LangevinOptimizer<float>;
+// template class jankmachine::LangevinOptimizer<double>;
+// template class jankmachine::LangevinOptimizer<float>;

--- a/timemachine/cpp/src/langevin.hpp
+++ b/timemachine/cpp/src/langevin.hpp
@@ -2,7 +2,7 @@
 
 // #include "optimizer.hpp"
 
-// namespace timemachine {
+// namespace jankmachine {
 
 
 // // immutable, stateless class with only const methods

--- a/timemachine/cpp/src/lennard_jones.cu
+++ b/timemachine/cpp/src/lennard_jones.cu
@@ -12,7 +12,7 @@
 #include "k_lennard_jones_jvp.cuh"
 
 
-namespace timemachine {
+namespace jankmachine {
 
 template <typename RealType>
 LennardJones<RealType>::LennardJones(
@@ -192,4 +192,4 @@ void LennardJones<RealType>::execute_device(
 template class LennardJones<double>;
 template class LennardJones<float>;
 
-} // namespace timemachine
+} // namespace jankmachine

--- a/timemachine/cpp/src/lennard_jones.hpp
+++ b/timemachine/cpp/src/lennard_jones.hpp
@@ -4,7 +4,7 @@
 #include "potential.hpp"
 #include <vector>
 
-namespace timemachine {
+namespace jankmachine {
 
 template<typename RealType>
 class LennardJones : public Potential {

--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -6,7 +6,7 @@
 #include "k_neighborlist.cuh"
 #include "gpu_utils.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 template<typename RealType>
 Neighborlist<RealType>::Neighborlist(

--- a/timemachine/cpp/src/neighborlist.hpp
+++ b/timemachine/cpp/src/neighborlist.hpp
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-namespace timemachine {
+namespace jankmachine {
 
 // enable 64bit stuff later
 template<typename RealType>

--- a/timemachine/cpp/src/nonbonded.cu
+++ b/timemachine/cpp/src/nonbonded.cu
@@ -13,7 +13,7 @@
 
 #include "k_nonbonded.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 template <typename RealType, bool Interpolated>
 Nonbonded<RealType, Interpolated>::Nonbonded(
@@ -479,4 +479,4 @@ template class Nonbonded<double, false>;
 template class Nonbonded<float, false>;
 
 
-} // namespace timemachine
+} // namespace jankmachine

--- a/timemachine/cpp/src/nonbonded.hpp
+++ b/timemachine/cpp/src/nonbonded.hpp
@@ -5,7 +5,7 @@
 #include <vector>
 #include <array>
 
-namespace timemachine {
+namespace jankmachine {
 
 typedef void (*k_nonbonded_fn)(const int N,
     const double * __restrict__ coords,

--- a/timemachine/cpp/src/observable.cu
+++ b/timemachine/cpp/src/observable.cu
@@ -3,7 +3,7 @@
 #include <iostream>
 
 
-namespace timemachine {
+namespace jankmachine {
 
 AvgPartialUPartialParam::AvgPartialUPartialParam(
     BoundPotential *bp, int interval) : bp_(bp), count_(0), interval_(interval) {

--- a/timemachine/cpp/src/observable.hpp
+++ b/timemachine/cpp/src/observable.hpp
@@ -4,7 +4,7 @@
 #include "bound_potential.hpp"
 
 
-namespace timemachine {
+namespace jankmachine {
 
 class Observable {
 

--- a/timemachine/cpp/src/optimizer.cu
+++ b/timemachine/cpp/src/optimizer.cu
@@ -1,7 +1,7 @@
 #include "optimizer.hpp"
 #include "kernel_utils.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 template<typename RealType> 
 void Optimizer<RealType>::step_host(

--- a/timemachine/cpp/src/optimizer.hpp
+++ b/timemachine/cpp/src/optimizer.hpp
@@ -7,7 +7,7 @@
 #include <stdexcept>
 #include <cstdio>
 
-namespace timemachine {
+namespace jankmachine {
 
 // Optimizer owns *everything*. This design basically
 // goes against the design of almost every text-book pattern.

--- a/timemachine/cpp/src/periodic_torsion.cu
+++ b/timemachine/cpp/src/periodic_torsion.cu
@@ -6,7 +6,7 @@
 #include "gpu_utils.cuh"
 #include "k_periodic_torsion.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 template <typename RealType>
 PeriodicTorsion<RealType>::PeriodicTorsion(
@@ -107,4 +107,4 @@ void PeriodicTorsion<RealType>::execute_device(
 template class PeriodicTorsion<double>;
 template class PeriodicTorsion<float>;
 
-} // namespace timemachine
+} // namespace jankmachine

--- a/timemachine/cpp/src/periodic_torsion.hpp
+++ b/timemachine/cpp/src/periodic_torsion.hpp
@@ -3,7 +3,7 @@
 #include "potential.hpp"
 #include <vector>
 
-namespace timemachine {
+namespace jankmachine {
 
 template<typename RealType>
 class PeriodicTorsion : public Potential {

--- a/timemachine/cpp/src/potential.cu
+++ b/timemachine/cpp/src/potential.cu
@@ -4,7 +4,7 @@
 #include "gpu_utils.cuh"
 #include "surreal.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 void Potential::execute_host(
     const int N,

--- a/timemachine/cpp/src/potential.hpp
+++ b/timemachine/cpp/src/potential.hpp
@@ -2,7 +2,7 @@
 
 #include <cuda_runtime.h>
 
-namespace timemachine {
+namespace jankmachine {
 
 // *Not* guaranteed to be thread-safe.
 class Potential {

--- a/timemachine/cpp/src/restraint.cu
+++ b/timemachine/cpp/src/restraint.cu
@@ -6,7 +6,7 @@
 #include "gpu_utils.cuh"
 #include "k_restraint.cuh"
 
-namespace timemachine {
+namespace jankmachine {
 
 template <typename RealType>
 Restraint<RealType>::Restraint(
@@ -158,4 +158,4 @@ void Restraint<RealType>::execute_lambda_jvp_device(
 template class Restraint<double>;
 template class Restraint<float>;
 
-} // namespace timemachine
+} // namespace jankmachine

--- a/timemachine/cpp/src/restraint.hpp
+++ b/timemachine/cpp/src/restraint.hpp
@@ -3,7 +3,7 @@
 #include "gradient.hpp"
 #include <vector>
 
-namespace timemachine {
+namespace jankmachine {
 
 template<typename RealType>
 class Restraint : public Gradient {

--- a/timemachine/cpp/src/shape.cu
+++ b/timemachine/cpp/src/shape.cu
@@ -8,7 +8,7 @@
 
 #define PI 3.141592653589793115997963468544185161
 
-namespace timemachine {
+namespace jankmachine {
 
 
 // tbd chain rule for parameter derivatives
@@ -309,4 +309,4 @@ void Shape<RealType>::execute_device(
 template class Shape<double>;
 template class Shape<float>;
 
-} // namespace timemachine
+} // namespace jankmachine

--- a/timemachine/cpp/src/shape.hpp
+++ b/timemachine/cpp/src/shape.hpp
@@ -3,7 +3,7 @@
 #include "potential.hpp"
 #include <vector>
 
-namespace timemachine {
+namespace jankmachine {
 
 template<typename RealType>
 class Shape : public Potential {

--- a/timemachine/cpp/src/stepper.cu
+++ b/timemachine/cpp/src/stepper.cu
@@ -5,7 +5,7 @@
 #define PI  3.1415926535897932384626433
 
 #include <iostream>
-namespace timemachine {
+namespace jankmachine {
 
 Stepper::Stepper(int F) : streams_(F) {
     for(int i=0; i < F; i++) {

--- a/timemachine/cpp/src/stepper.hpp
+++ b/timemachine/cpp/src/stepper.hpp
@@ -4,7 +4,7 @@
 
 #include "gradient.hpp"
 
-namespace timemachine {
+namespace jankmachine {
 
 class Stepper {
 

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -33,7 +33,7 @@ namespace py = pybind11;
 template <typename RealType>
 void declare_neighborlist(py::module &m, const char *typestr) {
 
-    using Class = timemachine::Neighborlist<RealType>;
+    using Class = jankmachine::Neighborlist<RealType>;
     std::string pyclass_name = std::string("Neighborlist_") + typestr;
     py::class_<Class>(
         m,
@@ -42,10 +42,10 @@ void declare_neighborlist(py::module &m, const char *typestr) {
         py::dynamic_attr()
     )
     .def(py::init([](int N) {
-        return new timemachine::Neighborlist<RealType>(N);
+        return new jankmachine::Neighborlist<RealType>(N);
     }))
     .def("compute_block_bounds", [](
-        timemachine::Neighborlist<RealType> &nblist,
+        jankmachine::Neighborlist<RealType> &nblist,
         const py::array_t<double, py::array::c_style> &coords,
         const py::array_t<double, py::array::c_style> &box,
         int block_size) -> py::tuple {
@@ -75,7 +75,7 @@ void declare_neighborlist(py::module &m, const char *typestr) {
 
     })
     .def("get_nblist", [](
-        timemachine::Neighborlist<RealType> &nblist,
+        jankmachine::Neighborlist<RealType> &nblist,
         const py::array_t<double, py::array::c_style> &coords,
         const py::array_t<double, py::array::c_style> &box,
         const double cutoff) -> std::vector<std::vector<int> > {
@@ -99,7 +99,7 @@ void declare_neighborlist(py::module &m, const char *typestr) {
 
 void declare_context(py::module &m) {
 
-    using Class = timemachine::Context;
+    using Class = jankmachine::Context;
     std::string pyclass_name = std::string("Context");
     py::class_<Class>(
         m,
@@ -111,9 +111,9 @@ void declare_context(py::module &m) {
         const py::array_t<double, py::array::c_style> &x0,
         const py::array_t<double, py::array::c_style> &v0,
         const py::array_t<double, py::array::c_style> &box0,
-        timemachine::Integrator *intg,
-        std::vector<timemachine::BoundPotential *> bps) {
-        // std::vector<timemachine::Observable *> obs) {
+        jankmachine::Integrator *intg,
+        std::vector<jankmachine::BoundPotential *> bps) {
+        // std::vector<jankmachine::Observable *> obs) {
 
         int N = x0.shape()[0];
         int D = x0.shape()[1];
@@ -126,7 +126,7 @@ void declare_context(py::module &m) {
             throw std::runtime_error("v0 D != x0 D");
         }
 
-        return new timemachine::Context(
+        return new jankmachine::Context(
             N,
             x0.data(),
             v0.data(),
@@ -137,9 +137,9 @@ void declare_context(py::module &m) {
         );
 
     }))
-    .def("add_observable", &timemachine::Context::add_observable)
-    .def("step", &timemachine::Context::step)
-    .def("multiple_steps", [](timemachine::Context &ctxt,
+    .def("add_observable", &jankmachine::Context::add_observable)
+    .def("step", &jankmachine::Context::step)
+    .def("multiple_steps", [](jankmachine::Context &ctxt,
         const py::array_t<double, py::array::c_style> &lambda_schedule,
         int store_du_dl_interval,
         int store_x_interval) -> py::tuple {
@@ -163,22 +163,22 @@ void declare_context(py::module &m) {
 
         return py::make_tuple(out_du_dl_buffer, out_x_buffer);
     }, py::arg("lambda_schedule"), py::arg("store_du_dl_interval") = 0, py::arg("store_x_interval") = 0)
-    // .def("multiple_steps", &timemachine::Context::multiple_steps)
-    .def("get_x_t", [](timemachine::Context &ctxt) -> py::array_t<double, py::array::c_style> {
+    // .def("multiple_steps", &jankmachine::Context::multiple_steps)
+    .def("get_x_t", [](jankmachine::Context &ctxt) -> py::array_t<double, py::array::c_style> {
         unsigned int N = ctxt.num_atoms();
         unsigned int D = 3;
         py::array_t<double, py::array::c_style> buffer({N, D});
         ctxt.get_x_t(buffer.mutable_data());
         return buffer;
     })
-    .def("get_v_t", [](timemachine::Context &ctxt) -> py::array_t<double, py::array::c_style> {
+    .def("get_v_t", [](jankmachine::Context &ctxt) -> py::array_t<double, py::array::c_style> {
         unsigned int N = ctxt.num_atoms();
         unsigned int D = 3;
         py::array_t<double, py::array::c_style> buffer({N, D});
         ctxt.get_v_t(buffer.mutable_data());
         return buffer;
     })
-    .def("_get_du_dx_t_minus_1", [](timemachine::Context &ctxt) -> py::array_t<double, py::array::c_style> {
+    .def("_get_du_dx_t_minus_1", [](jankmachine::Context &ctxt) -> py::array_t<double, py::array::c_style> {
         PyErr_WarnEx(PyExc_DeprecationWarning,
             "_get_du_dx_t_minus_1() should only be used for testing. It will be removed in a future release.",
             1);
@@ -197,7 +197,7 @@ void declare_context(py::module &m) {
 
 void declare_observable(py::module &m) {
 
-    using Class = timemachine::Observable;
+    using Class = jankmachine::Observable;
     std::string pyclass_name = std::string("Observable");
     py::class_<Class>(
         m,
@@ -209,20 +209,20 @@ void declare_observable(py::module &m) {
 
 void declare_avg_partial_u_partial_param(py::module &m) {
 
-    using Class = timemachine::AvgPartialUPartialParam;
+    using Class = jankmachine::AvgPartialUPartialParam;
     std::string pyclass_name = std::string("AvgPartialUPartialParam");
-    py::class_<Class, timemachine::Observable>(
+    py::class_<Class, jankmachine::Observable>(
         m,
         pyclass_name.c_str(),
         py::buffer_protocol(),
         py::dynamic_attr()
     )
     .def(py::init([](
-        timemachine::BoundPotential *bp,
+        jankmachine::BoundPotential *bp,
         int interval) {
-        return new timemachine::AvgPartialUPartialParam(bp, interval);
+        return new jankmachine::AvgPartialUPartialParam(bp, interval);
     }))
-    .def("avg_du_dp", [](timemachine::AvgPartialUPartialParam &obj) -> py::array_t<double, py::array::c_style> {
+    .def("avg_du_dp", [](jankmachine::AvgPartialUPartialParam &obj) -> py::array_t<double, py::array::c_style> {
         std::vector<int> shape = obj.shape();
         py::array_t<double, py::array::c_style> buffer(shape);
 
@@ -234,7 +234,7 @@ void declare_avg_partial_u_partial_param(py::module &m) {
 
 void declare_integrator(py::module &m) {
 
-    using Class = timemachine::Integrator;
+    using Class = jankmachine::Integrator;
     std::string pyclass_name = std::string("Integrator");
     py::class_<Class>(
         m,
@@ -247,9 +247,9 @@ void declare_integrator(py::module &m) {
 
 void declare_langevin_integrator(py::module &m) {
 
-    using Class = timemachine::LangevinIntegrator;
+    using Class = jankmachine::LangevinIntegrator;
     std::string pyclass_name = std::string("LangevinIntegrator");
-    py::class_<Class, timemachine::Integrator>(
+    py::class_<Class, jankmachine::Integrator>(
         m,
         pyclass_name.c_str(),
         py::buffer_protocol(),
@@ -262,7 +262,7 @@ void declare_langevin_integrator(py::module &m) {
         const py::array_t<double, py::array::c_style> &ccs,
         int seed) {
 
-        return new timemachine::LangevinIntegrator(
+        return new jankmachine::LangevinIntegrator(
             cbs.size(),
             dt,
             ca,
@@ -278,14 +278,14 @@ void declare_langevin_integrator(py::module &m) {
 
 void declare_potential(py::module &m) {
 
-    using Class = timemachine::Potential;
+    using Class = jankmachine::Potential;
     std::string pyclass_name = std::string("Potential");
     py::class_<Class, std::shared_ptr<Class> >(
         m,
         pyclass_name.c_str(),
         py::buffer_protocol(),
         py::dynamic_attr())
-    .def("execute", [](timemachine::Potential &pot,
+    .def("execute", [](jankmachine::Potential &pot,
         const py::array_t<double, py::array::c_style> &coords,
         const py::array_t<double, py::array::c_style> &params,
         const py::array_t<double, py::array::c_style> &box,
@@ -334,7 +334,7 @@ void declare_potential(py::module &m) {
             return py::make_tuple(py_du_dx, py_du_dp, FIXED_TO_FLOAT<double>(du_dl_sum), FIXED_TO_FLOAT<double>(u_sum));
 
     })
-    .def("execute_selective", [](timemachine::Potential &pot,
+    .def("execute_selective", [](jankmachine::Potential &pot,
         const py::array_t<double, py::array::c_style> &coords,
         const py::array_t<double, py::array::c_style> &params,
         const py::array_t<double, py::array::c_style> &box,
@@ -404,7 +404,7 @@ void declare_potential(py::module &m) {
 
             return result;
     })
-    .def("execute_du_dx", [](timemachine::Potential &pot,
+    .def("execute_du_dx", [](jankmachine::Potential &pot,
         const py::array_t<double, py::array::c_style> &coords,
         const py::array_t<double, py::array::c_style> &params,
         const py::array_t<double, py::array::c_style> &box,
@@ -439,7 +439,7 @@ void declare_potential(py::module &m) {
 
 void declare_bound_potential(py::module &m) {
 
-    using Class = timemachine::BoundPotential;
+    using Class = jankmachine::BoundPotential;
     std::string pyclass_name = std::string("BoundPotential");
     py::class_<Class>(
         m,
@@ -447,21 +447,21 @@ void declare_bound_potential(py::module &m) {
         py::buffer_protocol(),
         py::dynamic_attr())
     .def(py::init([](
-        std::shared_ptr<timemachine::Potential> potential,
+        std::shared_ptr<jankmachine::Potential> potential,
         const py::array_t<double, py::array::c_style> &params
     ) {
 
         std::vector<int> pshape(params.shape(), params.shape()+params.ndim());
 
-        return new timemachine::BoundPotential(
+        return new jankmachine::BoundPotential(
             potential,
             pshape,
             params.data()
         );
     }
     ))
-    .def("size", &timemachine::BoundPotential::size)
-    .def("execute", [](timemachine::BoundPotential &bp,
+    .def("size", &jankmachine::BoundPotential::size)
+    .def("execute", [](jankmachine::BoundPotential &bp,
         const py::array_t<double, py::array::c_style> &coords,
         const py::array_t<double, py::array::c_style> &box,
         double lambda) -> py::tuple  {
@@ -499,9 +499,9 @@ void declare_bound_potential(py::module &m) {
 // template <typename RealType>
 // void declare_shape(py::module &m, const char *typestr) {
 
-//     using Class = timemachine::Shape<RealType>;
+//     using Class = jankmachine::Shape<RealType>;
 //     std::string pyclass_name = std::string("Shape_") + typestr;
-//     py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+//     py::class_<Class, std::shared_ptr<Class>, jankmachine::Potential>(
 //         m,
 //         pyclass_name.c_str(),
 //         py::buffer_protocol(),
@@ -520,7 +520,7 @@ void declare_bound_potential(py::module &m) {
 //             std::vector<double> vec_alphas(alphas.data(), alphas.data()+alphas.size());
 //             std::vector<double> vec_weights(weights.data(), weights.data()+weights.size());
 
-//             return new timemachine::Shape<RealType>(
+//             return new jankmachine::Shape<RealType>(
 //                 N,
 //                 vec_a_idxs,
 //                 vec_b_idxs,
@@ -538,9 +538,9 @@ void declare_bound_potential(py::module &m) {
 template <typename RealType>
 void declare_harmonic_bond(py::module &m, const char *typestr) {
 
-    using Class = timemachine::HarmonicBond<RealType>;
+    using Class = jankmachine::HarmonicBond<RealType>;
     std::string pyclass_name = std::string("HarmonicBond_") + typestr;
-    py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+    py::class_<Class, std::shared_ptr<Class>, jankmachine::Potential>(
         m,
         pyclass_name.c_str(),
         py::buffer_protocol(),
@@ -560,7 +560,7 @@ void declare_harmonic_bond(py::module &m, const char *typestr) {
         if(lamb_offset.has_value()) {
             vec_lamb_offset.assign(lamb_offset.value().data(), lamb_offset.value().data()+lamb_offset.value().size());
         }
-        return new timemachine::HarmonicBond<RealType>(
+        return new jankmachine::HarmonicBond<RealType>(
             vec_bond_idxs,
             vec_lamb_mult,
             vec_lamb_offset
@@ -574,9 +574,9 @@ void declare_harmonic_bond(py::module &m, const char *typestr) {
 template <typename RealType>
 void declare_harmonic_angle(py::module &m, const char *typestr) {
 
-    using Class = timemachine::HarmonicAngle<RealType>;
+    using Class = jankmachine::HarmonicAngle<RealType>;
     std::string pyclass_name = std::string("HarmonicAngle_") + typestr;
-    py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+    py::class_<Class, std::shared_ptr<Class>, jankmachine::Potential>(
         m,
         pyclass_name.c_str(),
         py::buffer_protocol(),
@@ -597,7 +597,7 @@ void declare_harmonic_angle(py::module &m, const char *typestr) {
         if(lamb_offset.has_value()) {
             vec_lamb_offset.assign(lamb_offset.value().data(), lamb_offset.value().data()+lamb_offset.value().size());
         }
-        return new timemachine::HarmonicAngle<RealType>(
+        return new jankmachine::HarmonicAngle<RealType>(
             vec_angle_idxs,
             vec_lamb_mult,
             vec_lamb_offset
@@ -613,9 +613,9 @@ void declare_harmonic_angle(py::module &m, const char *typestr) {
 // template <typename RealType>
 // void declare_restraint(py::module &m, const char *typestr) {
 
-//     using Class = timemachine::Restraint<RealType>;
+//     using Class = jankmachine::Restraint<RealType>;
 //     std::string pyclass_name = std::string("Restraint_") + typestr;
-//     py::class_<Class, timemachine::Gradient>(
+//     py::class_<Class, jankmachine::Gradient>(
 //         m,
 //         pyclass_name.c_str(),
 //         py::buffer_protocol(),
@@ -633,20 +633,20 @@ void declare_harmonic_angle(py::module &m, const char *typestr) {
 //         std::vector<int> vec_lambda_flags(lambda_flags.size());
 //         std::memcpy(vec_lambda_flags.data(), lambda_flags.data(), vec_lambda_flags.size()*sizeof(int));
 
-//         return new timemachine::Restraint<RealType>(
+//         return new jankmachine::Restraint<RealType>(
 //             vec_bond_idxs,
 //             vec_params,
 //             vec_lambda_flags
 //         );
 //     }
 //     ))
-//     .def("get_du_dp_primals", [](timemachine::Restraint<RealType> &grad) -> py::array_t<double, py::array::c_style> {
+//     .def("get_du_dp_primals", [](jankmachine::Restraint<RealType> &grad) -> py::array_t<double, py::array::c_style> {
 //         const int B = grad.num_bonds();
 //         py::array_t<double, py::array::c_style> buffer({B, 3});
 //         grad.get_du_dp_primals(buffer.mutable_data());
 //         return buffer;
 //     })
-//     .def("get_du_dp_tangents", [](timemachine::Restraint<RealType> &grad) -> py::array_t<double, py::array::c_style> {
+//     .def("get_du_dp_tangents", [](jankmachine::Restraint<RealType> &grad) -> py::array_t<double, py::array::c_style> {
 //         const int B = grad.num_bonds();
 //         py::array_t<double, py::array::c_style> buffer({B, 3});
 //         grad.get_du_dp_tangents(buffer.mutable_data());
@@ -659,9 +659,9 @@ void declare_harmonic_angle(py::module &m, const char *typestr) {
 // template <typename RealType>
 // void declare_centroid_restraint(py::module &m, const char *typestr) {
 
-//     using Class = timemachine::CentroidRestraint<RealType>;
+//     using Class = jankmachine::CentroidRestraint<RealType>;
 //     std::string pyclass_name = std::string("CentroidRestraint_") + typestr;
-//     py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+//     py::class_<Class, std::shared_ptr<Class>, jankmachine::Potential>(
 //         m,
 //         pyclass_name.c_str(),
 //         py::buffer_protocol(),
@@ -681,7 +681,7 @@ void declare_harmonic_angle(py::module &m, const char *typestr) {
 //         std::vector<double> vec_masses(masses.size());
 //         std::memcpy(vec_masses.data(), masses.data(), vec_masses.size()*sizeof(double));
 
-//         return new timemachine::CentroidRestraint<RealType>(
+//         return new jankmachine::CentroidRestraint<RealType>(
 //             vec_group_a_idxs,
 //             vec_group_b_idxs,
 //             vec_masses,
@@ -697,9 +697,9 @@ void declare_harmonic_angle(py::module &m, const char *typestr) {
 // template <typename RealType>
 // void declare_inertial_restraint(py::module &m, const char *typestr) {
 
-//     using Class = timemachine::InertialRestraint<RealType>;
+//     using Class = jankmachine::InertialRestraint<RealType>;
 //     std::string pyclass_name = std::string("InertialRestraint_") + typestr;
-//     py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+//     py::class_<Class, std::shared_ptr<Class>, jankmachine::Potential>(
 //         m,
 //         pyclass_name.c_str(),
 //         py::buffer_protocol(),
@@ -718,7 +718,7 @@ void declare_harmonic_angle(py::module &m, const char *typestr) {
 //         std::vector<double> vec_masses(masses.size());
 //         std::memcpy(vec_masses.data(), masses.data(), vec_masses.size()*sizeof(double));
 
-//         return new timemachine::InertialRestraint<RealType>(
+//         return new jankmachine::InertialRestraint<RealType>(
 //             vec_group_a_idxs,
 //             vec_group_b_idxs,
 //             vec_masses,
@@ -733,9 +733,9 @@ void declare_harmonic_angle(py::module &m, const char *typestr) {
 template <typename RealType>
 void declare_periodic_torsion(py::module &m, const char *typestr) {
 
-    using Class = timemachine::PeriodicTorsion<RealType>;
+    using Class = jankmachine::PeriodicTorsion<RealType>;
     std::string pyclass_name = std::string("PeriodicTorsion_") + typestr;
-    py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+    py::class_<Class, std::shared_ptr<Class>, jankmachine::Potential>(
         m,
         pyclass_name.c_str(),
         py::buffer_protocol(),
@@ -755,7 +755,7 @@ void declare_periodic_torsion(py::module &m, const char *typestr) {
         if(lamb_offset.has_value()) {
             vec_lamb_offset.assign(lamb_offset.value().data(), lamb_offset.value().data()+lamb_offset.value().size());
         }
-        return new timemachine::PeriodicTorsion<RealType>(
+        return new jankmachine::PeriodicTorsion<RealType>(
             vec_torsion_idxs,
             vec_lamb_mult,
             vec_lamb_offset
@@ -768,22 +768,22 @@ void declare_periodic_torsion(py::module &m, const char *typestr) {
 
 // void declare_lambda_potential(py::module &m) {
 
-//     using Class = timemachine::LambdaPotential;
+//     using Class = jankmachine::LambdaPotential;
 //     std::string pyclass_name = std::string("LambdaPotential");
-//     py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+//     py::class_<Class, std::shared_ptr<Class>, jankmachine::Potential>(
 //         m,
 //         pyclass_name.c_str(),
 //         py::buffer_protocol(),
 //         py::dynamic_attr()
 //     )
 //     .def(py::init([](
-//         std::shared_ptr<timemachine::Potential> potential,
+//         std::shared_ptr<jankmachine::Potential> potential,
 //         int N,
 //         int P,
 //         double multiplier,
 //         double offset) {
 
-//         return new timemachine::LambdaPotential(
+//         return new jankmachine::LambdaPotential(
 //             potential,
 //             N,
 //             P,
@@ -799,20 +799,20 @@ void declare_periodic_torsion(py::module &m, const char *typestr) {
 
 // void declare_interpolated_potential(py::module &m) {
 
-//     using Class = timemachine::InterpolatedPotential;
+//     using Class = jankmachine::InterpolatedPotential;
 //     std::string pyclass_name = std::string("InterpolatedPotential");
-//     py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+//     py::class_<Class, std::shared_ptr<Class>, jankmachine::Potential>(
 //         m,
 //         pyclass_name.c_str(),
 //         py::buffer_protocol(),
 //         py::dynamic_attr()
 //     )
 //     .def(py::init([](
-//         std::shared_ptr<timemachine::Potential> potential,
+//         std::shared_ptr<jankmachine::Potential> potential,
 //         int N,
 //         int P) {
 
-//         return new timemachine::InterpolatedPotential(
+//         return new jankmachine::InterpolatedPotential(
 //             potential,
 //             N,
 //             P
@@ -826,16 +826,16 @@ void declare_periodic_torsion(py::module &m, const char *typestr) {
 template <typename RealType, bool Interpolated>
 void declare_nonbonded(py::module &m, const char *typestr) {
 
-    using Class = timemachine::Nonbonded<RealType, Interpolated>;
+    using Class = jankmachine::Nonbonded<RealType, Interpolated>;
     std::string pyclass_name = std::string("Nonbonded_") + typestr;
-    py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+    py::class_<Class, std::shared_ptr<Class>, jankmachine::Potential>(
         m,
         pyclass_name.c_str(),
         py::buffer_protocol(),
         py::dynamic_attr()
     )
-    .def("set_nblist_padding", &timemachine::Nonbonded<RealType, Interpolated>::set_nblist_padding)
-    .def("disable_hilbert_sort", &timemachine::Nonbonded<RealType, Interpolated>::disable_hilbert_sort)
+    .def("set_nblist_padding", &jankmachine::Nonbonded<RealType, Interpolated>::set_nblist_padding)
+    .def("disable_hilbert_sort", &jankmachine::Nonbonded<RealType, Interpolated>::disable_hilbert_sort)
     .def(py::init([](
         const py::array_t<int, py::array::c_style> &exclusion_i,  // [E, 2] comprised of elements from N
         const py::array_t<double, py::array::c_style> &scales_i,  // [E, 2]
@@ -856,7 +856,7 @@ void declare_nonbonded(py::module &m, const char *typestr) {
         std::vector<int> lambda_offset_idxs(lambda_offset_idxs_i.size());
         std::memcpy(lambda_offset_idxs.data(), lambda_offset_idxs_i.data(), lambda_offset_idxs_i.size()*sizeof(int));
 
-        return new timemachine::Nonbonded<RealType, Interpolated>(
+        return new jankmachine::Nonbonded<RealType, Interpolated>(
             exclusion_idxs,
             scales,
             lambda_plane_idxs,

--- a/timemachine/integrator.py
+++ b/timemachine/integrator.py
@@ -1,4 +1,4 @@
-from timemachine.constants import BOLTZ
+from jankmachine.constants import BOLTZ
 import numpy as np
 
 

--- a/timemachine/lib/__init__.py
+++ b/timemachine/lib/__init__.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-from timemachine.lib import custom_ops
-from timemachine.integrator import langevin_coefficients
+from jankmachine.lib import custom_ops
+from jankmachine.integrator import langevin_coefficients
 
 # safe to pickle!
 

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -1,5 +1,5 @@
 import numpy as np
-from timemachine.lib import custom_ops
+from jankmachine.lib import custom_ops
 
 # (ytz): classes in this class wrap custom_ops but have the added benefit
 # of being pickleable.

--- a/timemachine/potentials/evp.py
+++ b/timemachine/potentials/evp.py
@@ -7,7 +7,7 @@ from jax.config import config; config.update("jax_enable_x64", True)
 from scipy.stats import special_ortho_group
 
 
-from timemachine.potentials import evp
+from jankmachine.potentials import evp
 
 def recenter(conf):
     return conf - np.mean(conf, axis=0)

--- a/timemachine/potentials/gbsa.py
+++ b/timemachine/potentials/gbsa.py
@@ -3,7 +3,7 @@
 
 import jax.numpy as np
 from jax import grad, jit
-from timemachine.potentials.jax_utils import delta_r, distance, convert_to_4d
+from jankmachine.potentials.jax_utils import delta_r, distance, convert_to_4d
 
 def step(x):
     # return (x > 0)

--- a/timemachine/potentials/nonbonded.py
+++ b/timemachine/potentials/nonbonded.py
@@ -3,8 +3,8 @@ import jax.numpy as np
 from jax.scipy.special import erf, erfc
 from jax.ops import index_update, index
 
-from timemachine.constants import ONE_4PI_EPS0
-from timemachine.potentials.jax_utils import delta_r, distance, convert_to_4d
+from jankmachine.constants import ONE_4PI_EPS0
+from jankmachine.potentials.jax_utils import delta_r, distance, convert_to_4d
 
 
 

--- a/training/hydration_fe.py
+++ b/training/hydration_fe.py
@@ -26,7 +26,7 @@ from training import hydration_model, hydration_setup
 from training import simulation
 from training import service_pb2_grpc
 
-from timemachine.lib import LangevinIntegrator
+from jankmachine.lib import LangevinIntegrator
 from md import builders
 
 # used during visualization to bring everything back to home box

--- a/training/hydration_setup.py
+++ b/training/hydration_setup.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from ff.handlers import bonded, nonbonded, openmm_deserializer
-from timemachine.lib import potentials
+from jankmachine.lib import potentials
 
 
 def combine_coordinates(


### PR DESCRIPTION
The timemachine name from a time (no pun intended) when we used to do backpropagation through time. Since we no longer are script-kiddies who recently discovered recurrent networks and are now firm believers of statistical mechanics and all of its jank, it's time (no pun intended) we choose a name that properly reflects the nature of the package to avoid any future confusion. 