### PR TITLE
Restore centroid restraints

### DIFF
--- a/tests/test_bonded.py
+++ b/tests/test_bonded.py
@@ -61,6 +61,59 @@ class TestBonded(GradientTest):
                 precision=precision
             )
 
+    def test_centroid_restraint_singularity(self):
+        # test singularity is stable when dij=0 and b0 = 0
+        box = np.eye(3) * 100
+
+        # specific to centroid restraint force
+        relative_tolerance_at_precision = {np.float32: 2e-5, np.float64: 1e-9}
+
+        n_particles = 5
+
+        for precision, rtol in relative_tolerance_at_precision.items():
+            x0 = self.get_random_coords(n_particles, 3)
+            coords = np.concatenate([x0, x0])
+
+            gai = np.arange(5).astype(np.int32)
+            gbi = (np.arange(5) + 5).astype(np.int32)
+
+            masses = np.random.rand(n_particles)
+
+            kb = 10.0
+            b0 = 0.0
+
+            ref_nrg = jax.partial(
+                bonded.centroid_restraint,
+                group_a_idxs=gai,
+                group_b_idxs=gbi,
+                kb=kb,
+                b0=b0
+            )
+
+            # we need to clear the du_dp buffer each time, so we need
+            # to instantiate test_nrg inside here
+            test_nrg = potentials.CentroidRestraint(
+                gai,
+                gbi,
+                kb,
+                b0
+            )
+
+            params = np.array([], dtype=np.float64)
+            lamb = 0.3  # doesn't matter
+
+            self.compare_forces(
+                coords,
+                params,
+                box,
+                lamb,
+                ref_nrg,
+                test_nrg,
+                rtol,
+                precision=precision
+            )
+
+
     def test_harmonic_bond(self, n_particles=64, n_bonds=35, dim=3):
         """Randomly connect pairs of particles, then validate the resulting HarmonicBond force"""
         np.random.seed(125)  # TODO: where should this seed be set?

--- a/tests/test_bonded.py
+++ b/tests/test_bonded.py
@@ -12,54 +12,54 @@ from timemachine.potentials import bonded
 
 class TestBonded(GradientTest):
 
-    # def test_centroid_restraint(self, n_particles=10, n_A=4, n_B=3, kb=5.4, b0=2.3):
-    #     """Randomly define subsets A and B of a larger collection of particles,
-    #     generate a centroid restraint between A and B, and then validate the resulting CentroidRestraint force"""
-    #     box = np.eye(3) * 100
+    def test_centroid_restraint(self, n_particles=10, n_A=4, n_B=3, kb=5.4, b0=2.3):
+        """Randomly define subsets A and B of a larger collection of particles,
+        generate a centroid restraint between A and B, and then validate the resulting CentroidRestraint force"""
+        box = np.eye(3) * 100
 
-    #     # specific to centroid restraint force
-    #     relative_tolerance_at_precision = {np.float32: 2e-5, np.float64: 1e-9}
+        # specific to centroid restraint force
+        relative_tolerance_at_precision = {np.float32: 2e-5, np.float64: 1e-9}
 
-    #     for precision, rtol in relative_tolerance_at_precision.items():
-    #         x_primal = self.get_random_coords(n_particles, 3)
+        for precision, rtol in relative_tolerance_at_precision.items():
+            x_primal = self.get_random_coords(n_particles, 3)
 
-    #         gai = np.random.randint(0, n_particles, n_A, dtype=np.int32)
-    #         gbi = np.random.randint(0, n_particles, n_B, dtype=np.int32)
+            gai = np.random.randint(0, n_particles, n_A, dtype=np.int32)
+            gbi = np.random.randint(0, n_particles, n_B, dtype=np.int32)
 
-    #         masses = np.random.rand(n_particles)
+            masses = np.random.rand(n_particles)
 
-    #         ref_nrg = jax.partial(
-    #             bonded.centroid_restraint,
-    #             masses=masses,
-    #             group_a_idxs=gai,
-    #             group_b_idxs=gbi,
-    #             kb=kb,
-    #             b0=b0
-    #         )
+            ref_nrg = jax.partial(
+                bonded.centroid_restraint,
+                # masses=masses,
+                group_a_idxs=gai,
+                group_b_idxs=gbi,
+                kb=kb,
+                b0=b0
+            )
 
