### PR TITLE
Dual topology hydration

### DIFF
--- a/examples/validate_relative_hydration.py
+++ b/examples/validate_relative_hydration.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
                     prefix='epoch_'+str(epoch)+'_solvent_relative_'+mol_a.GetProp('_Name')+'_'+mol_b.GetProp('_Name')
                 )
 
-                # dG_a = model_absolute.predict(ordered_params, mol_a, prefix='solvent_absolute_'+mol_a.GetProp('_Name'))
-                # dG_b = model_absolute.predict(ordered_params, mol_b, prefix='solvent_absolute_'+mol_b.GetProp('_Name'))
+                dG_a = model_absolute.predict(ordered_params, mol_a, prefix='solvent_absolute_'+mol_a.GetProp('_Name'))
+                dG_b = model_absolute.predict(ordered_params, mol_b, prefix='solvent_absolute_'+mol_b.GetProp('_Name'))
 
-                # print("mol_i", i, mol_a.GetProp("_Name"), "mol_j", j, mol_b.GetProp("_Name"), "ddG_ab", ddG_ab, "dG_a-dG_b", dG_a-dG_b)
+                print("mol_i", i, mol_a.GetProp("_Name"), "mol_j", j, mol_b.GetProp("_Name"), "ddG_ab", ddG_ab, "dG_a-dG_b", dG_a-dG_b)

--- a/examples/validate_relative_hydration.py
+++ b/examples/validate_relative_hydration.py
@@ -146,6 +146,17 @@ if __name__ == "__main__":
 
     M = len(dataset.data)
 
+
+    for epoch in range(100):
+
+        i = 0
+
+        mol_a = dataset.data[i]
+
+        dG_a = model_absolute.predict(ordered_params, mol_a, prefix='solvent_absolute_'+mol_a.GetProp('_Name'))
+
+    assert 0
+
     for epoch in range(100):
 
         for i in range(M):

--- a/examples/validate_relative_hydration.py
+++ b/examples/validate_relative_hydration.py
@@ -125,7 +125,6 @@ if __name__ == "__main__":
         cmd_args.num_prod_steps
     )
 
