### PR TITLE
Increase number of argument names included in Python bindings

### DIFF
--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -291,7 +291,9 @@ void declare_langevin_integrator(py::module &m) {
         );
 
     }
-    ));
+    ),
+    py::arg("dt"), py::arg("ca"),  py::arg("cbs"), py::arg("ccs"), py::arg("seed")
+    );
 
 }
 

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -487,7 +487,9 @@ void declare_bound_potential(py::module &m) {
             params.data()
         );
     }
-    ))
+    ),
+    py::arg("potential"), py::arg("params")
+    )
     .def("size", &timemachine::BoundPotential::size)
     .def("execute", [](timemachine::BoundPotential &bp,
         const py::array_t<double, py::array::c_style> &coords,

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -426,7 +426,10 @@ void declare_potential(py::module &m) {
             }
 
             return result;
-    })
+    },
+    py::arg("coords"), py::arg("params"), py::arg("box"), py::arg("lam"),
+    py::arg("compute_du_dx"), py::arg("compute_du_dp"), py::arg("compute_du_dl"), py::arg("compute_u")
+    )
     .def("execute_du_dx", [](timemachine::Potential &pot,
         const py::array_t<double, py::array::c_style> &coords,
         const py::array_t<double, py::array::c_style> &params,

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -458,7 +458,9 @@ void declare_potential(py::module &m) {
             }
 
             return py_du_dx;
-    });
+    },
+    py::arg("coords"), py::arg("params"), py::arg("box"), py::arg("lam")
+    );
 
 }
 

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -522,7 +522,9 @@ void declare_bound_potential(py::module &m) {
             unsigned long long u_sum = std::accumulate(u.begin(), u.end(), decltype(u)::value_type(0));
 
             return py::make_tuple(py_du_dx, FIXED_TO_FLOAT<double>(du_dl_sum), FIXED_TO_FLOAT<double>(u_sum));
-    });
+    },
+    py::arg("coords"), py::arg("box"), py::arg("lam")
+    );
 
 }
 

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -354,7 +354,9 @@ void declare_potential(py::module &m) {
 
             return py::make_tuple(py_du_dx, py_du_dp, FIXED_TO_FLOAT<double>(du_dl_sum), FIXED_TO_FLOAT<double>(u_sum));
 
-    })
+    },
+    py::arg("coords"), py::arg("params"), py::arg("box"), py::arg("lam")
+    )
     .def("execute_selective", [](timemachine::Potential &pot,
         const py::array_t<double, py::array::c_style> &coords,
         const py::array_t<double, py::array::c_style> &params,


### PR DESCRIPTION
Increases informativeness of `help(Potential.execute_selective)` (and a couple others), following https://pybind11.readthedocs.io/en/stable/basics.html#keyword-args .

Consistent with how argument names have been supplied elsewhere in `wrap_kernels.cpp`, such as https://github.com/proteneer/timemachine/blob/be9db7961ab8d0007740ebc7bb764c519f3f26c5/timemachine/cpp/src/wrap_kernels.cpp#L144

-------------
Before:
```
Help on instancemethod in module timemachine.lib.custom_ops:

execute_selective(...)
    execute_selective(self: timemachine.lib.custom_ops.Potential, arg0: numpy.ndarray[numpy.float64], arg1: numpy.ndarray[numpy.float64], arg2: numpy.ndarray[numpy.float64], arg3: float, arg4: bool, arg5: bool, arg6: bool, arg7: bool) -> tuple
```

After:
```
Help on instancemethod in module timemachine.lib.custom_ops:

execute_selective(...)
    execute_selective(self: timemachine.lib.custom_ops.Potential, coords: numpy.ndarray[numpy.float64], params: numpy.ndarray[numpy.float64], box: numpy.ndarray[numpy.float64], lam: float, compute_du_dx: bool, compute_du_dp: bool, compute_du_dl: bool, compute_u: bool) -> tuple
```