### PR TITLE
Task/optimize rmsd restraints

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -469,9 +469,7 @@ class GradientTest(unittest.TestCase):
         errors = np.abs(errors) > rtol
 
         # print("max relative error", max_error, "rtol", rtol, norms[max_error_arg], "mean error", mean_error, "std error", std_error)
-        if np.sum(errors) > 0:
-            print("FATAL: max relative error", max_error, truth[max_error_arg], test[max_error_arg])
-            assert 0
+        assert np.sum(errors) <= 0, f"Max relative error: {max_error}, rtol: {rtol}, {truth[max_error_arg]}, {test[max_error_arg]}"
 
     def compare_forces(
         self,

--- a/tests/test_bonded.py
+++ b/tests/test_bonded.py
@@ -128,55 +128,51 @@ class TestBonded(GradientTest):
         n_particles_a = 25
         n_particles_b = 7
 
-        relative_tolerance_at_precision = {np.float32: 2e-5, np.float64: 1e-9}
+        for _ in range(100):
+            coords = self.get_random_coords(n_particles_a + n_particles_b, 3)
 
-        for precision, rtol in relative_tolerance_at_precision.items():
+            n = coords.shape[0]
+            n_mapped_atoms = 5
 
-            for _ in range(100):
-                coords = self.get_random_coords(n_particles_a + n_particles_b, 3)
+            atom_idxs_a = np.arange(n_particles_a)
+            atom_idxs_b = np.arange(n_particles_b)
 
-                n = coords.shape[0]
-                n_mapped_atoms = 5
+            atom_map = np.stack([
+                np.random.randint(0, n_particles_a, n_mapped_atoms, dtype=np.int32),
+                np.random.randint(0, n_particles_b, n_mapped_atoms, dtype=np.int32) + n_particles_a
+            ], axis=1)
 
-                atom_idxs_a = np.arange(n_particles_a)
-                atom_idxs_b = np.arange(n_particles_b)
+            atom_map = atom_map.astype(np.int32)
 
-                atom_map = np.stack([
-                    np.random.randint(0, n_particles_a, n_mapped_atoms, dtype=np.int32),
-                    np.random.randint(0, n_particles_b, n_mapped_atoms, dtype=np.int32) + n_particles_a
-                ], axis=1)
+            params = np.array([], dtype=np.float64)
+            k = 1.35
+            lamb = 0.0
 
-                atom_map = atom_map.astype(np.int32)
+            for precision, rtol, atol in [(np.float64, 1e-6, 1e-6), (np.float32, 1e-4, 1e-6)]:
 
-                params = np.array([], dtype=np.float64)
-                k = 1.35
-                lamb = 0.0
+                ref_u = functools.partial(bonded.rmsd_restraint,
+                    group_a_idxs=atom_map[:, 0],
+                    group_b_idxs=atom_map[:, 1],
+                    k=k
+                )
 
-                for precision, rtol, atol in [(np.float64, 1e-6, 1e-6), (np.float32, 1e-4, 1e-6)]:
+                test_u = potentials.RMSDRestraint(atom_map, n, k)
 
-                    ref_u = functools.partial(bonded.rmsd_restraint,
-                        group_a_idxs=atom_map[:, 0],
-                        group_b_idxs=atom_map[:, 1],
-                        k=k
-                    )
-
-                    test_u = potentials.RMSDRestraint(atom_map, n, k)
-
-                    # note the slightly higher than usual atol (1e-6 vs 1e-8)
-                    # this is due to fixed point accumulation of energy wipes out
-                    # the low magnitude energies as some of test cases have
-                    # an infinitesmally small absolute error (on the order of 1e-12)
-                    self.compare_forces(
-                        coords,
-                        params,
-                        box,
-                        lamb,
-                        ref_u,
-                        test_u,
-                        rtol,
-                        atol=atol,
-                        precision=precision
-                    )
+                # note the slightly higher than usual atol (1e-6 vs 1e-8)
+                # this is due to fixed point accumulation of energy wipes out
+                # the low magnitude energies as some of test cases have
+                # an infinitesimally small absolute error (on the order of 1e-12)
+                self.compare_forces(
+                    coords,
+                    params,
+                    box,
+                    lamb,
+                    ref_u,
+                    test_u,
+                    rtol,
+                    atol=atol,
+                    precision=precision
+                )
 
 
 

--- a/timemachine/cpp/src/rmsd_restraint.cu
+++ b/timemachine/cpp/src/rmsd_restraint.cu
@@ -135,10 +135,10 @@ void RMSDRestraint<RealType>::execute_device(
     x1 = x1.rowwise() - h_a_centroid_mean.transpose();
     x2 = x2.rowwise() - h_b_centroid_mean.transpose();
 
-    Eigen::Matrix<RealType, 3, 3> c = x2.transpose() * x1;
+    Eigen::Matrix<double, 3, 3> c = x2.transpose().template cast<double>() * x1.template cast<double>();
 
     // Keep SVD in double to avoid inconsistent behavior in float32
-    Eigen::JacobiSVD<Eigen::Matrix<double, 3, 3>> svd(c.template cast<double>(), Eigen::ComputeFullU | Eigen::ComputeFullV);
+    Eigen::JacobiSVD<Eigen::Matrix<double, 3, 3>> svd(c, Eigen::ComputeFullU | Eigen::ComputeFullV);
     auto s = svd.singularValues();
 
     RealType epsilon = 1e-8;
@@ -147,13 +147,13 @@ void RMSDRestraint<RealType>::execute_device(
         return;
     }
 
-    Eigen::Matrix<RealType, 3, 3> u = svd.matrixU().template cast<RealType>();
-    Eigen::Matrix<RealType, 3, 3> v = svd.matrixV().template cast<RealType>();
-    Eigen::Matrix<RealType, 3, 3> v_t = v.transpose();
+    Eigen::Matrix<double, 3, 3> u = svd.matrixU();
+    Eigen::Matrix<double, 3, 3> v = svd.matrixV();
+    Eigen::Matrix<double, 3, 3> v_t = v.transpose();
 
     bool is_reflection = u.determinant() * v_t.determinant() < 0.0;
 
-    Eigen::Matrix<RealType, 3, 3> rotation = u * v_t;
+    Eigen::Matrix<double, 3, 3> rotation = u * v_t;
 
     RealType term = 0;
     if(is_reflection) {
@@ -163,17 +163,17 @@ void RMSDRestraint<RealType>::execute_device(
     }
 
     // backprop'd forces
-    Eigen::Matrix<RealType, 3, 3> eye = Eigen::Matrix<RealType, 3, 3>::Identity(3, 3);
+    Eigen::Matrix<double, 3, 3> eye = Eigen::Matrix<double, 3, 3>::Identity(3, 3);
 
     RealType squared_term_adjoint = 1.0;
     RealType term_adjoint = squared_term_adjoint*2*term;
-    Eigen::Matrix<RealType, 3, 3> r_a = eye*term_adjoint/2;
-    Eigen::Matrix<RealType, 3, 3> u_a = r_a * v;
-    Eigen::Matrix<RealType, 3, 3> v_a_t = u.transpose() * r_a;
+    Eigen::Matrix<double, 3, 3> r_a = eye*term_adjoint/2;
+    Eigen::Matrix<double, 3, 3> u_a = r_a * v;
+    Eigen::Matrix<double, 3, 3> v_a_t = u.transpose() * r_a;
 
-    Eigen::Matrix<RealType, 3, 3> smat(3,3);
-    Eigen::Matrix<RealType, 3, 3> smat_inv(3,3);
-    Eigen::Matrix<RealType, 3, 3> F(3,3);
+    Eigen::Matrix<double, 3, 3> smat(3,3);
+    Eigen::Matrix<double, 3, 3> smat_inv(3,3);
+    Eigen::Matrix<double, 3, 3> F(3,3);
     for(int i=0; i < 3; i++) {
         for(int j=0; j < 3; j++) {
             if(i == j) {
@@ -192,17 +192,17 @@ void RMSDRestraint<RealType>::execute_device(
     // (ytz): taken from here https://j-towns.github.io/papers/svd-derivative.pdf
     // using equations 30-31. note that adjoints of the singular values are always zero,
     // so the middle term is skipped.
-    Eigen::Matrix<RealType, 3, 3> v_a = v_a_t.transpose();
-    Eigen::Matrix<RealType, 3, 3> lhs_1 = u*F.cwiseProduct(u.transpose()*u_a - u_a.transpose()*u)*smat;
-    Eigen::Matrix<RealType, 3, 3> lhs_2 = (eye - u*u.transpose())*u_a*smat_inv;
-    Eigen::Matrix<RealType, 3, 3> lhs = (lhs_1+lhs_2)*v_t;
-    Eigen::Matrix<RealType, 3, 3> rhs_1 = smat*(F.cwiseProduct(v_t*v_a - v_a_t*v))*v_t;
-    Eigen::Matrix<RealType, 3, 3> rhs_2 = smat_inv*v_a_t*(eye - v*v_t);
-    Eigen::Matrix<RealType, 3, 3> rhs = u*(rhs_1 + rhs_2);
-    Eigen::Matrix<RealType, 3, 3> c_adjoint = lhs + rhs;
+    Eigen::Matrix<double, 3, 3> v_a = v_a_t.transpose();
+    Eigen::Matrix<double, 3, 3> lhs_1 = u*F.cwiseProduct(u.transpose()*u_a - u_a.transpose()*u)*smat;
+    Eigen::Matrix<double, 3, 3> lhs_2 = (eye - u*u.transpose())*u_a*smat_inv;
+    Eigen::Matrix<double, 3, 3> lhs = (lhs_1+lhs_2)*v_t;
+    Eigen::Matrix<double, 3, 3> rhs_1 = smat*(F.cwiseProduct(v_t*v_a - v_a_t*v))*v_t;
+    Eigen::Matrix<double, 3, 3> rhs_2 = smat_inv*v_a_t*(eye - v*v_t);
+    Eigen::Matrix<double, 3, 3> rhs = u*(rhs_1 + rhs_2);
+    Eigen::Matrix<double, 3, 3> c_adjoint = lhs + rhs;
     // Eigen::RowMajor required to be able to copy out of device
-    Eigen::Matrix<RealType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> x2_adjoint = (c_adjoint*x1.transpose()).transpose();
-    Eigen::Matrix<RealType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> x1_adjoint = x2*c_adjoint;
+    Eigen::Matrix<RealType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> x2_adjoint = (c_adjoint.cast<RealType>()*x1.transpose()).transpose();
+    Eigen::Matrix<RealType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> x1_adjoint = x2*c_adjoint.cast<RealType>();
 
     // Reusing d_centroid_a_ and d_centroid_b_ for x1 and x2 adjoints
     gpuErrchk(cudaMemcpy(d_centroid_a_, x1_adjoint.data(), B*3*sizeof(RealType), cudaMemcpyHostToDevice));

--- a/timemachine/cpp/src/rmsd_restraint.cu
+++ b/timemachine/cpp/src/rmsd_restraint.cu
@@ -6,7 +6,7 @@
 #include <Eigen/Dense>
 
 #include "fixed_point.hpp"
-// #include "k_fixed_point.hpp"
+#include "kernels/k_fixed_point.cuh"
 
 #include <chrono>
 // using namespace std::chrono;
@@ -22,42 +22,70 @@ RMSDRestraint<RealType>::RMSDRestraint(
         throw std::runtime_error("Bad atom map size!");
     }
 
-    gpuErrchk(cudaMalloc(&d_u_buf_, sizeof(d_u_buf_)));
-    gpuErrchk(cudaMalloc(&d_du_dx_buf_, N*3*sizeof(d_du_dx_buf_)));
+    const int B = h_atom_map_.size() / 2;
 
+    gpuErrchk(cudaMalloc(&d_centroid_a_, B*3*sizeof(RealType)));
+    gpuErrchk(cudaMalloc(&d_centroid_b_, B*3*sizeof(RealType)));
+    gpuErrchk(cudaMalloc(&d_atom_map_, h_atom_map_.size()*sizeof(*d_atom_map_)));
+    gpuErrchk(cudaMemcpy(d_atom_map_, &h_atom_map_[0], h_atom_map_.size()*sizeof(int), cudaMemcpyHostToDevice));
 }
 
 
 template<typename RealType>
 RMSDRestraint<RealType>::~ RMSDRestraint() {
-    gpuErrchk(cudaFree(d_u_buf_));
-    gpuErrchk(cudaFree(d_du_dx_buf_));
+    gpuErrchk(cudaFree(d_atom_map_));
+    gpuErrchk(cudaFree(d_centroid_a_));
+    gpuErrchk(cudaFree(d_centroid_b_));
 }
 
+template<typename RealType>
+void __global__ k_centroid_sums(
+    const int * d_atom_map,
+    const int B,
+    const double * __restrict__ d_x,
+    RealType * d_centroid_a,
+    RealType * d_centroid_b
+    ) {
+    const int row_idx = blockIdx.x*blockDim.x + threadIdx.x;
+    const int col_idx = blockIdx.y * blockDim.y + threadIdx.y;
+    if (row_idx >= B || col_idx >= 3) {
+        return;
+    }
+    const int src_idx = d_atom_map[row_idx*2+0];
+    atomicAdd(d_centroid_a + row_idx*3 + col_idx, d_x[src_idx*3+col_idx]);
+
+    const int dst_idx = d_atom_map[row_idx*2+1];
+    atomicAdd(d_centroid_b + row_idx*3 + col_idx, d_x[dst_idx*3+col_idx]);
+}
+
+template<typename RealType>
 void __global__ k_finalize(
-    const int N,
-    const unsigned long long *d_du_dx_buf,
-    const unsigned long long *d_u_buf,
+    const int * d_atom_map,
+    const RealType *d_x1,
+    const RealType *d_x2,
+    const int B,
+    const double k,
+    const RealType squared_term,
     unsigned long long *d_du_dx_out,
     unsigned long long *d_u_out) {
 
-    const int atom_idx = blockIdx.x*blockDim.x + threadIdx.x;
-
-    if(d_u_out && atom_idx == 0) {
-        atomicAdd(d_u_out, *d_u_buf);
-    }
-
-
-    if(atom_idx >= N) {
+    const int row_idx = blockIdx.x*blockDim.x + threadIdx.x;
+    const int col_idx = blockIdx.y * blockDim.y + threadIdx.y;
+    if (row_idx >= B || col_idx >= 3) {
         return;
     }
 
-    if(d_du_dx_out) {
-        for(int d=0; d < 3; d++) {
-            atomicAdd(d_du_dx_out + atom_idx*3 + d, d_du_dx_buf[atom_idx*3 + d]);
-        }
+    if(d_u_out && row_idx == 0 && col_idx == 0) {
+        atomicAdd(d_u_out, FLOAT_TO_FIXED<RealType>(k*squared_term));
     }
 
+    if(d_du_dx_out) {
+        int src_idx = d_atom_map[row_idx*2+0];
+        atomicAdd(d_du_dx_out + src_idx*3+col_idx, FLOAT_TO_FIXED<RealType>(k*d_x1[row_idx*3 + col_idx]));
+
+        int dst_idx = d_atom_map[row_idx*2+1];
+        atomicAdd(d_du_dx_out + dst_idx*3+col_idx, FLOAT_TO_FIXED<RealType>(k*d_x2[row_idx*3 + col_idx]));
+    }
 }
 
 template<typename RealType>
@@ -74,87 +102,82 @@ void RMSDRestraint<RealType>::execute_device(
     unsigned long long *d_u,  // buffered
     cudaStream_t stream) {
 
-
     if(N != N_) {
         throw std::runtime_error("N_! = N");
     }
-
-    std::vector<double> h_x(N*3);
-
-    gpuErrchk(cudaMemcpy(&h_x[0], d_x, h_x.size()*sizeof(*d_x), cudaMemcpyDeviceToHost));
-
+    const int tpb = 32;
     const int B = h_atom_map_.size() / 2;
 
-    Eigen::MatrixXd x1(B,3);
-    Eigen::MatrixXd x2(B,3);
+    dim3 grid_blocks(B, 3);
 
-    // compute centroids etc. on the GPU directly
+    gpuErrchk(cudaMemset(d_centroid_a_, 0.0, B*3*sizeof(RealType)));
+    gpuErrchk(cudaMemset(d_centroid_b_, 0.0, B*3*sizeof(RealType)));
 
-    for(int b=0; b < B; b++) {
+    k_centroid_sums<RealType><<<grid_blocks, tpb, 0, stream>>>(
+        d_atom_map_,
+        B,
+        d_x,
+        d_centroid_a_,
+        d_centroid_b_
+    );
+    gpuErrchk(cudaPeekAtLastError());
 
-        int src_idx = h_atom_map_[b*2+0];
-        x1(b, 0) = h_x[src_idx*3+0];
-        x1(b, 1) = h_x[src_idx*3+1];
-        x1(b, 2) = h_x[src_idx*3+2];
+    // Need to use RowMajor storage to allow copying
+    Eigen::Matrix<RealType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> x1(B, 3);
+    Eigen::Matrix<RealType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> x2(B, 3);
 
-        int dst_idx = h_atom_map_[b*2+1];
-        x2(b, 0) = h_x[dst_idx*3+0];
-        x2(b, 1) = h_x[dst_idx*3+1];
-        x2(b, 2) = h_x[dst_idx*3+2];
-    }
+    gpuErrchk(cudaMemcpy(x1.data(), d_centroid_a_, B*3*sizeof(RealType), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(x2.data(), d_centroid_b_, B*3*sizeof(RealType), cudaMemcpyDeviceToHost));
 
+    Eigen::Matrix<RealType, 3, 1> h_a_centroid_mean = x1.colwise().mean();
+    Eigen::Matrix<RealType, 3, 1> h_b_centroid_mean = x2.colwise().mean();
 
-    Eigen::Vector3d h_a_centroid = x1.colwise().mean();
-    Eigen::Vector3d h_b_centroid = x2.colwise().mean();
+    x1 = x1.rowwise() - h_a_centroid_mean.transpose();
+    x2 = x2.rowwise() - h_b_centroid_mean.transpose();
 
-    x1 = x1.rowwise() - h_a_centroid.transpose();
-    x2 = x2.rowwise() - h_b_centroid.transpose();
+    // Keep Matrices in doubles to avoid bad behavior in float32
+    Eigen::Matrix<double, 3, 3> c = (x2.transpose().template cast<double> () * x1.template cast<double> ());
 
-    Eigen::MatrixXd c = x2.transpose() * x1;
-
-    Eigen::JacobiSVD<Eigen::MatrixXd> svd(c, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    Eigen::JacobiSVD<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> svd(c, Eigen::ComputeFullU | Eigen::ComputeFullV);
     auto s = svd.singularValues();
 
-    double epsilon = 1e-8;
-
-    gpuErrchk(cudaMemset(d_u_buf_, 0, sizeof(*d_u_buf_)));
-    gpuErrchk(cudaMemset(d_du_dx_buf_, 0, N*3*sizeof(*d_du_dx_buf_)));
+    RealType epsilon = 1e-8;
 
     if(s[0] < epsilon || s[1] < epsilon || s[2] < epsilon) {
         return;
     }
 
-    Eigen::MatrixXd u = svd.matrixU();
-    Eigen::MatrixXd v = svd.matrixV();
-    Eigen::MatrixXd v_t = v.transpose();
+    // Don't think we need these, because they are overridden with a copy at the end
+    //gpuErrchk(cudaMemset(d_u_buf_, 0, sizeof(*d_u_buf_)));
+    //gpuErrchk(cudaMemset(d_du_dx_buf_, 0, N*3*sizeof(*d_du_dx_buf_)));
+
+    Eigen::Matrix<double, 3, 3> u = svd.matrixU();
+    Eigen::Matrix<double, 3, 3> v = svd.matrixV();
+    Eigen::Matrix<double, 3, 3> v_t = v.transpose();
 
     bool is_reflection = u.determinant() * v_t.determinant() < 0.0;
 
-    Eigen::MatrixXd rotation = u * v_t;
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> rotation = u * v_t;
 
-    double term = 0;
+    RealType term = 0;
     if(is_reflection) {
         term = (rotation.trace() + 1)/2 - 1;
     } else {
         term = (rotation.trace() - 1)/2 - 1;
     }
 
-    double squared_term = term*term;
-
-    unsigned long long nrg = static_cast<unsigned long long>(llrint(k_*squared_term*FIXED_EXPONENT));
-
     // backprop'd forces
-    Eigen::MatrixXd eye = Eigen::MatrixXd::Identity(3, 3);
+    Eigen::Matrix<double, 3, 3> eye = Eigen::Matrix<double, 3, 3>::Identity(3, 3);
 
-    double squared_term_adjoint = 1.0;
-    double term_adjoint = squared_term_adjoint*2*term;
-    Eigen::MatrixXd r_a = eye*term_adjoint/2;
-    Eigen::MatrixXd u_a = r_a * v_t.transpose();
-    Eigen::MatrixXd v_a_t = u.transpose() * r_a;
+    RealType squared_term_adjoint = 1.0;
+    RealType term_adjoint = squared_term_adjoint*2*term;
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> r_a = eye*term_adjoint/2;
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> u_a = r_a * v_t.transpose();
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> v_a_t = u.transpose() * r_a;
 
-    Eigen::MatrixXd smat(3,3);
-    Eigen::MatrixXd smat_inv(3,3);
-    Eigen::MatrixXd F(3,3);
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> smat(3,3);
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> smat_inv(3,3);
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> F(3,3);
     for(int i=0; i < 3; i++) {
         for(int j=0; j < 3; j++) {
             if(i == j) {
@@ -173,47 +196,36 @@ void RMSDRestraint<RealType>::execute_device(
     // (ytz): taken from here https://j-towns.github.io/papers/svd-derivative.pdf
     // using equations 30-31. note that adjoints of the singular values are always zero,
     // so the middle term is skipped.
-    Eigen::MatrixXd v_a = v_a_t.transpose();
-    Eigen::MatrixXd lhs_1 = u*F.cwiseProduct(u.transpose()*u_a - u_a.transpose()*u)*smat;
-    Eigen::MatrixXd lhs_2 = (eye - u*u.transpose())*u_a*smat_inv;
-    Eigen::MatrixXd lhs = (lhs_1+lhs_2)*v.transpose();
-    Eigen::MatrixXd rhs_1 = smat*(F.cwiseProduct(v.transpose()*v_a - v_a.transpose()*v))*v.transpose();
-    Eigen::MatrixXd rhs_2 = smat_inv*v_a.transpose()*(eye - v*v.transpose());
-    Eigen::MatrixXd rhs = u*(rhs_1 + rhs_2);
-    Eigen::MatrixXd c_adjoint = lhs + rhs;
-    Eigen::MatrixXd x2_adjoint = (c_adjoint*x1.transpose()).transpose();
-    Eigen::MatrixXd x1_adjoint = x2*c_adjoint;
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> v_a = v_a_t.transpose();
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> lhs_1 = u*F.cwiseProduct(u.transpose()*u_a - u_a.transpose()*u)*smat;
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> lhs_2 = (eye - u*u.transpose())*u_a*smat_inv;
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> lhs = (lhs_1+lhs_2)*v.transpose();
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> rhs_1 = smat*(F.cwiseProduct(v.transpose()*v_a - v_a.transpose()*v))*v.transpose();
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> rhs_2 = smat_inv*v_a.transpose()*(eye - v*v.transpose());
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> rhs = u*(rhs_1 + rhs_2);
+    Eigen::Matrix<RealType, Eigen::Dynamic, Eigen::Dynamic> c_adjoint = (lhs + rhs).cast<RealType>();
+    // Eigen::RowMajor required to be able to copy out of device
+    Eigen::Matrix<RealType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> x2_adjoint = (c_adjoint*x1.transpose()).transpose();
+    Eigen::Matrix<RealType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> x1_adjoint = x2*c_adjoint;
 
-    std::vector<unsigned long long> du_dx(N*3, 0);
+    // Reusing d_centroid_a_ and d_centroid_b_ for x1 and x2 adjoints
+    gpuErrchk(cudaMemcpy(d_centroid_a_, x1_adjoint.data(), B*3*sizeof(RealType), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_centroid_b_, x2_adjoint.data(), B*3*sizeof(RealType), cudaMemcpyHostToDevice));
 
-    for(int b=0; b < B; b++) {
-        int src_idx = h_atom_map_[b*2+0];
-        du_dx[src_idx*3+0] += static_cast<unsigned long long>(llrint(k_*x1_adjoint(b, 0)*FIXED_EXPONENT));
-        du_dx[src_idx*3+1] += static_cast<unsigned long long>(llrint(k_*x1_adjoint(b, 1)*FIXED_EXPONENT));
-        du_dx[src_idx*3+2] += static_cast<unsigned long long>(llrint(k_*x1_adjoint(b, 2)*FIXED_EXPONENT));
+    RealType squared_term = term*term;
 
-        int dst_idx = h_atom_map_[b*2+1];
-        du_dx[dst_idx*3+0] += static_cast<unsigned long long>(llrint(k_*x2_adjoint(b, 0)*FIXED_EXPONENT));
-        du_dx[dst_idx*3+1] += static_cast<unsigned long long>(llrint(k_*x2_adjoint(b, 1)*FIXED_EXPONENT));
-        du_dx[dst_idx*3+2] += static_cast<unsigned long long>(llrint(k_*x2_adjoint(b, 2)*FIXED_EXPONENT));
-    }
-
-    gpuErrchk(cudaMemcpy(d_u_buf_, &nrg, sizeof(*d_u_buf_), cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(d_du_dx_buf_, &du_dx[0], N*3*sizeof(*d_du_dx_buf_), cudaMemcpyHostToDevice));
-
-    const int blocks= (N_+32-1)/32;
-    const int tpb = 32;
-
-    k_finalize<<<blocks, tpb, 0, stream>>>(
-        N,
-        d_du_dx_buf_,
-        d_u_buf_,
+    k_finalize<<<grid_blocks, tpb, 0, stream>>>(
+        d_atom_map_,
+        d_centroid_a_,
+        d_centroid_b_,
+        B,
+        k_,
+        squared_term,
         d_du_dx,
         d_u
     );
 
     gpuErrchk(cudaPeekAtLastError());
-
 };
 
 

--- a/timemachine/cpp/src/rmsd_restraint.hpp
+++ b/timemachine/cpp/src/rmsd_restraint.hpp
@@ -13,8 +13,10 @@ private:
     const std::vector<int> h_atom_map_;
     const int N_;
     const double k_;
-    unsigned long long *d_u_buf_;
-    unsigned long long *d_du_dx_buf_;
+    int * d_atom_map_;
+    // Centroids are also used as adjoints
+    RealType * d_centroid_a_;
+    RealType * d_centroid_b_;
 
 public:
 


### PR DESCRIPTION
Previously the implementation would slow down as the total number of particles increased due to copying d_x to host. The GPU implementation is approximately 60 microseconds with a system containing 32 atoms with 5 mapped atoms. Increasing the system to 20k atoms, it is the same. The original implementation would take about 40 microseconds for the 32 atom system, and at 20k atoms it would take a bit over 400 microseconds.