-    # assert 0
     model_absolute = model_rabfe.AbsoluteHydrationModel(
         client,
         forcefield,
@@ -146,22 +145,9 @@ if __name__ == "__main__":
 
     for epoch in range(100):
 
-        i = 0
-
-        mol_a = dataset.data[i]
-
-        dG_a = model_absolute.predict(ordered_params, mol_a, prefix='solvent_absolute_'+mol_a.GetProp('_Name'))
-
-    assert 0
-
-    for epoch in range(100):
-
         for i in range(M):
 
             for j in range(i+1, M):
-
-                if i != 0 or j != 3:
-                    continue
 
                 mol_a = dataset.data[i]
                 mol_b = dataset.data[j]

--- a/examples/validate_relative_hydration.py
+++ b/examples/validate_relative_hydration.py
@@ -1,0 +1,171 @@
+# this script validates the endpoint correction protocol on relative hydration free energies
+
+# This script repeatedly estimates the relative binding free energy of a single edge, along with the gradient of the
+# estimate with respect to force field parameters, and adjusts the force field parameters to improve tha accuracy
+# of the free energy prediction.
+
+
+import argparse
+import numpy as np
+import jax
+from jax import numpy as jnp
+
+from fe.free_energy import construct_absolute_lambda_schedule
+from fe.utils import convert_uIC50_to_kJ_per_mole
+from fe import model_rabfe
+from md import builders
+
+from testsystems.relative import hif2a_ligand_pair
+
+from ff import Forcefield
+from ff.handlers.deserialize import deserialize_handlers
+from ff.handlers.serialize import serialize_handlers
+from ff.handlers.nonbonded import AM1CCCHandler, LennardJonesHandler
+from parallel.client import CUDAPoolClient, GRPCClient
+from parallel.utils import get_gpu_count
+
+from typing import Union, Optional, Iterable, Any, Tuple, Dict
+
+from optimize.step import truncated_step
+
+import multiprocessing
+from training.dataset import Dataset
+from rdkit import Chem
+
+array = Union[np.array, jnp.array]
+Handler = Union[AM1CCCHandler, LennardJonesHandler] # TODO: do these all inherit from a Handler class already?
+
+if __name__ == "__main__":
+
+    multiprocessing.set_start_method('spawn')
+
+    parser = argparse.ArgumentParser(
+        description="Absolute Binding Free Energy Testing",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--hosts",
+        nargs="*",
+        default=None,
+        help="Hosts running GRPC worker to use for compute"
+    )
+
+    parser.add_argument(
+        "--num_gpus",
+        type=int,
+        help="number of gpus",
+        default=get_gpu_count()
+    )
+
+    parser.add_argument(
+        "--num_windows",
+        type=int,
+        help="number of solvent lambda windows",
+        required=True
+    )
+
+    parser.add_argument(
+        "--num_equil_steps",
+        type=int,
+        help="number of equilibration steps for each solvent lambda window",
+        required=True
+    )
+
+    parser.add_argument(
+        "--num_prod_steps",
+        type=int,
+        help="number of production steps for each solvent lambda window",
+        required=True
+    )
+
+    cmd_args = parser.parse_args()
+
+    if not cmd_args.hosts:
+        num_gpus = cmd_args.num_gpus
+        # set up multi-GPU client
+        client = CUDAPoolClient(max_workers=num_gpus)
+    else:
+        # Setup GRPC client
+        print("Connecting to GRPC workers...")
+        client = GRPCClient(hosts=cmd_args.hosts)
+    client.verify()
+
+    path_to_ligand = 'tests/data/ligands_40.sdf'
+    suppl = Chem.SDMolSupplier(path_to_ligand, removeHs=False)
+
+    with open('ff/params/smirnoff_1_1_0_ccc.py') as f:
+        ff_handlers = deserialize_handlers(f.read())
+
+    forcefield = Forcefield(ff_handlers)
+    mols = [x for x in suppl]
+
+    dataset = Dataset(mols)
+
+    absolute_solvent_schedule = construct_absolute_lambda_schedule(cmd_args.num_windows)
+    relative_solvent_schedule = construct_absolute_lambda_schedule(cmd_args.num_windows-1)
+    solvent_system, solvent_coords, solvent_box, solvent_topology = builders.build_water_system(4.0)
+
+    # pick the largest mol as the blocker
+    largest_size = 0
+    ref_mol = None
+    for mol in mols:
+        if mol.GetNumAtoms() > largest_size:
+            largest_size = mol.GetNumAtoms()
+            ref_mol = mol
+
+    print("Reference Molecule:", ref_mol.GetProp("_Name"), Chem.MolToSmiles(ref_mol))
+
+    model_relative = model_rabfe.RelativeHydrationModel(
+        client,
+        forcefield,
+        solvent_system,
+        solvent_coords,
+        solvent_box,
+        relative_solvent_schedule,
+        solvent_topology,
+        cmd_args.num_equil_steps,
+        cmd_args.num_prod_steps
+    )
+
+    # assert 0
+    model_absolute = model_rabfe.AbsoluteHydrationModel(
+        client,
+        forcefield,
+        solvent_system,
+        solvent_coords,
+        solvent_box,
+        absolute_solvent_schedule,
+        solvent_topology,
+        cmd_args.num_equil_steps,
+        cmd_args.num_prod_steps
+    )
+
+    ordered_params = forcefield.get_ordered_params()
+    ordered_handles = forcefield.get_ordered_handles()
+
+    M = len(dataset.data)
+
+    for epoch in range(100):
+
+        for i in range(M):
+
+            for j in range(i+1, M):
+
+                if i != 0 or j != 3:
+                    continue
+
+                mol_a = dataset.data[i]
+                mol_b = dataset.data[j]
+
+                ddG_ab = model_relative.predict(
+                    ordered_params,
+                    mol_a,
+                    mol_b,
+                    prefix='epoch_'+str(epoch)+'_solvent_relative_'+mol_a.GetProp('_Name')+'_'+mol_b.GetProp('_Name')
+                )
+
+                dG_a = model_absolute.predict(ordered_params, mol_a, prefix='solvent_absolute_'+mol_a.GetProp('_Name'))
+                dG_b = model_absolute.predict(ordered_params, mol_b, prefix='solvent_absolute_'+mol_b.GetProp('_Name'))
+
+                print("mol_i", i, mol_a.GetProp("_Name"), "mol_j", j, mol_b.GetProp("_Name"), "ddG_ab", ddG_ab, "dG_a-dG_b", dG_a-dG_b)

--- a/examples/validate_relative_hydration.py
+++ b/examples/validate_relative_hydration.py
@@ -1,9 +1,6 @@
-# this script validates the endpoint correction protocol on relative hydration free energies
-
-# This script repeatedly estimates the relative binding free energy of a single edge, along with the gradient of the
-# estimate with respect to force field parameters, and adjusts the force field parameters to improve tha accuracy
-# of the free energy prediction.
-
+# This script validates the endpoint correction protocol on
+# relative hydration free energies by comparing two absolute differences
+# against the relative difference.
 
 import argparse
 import numpy as np
@@ -40,7 +37,7 @@ if __name__ == "__main__":
     multiprocessing.set_start_method('spawn')
 
     parser = argparse.ArgumentParser(
-        description="Absolute Binding Free Energy Testing",
+        description="Absolute Hydration Free Energy Testing",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 

--- a/examples/validate_relative_hydration.py
+++ b/examples/validate_relative_hydration.py
@@ -10,7 +10,7 @@ import numpy as np
 import jax
 from jax import numpy as jnp
 
-from fe.free_energy import construct_absolute_lambda_schedule
+from fe.free_energy_rabfe import construct_absolute_lambda_schedule
 from fe.utils import convert_uIC50_to_kJ_per_mole
 from fe import model_rabfe
 from md import builders

--- a/examples/validate_relative_hydration.py
+++ b/examples/validate_relative_hydration.py
@@ -7,7 +7,7 @@ import numpy as np
 import jax
 from jax import numpy as jnp
 
-from fe.free_energy_rabfe import construct_absolute_lambda_schedule
+from fe.free_energy_rabfe import construct_absolute_lambda_schedule, construct_relative_lambda_schedule
 from fe.utils import convert_uIC50_to_kJ_per_mole
 from fe import model_rabfe
 from md import builders
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     dataset = Dataset(mols)
 
     absolute_solvent_schedule = construct_absolute_lambda_schedule(cmd_args.num_windows)
-    relative_solvent_schedule = construct_absolute_lambda_schedule(cmd_args.num_windows-1)
+    relative_solvent_schedule = construct_relative_lambda_schedule(cmd_args.num_windows-1)
     solvent_system, solvent_coords, solvent_box, solvent_topology = builders.build_water_system(4.0)
 
     # pick the largest mol as the blocker
@@ -159,7 +159,7 @@ if __name__ == "__main__":
                     prefix='epoch_'+str(epoch)+'_solvent_relative_'+mol_a.GetProp('_Name')+'_'+mol_b.GetProp('_Name')
                 )
 
-                dG_a = model_absolute.predict(ordered_params, mol_a, prefix='solvent_absolute_'+mol_a.GetProp('_Name'))
-                dG_b = model_absolute.predict(ordered_params, mol_b, prefix='solvent_absolute_'+mol_b.GetProp('_Name'))
+                # dG_a = model_absolute.predict(ordered_params, mol_a, prefix='solvent_absolute_'+mol_a.GetProp('_Name'))
+                # dG_b = model_absolute.predict(ordered_params, mol_b, prefix='solvent_absolute_'+mol_b.GetProp('_Name'))
 
-                print("mol_i", i, mol_a.GetProp("_Name"), "mol_j", j, mol_b.GetProp("_Name"), "ddG_ab", ddG_ab, "dG_a-dG_b", dG_a-dG_b)
+                # print("mol_i", i, mol_a.GetProp("_Name"), "mol_j", j, mol_b.GetProp("_Name"), "ddG_ab", ddG_ab, "dG_a-dG_b", dG_a-dG_b)

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -321,10 +321,10 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
         lamb_start = model.lambda_schedule[lambda_idx]
         lamb_end = model.lambda_schedule[lambda_idx+1]
         delta_lamb = lamb_end - lamb_start
-        fwd_work = ti_results[lambda_idx].du_dls*delta_lamb
-        rev_work = -ti_results[lambda_idx+1].du_dls*delta_lamb
-        tibar, ti_bar_err = pymbar.BAR(model.beta*fwd_work, model.beta*rev_work)
-        tibar_overlap = endpoint_correction.overlap_from_cdf(fwd_work, rev_work)
+        fwd_work_approx = ti_results[lambda_idx].du_dls*delta_lamb
+        rev_work_approx = -ti_results[lambda_idx+1].du_dls*delta_lamb
+        tibar, ti_bar_err = pymbar.BAR(model.beta*fwd_work_approx, model.beta*rev_work_approx)
+        tibar_overlap = endpoint_correction.overlap_from_cdf(fwd_work_approx, rev_work_approx)
         tibar_dG += tibar/model.beta
 
         # exact_bar
@@ -333,7 +333,7 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
 
         dG_exact, exact_bar_err = pymbar.BAR(fwd_work_exact, rev_work_exact)
         bar_dG += dG_exact/model.beta
-        exact_bar_overlap = endpoint_correction.overlap_from_cdf(fwd_work_exact, -rev_work_exact)
+        exact_bar_overlap = endpoint_correction.overlap_from_cdf(fwd_work_exact, rev_work_exact)
 
         print("BAR: lamb_start", lamb_start, "ti_bar", tibar/model.beta, "exact_bar", dG_exact/model.beta, "tibar_overlap", tibar_overlap, "exact_bar_overlap", exact_bar_overlap, "ti_bar_err", ti_bar_err/model.beta, "exact_bar_err", exact_bar_err/model.beta)
 

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -238,12 +238,15 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
 
     tibar_dG = 0
     for lambda_idx in range(len(model.lambda_schedule) - 1):
-        delta_lamb = model.lambda_schedule[lambda_idx+1] - model.lambda_schedule[lambda_idx]
+        lamb_start = model.lambda_schedule[lambda_idx]
+        lamb_end = model.lambda_schedule[lambda_idx+1]
+        delta_lamb = lamb_end - lamb_start
         fwd_work = ti_results[lambda_idx].du_dls*delta_lamb
         rev_work = -ti_results[lambda_idx+1].du_dls*delta_lamb
         tibar, err = pymbar.BAR(model.beta*fwd_work, model.beta*rev_work)
         overlap = endpoint_correction.overlap_from_cdf(fwd_work, rev_work)
-        print("tibar", tibar/model.beta, "delta", delta_lamb, "overlap", overlap)
+        # print(f"{model.prefix} index {lambda_idx} lambda {lambda_window:.5f} <du/dl> {np.mean(result.du_dls):.5f} med(du/dl) {np.median(result.du_dls):.5f}  o(du/dl) {np.std(result.du_dls):.5f}")
+        print("lamb_start", lamb_start, "tibar", tibar/model.beta, "delta", delta_lamb, "overlap", overlap, "err", err/model.beta)
         tibar_dG += tibar/model.beta
 
     dG = np.trapz(mean_du_dls, model.lambda_schedule)

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -345,7 +345,7 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
 
     bar_dG_err = np.sqrt(bar_dG_err)
 
-    # dG = np.trapz(mean_du_dls, model.lambda_schedule)
+    dG_ti = np.trapz(mean_du_dls, model.lambda_schedule)
     dG = bar_dG
     dG_grad = []
     for rhs, lhs in zip(all_grads[-1], all_grads[0]):
@@ -379,12 +379,12 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
         overlap = endpoint_correction.overlap_from_cdf(lhs_du, rhs_du)
         lhs_mean = np.mean(lhs_du)
         rhs_mean = np.mean(rhs_du)
-        print(f"{model.prefix} dG_ti {dG:.3f} exact_bar {bar_dG:.3f} exact_bar_err {bar_dG_err:.3f} dG_endpoint {dG_endpoint:.3f} dG_endpoint_err {endpoint_err:.3f} dG_ssc_translation {dG_ssc_translation:.3f} dG_ssc_rotation {dG_ssc_rotation:.3f} overlap {overlap:.3f} lhs_mean {lhs_mean:.3f} rhs_mean {rhs_mean:.3f} lhs_n {len(lhs_du)} rhs_n {len(rhs_du)} | time: {time.time()-start:.3f}s")
+        print(f"{model.prefix} dG_ti {dG_ti:.3f} exact_bar {bar_dG:.3f} exact_bar_err {bar_dG_err:.3f} dG_endpoint {dG_endpoint:.3f} dG_endpoint_err {endpoint_err:.3f} dG_ssc_translation {dG_ssc_translation:.3f} dG_ssc_rotation {dG_ssc_rotation:.3f} overlap {overlap:.3f} lhs_mean {lhs_mean:.3f} rhs_mean {rhs_mean:.3f} lhs_n {len(lhs_du)} rhs_n {len(rhs_du)} | time: {time.time()-start:.3f}s")
         dG += dG_endpoint + dG_ssc_translation + dG_ssc_rotation
         bar_dG_err += endpoint_err**2
         bar_dG_err = np.sqrt(bar_dG_err)
     else:
-        print(f"{model.prefix} dG_ti {dG:.3f} exact_bar {bar_dG:.3f} exact_bar_err {bar_dG_err:.3f} ")
+        print(f"{model.prefix} dG_ti {dG_ti:.3f} exact_bar {bar_dG:.3f} exact_bar_err {bar_dG_err:.3f} ")
 
     return (dG, results), dG_grad
 

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -331,7 +331,7 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
         fwd_work_exact = model.beta*ti_results[lambda_idx].right_dus
         rev_work_exact = model.beta*ti_results[lambda_idx+1].left_dus
 
-        dG_exact, exact_bar_err = pymbar.BAR(fwd_work, rev_work)
+        dG_exact, exact_bar_err = pymbar.BAR(fwd_work_exact, rev_work_exact)
         bar_dG += dG_exact/model.beta
         exact_bar_overlap = endpoint_correction.overlap_from_cdf(fwd_work_exact, -rev_work_exact)
 

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -243,7 +243,7 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
         delta_lamb = model.lambda_schedule[lambda_idx+1] - model.lambda_schedule[lambda_idx]
         tibar, err = pymbar.BAR(model.beta*fwd_work, model.beta*rev_work)
         overlap = endpoint_correction.overlap_from_cdf(fwd_work, rev_work)
-        print("tibar increment", (tibar/model.beta), "delta", delta_lamb, "overlap", overlap)
+        print("tibar", (tibar/model.beta), "delta", delta_lamb, "overlap", overlap, "increment", (tibar/model.beta)*delta_lamb)
         tibar_dG += (tibar/model.beta)*delta_lamb
 
     dG = np.trapz(mean_du_dls, model.lambda_schedule)

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -1,0 +1,293 @@
+import pymbar
+from fe import endpoint_correction
+from collections import namedtuple
+
+import dataclasses
+import time
+import functools
+import copy
+import jax
+import numpy as np
+from md import minimizer
+
+from typing import Tuple, List, Any
+import os
+
+from fe import standard_state
+
+from timemachine.lib import potentials, custom_ops
+
+@dataclasses.dataclass
+class SimulationResult:
+   xs: np.array
+   boxes: np.array
+   du_dls: np.array
+   du_dps: np.array
+
+def flatten(v):
+    return tuple(), (v.xs, v.boxes, v.du_dls, v.du_dps)
+
+def unflatten(aux_data, children):
+    xs, boxes, du_dls, du_dps = aux_data
+    return SimulationResult(xs, boxes, du_dls, du_dps)
+
+jax.tree_util.register_pytree_node(SimulationResult, flatten, unflatten)
+
+def simulate(lamb, box, x0, v0, final_potentials, integrator, barostat, equil_steps, prod_steps,
+    x_interval=50, du_dl_interval=5):
+    """
+    Run a simulation and collect relevant statistics for this simulation.
+
+    Parameters
+    ----------
+    lamb: float
+        lambda parameter
+
+    box: np.array
+        3x3 numpy array of the box, dtype should be np.float64
+
+    x0: np.array
+        Nx3 numpy array of the coordinates
+
+    v0: np.array
+        Nx3 numpy array of the velocities
+
+    final_potentials: list
+        list of unbound potentials
+
+    integrator: timemachine.Integrator
+        integrator to be used for dynamics
+
+    barostat: timemachine.Barostat
+        barostat to be used for dynamics
+
+    equil_steps: int
+        number of equilibration steps
+
+    prod_steps: int
+        number of production steps
+
+    x_interval: int
+        how often we store coordinates. if x_interval == 0 then
+        no frames are returned.
+
+    du_dl_interval: int
+        how often we store du_dls. if du_dl_interval == 0 then
+        no du_dls are returned
+
+    Returns
+    -------
+    SimulationResult
+        Results of the simulation.
+
+    """
+
+    all_impls = []
+
+    # set up observables for du_dps here as well.
+    du_dp_obs = []
+
+    for bp in final_potentials:
+        impl = bp.bound_impl(np.float32)
+        all_impls.append(impl)
+        du_dp_obs.append(custom_ops.AvgPartialUPartialParam(impl, 5))
+
+    # fire minimize once again, needed for parameter interpolation
+    x0 = minimizer.fire_minimize(x0, all_impls, box, np.ones(100, dtype=np.float64)*lamb)
+
+    # sanity check that forces are well behaved
+    for bp in all_impls:
+        du_dx, du_dl, u = bp.execute(x0, box, lamb)
+        norm_forces = np.linalg.norm(du_dx, axis=1)
+        assert np.all(norm_forces < 25000)
+
+    if integrator.seed == 0:
+        # this deepcopy is needed if we're running if client == None
+        integrator = copy.deepcopy(integrator)
+        integrator.seed = np.random.randint(np.iinfo(np.int32).max)
+
+    if barostat.seed == 0:
+        barostat = copy.deepcopy(barostat)
+        barostat.seed = np.random.randint(np.iinfo(np.int32).max)
+
+    intg_impl = integrator.impl()
+     # technically we need to only pass in the nonbonded impl
+    barostat_impl = barostat.impl(all_impls)
+    # context components: positions, velocities, box, integrator, energy fxns
+    ctxt = custom_ops.Context(
+        x0,
+        v0,
+        box,
+        intg_impl,
+        all_impls,
+        barostat_impl
+    )
+
+    # equilibration
+    equil_schedule = np.ones(equil_steps)*lamb
+    ctxt.multiple_steps(equil_schedule)
+
+    for obs in du_dp_obs:
+        ctxt.add_observable(obs)
+
+    prod_schedule = np.ones(prod_steps)*lamb
+
+    full_du_dls, xs, boxes, = ctxt.multiple_steps(prod_schedule, du_dl_interval, x_interval)
+
+    # keep the structure of grads the same as that of final_potentials so we can properly
+    # form their vjps.
+    grads = []
+    for obs in du_dp_obs:
+        grads.append(obs.avg_du_dp())
+
+    result = SimulationResult(xs=xs, boxes=boxes, du_dls=full_du_dls, du_dps=grads)
+    return result
+
+
+FreeEnergyModel = namedtuple(
+    "FreeEnergyModel",
+    [
+     "unbound_potentials",
+     "endpoint_correct",
+     "client",
+     "box",
+     "x0",
+     "v0",
+     "integrator",
+     "barostat",
+     "lambda_schedule",
+     "equil_steps",
+     "prod_steps",
+     "beta",
+     "prefix",
+    ]
+)
+
+gradient = List[Any] # TODO: make this more descriptive of dG_grad structure
+
+def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
+
+    assert len(sys_params) == len(model.unbound_potentials)
+
+    bound_potentials = []
+    for params, unbound_pot in zip(sys_params, model.unbound_potentials):
+        bp = unbound_pot.bind(np.asarray(params))
+        bound_potentials.append(bp)
+
+    all_args = []
+    for lamb_idx, lamb in enumerate(model.lambda_schedule):
+
+        if model.endpoint_correct and lamb_idx == len(model.lambda_schedule) - 1:
+            x_interval = 200
+        else:
+            x_interval = 10000
+
+        all_args.append((
+            lamb,
+            model.box,
+            model.x0,
+            model.v0,
+            bound_potentials,
+            model.integrator,
+            model.barostat,
+            model.equil_steps,
+            model.prod_steps,
+            x_interval
+        ))
+
+    if model.endpoint_correct:
+        all_args.append((
+            1.0,
+            model.box,
+            model.x0,
+            model.v0,
+            bound_potentials[:-1],
+            model.integrator,
+            model.barostat,
+            model.equil_steps,
+            model.prod_steps,
+            200
+        ))
+
+    if model.client is None:
+        results = []
+        for args in all_args:
+            results.append(simulate(*args))
+    else:
+        futures = []
+        for args in all_args:
+            futures.append(model.client.submit(simulate, *args))
+
+        results = []
+        for future in futures:
+            results.append(future.result())
+
+    mean_du_dls = []
+    all_grads = []
+
+    if model.endpoint_correct:
+        ti_results = results[:-1]
+    else:
+        ti_results = results
+
+    for lambda_idx, (lambda_window, result) in enumerate(zip(model.lambda_schedule, ti_results)):
+        # (ytz): figure out what to do with stddev(du_dl) later
+        print(f"{model.prefix} index {lambda_idx} lambda {lambda_window:.5f} <du/dl> {np.mean(result.du_dls):.5f} med(du/dl) {np.median(result.du_dls):.5f}  o(du/dl) {np.std(result.du_dls):.5f}")
+        mean_du_dls.append(np.mean(result.du_dls))
+        all_grads.append(result.du_dps)
+
+    dG = np.trapz(mean_du_dls, model.lambda_schedule)
+    dG_grad = []
+    for rhs, lhs in zip(all_grads[-1], all_grads[0]):
+        dG_grad.append(rhs - lhs)
+
+    if model.endpoint_correct:
+        core_restr = bound_potentials[-1]
+        # (ytz): tbd, automatically find optimal k_translation/k_rotation such that
+        # standard deviation and/or overlap is maximized
+        k_translation = 200.0
+        k_rotation = 100.0
+        start = time.time()
+        lhs_du, rhs_du, rotation_samples, translation_samples = endpoint_correction.estimate_delta_us(
+            k_translation=k_translation,
+            k_rotation=k_rotation,
+            core_idxs=core_restr.get_idxs(),
+            core_params=core_restr.params.reshape((-1,2)),
+            beta=model.beta,
+            lhs_xs=results[-2].xs,
+            rhs_xs=results[-1].xs
+        )
+        dG_endpoint = pymbar.BAR(model.beta*lhs_du, model.beta*np.array(rhs_du))[0]/model.beta
+        # compute standard state corrections for translation and rotation
+        dG_ssc_translation, dG_ssc_rotation = standard_state.release_orientational_restraints(
+            k_translation,
+            k_rotation,
+            model.beta
+        )
+        overlap = endpoint_correction.overlap_from_cdf(lhs_du, rhs_du)
+        lhs_mean = np.mean(lhs_du)
+        rhs_mean = np.mean(rhs_du)
+        print(f"{model.prefix} dG_ti {dG:.3f} dG_endpoint {dG_endpoint:.3f} dG_ssc_translation {dG_ssc_translation:.3f} dG_ssc_rotation {dG_ssc_rotation:.3f} overlap {overlap:.3f} lhs_mean {lhs_mean:.3f} rhs_mean {rhs_mean:.3f} lhs_n {len(lhs_du)} rhs_n {len(rhs_du)} | time: {time.time()-start:.3f}s")
+        dG += dG_endpoint + dG_ssc_translation + dG_ssc_rotation
+    else:
+        print(f"{model.prefix} dG_ti {dG:.3f}")
+
+    return (dG, results), dG_grad
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=(0,))
+def deltaG(model, sys_params) -> Tuple[float, List]:
+    return _deltaG(model=model, sys_params=sys_params)[0]
+
+def deltaG_fwd(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
+    """same signature as DeltaG, but returns the full tuple"""
+    return _deltaG(model=model, sys_params=sys_params)
+
+def deltaG_bwd(model, residual, grad) -> Tuple[np.array]:
+    """Note: nondiff args must appear first here, even though one of them appears last in the original function's signature!
+    """
+    # residual are the partial dG / partial dparams for each term
+    # grad[0] is the adjoint of dG w.r.t. loss: partial L/partial dG
+    # grad[1] is the adjoint of dG w.r.t. simulation result, which we don't use
+    return ([grad[0]*r for r in residual],)
+
+deltaG.defvjp(deltaG_fwd, deltaG_bwd)

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -264,8 +264,8 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
             model.barostat,
             model.equil_steps,
             model.prod_steps,
-            x_interval,
-            200,
+            x_interval, # x_interval
+            200,        # du_dl_interval
             lambda_left,
             lambda_right
         ))
