### PR TITLE
RMSD-based Rotational Restraints

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -483,6 +483,7 @@ class GradientTest(unittest.TestCase):
         test_potential,
         rtol,
         precision,
+        atol=1e-8,
         benchmark=False):
 
         test_impl = test_potential.unbound_impl(precision)
@@ -515,7 +516,7 @@ class GradientTest(unittest.TestCase):
                 compute_u
             )
             if compute_u:
-                np.testing.assert_allclose(ref_u, test_u, rtol)
+                np.testing.assert_allclose(ref_u, test_u, rtol=rtol, atol=atol)
             if compute_du_dx:
                 self.assert_equal_vectors(np.array(ref_du_dx), np.array(test_du_dx), rtol)
             if compute_du_dl:

--- a/tests/test_bonded.py
+++ b/tests/test_bonded.py
@@ -117,6 +117,69 @@ class TestBonded(GradientTest):
                 )
 
 
+
+    def test_rmsd_restraint(self):
+        # test the RMSD force by generating random coordinates.
+
+        np.random.seed(2021)
+
+        box = np.eye(3) * 100
+
+        n_particles_a = 25
+        n_particles_b = 7
+
+        relative_tolerance_at_precision = {np.float32: 2e-5, np.float64: 1e-9}
+
+        for precision, rtol in relative_tolerance_at_precision.items():
+
+            for _ in range(100):
+                coords = self.get_random_coords(n_particles_a + n_particles_b, 3)
+
+                n = coords.shape[0]
+                n_mapped_atoms = 5
+
+                atom_idxs_a = np.arange(n_particles_a)
+                atom_idxs_b = np.arange(n_particles_b)
+
+                atom_map = np.stack([
+                    np.random.randint(0, n_particles_a, n_mapped_atoms, dtype=np.int32),
+                    np.random.randint(0, n_particles_b, n_mapped_atoms, dtype=np.int32) + n_particles_a
+                ], axis=1)
+
+                atom_map = atom_map.astype(np.int32)
+
+                params = np.array([], dtype=np.float64)
+                k = 1.35
+                lamb = 0.0
+
+                for precision, rtol, atol in [(np.float64, 1e-6, 1e-6), (np.float32, 1e-4, 1e-6)]:
+
+                    ref_u = functools.partial(bonded.rmsd_restraint,
+                        group_a_idxs=atom_map[:, 0],
+                        group_b_idxs=atom_map[:, 1],
+                        k=k
+                    )
+
+                    test_u = potentials.RMSDRestraint(atom_map, n, k)
+
+                    # note the slightly higher than usual atol (1e-6 vs 1e-8)
+                    # this is due to fixed point accumulation of energy wipes out
+                    # the low magnitude energies as some of test cases have
+                    # an infinitesmally small absolute error (on the order of 1e-12)
+                    self.compare_forces(
+                        coords,
+                        params,
+                        box,
+                        lamb,
+                        ref_u,
+                        test_u,
+                        rtol,
+                        atol=atol,
+                        precision=precision
+                    )
+
+
+
     def test_harmonic_bond(self, n_particles=64, n_bonds=35, dim=3):
         """Randomly connect pairs of particles, then validate the resulting HarmonicBond force"""
         np.random.seed(125)  # TODO: where should this seed be set?

--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -20,9 +20,13 @@ endif()
 set(LIBRARY_NAME custom_ops)
 set(PYBIND_SRC_DIR pybind11)
 
