### PR TITLE
Change default precision of Python wrappers from F64 -> F32

### DIFF
--- a/fe/functional.py
+++ b/fe/functional.py
@@ -37,7 +37,7 @@ def wrap_impl(impl):
     return U
 
 
-def construct_differentiable_interface(unbound_potentials, precision=np.float64):
+def construct_differentiable_interface(unbound_potentials, precision=np.float32):
     """Construct a differentiable function U(x, params, box, lam) -> float
 
     >>> U = construct_differentiable_interface(unbound_potentials)

--- a/md/ensembles.py
+++ b/md/ensembles.py
@@ -13,7 +13,7 @@ class PotentialEnergyModel:
     def __init__(self, sys_params, unbound_potentials, precision=np.float64, guard_threshold=1e6):
         self.sys_params = sys_params
         self.unbound_potentials = unbound_potentials
-        self.bp_cache = dict()
+        self.all_impls = []
         self.precision = precision
         self._initialize()
 
@@ -21,22 +21,15 @@ class PotentialEnergyModel:
         self.guard_threshold = guard_threshold
 
     def _initialize(self):
+        assert len(self.all_impls) == 0
         for component_params, unbound_pot in zip(self.sys_params, self.unbound_potentials):
-            key = unbound_pot
-
-            if key not in self.bp_cache:
-                impl = unbound_pot.bind(np.asarray(component_params)).bound_impl(self.precision)
-                self.bp_cache[key] = impl
-
-    @property
-    def all_impls(self):
-        """List of impl, e.g. as required by context constructor"""
-        return [self.bp_cache[key] for key in self.unbound_potentials]
+            impl = unbound_pot.bind(np.asarray(component_params)).bound_impl(self.precision)
+            self.all_impls.append(impl)
 
     def energy_and_gradient(self, x, box, lam):
         Us, dU_dxs = [], []
-        for key in self.unbound_potentials:
-            dU_dx, dU_dl, U = self.bp_cache[key].execute(x, box, lam)
+        for impl in self.all_impls:
+            dU_dx, dU_dl, U = impl.execute(x, box, lam)
 
             Us.append(U)
             dU_dxs.append(dU_dx)

--- a/md/ensembles.py
+++ b/md/ensembles.py
@@ -10,7 +10,7 @@ non_unitted = Union[float, np.ndarray, jnp.ndarray]  # raw value without simtk u
 
 
 class PotentialEnergyModel:
-    def __init__(self, sys_params, unbound_potentials, precision=np.float64, guard_threshold=1e6):
+    def __init__(self, sys_params, unbound_potentials, precision=np.float32, guard_threshold=1e6):
         self.sys_params = sys_params
         self.unbound_potentials = unbound_potentials
         self.all_impls = []


### PR DESCRIPTION
There appears to be about [a 10-15x performance difference](https://gist.github.com/maxentile/c7a3624c3d9579e281f7787834c709ab) between precision modes for `ctxt.multiple_steps`, but [no apparent accuracy impact](https://github.com/proteneer/timemachine/pull/436#discussion_r639239726) for uses so far, so this would be a more sensible default. (Also, the default throughout the rest of timemachine has been to use the float32 implementations, so this was an outlier.)

The performance difference between precision modes for the wrapped unbound potentials is less dramatic, [maybe 20-40%](https://gist.github.com/maxentile/520e2a04c76f424619b068d8d7e889e7), but I updated these as well for consistency.