@@ -281,8 +281,8 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
             model.barostat,
             model.equil_steps,
             model.prod_steps,
-            200,
-            200,
+            200,       # x_interval
+            200,       # du_dl_interval
             None,
             None
         ))
@@ -318,9 +318,6 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
     bar_dG = 0
     bar_dG_err = 0
 
-    # for ti_idx, ti_res in enumerate(ti_results):
-        # pickle.dump(ti_res, open("ti_results_pickle_idx_"+str(ti_idx)+".pkl", "wb"))
-
     for lambda_idx in range(len(model.lambda_schedule) - 1):
         # tibar
         lamb_start = model.lambda_schedule[lambda_idx]
@@ -343,14 +340,12 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
         # probably off by a factor of two
         bar_dG_err += (exact_bar_err/model.beta)**2
 
-        # print("BAR: lamb_start", lamb_start, "ti_bar", tibar/model.beta, "exact_bar", dG_exact/model.beta, "tibar_overlap", tibar_overlap, "exact_bar_overlap", exact_bar_overlap, "ti_bar_err", ti_bar_err/model.beta, "exact_bar_err", exact_bar_err/model.beta)
-        # print("BAR:", lamb_start, "ti_bar", tibar/model.beta, "exact_bar", dG_exact/model.beta, "tibar_overlap", tibar_overlap, "exact_bar_overlap", exact_bar_overlap, "ti_bar_err", ti_bar_err/model.beta, "exact_bar_err", exact_bar_err/model.beta)
         print(f"{model.prefix}_BAR: lambda {lamb_start:.3f} -> {lamb_end:.3f} dG: {dG_exact/model.beta:.3f} dG_err: {exact_bar_err/model.beta:.3f} overlap: {exact_bar_overlap:.3f}")
 
     bar_dG_err = np.sqrt(bar_dG_err)
 
     dG_ti = np.trapz(mean_du_dls, model.lambda_schedule)
