### PR TITLE
Topology improvements for RABFE.

### DIFF
--- a/fe/topology.py
+++ b/fe/topology.py
@@ -589,13 +589,21 @@ class DualTopologyRHFE(DualTopology):
 
 
 def get_ring_membership(mol):
+    """
+    Get the membership of each atom in the mol. The algorithm
+    finds islands that are formed connected by bond bridges.
 
-    # for _ in mol_a.
+    Let N = mol.GetNumAtoms()
+
+    The returned array is of length N, where each atom is marked
+    by a membership class K such that 0 < K < N.
+    """
+
     g = networkx.Graph()
     for bond in mol.GetBonds():
         g.add_edge(bond.GetBeginAtomIdx(), bond.GetEndAtomIdx())
 
-    # find bridges and remove them
+    # find bridges and remove them to form islands
     for bridge in networkx.bridges(g):
         g.remove_edge(*bridge)
 
@@ -606,6 +614,7 @@ def get_ring_membership(mol):
             membership[atom_idx] = group_idx
 
     return membership
+
 
 class DualTopologyStandardDecoupling(DualTopology):
     """

--- a/fe/topology.py
+++ b/fe/topology.py
@@ -337,6 +337,9 @@ class BaseTopologyConversion(BaseTopology):
 
     lambda=0 forcefield dependent state
     lambda=1 forcefield independent state
+
+    (ytz): Note that rdkit's RingInfo does something totally different. It is populated by either
+    FastFindRings or SSSRs (ring basis), of which neither is what we want.
     """
 
     def parameterize_proper_torsion(self, ff_params):
@@ -704,14 +707,9 @@ class DualTopologyMinimization(DualTopology):
         # we don't actually need derivatives for this stage.
         qlj_params, nb_potential = super().parameterize_nonbonded(ff_q_params, ff_lj_params)
 
-        combined_lambda_plane_idxs = np.zeros(
-            self.mol_a.GetNumAtoms() + self.mol_b.GetNumAtoms(),
-            dtype=np.int32
-        )
-        combined_lambda_offset_idxs = np.concatenate([
-            np.ones(self.mol_a.GetNumAtoms(), dtype=np.int32),
-            np.ones(self.mol_b.GetNumAtoms(), dtype=np.int32)
-        ])
+        N_A, N_B = self.mol_a.GetNumAtoms(), self.mol_b.GetNumAtoms()
+        combined_lambda_plane_idxs = np.zeros(N_A + N_B, dtype=np.int32)
+        combined_lambda_offset_idxs = np.ones(N_A + N_B, dtype=np.int32)
 
         nb_potential.set_lambda_offset_idxs(combined_lambda_offset_idxs)
         nb_potential.set_lambda_plane_idxs(combined_lambda_plane_idxs)

