### PR TITLE
Modify RMSD restraint to be over proper rotations

### DIFF
--- a/tests/test_bonded.py
+++ b/tests/test_bonded.py
@@ -117,7 +117,6 @@ class TestBonded(GradientTest):
                 )
 
 
-
     def test_rmsd_restraint(self):
         # test the RMSD force by generating random coordinates.
 
@@ -128,46 +127,121 @@ class TestBonded(GradientTest):
         n_particles_a = 25
         n_particles_b = 7
 
-        relative_tolerance_at_precision = {np.float32: 2e-5, np.float64: 1e-9}
 
-        for precision, rtol in relative_tolerance_at_precision.items():
+        for _ in range(100):
+            coords = self.get_random_coords(n_particles_a + n_particles_b, 3)
 
-            for _ in range(100):
-                coords = self.get_random_coords(n_particles_a + n_particles_b, 3)
+            n = coords.shape[0]
+            n_mapped_atoms = 5
 
-                n = coords.shape[0]
-                n_mapped_atoms = 5
+            atom_idxs_a = np.arange(n_particles_a)
+            atom_idxs_b = np.arange(n_particles_b)
 
-                atom_idxs_a = np.arange(n_particles_a)
-                atom_idxs_b = np.arange(n_particles_b)
+            atom_map = np.stack([
+                np.random.randint(0, n_particles_a, n_mapped_atoms, dtype=np.int32),
+                np.random.randint(0, n_particles_b, n_mapped_atoms, dtype=np.int32) + n_particles_a
+            ], axis=1)
 
-                atom_map = np.stack([
-                    np.random.randint(0, n_particles_a, n_mapped_atoms, dtype=np.int32),
-                    np.random.randint(0, n_particles_b, n_mapped_atoms, dtype=np.int32) + n_particles_a
-                ], axis=1)
+            atom_map = atom_map.astype(np.int32)
 
-                atom_map = atom_map.astype(np.int32)
+            params = np.array([], dtype=np.float64)
+            k = 1.35
+            lamb = 0.0
 
-                params = np.array([], dtype=np.float64)
-                k = 1.35
-                lamb = 0.0
+            for precision, rtol, atol in [(np.float64, 1e-6, 1e-6), (np.float32, 1e-4, 1e-6)]:
+
+                ref_u = functools.partial(bonded.rmsd_restraint,
+                    group_a_idxs=atom_map[:, 0],
+                    group_b_idxs=atom_map[:, 1],
+                    k=k
+                )
+
+                test_u = potentials.RMSDRestraint(atom_map, n, k)
+
+                # note the slightly higher than usual atol (1e-6 vs 1e-8)
+                # this is due to fixed point accumulation of energy wipes out
+                # the low magnitude energies as some of test cases have
+                # an infinitesmally small absolute error (on the order of 1e-12)
+                self.compare_forces(
+                    coords,
+                    params,
+                    box,
+                    lamb,
+                    ref_u,
+                    test_u,
+                    rtol,
+                    atol=atol,
+                    precision=precision
+                )
+
+
+    def test_rmsd_restraint_singularity(self):
+        # test the RMSD force by generating random coordinates.
+
+        #  *   and  + +
+        # * *        +
+        # the rotation and reflection matrix for this particular case is completely
+        # arbitrary, so we perturb the points slightly
+        x0 = np.array([
+            [ 0,  1, 0],
+            [-1, -1, 0],
+            [ 1, -1, 0]
+        ], dtype=np.float64)
+
+        x1 = np.array([
+            [-2, 0, 0],
+            [ 1, 0, 0],
+            [ 0,-1, 0]
+        ], dtype=np.float64)
+
+        np.random.seed(2021)
+
+        box = np.eye(3) * 100
+
+        # try some random mappings
+        for _ in range(10):
+
+            a_idxs = np.arange(3)
+            b_idxs = np.arange(3) + 3
+            group_a_idxs = np.random.choice(a_idxs, size=3, replace=False)
+            group_b_idxs = np.random.choice(b_idxs, size=3, replace=False)
+
+            n = 6
+            k = 1.35
+
+            params = np.array([], dtype=np.float64)
+            lamb = 0.0
+
+            ref_u = functools.partial(bonded.rmsd_restraint,
+                group_a_idxs=group_a_idxs,
+                group_b_idxs=group_b_idxs,
+                k=k
+            )
+
+            # generate small perturbations
+            x0_p = np.copy(x0)
+            x1_p = np.copy(x1)
+
+            xs = [np.concatenate([x0_p, x1_p])]
+
+            for _ in range(20):
+                delta = np.random.rand()*1e-5
+                # randomly perturb 3 coordinates
+                for _ in range(3):
+                    x0_p[np.random.randint(3), np.random.randint(3)] += delta
+                    x1_p[np.random.randint(3), np.random.randint(3)] += delta
+                xs.append(np.concatenate([x0_p, x1_p]))
+
+            for x in xs:
 
                 for precision, rtol, atol in [(np.float64, 1e-6, 1e-6), (np.float32, 1e-4, 1e-6)]:
 
-                    ref_u = functools.partial(bonded.rmsd_restraint,
-                        group_a_idxs=atom_map[:, 0],
-                        group_b_idxs=atom_map[:, 1],
-                        k=k
-                    )
+                    atom_map = np.stack([group_a_idxs, group_b_idxs], axis=1).astype(np.int32)
 
                     test_u = potentials.RMSDRestraint(atom_map, n, k)
 