-    dG = bar_dG
+    dG = bar_dG # use the exact answer
     dG_grad = []
     for rhs, lhs in zip(all_grads[-1], all_grads[0]):
         dG_grad.append(rhs - lhs)
@@ -383,12 +378,12 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
         overlap = endpoint_correction.overlap_from_cdf(lhs_du, rhs_du)
         lhs_mean = np.mean(lhs_du)
         rhs_mean = np.mean(rhs_du)
-        print(f"{model.prefix} dG_ti {dG_ti:.3f} exact_bar {bar_dG:.3f} exact_bar_err {bar_dG_err:.3f} dG_endpoint {dG_endpoint:.3f} dG_endpoint_err {endpoint_err:.3f} dG_ssc_translation {dG_ssc_translation:.3f} dG_ssc_rotation {dG_ssc_rotation:.3f} overlap {overlap:.3f} lhs_mean {lhs_mean:.3f} rhs_mean {rhs_mean:.3f} lhs_n {len(lhs_du)} rhs_n {len(rhs_du)} | time: {time.time()-start:.3f}s")
+        print(f"{model.prefix} dG_tibar {tibar_dG:.3f} dG_ti {dG_ti:.3f} exact_bar {bar_dG:.3f} exact_bar_err {bar_dG_err:.3f} dG_endpoint {dG_endpoint:.3f} dG_endpoint_err {endpoint_err:.3f} dG_ssc_translation {dG_ssc_translation:.3f} dG_ssc_rotation {dG_ssc_rotation:.3f} overlap {overlap:.3f} lhs_mean {lhs_mean:.3f} rhs_mean {rhs_mean:.3f} lhs_n {len(lhs_du)} rhs_n {len(rhs_du)} | time: {time.time()-start:.3f}s")
         dG += dG_endpoint + dG_ssc_translation + dG_ssc_rotation
         bar_dG_err += endpoint_err**2
         bar_dG_err = np.sqrt(bar_dG_err)
     else:
-        print(f"{model.prefix} dG_ti {dG_ti:.3f} exact_bar {bar_dG:.3f} exact_bar_err {bar_dG_err:.3f} ")
+        print(f"{model.prefix} dG_tibar {tibar_dG:.3f} dG_ti {dG_ti:.3f} exact_bar {bar_dG:.3f} exact_bar_err {bar_dG_err:.3f} ")
 
     return (dG, results), dG_grad
 

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -1,6 +1,7 @@
 import pymbar
 from fe import endpoint_correction
 from collections import namedtuple
+import pickle
 
 import dataclasses
 import time
@@ -316,6 +317,9 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
     tibar_dG = 0
     bar_dG = 0
     bar_dG_err = 0
+
+    # for ti_idx, ti_res in enumerate(ti_results):
+        # pickle.dump(ti_res, open("ti_results_pickle_idx_"+str(ti_idx)+".pkl", "wb"))
 
     for lambda_idx in range(len(model.lambda_schedule) - 1):
         # tibar

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -324,7 +324,7 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
         fwd_work = ti_results[lambda_idx].du_dls*delta_lamb
         rev_work = -ti_results[lambda_idx+1].du_dls*delta_lamb
         tibar, ti_bar_err = pymbar.BAR(model.beta*fwd_work, model.beta*rev_work)
-        overlap = endpoint_correction.overlap_from_cdf(fwd_work, rev_work)
+        tibar_overlap = endpoint_correction.overlap_from_cdf(fwd_work, rev_work)
         tibar_dG += tibar/model.beta
 
         # exact_bar
@@ -333,9 +333,9 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
 
         dG_exact, exact_bar_err = pymbar.BAR(fwd_work, rev_work)
         bar_dG += dG_exact/model.beta
-        overlap = endpoint_correction.overlap_from_cdf(fwd_work_exact, -rev_work_exact)
+        exact_bar_overlap = endpoint_correction.overlap_from_cdf(fwd_work_exact, -rev_work_exact)
 
-        print("BAR: lamb_start", lamb_start, "ti_bar", tibar/model.beta, "exact_bar", dG_exact/model.beta, "overlap", overlap, "ti_bar_err", ti_bar_err/model.beta, "exact_bar_err", exact_bar_err/model.beta)
+        print("BAR: lamb_start", lamb_start, "ti_bar", tibar/model.beta, "exact_bar", dG_exact/model.beta, "tibar_overlap", tibar_overlap, "exact_bar_overlap", exact_bar_overlap, "ti_bar_err", ti_bar_err/model.beta, "exact_bar_err", exact_bar_err/model.beta)
 
     dG = np.trapz(mean_du_dls, model.lambda_schedule)
     dG_grad = []

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -249,6 +249,24 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
         print("lamb_start", lamb_start, "tibar", tibar/model.beta, "delta", delta_lamb, "overlap", overlap, "err", err/model.beta)
         tibar_dG += tibar/model.beta
 
+    bar_dG = 0
+
+    for lambda_idx in range(len(model.lambda_schedule) - 1):
+        lamb_start = model.lambda_schedule[lambda_idx]
+        lamb_end = model.lambda_schedule[lambda_idx+1]
+        delta_U
+        for x, box in zip(ti_results[lambda_idx].xs, ti_results[lambda_idx].boxes):
+        # for bp in bound_potentials:
+            bp.execute_selective(x, box, lamb_start, False, False, False, True)
+        # delta_lamb = lamb_end - lamb_start
+        # fwd_work = ti_results[lambda_idx].du_dls*delta_lamb
+        # rev_work = -ti_results[lambda_idx+1].du_dls*delta_lamb
+        # tibar, err = pymbar.BAR(model.beta*fwd_work, model.beta*rev_work)
+        # overlap = endpoint_correction.overlap_from_cdf(fwd_work, rev_work)
+        # print(f"{model.prefix} index {lambda_idx} lambda {lambda_window:.5f} <du/dl> {np.mean(result.du_dls):.5f} med(du/dl) {np.median(result.du_dls):.5f}  o(du/dl) {np.std(result.du_dls):.5f}")
+        # print("lamb_start", lamb_start, "tibar", tibar/model.beta, "delta", delta_lamb, "overlap", overlap, "err", err/model.beta)
+        # tibar_dG += tibar/model.beta
+
     dG = np.trapz(mean_du_dls, model.lambda_schedule)
     dG_grad = []
     for rhs, lhs in zip(all_grads[-1], all_grads[0]):

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -242,6 +242,8 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
         rev_work = -ti_results[lambda_idx+1].du_dls
         delta_lamb = model.lambda_schedule[lambda_idx+1] - model.lambda_schedule[lambda_idx]
         tibar, err = pymbar.BAR(model.beta*fwd_work, model.beta*rev_work)
+        overlap = endpoint_correction.overlap_from_cdf(fwd_work, rev_work)
+        print("tibar increment", (tibar/model.beta), "delta", delta_lamb, "overlap", overlap)
         tibar_dG += (tibar/model.beta)*delta_lamb
 
     dG = np.trapz(mean_du_dls, model.lambda_schedule)

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -238,13 +238,13 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
 
     tibar_dG = 0
     for lambda_idx in range(len(model.lambda_schedule) - 1):
-        fwd_work = ti_results[lambda_idx].du_dls
-        rev_work = -ti_results[lambda_idx+1].du_dls
         delta_lamb = model.lambda_schedule[lambda_idx+1] - model.lambda_schedule[lambda_idx]
+        fwd_work = ti_results[lambda_idx].du_dls*delta_lamb
+        rev_work = -ti_results[lambda_idx+1].du_dls*delta_lamb
         tibar, err = pymbar.BAR(model.beta*fwd_work, model.beta*rev_work)
         overlap = endpoint_correction.overlap_from_cdf(fwd_work, rev_work)
