### PR TITLE
Standard state correction for RMSD restraints

### DIFF
--- a/fe/standard_state.py
+++ b/fe/standard_state.py
@@ -1,55 +1,167 @@
-
-import simtk.unit as unit
-import scipy.special
 import numpy as np
+import scipy.integrate
 
-from timemachine.constants import kB
+import functools
+from timemachine.potentials import rmsd
 
-def harmonic_com_vol(kb, b0, T):
+def integrate_radial_Z(
+    u_fn,
+    beta,
+    r_max):
     """
-    Compute the volume component of the standard state correction.
-
-    Parameters: see harmonic_com_ssc
-
-    Returns
-    -------
-    float
-        Restraint volume when released into infinity, in units of nm^3
-
-    """
-    kT = kB * (T*unit.kelvin)
-    kT = kT.value_in_unit(unit.kilojoules_per_mole)
-    k = kb/kT
-    b = b0
-    # (ytz): don't you love integrals?
-    # this is the analytical solution of the integral of:
-    # U = (1/kT)*kb*(r-b0)**2
-    # int_{r=0}^{r=infty} 4.0 * np.pi * r**2 * np.exp(-U)   
-    return 4.0 * np.pi*((b*np.exp(-b**2*k))/(2*k) + ((1 + 2*b**2*k)*np.sqrt(np.pi)*(1 + scipy.special.erf(b*np.sqrt(k))))/(4*k**(3/2)))
-
-def harmonic_com_ssc(kb, b0, T):
-    """
-    Compute the standard state correction of a harmonic oscillator between two centroids.
-    This is derived from the Yank code for RadiallySymmetricRestraints.
+    Evaluate the partition function of a radially symmetric
+    restraint.
 
     Parameters:
     -----------
-    kb: float
-        force constant in kJ/mol
-    
-    b0: float
-        ideal length in nanometers
-    
-    T: temperature
+    u_fn: f: R -> R
+        A radial function that takes in a distance r and returns
+        a scalar. This function must be integrable.
+
+    beta: float
+        1/kT
+
+    r_max: float
+        upper bound of integration
 
     Returns
     -------
     float
-        The analytical restraint correction in kJ/mol.
+        Free energy associated with release into a 1660A^3 volume.
 
     """
-    kT = kB * (T*unit.kelvin)
-    kT = kT.value_in_unit(unit.kilojoules_per_mole)
-    restr_vol = harmonic_com_vol(kb, b0, T)
-    return -np.log(1.660 / restr_vol)*kT # in kJ/mol
+    def integrand(r):
+        return 4*np.pi*(r**2)*np.exp(-beta*u_fn(r))
 
+    r_min = 0.0
+    Z, err = scipy.integrate.quad(integrand, r_min, r_max)
+
+    assert err < 1e-5
+
+    return Z
+
+
+def standard_state_correction(Z_infty, beta):
+    """
+    Compute the standard state of releasing a ligand into the standard
+    molar volume.
+
+    Parameters
+    ----------
+    Z_infty: float
+        Partition function when integrated to infinity
+
+    beta: float
+        1/kT
+
+    Returns
+    -------
+    dG
+        Free energy of releasing into the standard state
+
+    """
+    return -np.log(1.660/Z_infty)/beta # in kJ/mol
+
+def integrate_radial_Z_exact(k, beta):
+    k = k*beta
+    b = 0.0
+    # this is the analytical solution of the integral of:
+    # U = (1/kT)*kb*(r-b0)**2
+    # int_{r=0}^{r=infty} 4.0 * np.pi * r**2 * np.exp(-U)
+    Z_exact = 4.0*np.pi*((b*np.exp(-b**2*k))/(2*k) + ((1 + 2*b**2*k)*np.sqrt(np.pi)*(1 + scipy.special.erf(b*np.sqrt(k))))/(4*k**(3/2)))
+    return Z_exact
+
+def integrate_rotation_Z(u_fn, beta):
+    """
+    Compute the partition function a rotational restraint over SO(3)
+
+    Parameters
+    ----------
+    u_fn: f: R->R
+        Takes in an arbitrary scalar representing an angle relative
+        to the identity transformation and returns an energy.
+
+    beta: float
+        1/Kt
+
+    Returns
+    -------
+    scalar
+        Value of the partition function
+
+    """
+    # Integrating in the quaternion form requires only two integrals as opposed
+    # to three. The general technique is outlined here. See "Average Rotation Angle"
+    # for a direct analogy. The main difference is that we explicit do not compute the
+    # 1/pi^2 normalization constant.
+
+    # https://marc-b-reynolds.github.io/quaternions/2017/11/10/AveRandomRot.html
+
+    def integrand(alpha, theta):
+        nrg = u_fn(2*theta)
+        assert nrg > 0
+        return np.exp(-beta*nrg)*np.sin(theta)**2*np.sin(alpha)
+
+
+    Z, Z_err = scipy.integrate.dblquad(
+        integrand,
+        0, # theta low
+        np.pi/2, # theta high
+        lambda x: 0, # alpha low
+        lambda x: np.pi # alpha high
+    )
+
+    assert Z_err < 1e-5
+
+    # outer integral
+    Z *= 2*np.pi
+    return Z
+
+def release_orientational_restraints(k_t, k_r, beta):
+    """
+    Convenience function.
+
+    Compute the free energy of releasing orientational restraints
+    into the standard state. It assumes that a harmonic translational
+    restraint and an rmsd restraint is used. Do not use this function
+    if you use any other type of restraint.
+
+    The quantity computed is:
+
+    dG_release = -1/beta ln(Z_T Z_R)
+
+    Parameters
+    ----------
+    k_t: float
+        Force constant of the translational restraint
+
+    k_r: float
+        Force constant of the rotational restraint
+
+    beta: float
+        1/kT
+
+    Returns
+    -------
+    float, float
+        dG of the translational and rotational restraint
+
+    """
+
+    def harmonic_restraint(r):
+        return k_t*r**2
+
+    Z_numeric = integrate_radial_Z(
+        harmonic_restraint,
+        beta,
+        r_max=np.inf # i like to live dangerously
+    )
+    Z_exact = integrate_radial_Z_exact(k_t, beta)
+
+    np.testing.assert_almost_equal(Z_exact, Z_numeric)
+    dG_translation = standard_state_correction(Z_numeric, beta)
+    u_fn = functools.partial(rmsd.angle_u, k=k_r)
+    Z_rotation = integrate_rotation_Z(u_fn, beta)
+    # A_ij = (-1/beta)*ln(Z_j/Z_i)
+    dG_rotation = (-1/beta)*np.log(1/Z_rotation)
+    return dG_translation, dG_rotation