-    #         # we need to clear the du_dp buffer each time, so we need
-    #         # to instantiate test_nrg inside here
-    #         test_nrg = potentials.CentroidRestraint(
-    #             gai,
-    #             gbi,
-    #             masses,
-    #             kb,
-    #             b0
-    #         )
+            # we need to clear the du_dp buffer each time, so we need
+            # to instantiate test_nrg inside here
+            test_nrg = potentials.CentroidRestraint(
+                gai,
+                gbi,
+                # masses,
+                kb,
+                b0
+            )
 
-    #         params = np.array([], dtype=np.float64)
-    #         lamb = 0.3  # doesn't matter
+            params = np.array([], dtype=np.float64)
+            lamb = 0.3  # doesn't matter
 
-    #         self.compare_forces(
-    #             x_primal,
-    #             params,
-    #             box,
-    #             lamb,
-    #             ref_nrg,
-    #             test_nrg,
-    #             rtol,
-    #             precision=precision
-    #         )
+            self.compare_forces(
+                x_primal,
+                params,
+                box,
+                lamb,
+                ref_nrg,
+                test_nrg,
+                rtol,
+                precision=precision
+            )
 
     def test_harmonic_bond(self, n_particles=64, n_bonds=35, dim=3):
         """Randomly connect pairs of particles, then validate the resulting HarmonicBond force"""

--- a/tests/test_bonded.py
+++ b/tests/test_bonded.py
@@ -72,46 +72,49 @@ class TestBonded(GradientTest):
 
         for precision, rtol in relative_tolerance_at_precision.items():
             x0 = self.get_random_coords(n_particles, 3)
-            coords = np.concatenate([x0, x0])
+            coords_0 = np.concatenate([x0, x0])
+            coords_1 = self.get_random_coords(n_particles*2, 3)
 
-            gai = np.arange(5).astype(np.int32)
-            gbi = (np.arange(5) + 5).astype(np.int32)
+            for coords in [coords_0, coords_1]:
 
-            masses = np.random.rand(n_particles)
+                gai = np.arange(5).astype(np.int32)
+                gbi = (np.arange(5) + 5).astype(np.int32)
 
-            kb = 10.0
-            b0 = 0.0
+                masses = np.random.rand(n_particles)
 
-            ref_nrg = jax.partial(
-                bonded.centroid_restraint,
-                group_a_idxs=gai,
-                group_b_idxs=gbi,
-                kb=kb,
-                b0=b0
-            )
+                kb = 10.0
+                b0 = 0.0
 
-            # we need to clear the du_dp buffer each time, so we need
-            # to instantiate test_nrg inside here
-            test_nrg = potentials.CentroidRestraint(
-                gai,
-                gbi,
-                kb,
-                b0
-            )
+                ref_nrg = jax.partial(
+                    bonded.centroid_restraint,
+                    group_a_idxs=gai,
+                    group_b_idxs=gbi,
+                    kb=kb,
+                    b0=b0
+                )
 
-            params = np.array([], dtype=np.float64)
-            lamb = 0.3  # doesn't matter
+                # we need to clear the du_dp buffer each time, so we need
+                # to instantiate test_nrg inside here
+                test_nrg = potentials.CentroidRestraint(
+                    gai,
+                    gbi,
+                    kb,
+                    b0
+                )
 
-            self.compare_forces(
-                coords,
-                params,
-                box,
-                lamb,
-                ref_nrg,
-                test_nrg,
-                rtol,
-                precision=precision
-            )
+                params = np.array([], dtype=np.float64)
+                lamb = 0.3  # doesn't matter
+
+                self.compare_forces(
+                    coords,
+                    params,
+                    box,
+                    lamb,
+                    ref_nrg,
+                    test_nrg,
+                    rtol,
+                    precision=precision
+                )
 
 
     def test_harmonic_bond(self, n_particles=64, n_bonds=35, dim=3):