-        print("tibar", (tibar/model.beta), "delta", delta_lamb, "overlap", overlap, "increment", (tibar/model.beta)*delta_lamb)
-        tibar_dG += (tibar/model.beta)*delta_lamb
+        print("tibar", tibar/model.beta, "delta", delta_lamb, "overlap", overlap)
+        tibar_dG += tibar/model.beta
 
     dG = np.trapz(mean_du_dls, model.lambda_schedule)
     dG_grad = []

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -34,7 +34,7 @@ def unflatten(aux_data, children):
 jax.tree_util.register_pytree_node(SimulationResult, flatten, unflatten)
 
 def simulate(lamb, box, x0, v0, final_potentials, integrator, barostat, equil_steps, prod_steps,
-    x_interval=50, du_dl_interval=5):
+    x_interval=50, du_dl_interval=200):
     """
     Run a simulation and collect relevant statistics for this simulation.
 

--- a/fe/free_energy.py
+++ b/fe/free_energy.py
@@ -19,9 +19,6 @@ def get_romol_conf(mol):
     guest_conf = np.array(conformer.GetPositions(), dtype=np.float64)
     return guest_conf/10 # from angstroms to nm
 
-class UnsupportedTopology(Exception):
-    pass
-
 class BaseFreeEnergy():
 
     @staticmethod
@@ -219,65 +216,6 @@ class RelativeFreeEnergy(BaseFreeEnergy):
         return final_potentials, final_params, combined_masses, combined_coords
 
 
-
-# this class is serializable.
-class RelativeDualTopologyFreeEnergy(BaseFreeEnergy):
-
-    def __init__(self, dual_topology: topology.DualTopology, label=None, complex_path=None):
-        self.top = dual_topology
-        self.label = label
-        self.complex_path = complex_path
-
-    @property
-    def mol_a(self):
-        return self.top.mol_a
-
-    @property
-    def mol_b(self):
-        return self.top.mol_b
-
-    @property
-    def ff(self):
-        return self.top.ff
-
-    def prepare_host_edge(self, ff_params, host_system):
-        """
-        Prepares the host-edge system
-        Parameters
-        ----------
-        ff_params: tuple of np.array
-            Exactly equal to bond_params, angle_params, proper_params, improper_params, charge_params, lj_params
-        host_system: openmm.System
-            openmm System object to be deserialized
-
-        Returns
-        -------
-        3-tuple
-            unbound_potentials, system_params, combined_masses
-
-        """
-
-        ligand_masses_a = [a.GetMass() for a in self.mol_a.GetAtoms()]
-        ligand_masses_b = [b.GetMass() for b in self.mol_b.GetAtoms()]
-
-        # extract the 0th conformer
-        ligand_coords_a = get_romol_conf(self.mol_a)
-        ligand_coords_b = get_romol_conf(self.mol_b)
-
-        host_bps, host_masses = openmm_deserializer.deserialize_system(host_system, cutoff=1.2)
-
-        hgt = topology.HostGuestTopology(host_bps, self.top)
-
-        final_params, final_potentials = self._get_system_params_and_potentials(ff_params, hgt)
-
-        combined_masses = np.concatenate([host_masses, ligand_masses_a, ligand_masses_b])
-
-        return final_potentials, final_params, combined_masses
-
-
-
-
-
 class RBFETransformIndex:
     """Builds an index of relative free energy transformations to use
     with construct_mle_layer
@@ -328,17 +266,5 @@ def construct_lambda_schedule(num_windows):
     ])
 
     assert len(lambda_schedule) == num_windows
-
-    return lambda_schedule
-
-
-def construct_absolute_lambda_schedule(num_windows):
-    A = int(0.70 * num_windows)
-    B = num_windows - A
-
-    lambda_schedule = np.concatenate([
-        np.linspace(0.0, 0.3, A, endpoint=False),
-        np.linspace(0.3, 1.0, B, endpoint=True)
-    ])
 
     return lambda_schedule

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -177,7 +177,7 @@ class RBFETransformIndex:
         return MolToSmiles(mol)
 
 
-def construct_lambda_schedule(num_windows):
+def construct_absolute_lambda_schedule(num_windows):
     """Generate a length-num_windows list of lambda values from 0.0 up to 1.0
 
     Notes

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -187,15 +187,15 @@ def construct_absolute_lambda_schedule(num_windows):
 
     A = int(.2 * num_windows)
     B = int(.6 * num_windows)
-    C = num_windows - A - B
+    D = 1 # need only one window from 0.6 to 1.0
+    C = num_windows - A - B - D
 
-    # Empirically, we see the largest variance in std <du/dl> near the endpoints in the nonbonded
-    # terms. Bonded terms are roughly linear. So we add more lambda windows at the endpoint to
-    # help improve convergence.
+    # optimizing the overlap
     lambda_schedule = np.concatenate([
-        np.linspace(0.0, 0.1, A, endpoint=False),
-        np.linspace(0.1, 0.27, B, endpoint=False),
-        np.linspace(0.27, 1.0, C, endpoint=True)
+        np.linspace(0.0,  0.1,  A, endpoint=False),
+        np.linspace(0.1,  0.27, B, endpoint=False),
+        np.linspace(0.27, 0.6,  C, endpoint=True),
+        [1.0],
     ])
 
     assert len(lambda_schedule) == num_windows

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -1,0 +1,216 @@
+from typing import List
+from jax.config import config; config.update("jax_enable_x64", True)
+
+import jax
+import numpy as np
+
+from fe import topology
+
+from timemachine.lib import potentials, custom_ops
+from timemachine.lib import LangevinIntegrator
+
+from ff.handlers import openmm_deserializer
+
+from rdkit.Chem import MolToSmiles
+
+def get_romol_conf(mol):
+    """Coordinates of mol's 0th conformer, in nanometers"""
+    conformer = mol.GetConformer(0)
+    guest_conf = np.array(conformer.GetPositions(), dtype=np.float64)
+    return guest_conf/10 # from angstroms to nm
+
+class UnsupportedTopology(Exception):
+    pass
+
+class BaseFreeEnergy():
+
+    @staticmethod
+    def _get_system_params_and_potentials(ff_params, topology):
+
+        ff_tuples = [
+            [topology.parameterize_harmonic_bond, (ff_params[0],)],
+            [topology.parameterize_harmonic_angle, (ff_params[1],)],
+            [topology.parameterize_periodic_torsion, (ff_params[2], ff_params[3])],
+            [topology.parameterize_nonbonded, (ff_params[4], ff_params[5])]
+        ]
+
+        final_params = []
+        final_potentials = []
+
+        for fn, params in ff_tuples:
+            combined_params, combined_potential = fn(*params)
+            final_potentials.append(combined_potential)
+            final_params.append(combined_params)
+
+        return final_params, final_potentials
+
+# this class is serializable.
+class AbsoluteFreeEnergy(BaseFreeEnergy):
+
+    def __init__(self, mol, ff):
+        """
+        Compute the absolute free energy of a molecule via 4D decoupling.
+
+        Parameters
+        ----------
+        mol: rdkit mol
+            Ligand to be decoupled
+
+        ff: ff.Forcefield
+            Ligand forcefield
+
+        """
+        self.mol = mol
+        self.ff = ff
+        self.top = topology.BaseTopology(mol, ff)
+
+    def prepare_host_edge(self, ff_params, host_system):
+        """
+        Prepares the host-edge system
+
+        Parameters
+        ----------
+        ff_params: tuple of np.array
+            Exactly equal to bond_params, angle_params, proper_params, improper_params, charge_params, lj_params
+
+        host_system: openmm.System
+            openmm System object to be deserialized
+
+        Returns
+        -------
+        3-tuple
+            unbound_potentials, system_params, combined_masses
+
+        """
+        ligand_masses = [a.GetMass() for a in self.mol.GetAtoms()]
+        host_bps, host_masses = openmm_deserializer.deserialize_system(host_system, cutoff=1.2)
+
+        hgt = topology.HostGuestTopology(host_bps, self.top)
+
+        final_params, final_potentials = self._get_system_params_and_potentials(ff_params, hgt)
+
+        combined_masses = np.concatenate([host_masses, ligand_masses])
+
+        return final_potentials, final_params, combined_masses
+
+
+# this class is serializable.
+class RelativeFreeEnergy(BaseFreeEnergy):
+
+    def __init__(self, dual_topology: topology.DualTopology, label=None, complex_path=None):
+        self.top = dual_topology
+        self.label = label
+        self.complex_path = complex_path
+
+    @property
+    def mol_a(self):
+        return self.top.mol_a
+
+    @property
+    def mol_b(self):
+        return self.top.mol_b
+
+    @property
+    def ff(self):
+        return self.top.ff
+
+    def prepare_host_edge(self, ff_params, host_system):
+        """
+        Prepares the host-edge system
+        Parameters
+        ----------
+        ff_params: tuple of np.array
+            Exactly equal to bond_params, angle_params, proper_params, improper_params, charge_params, lj_params
+        host_system: openmm.System
+            openmm System object to be deserialized
+
+        Returns
+        -------
+        3-tuple
+            unbound_potentials, system_params, combined_masses
+
+        """
+
+        ligand_masses_a = [a.GetMass() for a in self.mol_a.GetAtoms()]
+        ligand_masses_b = [b.GetMass() for b in self.mol_b.GetAtoms()]
+
+        # extract the 0th conformer
+        ligand_coords_a = get_romol_conf(self.mol_a)
+        ligand_coords_b = get_romol_conf(self.mol_b)
+
+        host_bps, host_masses = openmm_deserializer.deserialize_system(host_system, cutoff=1.2)
+
+        hgt = topology.HostGuestTopology(host_bps, self.top)
+
+        final_params, final_potentials = self._get_system_params_and_potentials(ff_params, hgt)
+
+        combined_masses = np.concatenate([host_masses, ligand_masses_a, ligand_masses_b])
+
+        return final_potentials, final_params, combined_masses
+
+
+class RBFETransformIndex:
+    """Builds an index of relative free energy transformations to use
+    with construct_mle_layer
+    """
+
+    def __len__(self):
+        return len(self._indices)
+
+    def __init__(self):
+        self._indices = {}
+
+    def build(self, refs: List[RelativeFreeEnergy]):
+        for ref in refs:
+            self.get_transform_indices(ref)
+
+    def get_transform_indices(self, ref: RelativeFreeEnergy) -> List[int]:
+        return self.get_mol_idx(ref.mol_a), self.get_mol_idx(ref.mol_b)
+
+    def get_mol_idx(self, mol):
+        hashed = self._mol_hash(mol)
+        if hashed not in self._indices:
+            self._indices[hashed] = len(self._indices)
+        return self._indices[hashed]
+
+    def _mol_hash(self, mol):
+        return MolToSmiles(mol)
+
+
+def construct_lambda_schedule(num_windows):
+    """Generate a length-num_windows list of lambda values from 0.0 up to 1.0
+
+    Notes
+    -----
+    manually optimized by YTZ
+    """
+
+    A = int(.35 * num_windows)
+    B = int(.30 * num_windows)
+    C = num_windows - A - B
+
+    # Empirically, we see the largest variance in std <du/dl> near the endpoints in the nonbonded
+    # terms. Bonded terms are roughly linear. So we add more lambda windows at the endpoint to
+    # help improve convergence.
+    lambda_schedule = np.concatenate([
+        np.linspace(0.0, 0.25, A, endpoint=False),
+        np.linspace(0.25, 0.75, B, endpoint=False),
+        np.linspace(0.75, 1.0, C, endpoint=True)
+    ])
+
+    assert len(lambda_schedule) == num_windows
+
+    return lambda_schedule
+
+
+def construct_absolute_lambda_schedule(num_windows):
+    A = int(0.70 * num_windows)
+    B = num_windows - A
+
+    lambda_schedule = np.concatenate([
+        np.linspace(0.0, 0.3, A, endpoint=False),
+        np.linspace(0.3, 1.0, B, endpoint=True)
+    ])
+
+    return lambda_schedule
+

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -192,9 +192,9 @@ def construct_absolute_lambda_schedule(num_windows):
 
     # optimizing the overlap
     lambda_schedule = np.concatenate([
-        np.linspace(0.0,  0.1,  A, endpoint=False),
-        np.linspace(0.1,  0.27, B, endpoint=False),
-        np.linspace(0.27, 0.6,  C, endpoint=True),
+        np.linspace(0.0,  0.08,  A, endpoint=False),
+        np.linspace(0.08,  0.23, B, endpoint=False),
+        np.linspace(0.23, 0.45,  C, endpoint=True),
         [1.0],
     ])
 

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -193,8 +193,8 @@ def construct_absolute_lambda_schedule(num_windows):
     # optimizing the overlap
     lambda_schedule = np.concatenate([
         np.linspace(0.0,  0.08,  A, endpoint=False),
-        np.linspace(0.08,  0.23, B, endpoint=False),
-        np.linspace(0.23, 0.45,  C, endpoint=True),
+        np.linspace(0.08,  0.27, B, endpoint=False),
+        np.linspace(0.27, 0.41,  C, endpoint=True),
         [1.0],
     ])
 

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -185,17 +185,17 @@ def construct_lambda_schedule(num_windows):
     manually optimized by YTZ
     """
 
-    A = int(.35 * num_windows)
-    B = int(.30 * num_windows)
+    A = int(.2 * num_windows)
+    B = int(.6 * num_windows)
     C = num_windows - A - B
 
     # Empirically, we see the largest variance in std <du/dl> near the endpoints in the nonbonded
     # terms. Bonded terms are roughly linear. So we add more lambda windows at the endpoint to
     # help improve convergence.
     lambda_schedule = np.concatenate([
-        np.linspace(0.0, 0.25, A, endpoint=False),
-        np.linspace(0.25, 0.75, B, endpoint=False),
-        np.linspace(0.75, 1.0, C, endpoint=True)
+        np.linspace(0.0, 0.1, A, endpoint=False),
+        np.linspace(0.1, 0.35, B, endpoint=False),
+        np.linspace(0.35, 1.0, C, endpoint=True)
     ])
 
     assert len(lambda_schedule) == num_windows
@@ -203,16 +203,16 @@ def construct_lambda_schedule(num_windows):
     return lambda_schedule
 
 
-def construct_absolute_lambda_schedule(num_windows):
-    A = int(0.70 * num_windows)
-    B = num_windows - A
+# def construct_absolute_lambda_schedule(num_windows):
+#     A = int(0.70 * num_windows)
+#     B = num_windows - A
 
-    lambda_schedule = np.concatenate([
-        np.linspace(0.0, 0.3, A, endpoint=False),
-        np.linspace(0.3, 1.0, B, endpoint=True)
-    ])
+#     lambda_schedule = np.concatenate([
+#         np.linspace(0.0, 0.3, A, endpoint=False),
+#         np.linspace(0.3, 1.0, B, endpoint=True)
+#     ])
 
-    # lambda_schedule = np.linspace(0, 1, num_windows)
+#     # lambda_schedule = np.linspace(0, 1, num_windows)
 
-    return lambda_schedule
+#     return lambda_schedule
 

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -174,3 +174,27 @@ def construct_absolute_lambda_schedule(num_windows):
     assert len(lambda_schedule) == num_windows
 
     return lambda_schedule
+
+def construct_relative_lambda_schedule(num_windows):
+    """Generate a length-num_windows list of lambda values from 0.0 up to 1.0
+
+    Notes
+    -----
+    manually optimized by YTZ
+    """
+
+    A = int(.15 * num_windows)
+    B = int(.60 * num_windows)
+    C = num_windows - A - B
+
+    # optimizing the overlap based on eyeballing absolute hydration free energies
+    # there's probably some better way to deal with this by inspecting the curvature
+    lambda_schedule = np.concatenate([
+        np.linspace(0.00, 0.08, A, endpoint=False),
+        np.linspace(0.08, 0.27, B, endpoint=False),
+        np.linspace(0.27, 1.00, C, endpoint=True)
+    ])
+
+    assert len(lambda_schedule) == num_windows
+
+    return lambda_schedule

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -186,7 +186,7 @@ def construct_absolute_lambda_schedule(num_windows):
     """
 
     A = int(.2 * num_windows)