--- a/fe/topology.py
+++ b/fe/topology.py
@@ -618,9 +618,9 @@ def get_ring_membership(mol):
 
 class DualTopologyStandardDecoupling(DualTopology):
     """
-    Standardized variant, where both ligands A and B have their charges, sigma, and epsilons are set
+    Standardized variant, where both ligands A and B have their charges, sigmas, and epsilons set
     to standard, forcefield-independent values. There is no parameter interpolation. lambda=0 has both
-    Ligand A and B fully in the pocket. lambda=1 has ligand b fully decoupled, while ligand a is kept
+    ligand A and B fully in the pocket. lambda=1 has ligand B fully decoupled, while ligand A is kept
     in place.
 
     Furthermore, the ligand's non-ring torsions are turned off at the standard state to improve

--- a/fe/topology.py
+++ b/fe/topology.py
@@ -452,7 +452,7 @@ class DualTopology(ABC):
         ff_q_params,
         ff_lj_params):
 
-        # dummy is either "a or "b
+        # dummy is either "a or "b"
         q_params_a = self.ff.q_handle.partial_parameterize(ff_q_params, self.mol_a)
         q_params_b = self.ff.q_handle.partial_parameterize(ff_q_params, self.mol_b)
         lj_params_a = self.ff.lj_handle.partial_parameterize(ff_lj_params, self.mol_a)
@@ -1144,4 +1144,3 @@ class SingleTopology():
         combined_lambda_offset = np.concatenate([proper_potential.get_lambda_offset(), improper_potential.get_lambda_offset()])
         combined_potential = potentials.PeriodicTorsion(combined_idxs, combined_lambda_mult, combined_lambda_offset)
         return combined_params, combined_potential
-

--- a/md/minimizer.py
+++ b/md/minimizer.py
@@ -110,7 +110,7 @@ def minimize_host_4d(mols, host_system, host_coords, ff, box) -> np.ndarray:
     if len(mols) == 1:
         top = topology.BaseTopology(mols[0], ff)
     elif len(mols) == 2:
-        top = topology.DualTopology(mols[0], mols[1], ff)
+        top = topology.DualTopologyMinimization(mols[0], mols[1], ff)
     else:
         raise ValueError("mols must be length 1 or 2")
 

--- a/tests/test_rabfe_topology.py
+++ b/tests/test_rabfe_topology.py
@@ -1,0 +1,155 @@
+# test topology classes used in the RABFE protocol.
+from jax.config import config; config.update("jax_enable_x64", True)
+from ff import Forcefield
+from ff.handlers.deserialize import deserialize_handlers
+
+from fe import topology
+from rdkit import Chem
+import numpy as np
+
+from timemachine.lib import potentials
+
+def test_base_topology_conversion_ring_torsion():
+
+    # test that the conversion protocol behaves as intended on a
+    # simple linked cycle.
+
+    ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_sc.py').read())
+    ff = Forcefield(ff_handlers)
+    mol = Chem.MolFromSmiles("C1CC1C1CC1")
+    vanilla_mol_top = topology.BaseTopology(mol, ff)
+    vanilla_torsion_params, _ = vanilla_mol_top.parameterize_proper_torsion(ff.pt_handle.params)
+
+    mol_top = topology.BaseTopologyConversion(mol, ff)
+    conversion_torsion_params, torsion_potential = mol_top.parameterize_proper_torsion(ff.pt_handle.params)
+
+    np.testing.assert_array_equal(vanilla_torsion_params, conversion_torsion_params)
+
+    # in the conversion phase, torsions that bridge the two rings should be set to
+    # be alchemically turned off.
+    ring_group = [0,0,0,1,1,1]
+
+    for torsion_idxs, mult, offset in zip(torsion_potential.get_idxs(), torsion_potential.get_lambda_mult(), torsion_potential.get_lambda_offset()):
+        _, b, c, _ = torsion_idxs
+        assert offset == 1
+        if ring_group[b] != ring_group[c]:
+            assert mult == -1
+        else:
+            assert mult == 0
+
+    vanilla_qlj_params, _ = vanilla_mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
+    qlj_params, nonbonded_potential = mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
+
+    assert isinstance(nonbonded_potential, potentials.NonbondedInterpolated)
+
+    src_qlj_params = qlj_params[:len(qlj_params)//2]
+    dst_qlj_params = qlj_params[len(qlj_params)//2:]
+
+    np.testing.assert_array_equal(vanilla_qlj_params, src_qlj_params)
+    np.testing.assert_array_equal(topology.simple_lj_typer(mol), dst_qlj_params[:,1:])
+    np.testing.assert_array_equal(np.zeros_like(dst_qlj_params[:,0]), dst_qlj_params[:,0])
+
+
+def test_base_topology_conversion_r_group():
+
+    # check that phenol torsions are turned off
+    ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_sc.py').read())
+    ff = Forcefield(ff_handlers)
+    mol = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1O"))
+    mol_top = topology.BaseTopologyConversion(mol, ff)
+    result, potential = mol_top.parameterize_proper_torsion(ff.pt_handle.params)
+    # in the conversion phase, torsions that bridge the two rings should be set to
+    # be alchemically turned off.
+    is_in_ring = [1,1,1,1,1,1,0,0]
+
+    for torsion_idxs, mult, offset in zip(potential.get_idxs(), potential.get_lambda_mult(), potential.get_lambda_offset()):
+        _, b, c, _ = torsion_idxs
+        assert offset == 1
+        if is_in_ring[b] and is_in_ring[c]:
+            # should be always turned on
+            assert mult == 0
+        elif (not is_in_ring[b]) or (not is_in_ring[c]):
+            assert mult == -1
+
+def test_base_topology_standard_decoupling():
+
+    # this class is typically used in the second step of the RABFE protocol for the solvent leg.
+    # we expected the charges to be zero, and the lj parameters to be standardized. In addition,
+    # the torsions should be turned off.
+    ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_sc.py').read())
+    ff = Forcefield(ff_handlers)
+    mol = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1O"))
+    vanilla_mol_top = topology.BaseTopology(mol, ff)
+    vanilla_torsion_params, _ = vanilla_mol_top.parameterize_proper_torsion(ff.pt_handle.params)
+
+    mol_top = topology.BaseTopologyStandardDecoupling(mol, ff)
+    decouple_torsion_params, torsion_potential = mol_top.parameterize_proper_torsion(ff.pt_handle.params)
+
+    np.testing.assert_array_equal(vanilla_torsion_params, decouple_torsion_params)
+
+    # in the conversion phase, torsions that bridge the two rings should be set to
+    # be alchemically turned off.
+    is_in_ring = [1,1,1,1,1,1,0,0]
+
+    for torsion_idxs, mult, offset in zip(torsion_potential.get_idxs(), torsion_potential.get_lambda_mult(), torsion_potential.get_lambda_offset()):
+        _, b, c, _ = torsion_idxs
+        assert mult == 0
+        if is_in_ring[b] != is_in_ring[c]:
+            assert offset == 0
+        else:
+            assert offset == 1
+
+    qlj_params, nonbonded_potential = mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
+
+    np.testing.assert_array_equal(topology.simple_lj_typer(mol), qlj_params[:,1:])
+    np.testing.assert_array_equal(np.zeros_like(qlj_params[:,0]), qlj_params[:,0])
+
+    np.testing.assert_array_equal(nonbonded_potential.get_lambda_plane_idxs(), np.zeros(mol.GetNumAtoms(), dtype=np.int32))
+    np.testing.assert_array_equal(nonbonded_potential.get_lambda_offset_idxs(), np.ones(mol.GetNumAtoms(), dtype=np.int32))
+
+def test_dual_topology_standard_decoupling():
+
+    # this class is used in double decoupling stages of the RABFE protocol. It modifies the
+    # DualTopology class in two ways:
+    # 1) the torsions between non-ring atoms are turned off
+    # 2) the nonbonded terms are standardized, but also interpolated at lambda=0 such that
+    #    the epsilons are at half strength.
+
+    ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_sc.py').read())
+    ff = Forcefield(ff_handlers)
+    mol_a = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1O"))
+    mol_b = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1F"))
+    mol_c = Chem.CombineMols(mol_a, mol_b)
+    mol_top = topology.DualTopologyStandardDecoupling(mol_a, mol_b, ff)
+
+    decouple_torsion_params, torsion_potential = mol_top.parameterize_proper_torsion(ff.pt_handle.params)
+
+    # np.testing.assert_array_equal(vanilla_torsion_params, decouple_torsion_params)
+    #             C C C C C C O H H H H H H  C C C C C C F H H H H H H
+    is_in_ring = [1,1,1,1,1,1,0,0,0,0,0,0,0, 1,1,1,1,1,1,0,0,0,0,0,0,0]
+
+    for torsion_idxs, mult, offset in zip(torsion_potential.get_idxs(), torsion_potential.get_lambda_mult(), torsion_potential.get_lambda_offset()):
+        _, b, c, _ = torsion_idxs
+        assert mult == 0
+        if is_in_ring[b] != is_in_ring[c]:
+            assert offset == 0
+        else:
+            assert offset == 1
+
+    qlj_params, nonbonded_potential = mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
+
+    assert isinstance(nonbonded_potential, potentials.NonbondedInterpolated)
+
+    expected_lj = topology.simple_lj_typer(mol_c)
+    expected_lj[:, 1] = expected_lj[:, 1]/2
+
+    src_qlj_params = qlj_params[:len(qlj_params)//2]
+    dst_qlj_params = qlj_params[len(qlj_params)//2:]
+
+    np.testing.assert_array_equal(src_qlj_params[:, 0], np.zeros(mol_c.GetNumAtoms()))
+    np.testing.assert_array_equal(src_qlj_params[:, 1:], expected_lj)
+
+    expected_lj = topology.simple_lj_typer(mol_c)
+
+    np.testing.assert_array_equal(dst_qlj_params[:, 0], np.zeros(mol_c.GetNumAtoms()))
+    np.testing.assert_array_equal(dst_qlj_params[:, 1:], expected_lj)

--- a/tests/test_rabfe_topology.py
+++ b/tests/test_rabfe_topology.py
@@ -153,3 +153,21 @@ def test_dual_topology_standard_decoupling():
 
     np.testing.assert_array_equal(dst_qlj_params[:, 0], np.zeros(mol_c.GetNumAtoms()))
     np.testing.assert_array_equal(dst_qlj_params[:, 1:], expected_lj)
+
+def test_dual_topology_minimization():
+
+    # Identical to the vanilla Dual Topology class, except that both ligands are
+    # decouple simultaneously
+
+    ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_sc.py').read())
+    ff = Forcefield(ff_handlers)
+    mol_a = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1O"))
+    mol_b = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1F"))
+    mol_top = topology.DualTopologyMinimization(mol_a, mol_b, ff)
+
+    C = mol_a.GetNumAtoms() + mol_b.GetNumAtoms()
+
+    _, potential = mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
+
+    np.testing.assert_array_equal(potential.get_lambda_offset_idxs(), np.ones(C, dtype=np.int32))
+    np.testing.assert_array_equal(potential.get_lambda_plane_idxs(), np.zeros(C, dtype=np.int32))

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -132,6 +132,13 @@ class BondedWrapper(CustomOpWrapper):
         else:
             return None
 
+    def set_lambda_mult_and_offset(self, mult, offset):
+        if len(self.args) > 1:
+            self.args[1] = mult
+            self.args[2] = offset
+        else:
+            self.args.append(mult)
+            self.args.append(offset)
 
 class HarmonicBond(BondedWrapper):
     pass
@@ -226,6 +233,19 @@ class Nonbonded(CustomOpWrapper):
 
     def get_cutoff(self):
         return self.args[-1]
+
+    def interpolate(self):
+        """
+        Return an interpolated variant of this potential
+        """
+        return NonbondedInterpolated(
+            self.get_exclusion_idxs(),
+            self.get_scale_factors(),
+            self.get_lambda_plane_idxs(),
+            self.get_lambda_offset_idxs(),
+            self.get_beta(),
+            self.get_cutoff()
+        )
 
 class NonbondedInterpolated(Nonbonded):
 


### PR DESCRIPTION
This PR adds support for 3 additional topology classes used in our RABFE protocol:

**BaseTopologyConversion** - used for converting molecules from a forcefield dependent to a forcefield independent state. This is used for both complex and solvent stages. During training, we would only re-run this stage.
**BaseTopologyStandardDecoupling** - used for decoupling the standard ligand from the environment. This is used in the solvent stage.
**DualTopologyStandardDecoupling** - used for decoupling one of the two standard ligands from the environment. This is used in the complex stage, and is repeated. Note that the epsilons of the standardized ligand is halved in the lambda=0 state, and interpolated to the standard strength at lambda=1. 

There are two accessory classes:
**DualTopoloyMinimization** - Used by the minimizer.py code. This doesn't do any fancy indexing, it just sets the lambda_idxs to sane values
**DualTopologyRHFE** - Used for testing the RHFE code.

Most of this PR just involves setting up the various lambda_idxs, with some parameter interpolation mixed in.