### PR TITLE
Bugfix/speed up t4

### DIFF
--- a/timemachine/cpp/src/jitify.hpp
+++ b/timemachine/cpp/src/jitify.hpp
@@ -2465,7 +2465,7 @@ inline void detect_and_add_cuda_arch(std::vector<std::string>& options) {
   options.push_back("-arch=compute_" + ss.str());
 }
 
-inline void detect_and_add_cxx11_flag(std::vector<std::string>& options) {
+inline void detect_and_add_cxx17_flag(std::vector<std::string>& options) {
   // Reverse loop so we can erase on the fly.
   for (int i = (int)options.size() - 1; i >= 0; --i) {
     if (options[i].find("-std=c++98") != std::string::npos) {
@@ -2477,9 +2477,9 @@ inline void detect_and_add_cxx11_flag(std::vector<std::string>& options) {
       return;
     }
   }
-  // Jitify must be compiled with C++11 support, so we default to enabling it
+  // Jitify must be compiled with C++17 support, so we default to enabling it
   // for the JIT-compiled code too.
-  options.push_back("-std=c++11");
+  options.push_back("-std=c++17");
 }
 
 inline void split_compiler_and_linker_options(
@@ -2752,7 +2752,7 @@ inline void load_program(std::string const& cuda_source,
   // for arch-dependent compilation, e.g., some intrinsics are only
   // present for specific architectures.
   detail::detect_and_add_cuda_arch(compiler_options);
-  detail::detect_and_add_cxx11_flag(compiler_options);
+  detail::detect_and_add_cxx17_flag(compiler_options);
 
   // Iteratively try to compile the sources, and use the resulting errors to
   // identify missing headers.
@@ -3527,7 +3527,7 @@ Kernel_impl::Kernel_impl(Program_impl const& program, std::string name,
   _options.insert(_options.end(), _program.options().begin(),
                   _program.options().end());
   detail::detect_and_add_cuda_arch(_options);
-  detail::detect_and_add_cxx11_flag(_options);
+  detail::detect_and_add_cxx17_flag(_options);
   std::string options_string = reflection::reflect_list(_options);
   using detail::hash_combine;
   using detail::hash_larson64;
@@ -4110,7 +4110,7 @@ class KernelInstantiation {
     options.insert(options.begin(), kernel._options.begin(),
                    kernel._options.end());
     detail::detect_and_add_cuda_arch(options);
-    detail::detect_and_add_cxx11_flag(options);
+    detail::detect_and_add_cxx17_flag(options);
 
     std::string log, ptx, mangled_instantiation;
     std::vector<std::string> linker_files, linker_paths;

--- a/timemachine/cpp/src/kernels/k_fixed_point.cuh
+++ b/timemachine/cpp/src/kernels/k_fixed_point.cuh
@@ -17,7 +17,7 @@ RealType __device__ __forceinline__ FIXED_TO_FLOAT_DU_DP(unsigned long long v) {
 // (ytz): courtesy of @scottlegrand/NVIDIA, even faster conversion
 // This was original a hack to improve perf on Maxwell, that is now needed for Ampere
 long long __device__ __forceinline__ real_to_int64(float x) {
-#if __CUDA_ARCH__ == 860
+#if __CUDA_ARCH__ == 860 || __CUDA_ARCH__ == 750
   float z = x * (float)0x1.00000p-32;
   int hi = __float2int_rz( z );                         // First convert high bits
   float delta = x - ((float)0x1.00000p32*((float)hi));  // Check remainder sign


### PR DESCRIPTION
By using the Ampere optimization for real to int64 on the T4 GPUs, see about a 50% improvement on average time for the k_non_bonded_unified kernel

OLD
---
```
==4963== Profiling application: /home/ubuntu/.conda/envs/timemachine/bin/python /home/ubuntu/.conda/envs/timemachine/bin/pytest slow_tests/test_benchmark.py -k dhfr -s                                                                                                                    
==4963== Profiling result:                                                                                                                                                                                                                                                                 
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name                                                                                                                                                                                                          
 GPU activities:   75.30%  410.75ms       297  1.3830ms  910.36us  2.4729ms  void k_nonbonded_unified<float, bool=0, bool=1, bool=0, bool=0>(int, double const *, double const *, double const *, double const *, double const *, double const *, double, double, double, int const *, unsi
gned int const *, __int64*, __int64*, __int64*, __int64*)                                                                                                                                                                                                                                  
                    4.90%  26.750ms        44  607.95us  401.89us  1.0958ms  void k_find_blocks_with_ixns<float>(int, double const *, double const *, double const *, double const *, unsigned int*, int*, unsigned int*, unsigned int*, double)                                           
                    2.76%  15.073ms       300  50.243us  32.640us  89.568us  void gen_sequenced<curandStateXORWOW, double2, normal_args_double_st, __operator_&__(double2 curand_normal_scaled2_double<curandStateXORWOW>(curandStateXORWOW*, normal_args_double_st)), rng_config<curandSta
teXORWOW, curandOrdering=101>>(curandStateXORWOW*, double2*, unsigned long, unsigned long, normal_args_double_st)                                                                                                                                                                          
                    2.67%  14.567ms        17  856.88us  1.0560us  13.879ms  [CUDA memcpy HtoD]                                                                                                                                                                                            
                    2.46%  13.426ms       303  44.311us  23.168us  73.119us  void k_nonbonded_exclusions<float>(int, double const *, double const *, double const *, double const *, double const *, double const *, double, int const *, double const *, double, double, __int64*, __int64
*, __int64*, __int64*)
```

OPTIMIZED
---------
```
==5650== Profiling application: /home/ubuntu/.conda/envs/timemachine/bin/python /home/ubuntu/.conda/envs/timemachine/bin/pytest slow_tests/test_benchmark.py -k dhfr -s                                                                                                                    
==5650== Profiling result:                                                                                                                                                                                                                                                                 
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name                                                                                                                                                                                                          
 GPU activities:   65.38%  259.82ms       297  874.81us  605.12us  1.4670ms  void k_nonbonded_unified<float, bool=0, bool=1, bool=0, bool=0>(int, double const *, double const *, double const *, double const *, double const *, double const *, double, double, double, int const *, unsi
gned int const *, __int64*, __int64*, __int64*, __int64*)                                                                                                                                                                                                                                  
                    7.13%  28.319ms        44  643.61us  446.37us  1.1013ms  void k_find_blocks_with_ixns<float>(int, double const *, double const *, double const *, double const *, unsigned int*, int*, unsigned int*, unsigned int*, double)                                           
                    4.03%  16.033ms       300  53.443us  36.191us  89.599us  void gen_sequenced<curandStateXORWOW, double2, normal_args_double_st, __operator_&__(double2 curand_normal_scaled2_double<curandStateXORWOW>(curandStateXORWOW*, normal_args_double_st)), rng_config<curandSta
teXORWOW, curandOrdering=101>>(curandStateXORWOW*, double2*, unsigned long, unsigned long, normal_args_double_st)                                                                                                                                                                          
                    3.68%  14.622ms        17  860.14us  1.0240us  13.935ms  [CUDA memcpy HtoD]                                                                                                                                                                                            
                    3.41%  13.554ms       303  44.731us  22.368us  69.119us  void k_nonbonded_exclusions<float>(int, double const *, double const *, double const *, double const *, double const *, double const *, double, int const *, double const *, double, double, __int64*, __int64
*, __int64*, __int64*)
```