-    B = int(.8 * num_windows)
+    B = int(.6 * num_windows)
     C = num_windows - A - B
 
     # Empirically, we see the largest variance in std <du/dl> near the endpoints in the nonbonded
@@ -194,8 +194,8 @@ def construct_absolute_lambda_schedule(num_windows):
     # help improve convergence.
     lambda_schedule = np.concatenate([
         np.linspace(0.0, 0.1, A, endpoint=False),
-        np.linspace(0.1, 0.35, B, endpoint=False),
-        np.linspace(0.35, 1.0, C, endpoint=True)
+        np.linspace(0.1, 0.27, B, endpoint=False),
+        np.linspace(0.27, 1.0, C, endpoint=True)
     ])
 
     assert len(lambda_schedule) == num_windows

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -158,7 +158,7 @@ def construct_absolute_lambda_schedule(num_windows):
     """
 
     A = int(.20 * num_windows)
-    B = int(.68 * num_windows)
+    B = int(.75 * num_windows)
     D = 1 # need only one window from 0.6 to 1.0
     C = num_windows - A - B - D
 
@@ -174,18 +174,3 @@ def construct_absolute_lambda_schedule(num_windows):
     assert len(lambda_schedule) == num_windows
 
     return lambda_schedule
-
-
-# def construct_absolute_lambda_schedule(num_windows):
-#     A = int(0.70 * num_windows)
-#     B = num_windows - A
-
-#     lambda_schedule = np.concatenate([
-#         np.linspace(0.0, 0.3, A, endpoint=False),
-#         np.linspace(0.3, 1.0, B, endpoint=True)
-#     ])
-
-#     # lambda_schedule = np.linspace(0, 1, num_windows)
-
-#     return lambda_schedule
-

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -149,34 +149,6 @@ class RelativeFreeEnergy(BaseFreeEnergy):
         return final_potentials, final_params, combined_masses
 
 
-class RBFETransformIndex:
-    """Builds an index of relative free energy transformations to use
-    with construct_mle_layer
-    """
-
-    def __len__(self):
-        return len(self._indices)
-
-    def __init__(self):
-        self._indices = {}
-
-    def build(self, refs: List[RelativeFreeEnergy]):
-        for ref in refs:
-            self.get_transform_indices(ref)
-
-    def get_transform_indices(self, ref: RelativeFreeEnergy) -> List[int]:
-        return self.get_mol_idx(ref.mol_a), self.get_mol_idx(ref.mol_b)
-
-    def get_mol_idx(self, mol):
-        hashed = self._mol_hash(mol)
-        if hashed not in self._indices:
-            self._indices[hashed] = len(self._indices)
-        return self._indices[hashed]
-
-    def _mol_hash(self, mol):
-        return MolToSmiles(mol)
-
-
 def construct_absolute_lambda_schedule(num_windows):
     """Generate a length-num_windows list of lambda values from 0.0 up to 1.0
 
@@ -185,12 +157,13 @@ def construct_absolute_lambda_schedule(num_windows):
     manually optimized by YTZ
     """
 
-    A = int(.2 * num_windows)
-    B = int(.6 * num_windows)
+    A = int(.20 * num_windows)
+    B = int(.68 * num_windows)
     D = 1 # need only one window from 0.6 to 1.0
     C = num_windows - A - B - D
 
-    # optimizing the overlap
+    # optimizing the overlap based on eyeballing absolute hydration free energies
+    # there's probably some better way to deal with this by inspecting the curvature
     lambda_schedule = np.concatenate([
         np.linspace(0.0,  0.08,  A, endpoint=False),
         np.linspace(0.08,  0.27, B, endpoint=False),

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -204,13 +204,15 @@ def construct_lambda_schedule(num_windows):
 
 
 def construct_absolute_lambda_schedule(num_windows):
-    A = int(0.70 * num_windows)
-    B = num_windows - A
+    # A = int(0.70 * num_windows)
+    # B = num_windows - A
 
-    lambda_schedule = np.concatenate([
-        np.linspace(0.0, 0.3, A, endpoint=False),
-        np.linspace(0.3, 1.0, B, endpoint=True)
-    ])
+    # lambda_schedule = np.concatenate([
+    #     np.linspace(0.0, 0.3, A, endpoint=False),
+    #     np.linspace(0.3, 1.0, B, endpoint=True)
+    # ])
+
+    lambda_schedule = np.linspace(0, 1, num_windows)
 
     return lambda_schedule
 

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -158,7 +158,7 @@ def construct_absolute_lambda_schedule(num_windows):
     """
 
     A = int(.20 * num_windows)