--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -35,6 +35,7 @@ pybind11_add_module(${LIBRARY_NAME} SHARED NO_EXTRAS
   src/solver.cpp
   src/potential.cu
   src/bound_potential.cu
+  src/centroid_restraint.cu
   src/gpu_utils.cu
   src/observable.cu
   src/hilbert.cpp

--- a/timemachine/cpp/src/centroid_restraint.cu
+++ b/timemachine/cpp/src/centroid_restraint.cu
@@ -10,12 +10,12 @@ namespace timemachine {
 
 template <typename RealType>
 CentroidRestraint<RealType>::CentroidRestraint(
+    const int N,
     const std::vector<int> &group_a_idxs,
     const std::vector<int> &group_b_idxs,
-    const std::vector<double> &masses,
     const double kb,
     const double b0
-) : N_(masses.size()),
+) : N_(N),
     N_A_(group_a_idxs.size()),
     N_B_(group_b_idxs.size()),
     kb_(kb),
@@ -33,9 +33,6 @@ CentroidRestraint<RealType>::CentroidRestraint(
         }
     }
 
-    gpuErrchk(cudaMalloc(&d_masses_, N_*sizeof(*d_masses_)));
-    gpuErrchk(cudaMemcpy(d_masses_, &masses[0], N_*sizeof(*d_masses_), cudaMemcpyHostToDevice));
-
     gpuErrchk(cudaMalloc(&d_group_a_idxs_, N_A_*sizeof(*d_group_a_idxs_)));
     gpuErrchk(cudaMemcpy(d_group_a_idxs_, &group_a_idxs[0], N_A_*sizeof(*d_group_a_idxs_), cudaMemcpyHostToDevice));
 
