### PR TITLE
Variadic decoupling

### DIFF
--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -930,10 +930,10 @@ void declare_nonbonded(py::module &m, const char *typestr) {
     py::arg("lambda_offset_idxs_i"),
     py::arg("beta"),
     py::arg("cutoff"),
-    py::arg("transform_lambda_charge")="lambda",
-    py::arg("transform_lambda_sigma")="lambda",
-    py::arg("transform_lambda_epsilon")="lambda",
-    py::arg("transform_lambda_w")="lambda");
+    py::arg("transform_lambda_charge")="return lambda",
+    py::arg("transform_lambda_sigma")="return lambda",
+    py::arg("transform_lambda_epsilon")="return lambda",
+    py::arg("transform_lambda_w")="return lambda");
 
 }
 


### PR DESCRIPTION
This PR expands the flexilibity of the lambda scheduling to allow it vary on a per-particle basis. For example, one can introduce per-particle decoupling, so we can pull out (or even alchemically scale) particles at different rates. As an illustration, setting transform_w in the nonbonded constructor to:

```
args.append("""
    double offset = atom_idx / (2.0*N);
    if(lambda < offset) {
        return 0.0;
    } else if (lambda > (0.5 + offset)) {
        return 1.0;
    } else {
        NumericType term = sin((lambda - offset)*PI);
        return term*term;
    }

""")
```
will generate a decoupling schedule that allows the atoms in the ligand to be decoupled sequentially:
![Figure_1](https://user-images.githubusercontent.com/2280724/117467815-0aceb580-af22-11eb-973c-071d626f6f99.png)