-                    # note the slightly higher than usual atol (1e-6 vs 1e-8)
-                    # this is due to fixed point accumulation of energy wipes out
-                    # the low magnitude energies as some of test cases have
-                    # an infinitesmally small absolute error (on the order of 1e-12)
                     self.compare_forces(
-                        coords,
+                        x,
                         params,
                         box,
                         lamb,

--- a/timemachine/cpp/src/rmsd_restraint.cu
+++ b/timemachine/cpp/src/rmsd_restraint.cu
@@ -120,24 +120,36 @@ void RMSDRestraint<RealType>::execute_device(
     gpuErrchk(cudaMemset(d_u_buf_, 0, sizeof(*d_u_buf_)));
     gpuErrchk(cudaMemset(d_du_dx_buf_, 0, N*3*sizeof(*d_du_dx_buf_)));
 
+    // improper and proper rotations both satisfy this
     if(s[0] < epsilon || s[1] < epsilon || s[2] < epsilon) {
         return;
     }
+
+    double alpha = 1e-3;
+
+    // degenerate eigenvalues, set rotation to identity.
+    if(abs(s[0] -  s[1]) < alpha || abs(s[0] -  s[2]) < alpha || abs(s[1] -  s[2]) < alpha) {
+        return;
+    }
+
 
     Eigen::MatrixXd u = svd.matrixU();
     Eigen::MatrixXd v = svd.matrixV();
     Eigen::MatrixXd v_t = v.transpose();
 
-    bool is_reflection = u.determinant() * v_t.determinant() < 0.0;
+    bool is_reflection = (u.determinant() * v_t.determinant()) < 0.0;
 
-    Eigen::MatrixXd rotation = u * v_t;
+    Eigen::MatrixXd u_flip = u;
 
-    double term = 0;
     if(is_reflection) {
-        term = (rotation.trace() + 1)/2 - 1;
-    } else {
-        term = (rotation.trace() - 1)/2 - 1;
+        u_flip(0, 2) = -u_flip(0, 2);
+        u_flip(1, 2) = -u_flip(1, 2);
+        u_flip(2, 2) = -u_flip(2, 2);
     }
+
+    Eigen::MatrixXd rotation = u_flip * v_t;
+
+    double term = (rotation.trace() - 1)/2 - 1;
 
     double squared_term = term*term;
 
@@ -150,7 +162,14 @@ void RMSDRestraint<RealType>::execute_device(
     double term_adjoint = squared_term_adjoint*2*term;
     Eigen::MatrixXd r_a = eye*term_adjoint/2;
     Eigen::MatrixXd u_a = r_a * v_t.transpose();
-    Eigen::MatrixXd v_a_t = u.transpose() * r_a;
+
+    if(is_reflection) {
+        u_a(0, 2) = -u_a(0, 2);
+        u_a(1, 2) = -u_a(1, 2);
+        u_a(2, 2) = -u_a(2, 2);
+    }
+
+    Eigen::MatrixXd v_a_t = u_flip.transpose() * r_a;
 
     Eigen::MatrixXd smat(3,3);
     Eigen::MatrixXd smat_inv(3,3);
@@ -187,6 +206,16 @@ void RMSDRestraint<RealType>::execute_device(
     std::vector<unsigned long long> du_dx(N*3, 0);
 
     for(int b=0; b < B; b++) {
+
+        if(abs(x1_adjoint(b, 0)) > 100000 || abs(x1_adjoint(b, 1)) > 100000 || abs(x1_adjoint(b, 2)) > 100000) {
+            throw std::runtime_error("Rotation Force Blew Up");
+        }
+
+
+        if(abs(x2_adjoint(b, 0)) > 100000 || abs(x2_adjoint(b, 1)) > 100000 || abs(x2_adjoint(b, 2)) > 100000) {
+            throw std::runtime_error("Rotation Force Blew Up");
+        }
+
         int src_idx = h_atom_map_[b*2+0];
         du_dx[src_idx*3+0] += static_cast<unsigned long long>(llrint(k_*x1_adjoint(b, 0)*FIXED_EXPONENT));
         du_dx[src_idx*3+1] += static_cast<unsigned long long>(llrint(k_*x1_adjoint(b, 1)*FIXED_EXPONENT));

--- a/timemachine/potentials/bonded.py
+++ b/timemachine/potentials/bonded.py
@@ -141,7 +141,7 @@ def rmsd_restraint(conf, params, box, lamb, group_a_idxs, group_b_idxs, k):
     # by having degenerate singular values. jfass pointed out that this can probably be
     # reduced to two checks since the list is sorted, but the C++ code may not guarantee
     # this, so just for sanity and simplicity, we check all three comparisons.
-    if np.any(np.abs([s[0] -  s[1], s[0] -  s[2], s[1] -  s[2]])) < alpha:
+    if np.any(np.abs(np.array([S[0] - S[1], S[0] - S[2], S[1] - S[2]]))) < alpha:
         return 0.0
 
     is_reflection = (np.linalg.det(U) * np.linalg.det(V_tr)) < 0.0

--- a/timemachine/potentials/bonded.py
+++ b/timemachine/potentials/bonded.py
@@ -141,7 +141,7 @@ def rmsd_restraint(conf, params, box, lamb, group_a_idxs, group_b_idxs, k):
     # by having degenerate singular values. jfass pointed out that this can probably be
     # reduced to two checks since the list is sorted, but the C++ code may not guarantee
     # this, so just for sanity and simplicity, we check all three comparisons.
-    if np.any(np.abs(np.array([S[0] - S[1], S[0] - S[2], S[1] - S[2]]))) < alpha:
+    if np.any(np.abs(np.array([S[0] - S[1], S[0] - S[2], S[1] - S[2]])) < alpha):
         return 0.0
 
     is_reflection = (np.linalg.det(U) * np.linalg.det(V_tr)) < 0.0


### PR DESCRIPTION
This PR modifies the RMSD restraint to always return a proper rotation matrix. 