### PR TITLE
Feature/compute du dp variance

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Most of the training is using the correctable charge corrections [ccc forcefield
 2. The eps parameter in LJ have been replaced by an alpha such that alpha^2=eps in order to avoid negative eps values during training.
 3. We use a consistent 0.5 scaling for the 1-4 terms across LJ and electrostatics.
 4. The reaction field used is the real part of PME with a beta (alpha) coefficient of 2.0 
-5. The recharge BCC port is not yet complete, as there are some missing types that will cause very large errors (eg. P=S moeities).
+5. The recharge BCC port is not yet complete, as there are some missing types that will cause very large errors (eg. P=S moieties).
 
 # License
 

--- a/ff/handlers/nonbonded.py
+++ b/ff/handlers/nonbonded.py
@@ -135,7 +135,7 @@ class NonbondedHandler(SerializableMixIn):
     def static_parameterize(params, smirks, mol):
         """
         Carry out parameterization of given molecule, with an option to attach additional parameters
-        via concateation. Typically aux_params are protein charges etc.
+        via concatenation. Typically aux_params are protein charges etc.
 
         Parameters
         ----------

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -127,6 +127,9 @@ def benchmark(
             dp = du_dp_obs.avg_du_dp()
             print(potential, dp.shape)
             print(dp)
+            dp_std = du_dp_obs.std_du_dp()
+            print(potential, dp.shape)
+            print(dp)
 
 def benchmark_dhfr(verbose=False, num_batches=100, steps_per_batch=1000):
 

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -139,7 +139,20 @@ class TestContext(unittest.TestCase):
         for o in obs:
             ctxt.add_observable(o)
 
+        test_avg_du_dp = test_obs.avg_du_dp()
+        ref_init_du_dps = np.zeros_like(test_avg_du_dp)
+        np.testing.assert_array_equal(test_avg_du_dp[:, 0], ref_init_du_dps[:, 0])
+        np.testing.assert_array_equal(test_avg_du_dp[:, 1], ref_init_du_dps[:, 1])
+        np.testing.assert_array_equal(test_avg_du_dp[:, 2], ref_init_du_dps[:, 2])
+
         for step in range(num_steps):
+            if step < 2:
+                # Until we have run 3 steps, std is 0
+                test_std_du_dp = test_obs.std_du_dp()
+
+                np.testing.assert_array_equal(test_std_du_dp[:, 0], ref_init_du_dps[:, 0])
+                np.testing.assert_array_equal(test_std_du_dp[:, 1], ref_init_du_dps[:, 1])
+                np.testing.assert_array_equal(test_std_du_dp[:, 2], ref_init_du_dps[:, 2])
             print("comparing step", step)
             test_x_t = ctxt.get_x_t()
             np.testing.assert_allclose(test_x_t, ref_all_xs[step])
@@ -155,6 +168,7 @@ class TestContext(unittest.TestCase):
         ref_avg_du_dls_f2 = np.mean(ref_all_du_dls[::2], axis=0)
 
         ref_avg_du_dps = np.mean(ref_all_du_dps, axis=0)
+        ref_std_du_dps = np.std(ref_all_du_dps, axis=0)
         ref_avg_du_dps_f2 = np.mean(ref_all_du_dps[::2], axis=0)
 
         # the fixed point accumulator makes it hard to converge some of these
@@ -163,6 +177,10 @@ class TestContext(unittest.TestCase):
         np.testing.assert_allclose(test_obs.avg_du_dp()[:, 0], ref_avg_du_dps[:, 0], 1.5e-6)
         np.testing.assert_allclose(test_obs.avg_du_dp()[:, 1], ref_avg_du_dps[:, 1], 1.5e-6)
         np.testing.assert_allclose(test_obs.avg_du_dp()[:, 2], ref_avg_du_dps[:, 2], 5e-5)
+
+        np.testing.assert_allclose(test_obs.std_du_dp()[:, 0], ref_std_du_dps[:, 0], 1.5e-6)
+        np.testing.assert_allclose(test_obs.std_du_dp()[:, 1], ref_std_du_dps[:, 1], 1.5e-6)
+        np.testing.assert_allclose(test_obs.std_du_dp()[:, 2], ref_std_du_dps[:, 2], 5e-5)
 
         # test the multiple_steps method
         intg_2 = custom_ops.LangevinIntegrator(

--- a/timemachine/cpp/src/observable.cu
+++ b/timemachine/cpp/src/observable.cu
@@ -5,15 +5,47 @@
 
 namespace timemachine {
 
+void __global__ k_compute_variance(
+    const int N,
+    const int k,
+    const double * __restrict__ d_du_dp,
+    double *d_m,
+    double *d_s
+    ) {
+
+    const int idx = blockIdx.x*blockDim.x + threadIdx.x;
+
+    if(idx >= N) {
+        return;
+    }
+
+    if(d_du_dp) {
+        // Taken from https://www.johndcook.com/blog/standard_deviation/
+        double x = d_du_dp[idx];
+        if (k == 1) {
+            d_m[idx] = x;
+            d_s[idx] = 0;
+        } else {
+            const double m_old = d_m[idx];
+            const double m_new = m_old + (x - m_old) / k;
+            d_m[idx] = m_new;
+            d_s[idx] += (x - m_old) * (x - m_new);
+        }
+    }
+}
+
 AvgPartialUPartialParam::AvgPartialUPartialParam(
     BoundPotential *bp, int interval) : bp_(bp), count_(0), interval_(interval) {
     int P = bp_->size();
-    gpuErrchk(cudaMalloc(&d_sum_du_dp_, P*sizeof(*d_sum_du_dp_)));
-    gpuErrchk(cudaMemset(d_sum_du_dp_, 0, P*sizeof(*d_sum_du_dp_)));
+    gpuErrchk(cudaMalloc(&d_du_dp_, P*sizeof(*d_du_dp_)));
+    gpuErrchk(cudaMalloc(&d_m_, P*sizeof(*d_m_)));
+    gpuErrchk(cudaMalloc(&d_s_, P*sizeof(*d_s_)));
 }
 
 AvgPartialUPartialParam::~AvgPartialUPartialParam() {
-    gpuErrchk(cudaFree(d_sum_du_dp_));
+    gpuErrchk(cudaFree(d_du_dp_));
+    gpuErrchk(cudaFree(d_m_));
+    gpuErrchk(cudaFree(d_s_));
 }
 
 void AvgPartialUPartialParam::observe(
@@ -24,27 +56,61 @@ void AvgPartialUPartialParam::observe(
     double lambda) {
 
     if(step % interval_ == 0) {
+        cudaStream_t stream = static_cast<cudaStream_t>(0);
+        const int size = bp_->size();
+        // Need the latest du_dp, so reset to zero each round
+        gpuErrchk(cudaMemsetAsync(d_du_dp_, 0, size*sizeof(*d_du_dp_), stream));
         bp_->execute_device(
             N,
             d_x_t,
             d_box_t,
             lambda,
             nullptr,
-            d_sum_du_dp_,
+            d_du_dp_,
             nullptr,
             nullptr,
-            static_cast<cudaStream_t>(0) // TBD: parallelize me!
+            stream // TBD: parallelize me!
         );
-        count_ += 1;
+        count_++;
+        const int tpb = 32;
+        const int blocks = (size+tpb-1)/tpb;
+        k_compute_variance<<<blocks, tpb, 0, stream>>>(
+            size,
+            count_,
+            d_du_dp_,
+            d_m_,
+            d_s_
+        );
+
+        gpuErrchk(cudaPeekAtLastError());
     }
 
+}
+
+void AvgPartialUPartialParam::std_du_dp(double *h_buf) const {
+    // Copying is only necessary if there is a variance to return
+    if (count_ > 1) {
+        gpuErrchk(cudaMemcpy(h_buf, d_s_, this->bp_->size()*sizeof(*h_buf), cudaMemcpyDeviceToHost));
+    }
+    for(int i=0; i < this->bp_->size(); i++) {
+        if (count_ <= 1) {
+            h_buf[i] = 0.0;
+        } else {
+            // Population variance to copy default np.std behavior
+            h_buf[i] = std::sqrt(h_buf[i] / count_);
+        }
+    }
 }
 
 void AvgPartialUPartialParam::avg_du_dp(double *h_buf) const {
-    gpuErrchk(cudaMemcpy(h_buf, d_sum_du_dp_, this->bp_->size()*sizeof(*h_buf), cudaMemcpyDeviceToHost));
+    if (count_ > 0) {
+        gpuErrchk(cudaMemcpy(h_buf, d_m_, this->bp_->size()*sizeof(*h_buf), cudaMemcpyDeviceToHost));
+        return;
+    }
     for(int i=0; i < this->bp_->size(); i++) {
-        h_buf[i] /= count_;
+        h_buf[i] = 0.0;
     }
 }
+
 
 }

--- a/timemachine/cpp/src/observable.hpp
+++ b/timemachine/cpp/src/observable.hpp
@@ -25,7 +25,9 @@ class AvgPartialUPartialParam : public Observable {
 
 private:
 
-    double *d_sum_du_dp_;
+    double *d_du_dp_;
+    double *d_s_; // Same size as bp_.size()
+    double *d_m_; // Same size as bp_.size()
     BoundPotential *bp_;
     int count_;
     int interval_;
@@ -52,6 +54,8 @@ public:
     }
     // copy into buffer and return shape of params object.
     void avg_du_dp(double *buffer) const;
+
+    void std_du_dp(double *buffer) const;
 
 };
 

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -230,9 +230,16 @@ void declare_avg_partial_u_partial_param(py::module &m) {
         obj.avg_du_dp(buffer.mutable_data());
 
         return buffer;
+    })
+    .def("std_du_dp", [](timemachine::AvgPartialUPartialParam &obj) -> py::array_t<double, py::array::c_style> {
+        std::vector<int> shape = obj.shape();
+        py::array_t<double, py::array::c_style> buffer(shape);
+
+        obj.std_du_dp(buffer.mutable_data());
+
+        return buffer;
     });
 }
-
 void declare_integrator(py::module &m) {
 
     using Class = timemachine::Integrator;


### PR DESCRIPTION
This adds about 5 microseconds using the `tests/test_md.py::test_fwd_mode` test with `nvprof`. Most of the cost is presumably the kernel start up time. 

cuda-memcheck passes without issue

Truncated output from nvprof
```
Current Implementation
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:    0.57%  113.38us        30  3.7790us  3.6800us  4.0000us  [CUDA memcpy DtoD]
                    0.41%  82.879us        62  1.3360us  1.2800us  1.7920us  [CUDA memcpy DtoH]
                    0.39%  78.398us        15  5.2260us  5.1200us  6.5280us  k_compact_trim_atoms(int, int, unsigned int*, unsigned int*, int*, unsigned int*)
                    0.37%  74.464us        15  4.9640us  4.9280us  4.9920us  void timemachine::update_forward<double>(int, int, double, timemachine::update_forward<double> const *, timemachine::update_forward<double> const , timemachine::update_forward<double> const , timemachine::update_forward<double>*, timemachine::update_forward<double> const *, __int64 const *, timemachine::update_forward<double>)
                    0.33%  65.440us        15  4.3620us  4.3200us  4.4160us  void k_inv_permute_accum<__int64>(int, unsigned int const *, __int64 const *, __int64*)

Variance Computation Added
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:    0.56%  112.96us        30  3.7650us  3.6800us  3.8400us  [CUDA memcpy DtoD]
                    0.43%  87.294us        65  1.3420us  1.2800us  1.7920us  [CUDA memcpy DtoH]
                    0.38%  77.119us        15  5.1410us  5.0880us  5.1520us  k_compact_trim_atoms(int, int, unsigned int*, unsigned int*, int*, unsigned int*)
                    0.37%  74.656us        15  4.9770us  4.9280us  5.1520us  void timemachine::update_forward<double>(int, int, double, timemachine::update_forward<double> const *, timemachine::update_forward<double> const , timemachine::update_forward<double> const , timemachine::update_forward<double>*, timemachine::update_forward<double> const *, __int64 const *, timemachine::update_forward<double>)
                    0.32%  65.343us        15  4.3560us  4.3190us  4.4480us  void k_inv_permute_accum<__int64>(int, unsigned int const *, __int64 const *, __int64*)
                    0.19%  38.016us         8  4.7520us  3.9680us  5.0240us  timemachine::k_compute_variance(int, int, double const *, double*, double*)
```