### PR TITLE
Use optimized distance calculation

### DIFF
--- a/tests/test_nblist.py
+++ b/tests/test_nblist.py
@@ -26,13 +26,16 @@ def test_block_bounds():
             start_idx = bidx*block_size
             end_idx = min((bidx+1)*block_size, N)
             block_coords = coords[start_idx:end_idx]
-            block_coords -= box_diag*np.floor(block_coords//box_diag)
+            min_coords = block_coords[0]
+            max_coords = block_coords[0]
+            for new_coords in block_coords[1:]:
+                center = 0.5 * (max_coords + min_coords)
+                new_coords -= box_diag * np.floor((new_coords - center) / box_diag + 0.5)
+                min_coords = np.minimum(min_coords, new_coords)
+                max_coords = np.maximum(max_coords, new_coords)
 
-            c_max = np.amax(block_coords, axis=0)       
-            c_min = np.amin(block_coords, axis=0)
-
-            ref_ctrs.append((c_max + c_min)/2)
-            ref_exts.append((c_max - c_min)/2)
+            ref_ctrs.append((max_coords + min_coords)/2)
+            ref_exts.append((max_coords - min_coords)/2)
 
         ref_ctrs = np.array(ref_ctrs)
         ref_exts = np.array(ref_exts)

--- a/timemachine/cpp/src/kernels/k_neighborlist.cu
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cu
@@ -2,7 +2,6 @@
 
 #define TILESIZE 32
 
-
 void __global__ k_find_block_bounds(
     const int N, // Number of atoms
     const int D, // Box dimensions, typically 3
@@ -12,28 +11,62 @@ void __global__ k_find_block_bounds(
     double * __restrict__ block_bounds_ctr,
     double * __restrict__ block_bounds_ext) {
 
-    // each thread processes one tile
-    const int tile_idx = blockDim.x*blockIdx.x + threadIdx.x;
+    // Algorithm taken from https://github.com/openmm/openmm/blob/master/platforms/cuda/src/kernels/findInteractingBlocks.cu#L7
+    // Computes smaller bounding boxes than simpler form by accounting for periodic box conditions
 
-    if(tile_idx >= T) {
+    // each thread processes one tile
+    const int index = blockIdx.x*blockDim.x+threadIdx.x;
+    if(index >= T) {
         return;
     }
 
-    for(int d=0; d < D; d++) {
-        const double width = box[d*3+d];
-        double ci_min =  9999999;
-        double ci_max = -9999999;
-        for(int i=0; i < TILESIZE; i++) {
-            const int atom_idx = tile_idx*TILESIZE + i;
-            if(atom_idx < N) {
-                double ci = coords[atom_idx*D + d];
-                ci -= width*floor(ci/width); // move to home box
-                ci_min = ci < ci_min ? ci : ci_min;
-                ci_max = ci > ci_max ? ci : ci_max;
-            }
-        }
+    const double bx = box[0*3+0];
+    const double by = box[1*3+1];
+    const double bz = box[2*3+2];
 
-        block_bounds_ctr[tile_idx*D+d] = (ci_max + ci_min)/2.0;
-        block_bounds_ext[tile_idx*D+d] = (ci_max - ci_min)/2.0;
+    const double inv_bx = 1/bx;
+    const double inv_by = 1/by;
+    const double inv_bz = 1/bz;
+    const int base = index*TILESIZE;
+
+    double pos_x = coords[base*3+0];
+    double pos_y = coords[base*3+1];
+    double pos_z = coords[base*3+2];
+
+    double minPos_x = pos_x;
+    double minPos_y = pos_y;
+    double minPos_z = pos_z;
+
+    double maxPos_x = pos_x;
+    double maxPos_y = pos_y;
+    double maxPos_z = pos_z;
+    int last = min(base+TILESIZE, N);
+    for (int i = base+1; i < last; i++) {
+        pos_x = coords[i*3+0];
+        pos_y = coords[i*3+1];
+        pos_z = coords[i*3+2];
+        // Build up center over time, and recenter before computing
+        // min and max, to reduce overall size of box thanks to accounting
+        // for periodic boundary conditions
+        double center_x = 0.5f*(maxPos_x+minPos_x);
+        double center_y = 0.5f*(maxPos_y+minPos_y);
+        double center_z = 0.5f*(maxPos_z+minPos_z);
+        pos_x -= bx*nearbyint((pos_x-center_x)*inv_bx);
+        pos_y -= by*nearbyint((pos_y-center_y)*inv_by);
+        pos_z -= bz*nearbyint((pos_z-center_z)*inv_bz);
+        minPos_x = min(minPos_x,pos_x);
+        minPos_y = min(minPos_y,pos_y);
+        minPos_z = min(minPos_z,pos_z);
+
+        maxPos_x = max(maxPos_x,pos_x);
+        maxPos_y = max(maxPos_y,pos_y);
+        maxPos_z = max(maxPos_z,pos_z);
     }
+    block_bounds_ext[index*3+0] = 0.5f*(maxPos_x-minPos_x);
+    block_bounds_ext[index*3+1] = 0.5f*(maxPos_y-minPos_y);
+    block_bounds_ext[index*3+2] = 0.5f*(maxPos_z-minPos_z);
+
+    block_bounds_ctr[index*3+0] = 0.5f*(maxPos_x+minPos_x);
+    block_bounds_ctr[index*3+1] = 0.5f*(maxPos_y+minPos_y);
+    block_bounds_ctr[index*3+2] = 0.5f*(maxPos_z+minPos_z);
 }


### PR DESCRIPTION
* Expand distance calculation and store components outside of loops
  if all atoms in a tile fits within a single periodic box
* Aprox 4% speed up

NVProf Results
```
Current
-------
==99333== Profiling application: /home/ubuntu/.conda/envs/timemachine/bin/python /home/ubuntu/.conda/envs/timemachine/bin/pytest tests/test_nblist.py
==99333== Profiling result:
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   76.21%  7.5079ms        12  625.66us  15.456us  1.4234ms  void k_find_blocks_with_ixns<double>(int, double const *, double const *, double const *, double const *, unsigned int*, int*, unsigned int*, unsigned int*, double)
                   16.09%  1.5853ms        15  105.69us  103.49us  107.65us  k_find_block_bounds(int, int, int, double const *, double const *, double*, double*)
                    3.33%  327.87us        30  10.929us  1.0240us  64.224us  [CUDA memcpy HtoD]
                    3.26%  320.80us        42  7.6380us  1.2480us  80.000us  [CUDA memcpy DtoH]
                    0.66%  65.184us        12  5.4320us  5.0240us  5.9200us  k_compact_trim_atoms(int, int, unsigned int*, unsigned int*, int*, unsigned int*)
                    0.45%  44.256us        42  1.0530us     992ns  1.1840us  [CUDA memset]
      API calls:   94.58%  218.42ms        84  2.6003ms  2.1290us  217.88ms  cudaMalloc
                    3.92%  9.0479ms        15  603.19us  100.82us  1.5370ms  cudaDeviceSynchronize
                    0.86%  1.9969ms        72  27.734us  4.7720us  176.62us  cudaMemcpy
                    0.17%  383.34us        78  4.9140us  2.5760us  22.733us  cudaFree
                    0.16%  365.98us        39  9.3840us  4.5690us  22.721us  cudaLaunchKernel
                    0.15%  344.05us         1  344.05us  344.05us  344.05us  cuDeviceTotalMem
                    0.08%  173.81us       101  1.7200us     131ns  75.153us  cuDeviceGetAttribute
                    0.07%  151.92us        42  3.6170us  2.1140us  12.631us  cudaMemsetAsync
                    0.01%  31.659us         1  31.659us  31.659us  31.659us  cuDeviceGetName
                    0.00%  8.7200us        39     223ns     166ns     355ns  cudaPeekAtLastError
                    0.00%  5.6290us         1  5.6290us  5.6290us  5.6290us  cuDeviceGetPCIBusId
                    0.00%  1.7940us         3     598ns     217ns  1.3370us  cuDeviceGetCount
                    0.00%     714ns         2     357ns     153ns     561ns  cuDeviceGet
                    0.00%     300ns         1     300ns     300ns     300ns  cuDeviceGetUuid


Optimized Distance
------------------
==99998== Profiling application: /home/ubuntu/.conda/envs/timemachine/bin/python /home/ubuntu/.conda/envs/timemachine/bin/pytest tests/test_nblist.py
==99998== Profiling result:
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   75.33%  7.1946ms        12  599.55us  17.408us  1.1984ms  void k_find_blocks_with_ixns<double>(int, double const *, double const *, double const *, double const *, unsigned int*, int*, unsigned int*, unsigned int*, double)
                   16.60%  1.5858ms        15  105.72us  103.49us  107.65us  k_find_block_bounds(int, int, int, double const *, double const *, double*, double*)
                    3.47%  331.84us        42  7.9000us  1.2480us  79.968us  [CUDA memcpy DtoH]
                    3.43%  327.14us        30  10.904us  1.0560us  64.160us  [CUDA memcpy HtoD]
                    0.69%  65.984us        12  5.4980us  5.0240us  5.9520us  k_compact_trim_atoms(int, int, unsigned int*, unsigned int*, int*, unsigned int*)
                    0.47%  45.023us        42  1.0710us     992ns  1.4720us  [CUDA memset]
      API calls:   94.59%  214.47ms        84  2.5532ms  1.9940us  213.88ms  cudaMalloc
                    3.85%  8.7249ms        15  581.66us  104.98us  1.2982ms  cudaDeviceSynchronize
                    0.91%  2.0600ms        72  28.611us  5.2780us  182.89us  cudaMemcpy
                    0.17%  392.35us        39  10.060us  4.6810us  24.607us  cudaLaunchKernel
                    0.16%  368.65us        78  4.7260us  2.4190us  23.080us  cudaFree
                    0.15%  350.20us         1  350.20us  350.20us  350.20us  cuDeviceTotalMem
                    0.08%  182.73us       101  1.8090us     124ns  85.270us  cuDeviceGetAttribute
                    0.07%  147.67us        42  3.5160us  2.1220us  7.0140us  cudaMemsetAsync
                    0.01%  32.503us         1  32.503us  32.503us  32.503us  cuDeviceGetName
                    0.00%  9.3620us        39     240ns     161ns     456ns  cudaPeekAtLastError
                    0.00%  5.2530us         1  5.2530us  5.2530us  5.2530us  cuDeviceGetPCIBusId
                    0.00%  1.3990us         3     466ns     239ns     874ns  cuDeviceGetCount
                    0.00%     615ns         2     307ns     145ns     470ns  cuDeviceGet
                    0.00%     306ns         1     306ns     306ns     306ns  cuDeviceGetUuid
```