-
 if(NOT EXISTS ${PYBIND_SRC_DIR})
   execute_process(COMMAND git clone --branch v2.6 https://github.com/pybind/pybind11.git ${PYBIND_SRC_DIR})
+endif()
+
+set(EIGEN_SRC_DIR eigen)
+if(NOT EXISTS ${EIGEN_SRC_DIR})
+  execute_process(COMMAND git clone --branch 3.3.9 https://gitlab.com/libeigen/eigen.git ${EIGEN_SRC_DIR})
 endif()
 
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/${PYBIND_SRC_DIR})
@@ -44,6 +48,7 @@ pybind11_add_module(${LIBRARY_NAME} SHARED NO_EXTRAS
   src/harmonic_bond.cu
   src/harmonic_angle.cu
   src/periodic_torsion.cu
+  src/rmsd_restraint.cu
   src/integrator.cu
   src/context.cu
   src/kernels/k_neighborlist.cu
@@ -51,6 +56,7 @@ pybind11_add_module(${LIBRARY_NAME} SHARED NO_EXTRAS
 
 include_directories(${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
 include_directories(src/kernels)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/eigen)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/${CUB_SRC_DIR})
 
 set_property(TARGET ${LIBRARY_NAME} PROPERTY CUDA_STANDARD 14)

--- a/timemachine/cpp/src/rmsd_restraint.cu
+++ b/timemachine/cpp/src/rmsd_restraint.cu
@@ -1,0 +1,224 @@
+#include <vector>
+#include <stdexcept>
+
+#include "rmsd_restraint.hpp"
+#include "gpu_utils.cuh"
+#include <Eigen/Dense>
+
+#include "fixed_point.hpp"
+// #include "k_fixed_point.hpp"
+
+#include <chrono>
+// using namespace std::chrono;
+
+namespace timemachine {
+
+template<typename RealType>
+RMSDRestraint<RealType>::RMSDRestraint(
+    const std::vector<int> &atom_map,
+    const int N,
+    const double k) : h_atom_map_(atom_map), N_(N), k_(k) {
+    if(atom_map.size() % 2 != 0) {
+        throw std::runtime_error("Bad atom map size!");
+    }
+
+    gpuErrchk(cudaMalloc(&d_u_buf_, sizeof(d_u_buf_)));
+    gpuErrchk(cudaMalloc(&d_du_dx_buf_, N*3*sizeof(d_du_dx_buf_)));
+
+}
+
+
+template<typename RealType>
+RMSDRestraint<RealType>::~ RMSDRestraint() {
+    gpuErrchk(cudaFree(d_u_buf_));
+    gpuErrchk(cudaFree(d_du_dx_buf_));
+}
+
+void __global__ k_finalize(
+    const int N,
+    const unsigned long long *d_du_dx_buf,
+    const unsigned long long *d_u_buf,
+    unsigned long long *d_du_dx_out,
+    unsigned long long *d_u_out) {
+
+    const int atom_idx = blockIdx.x*blockDim.x + threadIdx.x;
+
+    if(d_u_out && atom_idx == 0) {
+        atomicAdd(d_u_out, *d_u_buf);
+    }
+
+
+    if(atom_idx >= N) {
+        return;
+    }
+
+    if(d_du_dx_out) {
+        for(int d=0; d < 3; d++) {
+            atomicAdd(d_du_dx_out + atom_idx*3 + d, d_du_dx_buf[atom_idx*3 + d]);
+        }
+    }
+
+}
+
+template<typename RealType>
+void RMSDRestraint<RealType>::execute_device(
+    const int N,
+    const int P,
+    const double *d_x,
+    const double *d_p,
+    const double *d_box,
+    const double lambda,
+    unsigned long long *d_du_dx, // buffered
+    double *d_du_dp,
+    unsigned long long *d_du_dl,  // buffered
+    unsigned long long *d_u,  // buffered
+    cudaStream_t stream) {
+
+
+    if(N != N_) {
+        throw std::runtime_error("N_! = N");
+    }
+
+    std::vector<double> h_x(N*3);
+
+    gpuErrchk(cudaMemcpy(&h_x[0], d_x, h_x.size()*sizeof(*d_x), cudaMemcpyDeviceToHost));
+
+    const int B = h_atom_map_.size() / 2;
+
+    Eigen::MatrixXd x1(B,3);
+    Eigen::MatrixXd x2(B,3);
+
+    // compute centroids etc. on the GPU directly
+
+    for(int b=0; b < B; b++) {
+
+        int src_idx = h_atom_map_[b*2+0];
+        x1(b, 0) = h_x[src_idx*3+0];
+        x1(b, 1) = h_x[src_idx*3+1];
+        x1(b, 2) = h_x[src_idx*3+2];
+
+        int dst_idx = h_atom_map_[b*2+1];
+        x2(b, 0) = h_x[dst_idx*3+0];
+        x2(b, 1) = h_x[dst_idx*3+1];
+        x2(b, 2) = h_x[dst_idx*3+2];
+    }
+
+
+    Eigen::Vector3d h_a_centroid = x1.colwise().mean();
+    Eigen::Vector3d h_b_centroid = x2.colwise().mean();
+
+    x1 = x1.rowwise() - h_a_centroid.transpose();
+    x2 = x2.rowwise() - h_b_centroid.transpose();
+
+    Eigen::MatrixXd c = x2.transpose() * x1;
+
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd(c, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    auto s = svd.singularValues();
+
+    double epsilon = 1e-8;
+
+    gpuErrchk(cudaMemset(d_u_buf_, 0, sizeof(*d_u_buf_)));
+    gpuErrchk(cudaMemset(d_du_dx_buf_, 0, N*3*sizeof(*d_du_dx_buf_)));
+
+    if(s[0] < epsilon || s[1] < epsilon || s[2] < epsilon) {
+        return;
+    }
+
+    Eigen::MatrixXd u = svd.matrixU();
+    Eigen::MatrixXd v = svd.matrixV();
+    Eigen::MatrixXd v_t = v.transpose();
+
+    bool is_reflection = u.determinant() * v_t.determinant() < 0.0;
+
+    Eigen::MatrixXd rotation = u * v_t;
+
+    double term = 0;
+    if(is_reflection) {
+        term = (rotation.trace() + 1)/2 - 1;
+    } else {
+        term = (rotation.trace() - 1)/2 - 1;
+    }
+
+    double squared_term = term*term;
+
+    unsigned long long nrg = static_cast<unsigned long long>(llrint(k_*squared_term*FIXED_EXPONENT));
+
+    // backprop'd forces
+    Eigen::MatrixXd eye = Eigen::MatrixXd::Identity(3, 3);
+
+    double squared_term_adjoint = 1.0;
+    double term_adjoint = squared_term_adjoint*2*term;
+    Eigen::MatrixXd r_a = eye*term_adjoint/2;
+    Eigen::MatrixXd u_a = r_a * v_t.transpose();
+    Eigen::MatrixXd v_a_t = u.transpose() * r_a;
+
+    Eigen::MatrixXd smat(3,3);
+    Eigen::MatrixXd smat_inv(3,3);
+    Eigen::MatrixXd F(3,3);
+    for(int i=0; i < 3; i++) {
+        for(int j=0; j < 3; j++) {
+            if(i == j) {
+                F(i, j) = 0;
+                smat(i, j) = s[i];
+                smat_inv(i, j) = 1/s[i];
+                // s_a_mat(i, j) = s_a
+            } else{
+                F(i, j) = 1/(s[j]*s[j] - s[i]*s[i]);
+                smat(i, j) = 0;
+                smat_inv(i, j) = 0;
+            }
+        }
+    }
+
+    // (ytz): taken from here https://j-towns.github.io/papers/svd-derivative.pdf
+    // using equations 30-31. note that adjoints of the singular values are always zero,
+    // so the middle term is skipped.
+    Eigen::MatrixXd v_a = v_a_t.transpose();
+    Eigen::MatrixXd lhs_1 = u*F.cwiseProduct(u.transpose()*u_a - u_a.transpose()*u)*smat;
+    Eigen::MatrixXd lhs_2 = (eye - u*u.transpose())*u_a*smat_inv;
+    Eigen::MatrixXd lhs = (lhs_1+lhs_2)*v.transpose();
+    Eigen::MatrixXd rhs_1 = smat*(F.cwiseProduct(v.transpose()*v_a - v_a.transpose()*v))*v.transpose();
+    Eigen::MatrixXd rhs_2 = smat_inv*v_a.transpose()*(eye - v*v.transpose());
+    Eigen::MatrixXd rhs = u*(rhs_1 + rhs_2);
+    Eigen::MatrixXd c_adjoint = lhs + rhs;
+    Eigen::MatrixXd x2_adjoint = (c_adjoint*x1.transpose()).transpose();
+    Eigen::MatrixXd x1_adjoint = x2*c_adjoint;
+
+    std::vector<unsigned long long> du_dx(N*3, 0);
+
+    for(int b=0; b < B; b++) {
+        int src_idx = h_atom_map_[b*2+0];
+        du_dx[src_idx*3+0] += static_cast<unsigned long long>(llrint(k_*x1_adjoint(b, 0)*FIXED_EXPONENT));
+        du_dx[src_idx*3+1] += static_cast<unsigned long long>(llrint(k_*x1_adjoint(b, 1)*FIXED_EXPONENT));
+        du_dx[src_idx*3+2] += static_cast<unsigned long long>(llrint(k_*x1_adjoint(b, 2)*FIXED_EXPONENT));
+
+        int dst_idx = h_atom_map_[b*2+1];
+        du_dx[dst_idx*3+0] += static_cast<unsigned long long>(llrint(k_*x2_adjoint(b, 0)*FIXED_EXPONENT));
+        du_dx[dst_idx*3+1] += static_cast<unsigned long long>(llrint(k_*x2_adjoint(b, 1)*FIXED_EXPONENT));
+        du_dx[dst_idx*3+2] += static_cast<unsigned long long>(llrint(k_*x2_adjoint(b, 2)*FIXED_EXPONENT));
+    }
+
+    gpuErrchk(cudaMemcpy(d_u_buf_, &nrg, sizeof(*d_u_buf_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_du_dx_buf_, &du_dx[0], N*3*sizeof(*d_du_dx_buf_), cudaMemcpyHostToDevice));
+
+    const int blocks= (N_+32-1)/32;
+    const int tpb = 32;
+
+    k_finalize<<<blocks, tpb, 0, stream>>>(
+        N,
+        d_du_dx_buf_,
+        d_u_buf_,
+        d_du_dx,
+        d_u
+    );
+
+    gpuErrchk(cudaPeekAtLastError());
+
+};
+
+
+template class RMSDRestraint<double>;
+template class RMSDRestraint<float>;
+
+
+}

--- a/timemachine/cpp/src/rmsd_restraint.hpp
+++ b/timemachine/cpp/src/rmsd_restraint.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "potential.hpp"
+#include <vector>
+
+namespace timemachine {
+
+template<typename RealType>
+class RMSDRestraint : public Potential {
+
+private:
+
+    const std::vector<int> h_atom_map_;
+    const int N_;
+    const double k_;
+    unsigned long long *d_u_buf_;
+    unsigned long long *d_du_dx_buf_;
+
+public:
+
+    RMSDRestraint(
+        const std::vector<int> &atom_map,
+        const int N_,
+        const double k
+    );
+
+    ~RMSDRestraint();
+
+    virtual void execute_device(
+        const int N,
+        const int P,
+        const double *d_x,
+        const double *d_p,
+        const double *d_box,
+        const double lambda,
+        unsigned long long *d_du_dx, // buffered
+        double *d_du_dp,
+        unsigned long long *d_du_dl,  // buffered
+        unsigned long long *d_u,  // buffered
+        cudaStream_t stream
+    ) override;
+
+};
+
+}
+

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -13,6 +13,7 @@
 // #include "restraint.hpp"
 // #include "inertial_restraint.hpp"
 #include "centroid_restraint.hpp"
+#include "rmsd_restraint.hpp"
 #include "periodic_torsion.hpp"
 #include "nonbonded.hpp"
 // #include "lennard_jones.hpp"
@@ -657,6 +658,36 @@ void declare_harmonic_angle(py::module &m, const char *typestr) {
 
 
 template <typename RealType>
+void declare_rmsd_restraint(py::module &m, const char *typestr) {
+
+    using Class = timemachine::RMSDRestraint<RealType>;
+    std::string pyclass_name = std::string("RMSDRestraint_") + typestr;
+    py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+        m,
+        pyclass_name.c_str(),
+        py::buffer_protocol(),
+        py::dynamic_attr()
+    )
+    .def(py::init([](
+        const py::array_t<int, py::array::c_style> &atom_map,
+        const int N,
+        const double k
+    ) {
+        std::vector<int> vec_atom_map(atom_map.size());
+        std::memcpy(vec_atom_map.data(), atom_map.data(), vec_atom_map.size()*sizeof(int));
+
+        return new timemachine::RMSDRestraint<RealType>(
+            vec_atom_map,
+            N,
+            k
+        );
+
+    }));
+
+}
+
+
+template <typename RealType>
 void declare_centroid_restraint(py::module &m, const char *typestr) {
 
     using Class = timemachine::CentroidRestraint<RealType>;
@@ -889,8 +920,8 @@ PYBIND11_MODULE(custom_ops, m) {
     // declare_inertial_restraint<double>(m, "f64");
     // declare_inertial_restraint<float>(m, "f32");
 
-    // declare_restraint<double>(m, "f64");
-    // declare_restraint<float>(m, "f32");
+    declare_rmsd_restraint<double>(m, "f64");
+    declare_rmsd_restraint<float>(m, "f32");
 
     // declare_shape<double>(m, "f64");
     // declare_shape<float>(m, "f32");

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -110,6 +110,9 @@ class CustomOpWrapper():
 #     def get_b_idxs(self):
 #         return self.args[2]
 
+class RMSDRestraint(CustomOpWrapper):
+    pass
+
 
 class BondedWrapper(CustomOpWrapper):
 
@@ -133,7 +136,6 @@ class BondedWrapper(CustomOpWrapper):
 
 
 class HarmonicBond(BondedWrapper):
-
     pass
 
 # this is an alias to make type checking easier


### PR DESCRIPTION
This PR implements a rotational restraint based on the rotation that minimizes the RMSD. This restraint can be left on through-out the course of an RBFE calculation without issue. It should be use in conjunction with a center of mass restraint (PR coming). 

On the engineering side, this adds an Eigen dependency. The current version of Eigen (3.3.9) will throw warnings with CUDA 11.2, once the next major version (3.4) completes the release candidate testing, we should upgrade the dependency. Furthermore, it uses purely CPU-based code. Usually this is terrible, but in this particular case we might be okay since:

-Current timings show ~80us overhead. (nonbonded kernels will take significantly longer). 
-The SVD is only 3x3, and is independent of system size.
-The generation of the correlation matrix can be parallelized onto the GPU easily should the need arise. 
-It's probably fast enough for us to do experiments with.

Sunday Edit: the performance impact on hif2a seems quite dramatic - GPU utilization seems to have dropped substantially (from 95% to 80%), will need to investigate this further. We may need to do a GPU port of this after all (but this is still fast enough for validation). 