-    B = int(.75 * num_windows)
+    B = int(.66 * num_windows)
     D = 1 # need only one window from 0.6 to 1.0
     C = num_windows - A - B - D
 

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -204,15 +204,15 @@ def construct_lambda_schedule(num_windows):
 
 
 def construct_absolute_lambda_schedule(num_windows):
-    # A = int(0.70 * num_windows)
-    # B = num_windows - A
+    A = int(0.70 * num_windows)
+    B = num_windows - A
 
-    # lambda_schedule = np.concatenate([
-    #     np.linspace(0.0, 0.3, A, endpoint=False),
-    #     np.linspace(0.3, 1.0, B, endpoint=True)
-    # ])
+    lambda_schedule = np.concatenate([
+        np.linspace(0.0, 0.3, A, endpoint=False),
+        np.linspace(0.3, 1.0, B, endpoint=True)
+    ])
 
-    lambda_schedule = np.linspace(0, 1, num_windows)
+    # lambda_schedule = np.linspace(0, 1, num_windows)
 
     return lambda_schedule
 

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -186,7 +186,7 @@ def construct_absolute_lambda_schedule(num_windows):
     """
 
     A = int(.2 * num_windows)
-    B = int(.6 * num_windows)
+    B = int(.8 * num_windows)
     C = num_windows - A - B
 
     # Empirically, we see the largest variance in std <du/dl> near the endpoints in the nonbonded

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -267,7 +267,7 @@ class RelativeModel(ABC):
 
         # setup restraints and align to the blocker
         num_host_atoms = len(self.host_coords)
-        combined_topology = model_utils.generate_topology(
+        combined_topology = model_utils.generate_openmm_topology(
             [self.host_topology, mol_a, mol_b],
             self.host_coords,
             prefix+".pdb"

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -1,0 +1,444 @@
+
+from abc import ABC
+import os
+import pickle
+
+import numpy as np
+import jax.numpy as jnp
+import functools
+import tempfile
+import mdtraj
+
+from simtk import openmm
+from simtk.openmm import app
+from rdkit import Chem
+
+from md import minimizer
+from timemachine.lib import potentials
+from timemachine.lib import LangevinIntegrator, MonteCarloBarostat
+from timemachine import constants
+from timemachine.potentials import rmsd
+from fe import free_energy, topology, estimator_abfe, model_utils
+from ff import Forcefield
+
+from parallel.client import AbstractClient
+from typing import Optional
+from functools import partial
+from scipy.optimize import linear_sum_assignment
+
+from md.barostat.utils import get_group_indices
+
+def get_romol_conf(mol):
+    """Coordinates of mol's 0th conformer, in nanometers"""
+    conformer = mol.GetConformer(0)
+    guest_conf = np.array(conformer.GetPositions(), dtype=np.float64)
+    return guest_conf/10 # from angstroms to nm
+
+def setup_relative_restraints(
+    mol_a,
+    mol_b):
+    """
+    Setup restraints between ring atoms in two molecules.
+
+    """
+    # setup relative orientational restraints
+    # rough sketch of algorithm:
+    # find core atoms in mol_a
+    # find core atoms in mol_b
+    # use the hungarian algorithm to assign matching
+
+    ligand_coords_a = get_romol_conf(mol_a)
+    ligand_coords_b = get_romol_conf(mol_b)
+
+    core_idxs_a = []
+    for idx, a in enumerate(mol_a.GetAtoms()):
+        if a.IsInRing():
+            core_idxs_a.append(idx)
+
+    core_idxs_b = []
+    for idx, b in enumerate(mol_b.GetAtoms()):
+        if b.IsInRing():
+            core_idxs_b.append(idx)
+
+    ri = np.expand_dims(ligand_coords_a[core_idxs_a], 1)
+    rj = np.expand_dims(ligand_coords_b[core_idxs_b], 0)
+    rij = np.sqrt(np.sum(np.power(ri-rj, 2), axis=-1))
+
+    row_idxs, col_idxs = linear_sum_assignment(rij)
+
+    core_idxs = []
+
+    for core_a, core_b in zip(row_idxs, col_idxs):
+        core_idxs.append((
+            core_idxs_a[core_a],
+            core_idxs_b[core_b]
+        ))
+
+    core_idxs = np.array(core_idxs, dtype=np.int32)
+
+    return core_idxs
+
+
+def get_romol_conf(mol):
+    """Coordinates of mol's 0th conformer, in nanometers"""
+    conformer = mol.GetConformer(0)
+    guest_conf = np.array(conformer.GetPositions(), dtype=np.float64)
+    return guest_conf/10 # from angstroms to nm
+
+class AbsoluteModel(ABC):
+
+    def __init__(
+        self,
+        client: AbstractClient or None,
+        ff: Forcefield,
+        host_system: openmm.System,
+        host_coords: np.ndarray,
+        host_box: np.ndarray,
+        host_schedule: np.ndarray,
+        host_topology: np.ndarray,
+        equil_steps: int,
+        prod_steps: int):
+
+        self.host_system = host_system
+        self.host_coords = host_coords
+        self.host_box = host_box
+        self.host_schedule = host_schedule
+        self.host_topology = host_topology
+
+        self.client = client
+        self.ff = ff
+        self.equil_steps = equil_steps
+        self.prod_steps = prod_steps
+
+    def setup_topology(self, mol):
+        raise NotImplementedError()
+
+    def predict(self,
+        ff_params,
+        mol,
+        prefix,
+        standardize=False):
+
+        print(f"Minimizing the host structure to remove clashes.")
+        minimized_coords, _, _ = minimizer.minimize_host_4d(
+            [mol],
+            self.host_system,
+            self.host_coords,
+            self.ff,
+            self.host_box
+        )
+
+        if standardize:
+            top = topology.BaseTopologyStandardDecoupling(mol, self.ff)
+        else:
+            top = topology.BaseTopology(mol, self.ff)
+
+        afe = free_energy.AbsoluteFreeEnergy(mol, self.ff)
+
+        unbound_potentials, sys_params, masses = afe.prepare_host_edge(
+            ff_params,
+            self.host_system,
+            top
+        )
+
+        endpoint_correct = False
+
+        seed = 0
+
+        temperature = 300.0
+        beta = 1/(constants.BOLTZ*temperature)
+
+        bond_list = get_bond_list(unbound_potentials[0])
+        masses = model_utils.apply_hmr(masses, bond_list)
+
+        integrator = LangevinIntegrator(
+            temperature,
+            2.5e-3,
+            1.0,
+            masses,
+            seed
+        )
+
+        group_indices = get_group_indices(bond_list)
+        barostat_interval = 5
+        barostat = MonteCarloBarostat(
+            minimized_coords.shape[0],
+            1.0,
+            temperature,
+            group_indices,
+            barostat_interval,
+            seed
+        )
+
+        x0 = minimized_coords
+        v0 = np.zeros_like(minimized_coords)
+
+        model = estimator_abfe.FreeEnergyModel(
+            unbound_potentials,
+            endpoint_correct,
+            self.client,
+            self.host_box,
+            x0,
+            v0,
+            integrator,
+            barostat,
+            self.host_schedule,
+            self.equil_steps,
+            self.prod_steps,
+            beta,
+            prefix
+        )
+
+        dG, results = estimator_abfe.deltaG(model, sys_params)
+
+        return dG
+
+        for idx, result in enumerate(results):
+            # print(result.xs.shape)
+            traj = mdtraj.Trajectory(result.xs, mdtraj.Topology.from_openmm(combined_topology))
+            unit_cell = np.repeat(self.host_box[None, :], len(result.xs), axis=0)
+            traj.unitcell_vectors = unit_cell
+            traj.image_molecules()
+            traj.save_xtc("complex_lambda_"+str(idx)+".xtc")
+
+        np.savez("results.npz", results=results)
+
+        assert 0
+
+        return dG, results
+
+class AbsoluteHydrationModel(AbsoluteModel):
+
+    def setup_topology(self, mol):
+        return topology.BaseTopology(mol, self.ff)
+
+
+class RelativeModel(ABC):
+    """
+    Absolute free energy using a reference molecule to block the binding pocket.
+    """
+
+    def __init__(
+        self,
+        client: Optional[AbstractClient],
+        ff: Forcefield,
+        host_system: openmm.System,
+        host_coords: np.ndarray,
+        host_box: np.ndarray,
+        host_schedule: np.ndarray,
+        host_topology,
+        equil_steps: int,
+        prod_steps: int):
+
+        self.host_system = host_system
+        self.host_coords = host_coords
+        self.host_box = host_box
+        self.host_schedule = host_schedule
+        self.host_topology = host_topology
+        self.client = client
+        self.ff = ff
+        self.equil_steps = equil_steps
+        self.prod_steps = prod_steps
+
+    def setup_topology(self, mol_a, mol_b):
+        raise NotImplementedError()
+
+    def _predict_a_to_b(
+        self,
+        ff_params,
+        mol_a,
+        mol_b,
+        core_idxs,
+        combined_coords,
+        prefix,
+        standardize):
+
+        dual_topology = self.setup_topology(mol_a, mol_b)
+        rfe = free_energy.RelativeDualTopologyFreeEnergy(dual_topology)
+
+        unbound_potentials, sys_params, masses = rfe.prepare_host_edge(
+            ff_params,
+            self.host_system
+        )
+
+        # setup restraints and align to the blocker
+        num_host_atoms = len(self.host_coords)
+        combined_topology = model_utils.generate_topology(
+            [self.host_topology, mol_a, mol_b],
+            self.host_coords,
+            prefix+".pdb"
+        )
+
+        # generate initial structure
+        coords = combined_coords
+
+        traj = mdtraj.Trajectory([coords], mdtraj.Topology.from_openmm(combined_topology))
+        traj.save_xtc("initial_coords_aligned.xtc")
+
+        k_core = 75.0
+        core_params = np.zeros_like(core_idxs).astype(np.float64)
+        core_params[:, 0] = k_core
+
+        B = len(core_idxs)
+
+        restraint_potential = potentials.HarmonicBond(
+            core_idxs,
+        )
+
+        unbound_potentials.append(restraint_potential)
+        sys_params.append(core_params)
+
+        endpoint_correct = True
+
+        # tbd sample from boltzmann distribution later
+        x0 = coords
+        v0 = np.zeros_like(coords)
+
+        seed = 0
+        temperature = 300.0
+        beta = 1/(constants.BOLTZ*temperature)
+
+        bond_list = np.concatenate([unbound_potentials[0].get_idxs(), core_idxs])
+        masses = model_utils.apply_hmr(masses, bond_list)
+
+        integrator = LangevinIntegrator(
+            temperature,
+            2.5e-3,
+            1.0,
+            masses,
+            seed
+        )
+        bond_list = list(map(tuple, bond_list))
+        group_indices = get_group_indices(bond_list)
+        barostat_interval = 5
+
+        barostat = MonteCarloBarostat(
+            coords.shape[0],
+            1.0,
+            temperature,
+            group_indices,
+            barostat_interval,
+            seed
+        )
+
+        endpoint_correct = True
+        model = estimator_abfe.FreeEnergyModel(
+            unbound_potentials,
+            endpoint_correct,
+            self.client,
+            self.host_box, # important, use equilibrated box.
+            x0,
+            v0,
+            integrator,
+            barostat,
+            self.host_schedule,
+            self.equil_steps,
+            self.prod_steps,
+            beta,
+            prefix
+        )
+
+        dG, results = estimator_abfe.deltaG(model, sys_params)
+
+        for idx, result in enumerate(results):
+            traj = mdtraj.Trajectory(result.xs, mdtraj.Topology.from_openmm(combined_topology))
+            traj.unitcell_vectors = result.boxes
+            traj.image_molecules()
+            traj.save_xtc(prefix+"_complex_lambda_"+str(idx)+".xtc")
+
+        return dG, results
+
+    def predict(self, ff_params: list, mol_a: Chem.Mol, mol_b: Chem.Mol, prefix: str):
+        """
+        Compute the free of energy of converting mol_a into mol_b.
+
+        This function is differentiable w.r.t. ff_params.
+
+        Parameters
+        ----------
+
+        ff_params: list of np.ndarray
+            This should match the ordered params returned by the forcefield
+
+        mol: Chem.Mol
+            Molecule we want to decouple
+
+        Returns
+        -------
+        float
+            delta delta G in kJ/mol
+        aux
+            list of TI results
+
+        """
+
+        host_system = self.host_system
+        host_lambda_schedule = self.host_schedule
+
+        minimized_host_coords = minimizer.minimize_host_4d(
+            [mol_a, mol_b],
+            self.host_system,
+            self.host_coords,
+            self.ff,
+            self.host_box
+        )
+
+        num_host_atoms = self.host_coords.shape[0]
+
+        # generate indices
+        core_idxs = setup_relative_restraints(mol_a, mol_b)
+
+        mol_a_coords = get_romol_conf(mol_a)
+        mol_b_coords = get_romol_conf(mol_b)
+
+        # pull out mol_b from combined state
+        combined_core_idxs = np.copy(core_idxs)
+        combined_core_idxs[:, 0] += num_host_atoms
+        combined_core_idxs[:, 1] += num_host_atoms + mol_a.GetNumAtoms()
+        combined_coords = np.concatenate([
+            minimized_host_coords,
+            mol_a_coords,
+            mol_b_coords
+        ])
+        dG_0, results_0 = self._predict_a_to_b(
+            ff_params,
+            mol_a,
+            mol_b,
+            combined_core_idxs,
+            combined_coords,
+            prefix+"_ref_to_mol",
+            standardize=None)
+
+        # pull out mol_a from combined state
+        combined_core_idxs = np.copy(core_idxs)
+        # swap
+        combined_core_idxs[:, 0] = core_idxs[:, 1]
+        combined_core_idxs[:, 1] = core_idxs[:, 0]
+        combined_core_idxs[:, 0] += num_host_atoms
+        combined_core_idxs[:, 1] += num_host_atoms + mol_b.GetNumAtoms()
+        combined_coords = np.concatenate([
+            minimized_host_coords,
+            mol_b_coords,
+            mol_a_coords
+        ])
+        dG_1, results_1 = self._predict_a_to_b(
+            ff_params,
+            mol_b,
+            mol_a,
+            combined_core_idxs,
+            combined_coords,
+            prefix+"_mol_to_ref",
+            standardize=None)
+
+        # dG_0 is the free energy of moving X-B-A into X-B+A
+        # dG_1 is the free energy of moving X-A-B into X-A+B
+        # -dG_1 + dG_0 is the free energy of moving X-A+B -> X-B+A
+        # i.e. the free energy of "unbinding" A
+
+        return -dG_0 + dG_1
+
+
+class RelativeHydrationModel(RelativeModel):
+
+    def setup_topology(self, mol_a, mol_b):
+        return topology.DualTopologyRHFE(mol_a, mol_b, self.ff)