--- a/tests/test_standard_state.py
+++ b/tests/test_standard_state.py
@@ -3,34 +3,73 @@ import functools
 
 from simtk import unit
 from fe import standard_state
+import rmsd
 
 import scipy.integrate
 
-def test_harmonic_com_ssc():
 
-    T = 300.0
-    kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA
-    kT = kB * T*unit.kelvin
-    kT = kT.value_in_unit(unit.kilojoules_per_mole)
+from timemachine.potentials import rmsd
 
-    def harmonic_com(r, kb, b0):
+def test_translational_restraint():
+    k = 25.0
+    b = 0.0
 
-        e = kb*(r-b0)**2
-        e = e/kT
-        dI = 4.0 * np.pi * r**2 * np.exp(-e)
-        return dI
+    def harmonic_restraint(r):
+        return k*(r-b)**2
 
-    test_kb = 1000.0
-    test_b0 = 0.02
+    beta = 0.67
+    Z_numeric = standard_state.integrate_radial_Z(
+        harmonic_restraint,
+        beta,
+        r_max = 10.0
+    )
 
+    k = k*beta
+    Z_exact = 4.0*np.pi*((b*np.exp(-b**2*k))/(2*k) + ((1 + 2*b**2*k)*np.sqrt(np.pi)*(1 + scipy.special.erf(b*np.sqrt(k))))/(4*k**(3/2)))
 
-    u_fn = functools.partial(harmonic_com, kb=test_kb, b0=test_b0) # kJ/mol, nanometers
-    numerical_restr_vol, err = scipy.integrate.quad(u_fn, 0, 10.0) # returns nm^3
-    analytical_restr_vol = standard_state.harmonic_com_vol(test_kb, test_b0, T)
+    np.testing.assert_almost_equal(Z_numeric, Z_exact)
 
-    np.testing.assert_allclose(numerical_restr_vol, analytical_restr_vol)
-  
-    numerical_ssc = -np.log(1.660 / numerical_restr_vol)*kT # in kJ/mol
-    analytical_ssc = standard_state.harmonic_com_ssc(test_kb, test_b0, T)
+    dG = standard_state.standard_state_correction(Z_exact, beta)
 
-    np.testing.assert_allclose(numerical_ssc, analytical_ssc)
+    assert dG < 0
+
+def test_rotational_restraint():
+
+    k = 25.0
+    u_fn = functools.partial(rmsd.angle_u, k=k)
+    beta = 0.67
+    Z_quat = standard_state.integrate_rotation_Z(u_fn, beta)
+
+    def integrand(phi_1,phi_2,psi):
+        delta = psi
+        alpha = phi_1
+        gamma = phi_2
+        cos_theta = np.cos(delta/2)**2*np.cos(gamma+alpha) - np.sin(delta/2)**2
+        nrg = rmsd.cos_angle_u(cos_theta, k)
+        assert nrg > 0
+        # constant = 1/(8*np.pi**2) # normalization constant not needed
+        constant = 1/8
+        return constant*np.sin(psi)*np.exp(-beta*nrg)
+
+    Z_euler, _ = scipy.integrate.tplquad(
+        integrand,
+        0, # psi low
+        np.pi, # psi high
+        lambda x: 0, # phi_1 low
+        lambda x: 2*np.pi, # phi_1 high
+        lambda x,y: 0, # phi_2 low
+        lambda x,y: 2*np.pi # phi_2 high
+    )
+
+    np.testing.assert_almost_equal(Z_quat, Z_euler)
+
+def test_release_restraints():
+    # test the release of orientational restraints.
+    k_t = 50.0
+    k_r = 25.0
+    beta = 0.67
+    dG_t, dG_r = standard_state.release_orientational_restraints(k_t, k_r, beta)
+
+    # these should be negative for sensible force constants
+    assert dG_t < 0
+    assert dG_r < 0

--- a/timemachine/potentials/rmsd.py
+++ b/timemachine/potentials/rmsd.py
@@ -2,7 +2,14 @@ import jax
 import jax.numpy as np
 
 def psi(rotation, k):
-    term = (np.trace(rotation) - 1)/2 - 1
+    cos_theta = (np.trace(rotation) - 1)/2
+    return cos_angle_u(cos_theta, k)
+
+def angle_u(theta, k):
+    return cos_angle_u(np.cos(theta), k)
+
+def cos_angle_u(cos_theta, k):
+    term = cos_theta - 1
     nrg = k*term*term
     return nrg
 


### PR DESCRIPTION
This PR implements the standard state correction for RMSD-based orientational restraints. This also cleans up the old translational restraints. This allows us to perform endpoint corrections to arbitrary force constants for rotational and translational restraints. With the help of @mkgilson I've also confirmed that the dG_translation and dG_rotation of release restraints are negative values, as expected.