@@ -46,7 +43,6 @@ CentroidRestraint<RealType>::CentroidRestraint(
 
 template <typename RealType>
 CentroidRestraint<RealType>::~CentroidRestraint() {
-    gpuErrchk(cudaFree(d_masses_));
     gpuErrchk(cudaFree(d_group_a_idxs_));
     gpuErrchk(cudaFree(d_group_b_idxs_));
 };
@@ -62,8 +58,8 @@ void CentroidRestraint<RealType>::execute_device(
         const double lambda,
         unsigned long long *d_du_dx,
         double *d_du_dp,
-        double *d_du_dl,
-        double *d_u,
+        unsigned long long *d_du_dl,
+        unsigned long long *d_u,
         cudaStream_t stream) {
 
     int tpb = 32;
@@ -75,7 +71,7 @@ void CentroidRestraint<RealType>::execute_device(
         d_group_b_idxs_,
         N_A_,
         N_B_,
-        d_masses_,
+        // d_masses_,
         kb_,
         b0_,
         d_du_dx,

--- a/timemachine/cpp/src/centroid_restraint.cu
+++ b/timemachine/cpp/src/centroid_restraint.cu
@@ -10,28 +10,14 @@ namespace timemachine {
 
 template <typename RealType>
 CentroidRestraint<RealType>::CentroidRestraint(
-    const int N,
     const std::vector<int> &group_a_idxs,
     const std::vector<int> &group_b_idxs,
     const double kb,
     const double b0
-) : N_(N),
-    N_A_(group_a_idxs.size()),
+) : N_A_(group_a_idxs.size()),
     N_B_(group_b_idxs.size()),
     kb_(kb),
     b0_(b0) {
-
-    for(int i=0; i < group_a_idxs.size(); i++) {
-        if(group_a_idxs[i] >= N_ || group_a_idxs[i] < 0) {
-            throw std::runtime_error("Invalid group_a_idx!");
-        }
-    }
-
-    for(int i=0; i < group_b_idxs.size(); i++) {
-        if(group_b_idxs[i] >= N_ || group_b_idxs[i] < 0) {
-            throw std::runtime_error("Invalid group_a_idx!");
-        }
-    }
 
     gpuErrchk(cudaMalloc(&d_group_a_idxs_, N_A_*sizeof(*d_group_a_idxs_)));
     gpuErrchk(cudaMemcpy(d_group_a_idxs_, &group_a_idxs[0], N_A_*sizeof(*d_group_a_idxs_), cudaMemcpyHostToDevice));
@@ -65,23 +51,18 @@ void CentroidRestraint<RealType>::execute_device(
     int tpb = 32;
 
     k_centroid_restraint<RealType><<<1, tpb, 0, stream>>>(
-        N_,
+        N,
         d_x,
         d_group_a_idxs_,
         d_group_b_idxs_,
         N_A_,
         N_B_,
-        // d_masses_,
         kb_,
         b0_,
         d_du_dx,
         d_u
     );
     gpuErrchk(cudaPeekAtLastError());
-
-    // auto finish = std::chrono::high_resolution_clock::now();
-    // std::chrono::duration<double> elapsed = finish - start;
-    // std::cout << "CentroidRestraint Elapsed time: " << elapsed.count() << " s\n";
 
 };
 

--- a/timemachine/cpp/src/centroid_restraint.hpp
+++ b/timemachine/cpp/src/centroid_restraint.hpp
@@ -13,7 +13,6 @@ private:
     int *d_group_a_idxs_;
     int *d_group_b_idxs_;
 
-    int N_;
     int N_A_;
     int N_B_;
 
@@ -23,7 +22,6 @@ private:
 public:
 
     CentroidRestraint(
-        const int N,
         const std::vector<int> &group_a_idxs,
         const std::vector<int> &group_b_idxs,
         const double kb,
@@ -41,8 +39,8 @@ public:
         const double lambda,
         unsigned long long *d_du_dx,
         double *d_du_dp,
-        double *d_du_dl,
-        double *d_u,
+        unsigned long long *d_du_dl,
+        unsigned long long *d_u,
         cudaStream_t stream
     ) override;
 

--- a/timemachine/cpp/src/centroid_restraint.hpp
+++ b/timemachine/cpp/src/centroid_restraint.hpp
@@ -12,7 +12,6 @@ private:
 
     int *d_group_a_idxs_;
     int *d_group_b_idxs_;
-    double *d_masses_;
 
     int N_;
     int N_A_;
@@ -24,9 +23,9 @@ private:
 public:
 
     CentroidRestraint(
+        const int N,
         const std::vector<int> &group_a_idxs,
         const std::vector<int> &group_b_idxs,
-        const std::vector<double> &masses,
         const double kb,
         const double b0
     );

--- a/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
@@ -57,16 +57,30 @@ void __global__ k_centroid_restraint(
     // grads
     if(grad_coords) {
         for(int d=0; d < 3; d++) {
-            double ddij_dxi = (group_a_ctr[d] - group_b_ctr[d])/dij;
 
-            for(int i=0; i < N_A; i++) {
-                double dx = du_ddij*ddij_dxi/N_A;
-                atomicAdd(grad_coords + group_a_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(dx));
+            if(b0 != 0) {
+                double ddij_dxi = (group_a_ctr[d] - group_b_ctr[d])/dij;
+                for(int i=0; i < N_A; i++) {
+                    double delta = du_ddij*ddij_dxi/N_A;
+                    atomicAdd(grad_coords + group_a_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(delta));
+                }
+
+                for(int i=0; i < N_B; i++) {
+                    double delta = -du_ddij*ddij_dxi/N_B;
+                    atomicAdd(grad_coords + group_b_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(delta));
+                }
+            } else {
+                for(int i=0; i < N_A; i++) {
+                    double delta = (group_a_ctr[d] - group_b_ctr[d])/N_A;
+                    atomicAdd(grad_coords + group_a_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(delta));
+                }
+
+                for(int i=0; i < N_B; i++) {
+                    double delta = -(group_a_ctr[d] - group_b_ctr[d])/N_B;
+                    atomicAdd(grad_coords + group_b_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(delta));
+                }
             }
-            for(int i=0; i < N_B; i++) {
-                double dx = -du_ddij*ddij_dxi/N_B;
-                atomicAdd(grad_coords + group_b_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(dx));
-            }
+
         }
     }
 

--- a/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
@@ -52,13 +52,15 @@ void __global__ k_centroid_restraint(
         atomicAdd(energy, FLOAT_TO_FIXED<RealType>(nrg));
     }
 
-    double du_ddij = 2*kb*(dij-b0);
+
 
     // grads
     if(grad_coords) {
         for(int d=0; d < 3; d++) {
 
             if(b0 != 0) {
+
+                double du_ddij = 2*kb*(dij-b0);
                 double ddij_dxi = (group_a_ctr[d] - group_b_ctr[d])/dij;
                 for(int i=0; i < N_A; i++) {
                     double delta = du_ddij*ddij_dxi/N_A;
@@ -71,12 +73,12 @@ void __global__ k_centroid_restraint(
                 }
             } else {
                 for(int i=0; i < N_A; i++) {
-                    double delta = (group_a_ctr[d] - group_b_ctr[d])/N_A;
+                    double delta = 2*kb*(group_a_ctr[d] - group_b_ctr[d])/N_A;
                     atomicAdd(grad_coords + group_a_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(delta));
                 }
 
                 for(int i=0; i < N_B; i++) {
-                    double delta = -(group_a_ctr[d] - group_b_ctr[d])/N_B;
+                    double delta = -2*kb*(group_a_ctr[d] - group_b_ctr[d])/N_B;
                     atomicAdd(grad_coords + group_b_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(delta));
                 }
             }

--- a/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
@@ -1,6 +1,6 @@
+#pragma once
 
-#include "k_fixed_point.hpp"
-
+#include "k_fixed_point.cuh"
 
 __device__ const double PI = 3.14159265358979323846;
 
@@ -16,7 +16,7 @@ void __global__ k_centroid_restraint(
     const double kb,
     const double b0,
     unsigned long long *grad_coords,
-    double *energy) {
+    unsigned long long *energy) {
 
     // (ytz): ultra shitty inefficient algorithm, optimize later
     const auto t_idx = blockDim.x*blockIdx.x + threadIdx.x;
@@ -26,24 +26,18 @@ void __global__ k_centroid_restraint(
     }
 
     double group_a_ctr[3] = {0};
-    // double mass_a_sums[3] = {0};
     for(int d=0; d < 3; d++) {
         for(int i=0; i < N_A; i++) {
-            // double mass_i = masses[group_a_idxs[i]];
             group_a_ctr[d] += coords[group_a_idxs[i]*3+d];
-            // mass_a_sums[d] += mass_i;
         }
-        group_a_ctr[d] /= N_A[d];
+        group_a_ctr[d] /= N_A;
     }
 
     double group_b_ctr[3] = {0};
-    double mass_b_sums[3] = {0};
     for(int d=0; d < 3; d++) {
 
         for(int i=0; i < N_B; i++) {
-            // double mass_i = masses[group_b_idxs[i]];
             group_b_ctr[d] += coords[group_b_idxs[i]*3+d];
-            // mass_b_sums[d] += mass_i;
         }
         group_b_ctr[d] /= N_B;
     }
@@ -66,13 +60,11 @@ void __global__ k_centroid_restraint(
             double ddij_dxi = (group_a_ctr[d] - group_b_ctr[d])/dij;
 
             for(int i=0; i < N_A; i++) {
-                // double mass_i = masses[group_a_idxs[i]];
-                double dx = du_ddij*ddij_dxi;
+                double dx = du_ddij*ddij_dxi/N_A;
                 atomicAdd(grad_coords + group_a_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(dx));
             }
             for(int i=0; i < N_B; i++) {
-                // double mass_i = masses[group_b_idxs[i]];
-                double dx = -du_ddij*ddij_dxi;
+                double dx = -du_ddij*ddij_dxi/N_B;
                 atomicAdd(grad_coords + group_b_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(dx));
             }
         }

--- a/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
@@ -1,6 +1,5 @@
 
-#include "surreal.cuh"
-#include "../fixed_point.hpp"
+#include "k_fixed_point.hpp"
 
 
 __device__ const double PI = 3.14159265358979323846;
@@ -13,7 +12,7 @@ void __global__ k_centroid_restraint(
     const int *group_b_idxs,
     const int N_A,
     const int N_B,
-    const double *masses, // ignore masses for now
+    // const double *masses, // ignore masses for now
     const double kb,
     const double b0,
     unsigned long long *grad_coords,
@@ -27,15 +26,14 @@ void __global__ k_centroid_restraint(
     }
 
     double group_a_ctr[3] = {0};
-    double mass_a_sums[3] = {0};
+    // double mass_a_sums[3] = {0};
     for(int d=0; d < 3; d++) {
-
         for(int i=0; i < N_A; i++) {
-            double mass_i = masses[group_a_idxs[i]];
-            group_a_ctr[d] += mass_i*coords[group_a_idxs[i]*3+d];
-            mass_a_sums[d] += mass_i;
+            // double mass_i = masses[group_a_idxs[i]];
+            group_a_ctr[d] += coords[group_a_idxs[i]*3+d];
+            // mass_a_sums[d] += mass_i;
         }
-        group_a_ctr[d] /= mass_a_sums[d];
+        group_a_ctr[d] /= N_A[d];
     }
 
     double group_b_ctr[3] = {0};
@@ -43,25 +41,22 @@ void __global__ k_centroid_restraint(
     for(int d=0; d < 3; d++) {
 
         for(int i=0; i < N_B; i++) {
-            double mass_i = masses[group_b_idxs[i]];
-            group_b_ctr[d] += mass_i*coords[group_b_idxs[i]*3+d];
-            mass_b_sums[d] += mass_i;
+            // double mass_i = masses[group_b_idxs[i]];
+            group_b_ctr[d] += coords[group_b_idxs[i]*3+d];
+            // mass_b_sums[d] += mass_i;
         }
-        group_b_ctr[d] /= mass_b_sums[d];
+        group_b_ctr[d] /= N_B;
     }
 
     double dx = group_a_ctr[0] - group_b_ctr[0];
     double dy = group_a_ctr[1] - group_b_ctr[1];
     double dz = group_a_ctr[2] - group_b_ctr[2];
-
     double dij = sqrt(dx*dx + dy*dy + dz*dz);
-
     double nrg = kb*(dij-b0)*(dij-b0);
 
     if(energy) {
-        atomicAdd(energy, nrg);
+        atomicAdd(energy, FLOAT_TO_FIXED<RealType>(nrg));
     }
-
 
     double du_ddij = 2*kb*(dij-b0);
 
@@ -71,14 +66,14 @@ void __global__ k_centroid_restraint(
             double ddij_dxi = (group_a_ctr[d] - group_b_ctr[d])/dij;
 
             for(int i=0; i < N_A; i++) {
-                double mass_i = masses[group_a_idxs[i]];
-                double dx = du_ddij*ddij_dxi*(mass_i/mass_a_sums[d]);
-                atomicAdd(grad_coords + group_a_idxs[i]*3 + d, static_cast<unsigned long long>((long long) (dx*FIXED_EXPONENT)));
+                // double mass_i = masses[group_a_idxs[i]];
+                double dx = du_ddij*ddij_dxi;
+                atomicAdd(grad_coords + group_a_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(dx));
             }
             for(int i=0; i < N_B; i++) {
-                double mass_i = masses[group_b_idxs[i]];
-                double dx = -du_ddij*ddij_dxi*(mass_i/mass_b_sums[d]);
-                atomicAdd(grad_coords + group_b_idxs[i]*3 + d, static_cast<unsigned long long>((long long) (dx*FIXED_EXPONENT)));
+                // double mass_i = masses[group_b_idxs[i]];
+                double dx = -du_ddij*ddij_dxi;
+                atomicAdd(grad_coords + group_b_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(dx));
             }
         }
     }

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -12,7 +12,7 @@
 // #include "interpolated_potential.hpp"
 // #include "restraint.hpp"
 // #include "inertial_restraint.hpp"
-// #include "centroid_restraint.hpp"
+#include "centroid_restraint.hpp"
 #include "periodic_torsion.hpp"
 #include "nonbonded.hpp"
 // #include "lennard_jones.hpp"
@@ -656,42 +656,38 @@ void declare_harmonic_angle(py::module &m, const char *typestr) {
 // }
 
 
-// template <typename RealType>
-// void declare_centroid_restraint(py::module &m, const char *typestr) {
+template <typename RealType>
+void declare_centroid_restraint(py::module &m, const char *typestr) {
 
-//     using Class = timemachine::CentroidRestraint<RealType>;
-//     std::string pyclass_name = std::string("CentroidRestraint_") + typestr;
-//     py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
-//         m,
-//         pyclass_name.c_str(),
-//         py::buffer_protocol(),
-//         py::dynamic_attr()
-//     )
-//     .def(py::init([](
-//         const py::array_t<int, py::array::c_style> &group_a_idxs,
-//         const py::array_t<int, py::array::c_style> &group_b_idxs,
-//         const py::array_t<double, py::array::c_style> &masses,
-//         double kb,
-//         double b0
-//     ) {
-//         std::vector<int> vec_group_a_idxs(group_a_idxs.size());
-//         std::memcpy(vec_group_a_idxs.data(), group_a_idxs.data(), vec_group_a_idxs.size()*sizeof(int));
-//         std::vector<int> vec_group_b_idxs(group_b_idxs.size());
-//         std::memcpy(vec_group_b_idxs.data(), group_b_idxs.data(), vec_group_b_idxs.size()*sizeof(int));
-//         std::vector<double> vec_masses(masses.size());
-//         std::memcpy(vec_masses.data(), masses.data(), vec_masses.size()*sizeof(double));
+    using Class = timemachine::CentroidRestraint<RealType>;
+    std::string pyclass_name = std::string("CentroidRestraint_") + typestr;
+    py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+        m,
+        pyclass_name.c_str(),
+        py::buffer_protocol(),
+        py::dynamic_attr()
+    )
+    .def(py::init([](
+        const py::array_t<int, py::array::c_style> &group_a_idxs,
+        const py::array_t<int, py::array::c_style> &group_b_idxs,
+        double kb,
+        double b0
+    ) {
+        std::vector<int> vec_group_a_idxs(group_a_idxs.size());
+        std::memcpy(vec_group_a_idxs.data(), group_a_idxs.data(), vec_group_a_idxs.size()*sizeof(int));
+        std::vector<int> vec_group_b_idxs(group_b_idxs.size());
+        std::memcpy(vec_group_b_idxs.data(), group_b_idxs.data(), vec_group_b_idxs.size()*sizeof(int));
 
-//         return new timemachine::CentroidRestraint<RealType>(
-//             vec_group_a_idxs,
-//             vec_group_b_idxs,
-//             vec_masses,
-//             kb,
-//             b0
-//         );
+        return new timemachine::CentroidRestraint<RealType>(
+            vec_group_a_idxs,
+            vec_group_b_idxs,
+            kb,
+            b0
+        );
 
-//     }));
+    }));
 
-// }
+}
 
 
 // template <typename RealType>
@@ -887,8 +883,8 @@ PYBIND11_MODULE(custom_ops, m) {
     declare_neighborlist<double>(m, "f64");
     declare_neighborlist<float>(m, "f32");
 
-    // declare_centroid_restraint<double>(m, "f64");
-    // declare_centroid_restraint<float>(m, "f32");
+    declare_centroid_restraint<double>(m, "f64");
+    declare_centroid_restraint<float>(m, "f32");
 
     // declare_inertial_restraint<double>(m, "f64");
     // declare_inertial_restraint<float>(m, "f32");

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -172,19 +172,13 @@ class InertialRestraint(CustomOpWrapper):
         self.args[2] = masses
 
 
-# class CentroidRestraint(CustomOpWrapper):
+class CentroidRestraint(CustomOpWrapper):
 
-#     def get_a_idxs(self):
-#         return self.args[0]
+    def get_a_idxs(self):
+        return self.args[0]
 
-#     def get_b_idxs(self):
-#         return self.args[1]
-
-#     def get_masses(self):
-#         return self.args[2]
-
-#     def set_masses(self, masses):
-#         self.args[2] = masses
+    def get_b_idxs(self):
+        return self.args[1]
 
 
 class Nonbonded(CustomOpWrapper):

--- a/timemachine/potentials/bonded.py
+++ b/timemachine/potentials/bonded.py
@@ -1,7 +1,13 @@
 import jax.numpy as np
 
 def centroid_restraint(conf, params, box, lamb, group_a_idxs, group_b_idxs, kb, b0):
-
+    """Computes kb  * (r - b0)**2 where r is the distance between the centroids of group_a and group_b
+    
+    Notes
+    ------
+    * Geometric centroid, not mass-weighted centroid
+    * Gradient undefined when `r - b0 == 0` and `b0 != 0` (explicitly stabilized in case `b0 == 0`)
+    """
     xi = conf[group_a_idxs]
     xj = conf[group_b_idxs]
 

--- a/timemachine/potentials/bonded.py
+++ b/timemachine/potentials/bonded.py
@@ -2,11 +2,11 @@ import jax.numpy as np
 
 def centroid_restraint(conf, params, box, lamb, group_a_idxs, group_b_idxs, kb, b0):
     """Computes kb  * (r - b0)**2 where r is the distance between the centroids of group_a and group_b
-    
+
     Notes
     ------
     * Geometric centroid, not mass-weighted centroid
-    * Gradient undefined when `r - b0 == 0` and `b0 != 0` (explicitly stabilized in case `b0 == 0`)
+    * Gradient undefined when `(r - b0) == 0` and `b0 != 0` (explicitly stabilized in case `b0 == 0`)
     """
     xi = conf[group_a_idxs]
     xj = conf[group_b_idxs]

--- a/timemachine/potentials/bonded.py
+++ b/timemachine/potentials/bonded.py
@@ -1,12 +1,12 @@
 import jax.numpy as np
 
-def centroid_restraint(conf, params, box, lamb, masses, group_a_idxs, group_b_idxs, kb, b0):
+def centroid_restraint(conf, params, box, lamb, group_a_idxs, group_b_idxs, kb, b0):
 
     xi = conf[group_a_idxs]
     xj = conf[group_b_idxs]
 
-    avg_xi = np.average(xi, axis=0, weights=masses[group_a_idxs])
-    avg_xj = np.average(xj, axis=0, weights=masses[group_b_idxs])
+    avg_xi = np.mean(xi, axis=0)
+    avg_xj = np.mean(xj, axis=0)
 
     dx = avg_xi - avg_xj
     dij = np.sqrt(np.sum(dx*dx))

--- a/timemachine/potentials/bonded.py
+++ b/timemachine/potentials/bonded.py
@@ -9,10 +9,18 @@ def centroid_restraint(conf, params, box, lamb, group_a_idxs, group_b_idxs, kb, 
     avg_xj = np.mean(xj, axis=0)
 
     dx = avg_xi - avg_xj
-    dij = np.sqrt(np.sum(dx*dx))
+    d2ij = np.sum(dx*dx)
+    d2ij = np.where(d2ij == 0, 0, d2ij) # stabilize derivative
+    dij = np.sqrt(d2ij)
     delta = dij - b0
 
-    return kb*delta*delta
+    # when b0 == 0 and dij == 0
+    return np.where(
+        b0 == 0,
+        kb * d2ij,
+        kb * np.power(dij - b0, 2.0)
+    )
+
 
 def restraint(conf, lamb, params, lamb_flags, box, bond_idxs):
     """

--- a/timemachine/potentials/bonded.py
+++ b/timemachine/potentials/bonded.py
@@ -18,7 +18,7 @@ def centroid_restraint(conf, params, box, lamb, group_a_idxs, group_b_idxs, kb, 
     return np.where(
         b0 == 0,
         kb * d2ij,
-        kb * np.power(dij - b0, 2.0)
+        kb * delta**2
     )
 
 


### PR DESCRIPTION
This PR restores the center of mass restraints that were disabled during the fixed point conversion PR. The mass argument has been intentionally removed (for now) to avoid subtle inconsistencies that may arise when used in conjunction with the RMSD-based rotational restraint.

This also fixes a singularity associated with `b0==0`, similar to the harmonic bond case.