### PR TITLE
Set random seed for MC barostat test initial velocities

### DIFF
--- a/slow_tests/test_barostat_molecular_ideal_gas.py
+++ b/slow_tests/test_barostat_molecular_ideal_gas.py
@@ -1,4 +1,5 @@
 import numpy as np
+np.random.seed(2021)
 from simtk import unit
 
 from testsystems.relative import hif2a_ligand_pair


### PR DESCRIPTION
I introduced a test in https://github.com/proteneer/timemachine/pull/433 that appears to be failing stochastically by small margins on unrelated PRs... Although the integrator seed is set, I missed setting the numpy random seed for initial velocities. This annoyance will be avoided completely when the slow barostat test is replaced with the 30x faster barostat implementation in https://github.com/proteneer/timemachine/pull/436 !