### PR TITLE
Task/optimize centroid restraint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 timemachine/cpp/build/
 *.so
 *.DS_Store
+oe_license.txt
+*.swp

--- a/tests/test_bonded.py
+++ b/tests/test_bonded.py
@@ -26,7 +26,7 @@ class TestBonded(GradientTest):
             gai = np.random.randint(0, n_particles, n_A, dtype=np.int32)
             gbi = np.random.randint(0, n_particles, n_B, dtype=np.int32)
 
-            masses = np.random.rand(n_particles)
+            # masses = np.random.rand(n_particles)
 
             ref_nrg = jax.partial(
                 bonded.centroid_restraint,

--- a/timemachine/cpp/src/centroid_restraint.hpp
+++ b/timemachine/cpp/src/centroid_restraint.hpp
@@ -13,6 +13,9 @@ private:
     int *d_group_a_idxs_;
     int *d_group_b_idxs_;
 
+    RealType * d_centroid_a_;
+    RealType * d_centroid_b_;
+
     int N_A_;
     int N_B_;
 

--- a/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
@@ -2,88 +2,77 @@
 
 #include "k_fixed_point.cuh"
 
-__device__ const double PI = 3.14159265358979323846;
+template<typename RealType>
+void __global__ k_calc_centroid(
+    const double * __restrict__ d_coords,  // [n, 3]
+    const int * __restrict__ d_group_a_idxs,
+    const int * __restrict__ d_group_b_idxs,
+    const int N_A,
+    const int N_B,
+    RealType * d_centroid_a, // [3]
+    RealType * d_centroid_b // [3]
+    ){
+    int t_idx = blockDim.x*blockIdx.x + threadIdx.x;
+    if (N_A + N_B <= t_idx) {
+        return;
+    }
+    int group_idx = t_idx < N_A ? t_idx : t_idx - N_A;
+    RealType * centroid = t_idx < N_A ? d_centroid_a : d_centroid_b;
+    const int * cur_array = t_idx < N_A ? d_group_a_idxs : d_group_b_idxs;
+    for(int d=0; d < 3; d++) {
+        atomicAdd(centroid + d, d_coords[cur_array[group_idx]*3+d]);
+    }
+ }
 
 template<typename RealType>
 void __global__ k_centroid_restraint(
-    const int N,     // number of bonds
-    const double *coords,  // [n, 3]
-    const int *group_a_idxs,
-    const int *group_b_idxs,
+    // const int N,     // number of bonds, ignore for now
+    const double * __restrict__ d_coords,  // [n, 3]
+    const int * __restrict__ d_group_a_idxs,
+    const int * __restrict__ d_group_b_idxs,
     const int N_A,
     const int N_B,
-    // const double *masses, // ignore masses for now
+    const RealType * __restrict__ d_centroid_a, // [3]
+    const RealType * __restrict__ d_centroid_b, // [3]
+    // const double *d_masses, // ignore d_masses for now
     const double kb,
     const double b0,
-    unsigned long long *grad_coords,
-    unsigned long long *energy) {
+    unsigned long long *d_du_dx,
+    unsigned long long *d_u) {
 
-    // (ytz): ultra shitty inefficient algorithm, optimize later
-    const auto t_idx = blockDim.x*blockIdx.x + threadIdx.x;
-
-    if(t_idx != 0) {
+    const int t_idx = blockDim.x*blockIdx.x + threadIdx.x;
+    if (N_A + N_B <= t_idx) {
         return;
     }
-
-    double group_a_ctr[3] = {0};
-    for(int d=0; d < 3; d++) {
-        for(int i=0; i < N_A; i++) {
-            group_a_ctr[d] += coords[group_a_idxs[i]*3+d];
-        }
-        group_a_ctr[d] /= N_A;
+    int group_idx = t_idx < N_A ? t_idx : t_idx - N_A;
+    int count = t_idx < N_A ? N_A : N_B;
+    const int * cur_array = t_idx < N_A ? d_group_a_idxs : d_group_b_idxs;
+    RealType sign = t_idx < N_A ? 1.0 : -1.0;
+    RealType dij = 0;
+    RealType deltas[3];
+    for (int d=0; d < 3; d++) {
+        deltas[d] = d_centroid_a[d] / N_A - d_centroid_b[d] / N_B;
+        dij += deltas[d]*deltas[d];
     }
+    dij = sqrt(dij);
 
-    double group_b_ctr[3] = {0};
-    for(int d=0; d < 3; d++) {
-
-        for(int i=0; i < N_B; i++) {
-            group_b_ctr[d] += coords[group_b_idxs[i]*3+d];
-        }
-        group_b_ctr[d] /= N_B;
+    if(t_idx == 0 && d_u) {
+        RealType nrg = kb*(dij-b0)*(dij-b0);
+        d_u[0] = FLOAT_TO_FIXED<RealType>(nrg);
     }
-
-    double dx = group_a_ctr[0] - group_b_ctr[0];
-    double dy = group_a_ctr[1] - group_b_ctr[1];
-    double dz = group_a_ctr[2] - group_b_ctr[2];
-    double dij = sqrt(dx*dx + dy*dy + dz*dz);
-    double nrg = kb*(dij-b0)*(dij-b0);
-
-    if(energy) {
-        atomicAdd(energy, FLOAT_TO_FIXED<RealType>(nrg));
-    }
-
-
 
     // grads
-    if(grad_coords) {
+    if(d_du_dx) {
         for(int d=0; d < 3; d++) {
-
             if(b0 != 0) {
-
-                double du_ddij = 2*kb*(dij-b0);
-                double ddij_dxi = (group_a_ctr[d] - group_b_ctr[d])/dij;
-                for(int i=0; i < N_A; i++) {
-                    double delta = du_ddij*ddij_dxi/N_A;
-                    atomicAdd(grad_coords + group_a_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(delta));
-                }
-
-                for(int i=0; i < N_B; i++) {
-                    double delta = -du_ddij*ddij_dxi/N_B;
-                    atomicAdd(grad_coords + group_b_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(delta));
-                }
+                RealType du_ddij = 2*kb*(dij-b0);
+                RealType ddij_dxi = deltas[d]/dij;
+                RealType delta = sign*du_ddij*ddij_dxi/count;
+                atomicAdd(d_du_dx + cur_array[group_idx]*3 + d, FLOAT_TO_FIXED<RealType>(delta));
             } else {
-                for(int i=0; i < N_A; i++) {
-                    double delta = 2*kb*(group_a_ctr[d] - group_b_ctr[d])/N_A;
-                    atomicAdd(grad_coords + group_a_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(delta));
-                }
-
-                for(int i=0; i < N_B; i++) {
-                    double delta = -2*kb*(group_a_ctr[d] - group_b_ctr[d])/N_B;
-                    atomicAdd(grad_coords + group_b_idxs[i]*3 + d, FLOAT_TO_FIXED<RealType>(delta));
-                }
+                RealType delta = sign*2*kb*deltas[d]/count;
+                atomicAdd(d_du_dx + cur_array[group_idx]*3 + d, FLOAT_TO_FIXED<RealType>(delta));
             }
-
         }
     }
-
 }


### PR DESCRIPTION
## Starting NVProf

```
GPU activities:   38.73%  t.10us        32  19.503us  13.600us  25.920us  void k_centroid_restraint<float>(int, double const *, int const *, int const *, int, int, double, double, __int64*, __int64*)
                   38.27%  616.70us        32  19.272us  13.216us  25.568us  void k_centroid_restraint<double>(int, double const *, int const *, int const *, int, int, double, double, __int64*, __int64*)
                    8.78%  141.47us       132  1.0710us  1.0240us  1.5040us  [CUDA memcpy HtoD]
                    7.95%  128.06us        96  1.3340us  1.2800us  1.7920us  [CUDA memcpy DtoH]
                    6.28%  101.25us        96  1.0540us  1.0240us  1.4080us  [CUDA memset]
      API calls:   97.82%  268.75ms       292  920.38us     256ns  267.51ms  cudaMalloc
                    1.13%  3.0930ms       292  10.592us     215ns  40.213us  cudaMemcpy
                    0.47%  1.2909ms       292  4.4200us     389ns  187.95us  cudaFree
                    0.26%  702.25us        64  10.972us  8.0320us  36.299us  cudaLaunchKernel
                    0.13%  353.88us         1  353.88us  353.88us  353.88us  cuDeviceTotalMem
                    0.12%  325.48us        96  3.3900us  2.1010us  7.3200us  cudaMemset
                    0.06%  165.26us       101  1.6360us     124ns  70.032us  cuDeviceGetAttribute
                    0.01%  32.033us         1  32.033us  32.033us  32.033us  cuDeviceGetName
                    0.01%  14.238us        64     222ns     185ns     321ns  cudaPeekAtLastError
                    0.00%  5.0440us         1  5.0440us  5.0440us  5.0440us  cuDeviceGetPCIBusId
                    0.00%  1.9460us         3     648ns     247ns  1.4330us  cuDeviceGetCount
                    0.00%     864ns         2     432ns     159ns     705ns  cuDeviceGet
                    0.00%     267ns         1     267ns     267ns     267ns  cuDeviceGetUuid
```

## Final NVProf

```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   23.72%  314.05us        32  9.8140us  3.4240us  13.408us  void k_centroid_restraint<double>(double const *, int const *, int const *, int, int, double const *, double const *, double, double, __int64*, __int64*)
                   17.97%  237.98us       224  1.0620us  1.0240us  1.4400us  [CUDA memset]
                   16.78%  222.18us        32  6.9430us  3.4240us  9.0560us  void k_centroid_restraint<float>(double const *, int const *, int const *, int, int, float const *, float const *, double, double, __int64*, __int64*)
                   10.74%  142.18us        32  4.4430us  4.3840us  4.8960us  void k_calc_centroid<float>(double const *, int const *, int const *, int, int, float*, float*)
                   10.62%  140.58us       132  1.0640us  1.0240us  1.4400us  [CUDA memcpy HtoD]
                   10.49%  138.88us        32  4.3400us  4.2880us  4.6400us  void k_calc_centroid<double>(double const *, int const *, int const *, int, int, double*, double*)
                    9.69%  128.35us        96  1.3370us  1.2800us  1.7600us  [CUDA memcpy DtoH]
      API calls:   97.16%  209.20ms       296  706.74us     270ns  207.90ms  cudaMalloc
                    1.18%  2.5490ms       292  8.7290us     217ns  32.144us  cudaMemcpy
                    0.60%  1.2910ms       296  4.3610us     399ns  182.20us  cudaFree
                    0.49%  1.0619ms       128  8.2960us  4.4820us  42.881us  cudaLaunchKernel
                    0.30%  641.64us       224  2.8640us  1.9910us  7.2870us  cudaMemset
                    0.16%  341.50us         1  341.50us  341.50us  341.50us  cuDeviceTotalMem
                    0.08%  167.71us       101  1.6600us     121ns  74.431us  cuDeviceGetAttribute
                    0.02%  33.476us         1  33.476us  33.476us  33.476us  cuDeviceGetName
                    0.01%  24.585us       128     192ns     139ns     325ns  cudaPeekAtLastError
                    0.00%  6.2780us         1  6.2780us  6.2780us  6.2780us  cuDeviceGetPCIBusId
                    0.00%  1.6150us         3     538ns     194ns  1.1570us  cuDeviceGetCount
                    0.00%     878ns         2     439ns     140ns     738ns  cuDeviceGet
                    0.00%     283ns         1     283ns     283ns     283ns  cuDeviceGetUuid
```

