### PR TITLE
Possibly JIT-safer `delta_r`

### DIFF
--- a/tests/test_jax_utils.py
+++ b/tests/test_jax_utils.py
@@ -8,12 +8,26 @@ onp.random.seed(2021)
 from timemachine.potentials.jax_utils import delta_r
 
 
-def test_jitted_delta_r_symmetric():
-    """assert jit(delta_r)(ri, rj, box) == - jit(delta_r)(rj, ri, box)"""
-    ri, rj = onp.random.randn(2, 1000, 3)
-    box = np.eye(3)
+def test_delta_r():
+    """assert that
+    * delta_r(ri, rj, box) == - delta_r(rj, ri, box)
+    * and that delta_r agrees with jit(delta_r)
+    on a few random inputs of varying size
+    """
 
-    dr_ij = jit(delta_r)(ri, rj, box)
-    dr_ji = jit(delta_r)(rj, ri, box)
+    for _ in range(5):
+        n_atoms = onp.random.randint(50, 1000)
+        dim = onp.random.randint(3, 5)
+        ri, rj = onp.random.randn(2,  n_atoms, dim)
+        box = np.eye(dim)
 
-    onp.testing.assert_allclose(dr_ij, -dr_ji)
+        dr_ij_1 = delta_r(ri, rj, box)
+        dr_ji_1 = delta_r(rj, ri, box)
+
+        onp.testing.assert_allclose(dr_ij_1, -dr_ji_1)
+
+        dr_ij_2 = jit(delta_r)(ri, rj, box)
+        dr_ji_2 = jit(delta_r)(rj, ri, box)
+
+        onp.testing.assert_allclose(dr_ij_1, dr_ij_2)
+        onp.testing.assert_allclose(dr_ji_1, dr_ji_2)

--- a/tests/test_jax_utils.py
+++ b/tests/test_jax_utils.py
@@ -1,0 +1,19 @@
+import jax
+jax.config.update("jax_enable_x64", True)
+
+from jax import numpy as np, jit
+import numpy as onp
+onp.random.seed(2021)
+
+from timemachine.potentials.jax_utils import delta_r
+
+
+def test_jitted_delta_r_symmetric():
+    """assert jit(delta_r)(ri, rj, box) == - jit(delta_r)(rj, ri, box)"""
+    ri, rj = onp.random.randn(2, 1000, 3)
+    box = np.eye(3)
+
+    dr_ij = jit(delta_r)(ri, rj, box)
+    dr_ji = jit(delta_r)(rj, ri, box)
+
+    onp.testing.assert_allclose(dr_ij, -dr_ji)

--- a/tests/test_jax_utils.py
+++ b/tests/test_jax_utils.py
@@ -11,9 +11,14 @@ from timemachine.potentials.jax_utils import delta_r
 def test_delta_r():
     """assert that
     * delta_r(ri, rj, box) == - delta_r(rj, ri, box)
-    * and that delta_r agrees with jit(delta_r)
+    * delta_r agrees with jit(delta_r)
+    * jit(norm(delta_r)) symmetric
     on a few random inputs of varying size
     """
+
+    @jit
+    def _distances(ri, rj, box):
+        return np.linalg.norm(delta_r(ri, rj, box), axis=1)
 
     for _ in range(5):
         n_atoms = onp.random.randint(50, 1000)
@@ -31,3 +36,8 @@ def test_delta_r():
 
         onp.testing.assert_allclose(dr_ij_1, dr_ij_2)
         onp.testing.assert_allclose(dr_ji_1, dr_ji_2)
+
+        dij = _distances(ri, rj, box)
+        dji = _distances(rj, ri, box)
+
+        onp.testing.assert_allclose(dij, dji)


### PR DESCRIPTION
On more recent jax/jaxlib versions than the versions pinned in requirements.txt, I noticed that `jit(delta_r)(ri, rj, box)` sometimes produces different results from `delta_r(ri, rj, box)`.

[Replacing](https://github.com/proteneer/timemachine/blob/1ed3176c56205726aebaff6b24d8ed1616f432ec/timemachine/potentials/jax_utils.py#L50-L56) the Python for-loop over `dims` with a [`lax.fori_loop`](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.fori_loop.html) seems to safeguard against this possibility.