### PR TITLE
Lambda improvements

### DIFF
--- a/tests/test_parameter_interpolation.py
+++ b/tests/test_parameter_interpolation.py
@@ -119,7 +119,7 @@ class TestInterpolatedPotential(GradientTest):
             return jnp.sin(lamb*np.pi/2)
 
         def transform_e(lamb):
-            return jnp.cos(lamb*np.pi/2)
+            return jnp.where(lamb < 0.5, jnp.sin(lamb*np.pi)*jnp.sin(lamb*np.pi), 1)
 
         def transform_w(lamb):
             return (1-lamb*lamb)
@@ -159,7 +159,7 @@ class TestInterpolatedPotential(GradientTest):
 
         for precision, rtol in [(np.float64, 1e-8), (np.float32, 1e-4)]:
 
-            for lamb in [0.0, 0.2, 1.0]:
+            for lamb in [0.0, 0.2, 0.6, 0.7, 0.8, 1.0]:
 
                     qlj = np.concatenate([qlj_src, qlj_dst])
 
@@ -168,7 +168,7 @@ class TestInterpolatedPotential(GradientTest):
                     args = copy.deepcopy(test_potential.args)
                     args.append("lambda*lambda") # transform q
                     args.append("sin(lambda*PI/2)") # transform sigma
-                    args.append("cos(lambda*PI/2)") # transform epsilon
+                    args.append("lambda < 0.5 ? sin(lambda*PI)*sin(lambda*PI) : 1") # transform epsilon
                     args.append("1-lambda*lambda") # transform w
 
                     test_interpolated_potential = potentials.NonbondedInterpolated(

--- a/timemachine/cpp/src/kernels/surreal.cuh
+++ b/timemachine/cpp/src/kernels/surreal.cuh
@@ -15,6 +15,7 @@ struct Surreal {
 
     DECL Surreal<RealType>() {}; // uninitialized for efficiency
     DECL Surreal<RealType>(const RealType& v, const RealType& d) : real(v), imag(d) {}
+    DECL Surreal<RealType>(const RealType& v) : real(v), imag(0) {}
 
     // copy constructor
     DECL Surreal<RealType>(const Surreal<RealType> &z) : real(z.real), imag(z.imag) {}

--- a/timemachine/cpp/src/nonbonded.cu
+++ b/timemachine/cpp/src/nonbonded.cu
@@ -20,9 +20,6 @@
 
 namespace timemachine {
 
-static jitify::JitCache kernel_cache;
-
-
 template <typename RealType, bool Interpolated>
 Nonbonded<RealType, Interpolated>::Nonbonded(
     const std::vector<int> &exclusion_idxs, // [E,2]
@@ -69,9 +66,9 @@ Nonbonded<RealType, Interpolated>::Nonbonded(
         &k_nonbonded_unified<RealType, 1, 1, 1, 0>,
         &k_nonbonded_unified<RealType, 1, 1, 1, 1>
     }),
-    compute_w_coords_instance_(kernel_cache.program(kernel_src.c_str()).kernel("k_compute_w_coords").instantiate()),
-    compute_permute_interpolated_(kernel_cache.program(kernel_src.c_str()).kernel("k_permute_interpolated").instantiate()),
-    compute_add_ull_to_real_interpolated_(kernel_cache.program(kernel_src.c_str()).kernel("k_add_ull_to_real_interpolated").instantiate()) {
+    compute_w_coords_instance_(kernel_cache_.program(kernel_src.c_str()).kernel("k_compute_w_coords").instantiate()),
+    compute_permute_interpolated_(kernel_cache_.program(kernel_src.c_str()).kernel("k_permute_interpolated").instantiate()),
+    compute_add_ull_to_real_interpolated_(kernel_cache_.program(kernel_src.c_str()).kernel("k_add_ull_to_real_interpolated").instantiate()) {
 
     if(lambda_offset_idxs.size() != N_) {
         throw std::runtime_error("lambda offset idxs need to have size N");

--- a/timemachine/cpp/src/nonbonded.hpp
+++ b/timemachine/cpp/src/nonbonded.hpp
@@ -82,6 +82,7 @@ private:
         cudaStream_t stream
     );
 
+    jitify::JitCache kernel_cache_;
     jitify::KernelInstantiation compute_w_coords_instance_;
     jitify::KernelInstantiation compute_permute_interpolated_;
     jitify::KernelInstantiation compute_add_ull_to_real_interpolated_;


### PR DESCRIPTION
This small PR does two things:

1) Enables one to use ternary operators by adding a default single arg constructor to the Surreal class
2) Modifies the kernel_cache_ to be bound to a nonbonded kernel, as opposed to having static scope. Previously, this would cause problems as importing the custom_op will occur *before* CUDA_VISIBLE_DEVICES is set, which will result in the driver using whatever the default is.