### PR TITLE
Shrink Nonbonded Interactions

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -163,7 +163,7 @@ def prepare_water_system(
 
     params = np.stack([
         (np.random.rand(N).astype(np.float64) - 0.5)*np.sqrt(138.935456), # q
-        np.random.rand(N).astype(np.float64)/5.0, # sig
+        np.random.rand(N).astype(np.float64)/6.0, # sig # fix me
         np.random.rand(N).astype(np.float64) # eps
     ], axis=1)
 
@@ -502,7 +502,8 @@ class GradientTest(unittest.TestCase):
         ref_du_dx, ref_du_dp, ref_du_dl = grad_fn(x, params, box, lamb)
 
         for combo in itertools.product([False, True], repeat=4):
-            (compute_du_dx, compute_du_dp, compute_du_dl, compute_u) = combo
+            # (compute_du_dx, compute_du_dp, compute_du_dl, compute_u) = combo
+            (compute_du_dx, compute_du_dp, compute_du_dl, compute_u) = (True, True, True, True)
 
             # do each computation twice to check determinism
             test_du_dx, test_du_dp, test_du_dl, test_u = test_impl.execute_selective(
@@ -517,12 +518,20 @@ class GradientTest(unittest.TestCase):
             )
             if compute_u:
                 np.testing.assert_allclose(ref_u, test_u, rtol=rtol, atol=atol)
+                # print("U PASSED")
             if compute_du_dx:
                 self.assert_equal_vectors(np.array(ref_du_dx), np.array(test_du_dx), rtol)
+                # print("DU_DX PASSED")
             if compute_du_dl:
+                # print(ref_du_dl, test_du_dl)
                 np.testing.assert_almost_equal(ref_du_dl, test_du_dl, rtol)
+                # print("DU_DL PASSED")
             if compute_du_dp:
                 np.testing.assert_almost_equal(ref_du_dp, test_du_dp, rtol)
+                # print("DU_DP PASSED")
+
+            # assert 0
+
 
             test_du_dx_2, test_du_dp_2, test_du_dl_2, test_u_2 = test_impl.execute_selective(
                 x,

--- a/tests/common.py
+++ b/tests/common.py
@@ -163,7 +163,7 @@ def prepare_water_system(
 
     params = np.stack([
         (np.random.rand(N).astype(np.float64) - 0.5)*np.sqrt(138.935456), # q
-        np.random.rand(N).astype(np.float64)/6.0, # sig # fix me
+        np.random.rand(N).astype(np.float64)/5.0, # sig # fix me
         np.random.rand(N).astype(np.float64) # eps
     ], axis=1)
 
@@ -502,8 +502,7 @@ class GradientTest(unittest.TestCase):
         ref_du_dx, ref_du_dp, ref_du_dl = grad_fn(x, params, box, lamb)
 
         for combo in itertools.product([False, True], repeat=4):
-            # (compute_du_dx, compute_du_dp, compute_du_dl, compute_u) = combo
-            (compute_du_dx, compute_du_dp, compute_du_dl, compute_u) = (True, True, True, True)
+            (compute_du_dx, compute_du_dp, compute_du_dl, compute_u) = combo
 
             # do each computation twice to check determinism
             test_du_dx, test_du_dp, test_du_dl, test_u = test_impl.execute_selective(
@@ -518,20 +517,12 @@ class GradientTest(unittest.TestCase):
             )
             if compute_u:
                 np.testing.assert_allclose(ref_u, test_u, rtol=rtol, atol=atol)
-                # print("U PASSED")
             if compute_du_dx:
                 self.assert_equal_vectors(np.array(ref_du_dx), np.array(test_du_dx), rtol)
-                # print("DU_DX PASSED")
             if compute_du_dl:
-                # print(ref_du_dl, test_du_dl)
                 np.testing.assert_almost_equal(ref_du_dl, test_du_dl, rtol)
-                # print("DU_DL PASSED")
             if compute_du_dp:
                 np.testing.assert_almost_equal(ref_du_dp, test_du_dp, rtol)
-                # print("DU_DP PASSED")
-
-            # assert 0
-
 
             test_du_dx_2, test_du_dp_2, test_du_dl_2, test_u_2 = test_impl.execute_selective(
                 x,

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -170,25 +170,6 @@ void __global__ k_permute(
 
 }
 
-
-// void __global__ k_permute_int(
-//     const int N,
-//     const unsigned int * __restrict__ perm,
-//     const int * __restrict__ array,
-//     int * __restrict__ sorted_array) {
-
-//     int idx = blockIdx.x*blockDim.x + threadIdx.x;
-//     int stride = gridDim.y;
-//     int stride_idx = blockIdx.y;
-
-//     if(idx >= N) {
-//         return;
-//     }
-
-//     sorted_array[idx*stride+stride_idx] = array[perm[idx]*stride+stride_idx];
-
-// }
-
 template <typename RealType>
 void __global__ k_inv_permute_accum(
     const int N,
@@ -1081,15 +1062,6 @@ void __global__ k_nonbonded_exclusions(
             real_du_dl -= term;
 
         }
-
-        // gi_x -= FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_x);
-        // gi_y -= FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_y);
-        // gi_z -= FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_z);
-
-        // gj_x -= FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_x);
-        // gj_y -= FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_y);
-        // gj_z -= FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_z);
-
 
         if(shrink_i == shrink_j) {
             gi_x -= FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_x);

--- a/timemachine/cpp/src/nonbonded.cu
+++ b/timemachine/cpp/src/nonbonded.cu
@@ -172,9 +172,7 @@ Nonbonded<RealType, Interpolated>::Nonbonded(
         }
         shrink_flags[atom_idx] = 1;
     }
-    // for(int i=0; i < shrink_flags.size(); i++) {
-        // std::cout << i << " " << shrink_flags[i] << std::endl;
-    // }
+
     gpuErrchk(cudaMemcpy(d_shrink_flags_, &shrink_flags[0], N_*sizeof(*d_shrink_flags_), cudaMemcpyHostToDevice));
 
 };
@@ -481,7 +479,6 @@ void Nonbonded<RealType, Interpolated>::execute_device(
 
     // exclusions use the non-sorted version
     if(E_ > 0) {
-        // std::cout << "RUNNING exclusions" << std::endl;
         const int tpb = 32;
         dim3 dimGridExclusions((E_+tpb-1)/tpb, 1, 1);
 

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -888,6 +888,7 @@ void declare_nonbonded(py::module &m, const char *typestr) {
         const py::array_t<int, py::array::c_style> &lambda_offset_idxs_i, //
         const double beta,
         const double cutoff,
+        const std::vector<int> shrink_idxs={},
         const std::string &transform_lambda_charge="lambda",
         const std::string &transform_lambda_sigma="lambda",
         const std::string &transform_lambda_epsilon="lambda",
@@ -921,6 +922,7 @@ void declare_nonbonded(py::module &m, const char *typestr) {
             lambda_offset_idxs,
             beta,
             cutoff,
+            shrink_idxs,
             source_str
         );
     }),
@@ -930,6 +932,7 @@ void declare_nonbonded(py::module &m, const char *typestr) {
     py::arg("lambda_offset_idxs_i"),
     py::arg("beta"),
     py::arg("cutoff"),
+    py::arg("shrink_idxs"),
     py::arg("transform_lambda_charge")="lambda",
     py::arg("transform_lambda_sigma")="lambda",
     py::arg("transform_lambda_epsilon")="lambda",

--- a/timemachine/potentials/jax_utils.py
+++ b/timemachine/potentials/jax_utils.py
@@ -55,17 +55,3 @@ def distance(x, box):
     d2ij = np.where(np.eye(N), 0, d2ij)
     dij = np.where(np.eye(N), 0, np.sqrt(d2ij))
     return dij
-
-
-
-def distance_multi(ri, rj, box):
-    # nonbonded distances require the periodic box
-    # assert x.shape[1] == 3 or x.shape[1] == 4 # 3d or 4d
-    ri = np.expand_dims(ri, 0)
-    rj = np.expand_dims(rj, 1)
-    d2ij = np.sum(np.power(delta_r(ri, rj, box), 2), axis=-1)
-    # N = d2ij.shape[0]
-    # d2ij = np.where(np.eye(N), 0, d2ij)
-    # dij = np.where(np.eye(N), 0, np.sqrt(d2ij))
-    return np.sqrt(d2ij)
-

--- a/timemachine/potentials/jax_utils.py
+++ b/timemachine/potentials/jax_utils.py
@@ -56,3 +56,16 @@ def distance(x, box):
     dij = np.where(np.eye(N), 0, np.sqrt(d2ij))
     return dij
 
+
+
+def distance_multi(ri, rj, box):
+    # nonbonded distances require the periodic box
+    # assert x.shape[1] == 3 or x.shape[1] == 4 # 3d or 4d
+    ri = np.expand_dims(ri, 0)
+    rj = np.expand_dims(rj, 1)
+    d2ij = np.sum(np.power(delta_r(ri, rj, box), 2), axis=-1)
+    # N = d2ij.shape[0]
+    # d2ij = np.where(np.eye(N), 0, d2ij)
+    # dij = np.where(np.eye(N), 0, np.sqrt(d2ij))
+    return np.sqrt(d2ij)
+

--- a/timemachine/potentials/nonbonded.py
+++ b/timemachine/potentials/nonbonded.py
@@ -4,7 +4,7 @@ from jax.scipy.special import erf, erfc
 from jax.ops import index_update, index
 
 from timemachine.constants import ONE_4PI_EPS0
-from timemachine.potentials.jax_utils import delta_r, distance, distance_multi, convert_to_4d
+from timemachine.potentials.jax_utils import delta_r, distance, convert_to_4d
 
 
 


### PR DESCRIPTION
This PR implements a ligand shrinking technique initially described by Gilson et al used for docking. This only applies to *intermolecular* nonbonded interactions.

The idea is to create virtual sites on every ligand atom, whose positions are adjusted relative to the centroid. At lambda=0, the ligand is full size, and at lambda=1, every ligand atom is located the centroid. The intuition for this is to allow for the environment atoms (water, side chains, etc.) to slowly flood to avoid phase-like transitions. 

This method has two neat properties:

1) automatically neutralizing the ligand
2) the ligand still has fully functioning bonded terms, and intramolecular nonbonded terms.
3) one can possibly get away with only center of mass restraints using this techniques, since it reduces the ligand to be featureless blob that is independent of orientation. Though we can still use endpoint-correction like before.

I don't particularly like the implementation, as its quite sub-optimal, so marking this as a draft until we've ran some experiments with it.