--- a/fe/model_utils.py
+++ b/fe/model_utils.py
@@ -1,0 +1,80 @@
+import numpy as np
+from simtk.openmm import app
+import tempfile
+from rdkit import Chem
+
+
+def apply_hmr(masses, bond_list, multiplier=2):
+    """
+    Implements hydrogen mass repartioning. Hydrogen masses
+    are increased by multiplied by multiplier, and the connecting
+    heavy atom has its mass decreased by the same amount.
+
+    Parameters
+    ----------
+    masses: np.ndarray
+        List of masses
+
+    bond_list: np.ndarray, Nx2
+        Nx2 array of bond pairs.
+
+    multiplier: float
+        How much to multiply the hydrogen mass by.
+
+    Returns
+    -------
+    np.array
+        Adjusted masses
+
+    """
+
+    def is_hydrogen(i):
+        return np.abs(masses[i] - 1.00794) < 1e-3
+
+    for i, j in bond_list:
+        i, j = np.array([i, j])[np.argsort([masses[i], masses[j]])]
+        if is_hydrogen(i):
+            if is_hydrogen(j):
+                # H-H, skip
+                continue
+            else:
+                # H-X
+                # order of operations is important!
+                masses[j] -= multiplier*masses[i]
+                masses[i] += multiplier*masses[i]
+        else:
+            # do nothing
+            continue
+
+    return masses
+
+
+def generate_topology(objs, host_coords, out_filename):
+    rd_mols = []
+    # super jank
+    for obj in objs:
+        if isinstance(obj, app.Topology):
+            with tempfile.NamedTemporaryFile(mode='w') as fp:
+                # write
+                app.PDBFile.writeHeader(obj, fp)
+                app.PDBFile.writeModel(obj, host_coords, fp, 0)
+                app.PDBFile.writeFooter(obj, fp)
+                fp.flush()
+                romol = Chem.MolFromPDBFile(fp.name, removeHs=False)
+                rd_mols.append(romol)
+
+        if isinstance(obj, Chem.Mol):
+            rd_mols.append(obj)
+
+    combined_mol = rd_mols[0]
+    for mol in rd_mols[1:]:
+        combined_mol = Chem.CombineMols(combined_mol, mol)
+
+    # with tempfile.NamedTemporaryFile(mode='w') as fp:
+    fp = open(out_filename, "w")
+    # write
+    Chem.MolToPDBFile(combined_mol, out_filename)
+    fp.flush()
+    # read
+    combined_pdb = app.PDBFile(out_filename)
+    return combined_pdb.topology

--- a/fe/model_utils.py
+++ b/fe/model_utils.py
@@ -49,7 +49,7 @@ def apply_hmr(masses, bond_list, multiplier=2):
     return masses
 
 
-def generate_topology(objs, host_coords, out_filename):
+def generate_openmm_topology(objs, host_coords, out_filename):
     rd_mols = []
     # super jank
     for obj in objs:

--- a/fe/topology.py
+++ b/fe/topology.py
@@ -588,7 +588,10 @@ class DualTopologyRHFE(DualTopology):
         src_qlj_params = jax.ops.index_update(qlj_params, jax.ops.index[:, 0], qlj_params[:, 0]*0.5)
         src_qlj_params = jax.ops.index_update(src_qlj_params, jax.ops.index[:, 2], qlj_params[:, 2]*0.5)
         dst_qlj_params = qlj_params
-        combined_qlj_params = jnp.concatenate([src_qlj_params, dst_qlj_params])
+        combined_qlj_params = jnp.concatenate([
+            src_qlj_params,
+            dst_qlj_params
+        ])
 
         combined_lambda_plane_idxs = np.zeros(
             self.mol_a.GetNumAtoms() + self.mol_b.GetNumAtoms(),

--- a/timemachine/lib/__init__.py
+++ b/timemachine/lib/__init__.py
@@ -28,8 +28,8 @@ class MonteCarloBarostat():
 
     def __init__(self, N, pressure, temperature, group_idxs, interval, seed):
         self.N = N
-        self.temperature = temperature
         self.pressure = pressure
+        self.temperature = temperature
         self.group_idxs = group_idxs
         self.interval = interval
         self.seed = seed


### PR DESCRIPTION
This PR implements the relative hydration protocol using the RMSD based restraints. There's a fair bit of duplication in this code as we are trying to figure out the best way to refactor it to be a little cleaner. Some parts of note:

-setting up the core restraints is done in a pretty adhoc way right now
-examples/validate_relative_hydration.py is the main script that compares the ddG_ab against dG_a - dG_b on the hif2a set
-there's a duplicated estimator_abfe.py code that does the endpoint correction as part of the deltaG estimate. We should try and merge the two estimators into a single function later.
-model_rabfe is mostly a copy of model.py, but with some with auxiliary functionality like setting up restraints.


