### PR TITLE
Task/improve system level performance

### DIFF
--- a/timemachine/cpp/src/centroid_restraint.cu
+++ b/timemachine/cpp/src/centroid_restraint.cu
@@ -55,8 +55,8 @@ void CentroidRestraint<RealType>::execute_device(
     int tpb = 32;
 
     int blocks = (N_B_ + N_A_ + tpb -1)/tpb;
-    gpuErrchk(cudaMemset(d_centroid_a_, 0.0, 3*sizeof(RealType)));
-    gpuErrchk(cudaMemset(d_centroid_b_, 0.0, 3*sizeof(RealType)));
+    gpuErrchk(cudaMemsetAsync(d_centroid_a_, 0.0, 3*sizeof(RealType), stream));
+    gpuErrchk(cudaMemsetAsync(d_centroid_b_, 0.0, 3*sizeof(RealType), stream));
     k_calc_centroid<RealType><<<blocks, tpb, 0, stream>>>(
         d_x,
         d_group_a_idxs_,

--- a/timemachine/cpp/src/harmonic_bond.cu
+++ b/timemachine/cpp/src/harmonic_bond.cu
@@ -77,10 +77,10 @@ void HarmonicBond<RealType>::execute_device(
     unsigned long long *d_u,
     cudaStream_t stream) {
 
-    int tpb = 32;
-    int blocks = (B_+tpb-1)/tpb;
-
     if(B_ > 0) {
+        int tpb = 32;
+        int blocks = (B_+tpb-1)/tpb;
+
         k_harmonic_bond<RealType><<<blocks, tpb, 0, stream>>>(
             B_,
             d_x,

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -89,6 +89,7 @@ void __global__ k_check_rebuild_coords_and_box(
         // we can probably derive a looser bound later on.
         if(old_box[idx] != new_box[idx]) {
             rebuild[0] = 1;
+            return;
         }
     }
 
@@ -422,6 +423,7 @@ template <
 >
 // void __device__ __forceinline__ v_nonbonded_unified(
 void __device__ v_nonbonded_unified(
+    const int tile_idx,
     const int N,
     const double * __restrict__ coords,
     const double * __restrict__ params, // [N]
@@ -440,8 +442,6 @@ void __device__ v_nonbonded_unified(
     unsigned long long * __restrict__ du_dp,
     unsigned long long * __restrict__ du_dl_buffer,
     unsigned long long * __restrict__ u_buffer) {
-
-    int tile_idx = blockIdx.x;
 
     RealType box_x = box[0*3+0];
     RealType box_y = box[1*3+1];
@@ -709,6 +709,7 @@ template <
     bool COMPUTE_DU_DP
 >
 void __global__ k_nonbonded_unified(
+    const unsigned int * ixn_count,
     const int N,
     const double * __restrict__ coords,
     const double * __restrict__ params, // [N]
@@ -724,76 +725,85 @@ void __global__ k_nonbonded_unified(
     unsigned long long * __restrict__ du_dx,
     unsigned long long * __restrict__ du_dp,
     unsigned long long * __restrict__ du_dl_buffer,
-    unsigned long long * __restrict__ u_buffer) {
-
+    unsigned long long * __restrict__ u_buffer
+) {
+    const int stride = gridDim.x;
     int tile_idx = blockIdx.x;
-    int row_block_idx = ixn_tiles[tile_idx];
-    int atom_i_idx = row_block_idx*32 + threadIdx.x;
+    const unsigned int interactions = ixn_count[0];
+    while (tile_idx < interactions) {
+        int row_block_idx = ixn_tiles[tile_idx];
+        int atom_i_idx = row_block_idx*32 + threadIdx.x;
 
-    RealType dq_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+0] : 0;
-    RealType dsig_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+1] : 0;
-    RealType deps_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+2] : 0;
-    RealType cw_i = atom_i_idx < N ? coords_w[atom_i_idx] : 0;
+        RealType dq_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+0] : 0;
+        RealType dsig_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+1] : 0;
+        RealType deps_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+2] : 0;
+        RealType cw_i = atom_i_idx < N ? coords_w[atom_i_idx] : 0;
 
-    int atom_j_idx = ixn_atoms[tile_idx*32 + threadIdx.x];
+        int atom_j_idx = ixn_atoms[tile_idx*32 + threadIdx.x];
 
-    RealType dq_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+0] : 0;
-    RealType dsig_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+1] : 0;
-    RealType deps_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+2] : 0;
-    RealType cw_j = atom_j_idx < N ? coords_w[atom_j_idx] : 0;
+        RealType dq_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+0] : 0;
+        RealType dsig_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+1] : 0;
+        RealType deps_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+2] : 0;
+        RealType cw_j = atom_j_idx < N ? coords_w[atom_j_idx] : 0;
 
-    int is_vanilla = (
-        cw_i == 0 &&
-        dq_dl_i == 0 &&
-        dsig_dl_i == 0 &&
-        deps_dl_i == 0 &&
-        cw_j == 0 &&
-        dq_dl_j == 0 &&
-        dsig_dl_j == 0 &&
-        deps_dl_j == 0
-    );
-
-    bool tile_is_vanilla = __all_sync(0xffffffff, is_vanilla);
-
-    if(tile_is_vanilla) {
-        v_nonbonded_unified<RealType, 0, COMPUTE_U, COMPUTE_DU_DX, COMPUTE_DU_DL, COMPUTE_DU_DP>(
-            N,
-            coords,
-            params,
-            box,
-            dp_dl,
-            coords_w,
-            dw_dl,
-            lambda,
-            beta,
-            cutoff,
-            ixn_tiles,
-            ixn_atoms,
-            du_dx,
-            du_dp,
-            du_dl_buffer,
-            u_buffer
+        int is_vanilla = (
+            cw_i == 0 &&
+            dq_dl_i == 0 &&
+            dsig_dl_i == 0 &&
+            deps_dl_i == 0 &&
+            cw_j == 0 &&
+            dq_dl_j == 0 &&
+            dsig_dl_j == 0 &&
+            deps_dl_j == 0
         );
-    } else {
-        v_nonbonded_unified<RealType, 1, COMPUTE_U, COMPUTE_DU_DX, COMPUTE_DU_DL, COMPUTE_DU_DP>(
-            N,
-            coords,
-            params,
-            box,
-            dp_dl,
-            coords_w,
-            dw_dl,
-            lambda,
-            beta,
-            cutoff,
-            ixn_tiles,
-            ixn_atoms,
-            du_dx,
-            du_dp,
-            du_dl_buffer,
-            u_buffer
-        );
-    };
+
+        bool tile_is_vanilla = __all_sync(0xffffffff, is_vanilla);
+
+        if(tile_is_vanilla) {
+            v_nonbonded_unified<RealType, 0, COMPUTE_U, COMPUTE_DU_DX, COMPUTE_DU_DL, COMPUTE_DU_DP>(
+                tile_idx,
+                N,
+                coords,
+                params,
+                box,
+                dp_dl,
+                coords_w,
+                dw_dl,
+                lambda,
+                beta,
+                cutoff,
+                // ixn_count,
+                ixn_tiles,
+                ixn_atoms,
+                du_dx,
+                du_dp,
+                du_dl_buffer,
+                u_buffer
+            );
+        } else {
+            v_nonbonded_unified<RealType, 1, COMPUTE_U, COMPUTE_DU_DX, COMPUTE_DU_DL, COMPUTE_DU_DP>(
+                tile_idx,
+                N,
+                coords,
+                params,
+                box,
+                dp_dl,
+                coords_w,
+                dw_dl,
+                lambda,
+                beta,
+                cutoff,
+                // ixn_count,
+                ixn_tiles,
+                ixn_atoms,
+                du_dx,
+                du_dp,
+                du_dl_buffer,
+                u_buffer
+            );
+        };
+        tile_idx += stride;
+    }
 
 
 }

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -137,6 +137,29 @@ void __global__ k_permute(
 }
 
 template <typename RealType>
+void __global__ k_permute_2x(
+    const int N,
+    const unsigned int * __restrict__ perm,
+    const RealType * __restrict__ array_1,
+    const RealType * __restrict__ array_2,
+    RealType * __restrict__ sorted_array_1,
+    RealType * __restrict__ sorted_array_2) {
+
+    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int stride = gridDim.y;
+    int stride_idx = blockIdx.y;
+
+    if(idx >= N) {
+        return;
+    }
+
+    sorted_array_1[idx*stride+stride_idx] = array_1[perm[idx]*stride+stride_idx];
+    sorted_array_2[idx*stride+stride_idx] = array_2[perm[idx]*stride+stride_idx];
+
+}
+
+
+template <typename RealType>
 void __global__ k_inv_permute_accum(
     const int N,
     const unsigned int * __restrict__ perm,

--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -10,7 +10,7 @@ namespace timemachine {
 
 template<typename RealType>
 Neighborlist<RealType>::Neighborlist(
-	int N) : N_(N) {
+    int N) : N_(N) {
 
     const int B = this->B(); //(N+32-1)/32;
     const int Y = this->Y(); //(B+32-1)/32;
@@ -221,12 +221,12 @@ void Neighborlist<RealType>::build_nblist_device(
 
 template <typename RealType>
 void Neighborlist<RealType>::compute_block_bounds_device(
-	const int N, // Number of atoms
-	const int D, // Box dimensions
-	const double *d_coords, // [N*3]
+    const int N, // Number of atoms
+    const int D, // Box dimensions
+    const double *d_coords, // [N*3]
     const double *d_box, // [D*3]
     const int * d_rebuild_nblist,
-	cudaStream_t stream) {
+    cudaStream_t stream) {
 
     assert(N == N_);
     assert(D == 3);

--- a/timemachine/cpp/src/neighborlist.hpp
+++ b/timemachine/cpp/src/neighborlist.hpp
@@ -37,10 +37,11 @@ public:
     );
 
     void build_nblist_device(
-        int N,
+        const int N,
         const double *d_coords,
         const double *d_box,
         const double cutoff,
+        int *d_rebuild_nblist,
         cudaStream_t stream
     );
 
@@ -82,9 +83,9 @@ private:
         int D,
         const double *coords,
         const double *box,
+        const int *rebuild,
         cudaStream_t stream
     );
-
 
 };
 

--- a/timemachine/cpp/src/nonbonded.cu
+++ b/timemachine/cpp/src/nonbonded.cu
@@ -18,6 +18,9 @@
 #include <fstream>
 #include <streambuf>
 
+#define NONBONDED_KERNEL_BLOCKS 8192
+#define HILBERT_SORT_INTERVAL 100
+
 namespace timemachine {
 
 template <typename RealType, bool Interpolated>
@@ -38,6 +41,7 @@ Nonbonded<RealType, Interpolated>::Nonbonded(
     E_(exclusion_idxs.size()/2),
     nblist_(lambda_offset_idxs.size()),
     beta_(beta),
+    cur_step_(0),
     d_sort_storage_(nullptr),
     d_sort_storage_bytes_(0),
     nblist_padding_(0.1),
@@ -111,14 +115,11 @@ Nonbonded<RealType, Interpolated>::Nonbonded(
     gpuErrchk(cudaMalloc(&d_scales_, E_*2*sizeof(*d_scales_)));
     gpuErrchk(cudaMemcpy(d_scales_, &scales[0], E_*2*sizeof(*d_scales_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMallocHost(&p_ixn_count_, 1*sizeof(*p_ixn_count_)));
-
     gpuErrchk(cudaMalloc(&d_nblist_x_, N_*3*sizeof(*d_nblist_x_)));
     gpuErrchk(cudaMemset(d_nblist_x_, 0, N_*3*sizeof(*d_nblist_x_))); // set non-sensical positions
     gpuErrchk(cudaMalloc(&d_nblist_box_, 3*3*sizeof(*d_nblist_x_)));
     gpuErrchk(cudaMemset(d_nblist_box_, 0, 3*3*sizeof(*d_nblist_x_)));
     gpuErrchk(cudaMalloc(&d_rebuild_nblist_, 1*sizeof(*d_rebuild_nblist_)));
-    gpuErrchk(cudaMallocHost(&p_rebuild_nblist_, 1*sizeof(*p_rebuild_nblist_)));
 
     gpuErrchk(cudaMalloc(&d_sort_keys_in_, N_*sizeof(d_sort_keys_in_)));
     gpuErrchk(cudaMalloc(&d_sort_keys_out_, N_*sizeof(d_sort_keys_out_)));
@@ -190,12 +191,9 @@ Nonbonded<RealType, Interpolated>::~Nonbonded() {
     gpuErrchk(cudaFree(d_sort_vals_in_));
     gpuErrchk(cudaFree(d_sort_storage_));
 
-    gpuErrchk(cudaFreeHost(p_ixn_count_));
-
     gpuErrchk(cudaFree(d_nblist_x_));
     gpuErrchk(cudaFree(d_nblist_box_));
     gpuErrchk(cudaFree(d_rebuild_nblist_));
-    gpuErrchk(cudaFreeHost(p_rebuild_nblist_));
 };
 
 
@@ -282,8 +280,9 @@ void Nonbonded<RealType, Interpolated>::execute_device(
         std::cout << N << " " << N_ << std::endl;
         throw std::runtime_error("Nonbonded::execute_device() N != N_");
     }
-
-    const int M = Interpolated? 2 : 1;
+    bool sort_indices = cur_step_ == 0;
+    cur_step_ = (cur_step_ + 1) % HILBERT_SORT_INTERVAL; // How often to sort
+    const int M = Interpolated ? 2 : 1;
 
     if(P != M*N_*3) {
         std::cout << P << " " << N_ << std::endl;
@@ -296,56 +295,47 @@ void Nonbonded<RealType, Interpolated>::execute_device(
     const int B = (N+tpb-1)/tpb;
 
     dim3 dimGrid(B, 3, 1);
-
-    // (ytz) see if we need to rebuild the neighborlist.
-    // (ytz + jfass): note that this logic needs to change if we use NPT later on since a resize in the box
-    // can introduce new interactions.
-    k_check_rebuild_coords_and_box<RealType><<<B, tpb, 0, stream>>>(
-        N,
-        d_x,
-        d_nblist_x_,
-        d_box,
-        d_nblist_box_,
-        nblist_padding_,
-        d_rebuild_nblist_
-    );
-    gpuErrchk(cudaPeekAtLastError());
-
-    // we can optimize this away by doing the check on the GPU directly.
-    gpuErrchk(cudaMemcpyAsync(p_rebuild_nblist_, d_rebuild_nblist_, 1*sizeof(*p_rebuild_nblist_), cudaMemcpyDeviceToHost, stream));
-    gpuErrchk(cudaStreamSynchronize(stream)); // slow!
-
-    if(p_rebuild_nblist_[0] > 0) {
-
-        // (ytz): update the permutation index before building neighborlist, as the neighborlist is tied
-        // to a particular sort order
+    // If we have to sort, we also have to rebuild the neighborlist
+    if (sort_indices) {
         if(!disable_hilbert_) {
             this->hilbert_sort(d_x, d_box, stream);
         } else {
             k_arange<<<B, tpb, 0, stream>>>(N, d_perm_);
             gpuErrchk(cudaPeekAtLastError());
         }
-
-        // compute new coordinates, new lambda_idxs, new_plane_idxs
-        k_permute<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_x, d_sorted_x_);
-        gpuErrchk(cudaPeekAtLastError());
-        nblist_.build_nblist_device(
-            N,
-            d_sorted_x_,
-            d_box,
-            cutoff_+nblist_padding_,
-            stream
-        );
-        gpuErrchk(cudaMemsetAsync(d_rebuild_nblist_, 0, sizeof(*d_rebuild_nblist_), stream));
-        gpuErrchk(cudaMemcpyAsync(p_ixn_count_, nblist_.get_ixn_count(), 1*sizeof(*p_ixn_count_), cudaMemcpyDeviceToHost, stream));
-        gpuErrchk(cudaMemcpyAsync(d_nblist_x_, d_x, N*3*sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
-        gpuErrchk(cudaMemcpyAsync(d_nblist_box_, d_box, 3*3*sizeof(*d_box), cudaMemcpyDeviceToDevice, stream));
-        gpuErrchk(cudaStreamSynchronize(stream));
-
+        // Indicate that the neighborlist must be rebuilt
+        gpuErrchk(cudaMemsetAsync(d_rebuild_nblist_, 1, 1*sizeof(*d_rebuild_nblist_), stream));
     } else {
-        k_permute<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_x, d_sorted_x_);
+        // (ytz) see if we need to rebuild the neighborlist.
+        // (ytz + jfass): note that this logic could be optimized when using NPT is
+        // enabled since a resize in the box can introduce new interactions.
+        k_check_rebuild_coords_and_box<RealType><<<B, tpb, 0, stream>>>(
+            N,
+            d_x,
+            d_nblist_x_,
+            d_box,
+            d_nblist_box_,
+            nblist_padding_,
+            d_rebuild_nblist_
+        );
         gpuErrchk(cudaPeekAtLastError());
     }
+
+    // compute new coordinates, new lambda_idxs, new_plane_idxs
+    k_permute<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_x, d_sorted_x_);
+    gpuErrchk(cudaPeekAtLastError());
+    nblist_.build_nblist_device(
+        N,
+        d_sorted_x_,
+        d_box,
+        cutoff_+nblist_padding_,
+        d_rebuild_nblist_,
+        stream
+    );
+
+    gpuErrchk(cudaMemcpyAsync(d_nblist_x_, d_x, N*3*sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
+    gpuErrchk(cudaMemcpyAsync(d_nblist_box_, d_box, 3*3*sizeof(*d_box), cudaMemcpyDeviceToDevice, stream));
+    gpuErrchk(cudaMemsetAsync(d_rebuild_nblist_, 0, sizeof(*d_rebuild_nblist_), stream));
 
     // do parameter interpolation here
     if(Interpolated) {
@@ -367,7 +357,6 @@ void Nonbonded<RealType, Interpolated>::execute_device(
         gpuErrchk(cudaMemsetAsync(d_sorted_dp_dl_, 0, N*3*sizeof(*d_sorted_dp_dl_), stream))
     }
 
-    // this stream needs to be synchronized so we can be sure that p_ixn_count_ is properly set.
     // reset buffers and sorted accumulators
     if(d_du_dx) {
 	    gpuErrchk(cudaMemsetAsync(d_sorted_du_dx_, 0, N*3*sizeof(*d_sorted_du_dx_), stream))
@@ -402,8 +391,8 @@ void Nonbonded<RealType, Interpolated>::execute_device(
     kernel_idx |= d_du_dl ? 1 << 1 : 0;
     kernel_idx |= d_du_dx ? 1 << 2 : 0;
     kernel_idx |= d_u ? 1 << 3 : 0;
-
-    kernel_ptrs_[kernel_idx]<<<p_ixn_count_[0], tpb, 0, stream>>>(
+    kernel_ptrs_[kernel_idx]<<<NONBONDED_KERNEL_BLOCKS, tpb, 0, stream>>>(
+        nblist_.get_ixn_count(),
         N,
         d_sorted_x_,
         d_sorted_p_,
@@ -431,7 +420,7 @@ void Nonbonded<RealType, Interpolated>::execute_device(
     }
 
     // params are N,3
-    // this needs to be an accumlated permute
+    // this needs to be an accumulated permute
     if(d_du_dp) {
         k_inv_permute_assign<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_sorted_du_dp_, d_du_dp_buffer_);
         gpuErrchk(cudaPeekAtLastError());

--- a/timemachine/cpp/src/nonbonded.cu
+++ b/timemachine/cpp/src/nonbonded.cu
@@ -393,9 +393,7 @@ void Nonbonded<RealType, Interpolated>::execute_device(
     }
 
     gpuErrchk(cudaPeekAtLastError());
-    k_permute<<<B, tpb, 0, stream>>>(N, d_perm_, d_w_, d_sorted_w_);
-    gpuErrchk(cudaPeekAtLastError());
-    k_permute<<<B, tpb, 0, stream>>>(N, d_perm_, d_dw_dl_, d_sorted_dw_dl_);
+    k_permute_2x<<<B, tpb, 0, stream>>>(N, d_perm_, d_w_, d_dw_dl_, d_sorted_w_, d_sorted_dw_dl_);
     gpuErrchk(cudaPeekAtLastError());
 
     // look up which kernel we need for this computation

--- a/timemachine/cpp/src/nonbonded.hpp
+++ b/timemachine/cpp/src/nonbonded.hpp
@@ -8,7 +8,9 @@
 
 namespace timemachine {
 
-typedef void (*k_nonbonded_fn)(const int N,
+typedef void (*k_nonbonded_fn)(
+    const unsigned int * ixn_count,
+    const int N,
     const double * __restrict__ coords,
     const double * __restrict__ params, // [N]
     const double * __restrict__ box,
@@ -36,10 +38,10 @@ private:
     double *d_scales_; // [E, 2]
     int *d_lambda_plane_idxs_;
     int *d_lambda_offset_idxs_;
-    int *p_ixn_count_; // pinned memory
 
     double beta_;
     double cutoff_;
+    unsigned int cur_step_;
     Neighborlist<RealType> nblist_;
 
     const int E_;
@@ -49,7 +51,6 @@ private:
     double *d_nblist_x_; // coords which were used to compute the nblist
     double *d_nblist_box_; // box which was used to rebuild the nblist
     int *d_rebuild_nblist_; // whether or not we have to rebuild the nblist
-    int *p_rebuild_nblist_; // pinned
 
     unsigned int *d_perm_; // hilbert curve permutation
 

--- a/timemachine/cpp/src/rmsd_restraint.cu
+++ b/timemachine/cpp/src/rmsd_restraint.cu
@@ -117,9 +117,6 @@ void RMSDRestraint<RealType>::execute_device(
 
     double epsilon = 1e-8;
 
-    gpuErrchk(cudaMemset(d_u_buf_, 0, sizeof(*d_u_buf_)));
-    gpuErrchk(cudaMemset(d_du_dx_buf_, 0, N*3*sizeof(*d_du_dx_buf_)));
-
     if(s[0] < epsilon || s[1] < epsilon || s[2] < epsilon) {
         return;
     }
@@ -198,8 +195,8 @@ void RMSDRestraint<RealType>::execute_device(
         du_dx[dst_idx*3+2] += static_cast<unsigned long long>(llrint(k_*x2_adjoint(b, 2)*FIXED_EXPONENT));
     }
 
-    gpuErrchk(cudaMemcpy(d_u_buf_, &nrg, sizeof(*d_u_buf_), cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(d_du_dx_buf_, &du_dx[0], N*3*sizeof(*d_du_dx_buf_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpyAsync(d_u_buf_, &nrg, sizeof(*d_u_buf_), cudaMemcpyHostToDevice, stream));
+    gpuErrchk(cudaMemcpyAsync(d_du_dx_buf_, &du_dx[0], N*3*sizeof(*d_du_dx_buf_), cudaMemcpyHostToDevice, stream));
 
     const int blocks= (N_+32-1)/32;
     const int tpb = 32;


### PR DESCRIPTION
Benchmarking RTX 2080

```
RTX 2080

No changes
----------------
dhfr-apo: N=23558 speed: 200.03ns/day dt: 1.5fs (ran 100000 steps in 64.80s)
building a protein system with 1758 protein atoms and 7047 water atoms
WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
hif2a-apo: N=8805 speed: 434.99ns/day dt: 1.5fs (ran 100000 steps in 29.80s)
hif2a-rbfe-with-du-dp: N=8840 speed: 340.17ns/day dt: 1.5fs (ran 100000 steps in 38.10s)
hif2a-rbfe-du-dl-interval-0: N=8840 speed: 341.67ns/day dt: 1.5fs (ran 100000 steps in 37.94s)
hif2a-rbfe-du-dl-interval-1: N=8840 speed: 331.94ns/day dt: 1.5fs (ran 100000 steps in 39.05s)
hif2a-rbfe-du-dl-interval-5: N=8840 speed: 337.33ns/day dt: 1.5fs (ran 100000 steps in 38.42s)
solvent-apo: N=6282 speed: 551.63ns/day dt: 1.5fs (ran 100000 steps in 23.50s)
solvent-rbfe-with-du-dp: N=6317 speed: 427.67ns/day dt: 1.5fs (ran 100000 steps in 30.31s)
solvent-rbfe-du-dl-interval-0: N=6317 speed: 429.55ns/day dt: 1.5fs (ran 100000 steps in 30.18s)
solvent-rbfe-du-dl-interval-1: N=6317 speed: 417.86ns/day dt: 1.5fs (ran 100000 steps in 31.02s)
solvent-rbfe-du-dl-interval-5: N=6317 speed: 426.89ns/day dt: 1.5fs (ran 100000 steps in 30.36s)

Changes
------------
dhfr-apo: N=23558 speed: 222.37ns/day dt: 1.5fs (ran 100000 steps in 58.29s)
building a protein system with 1758 protein atoms and 7047 water atoms
WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
hif2a-apo: N=8805 speed: 514.92ns/day dt: 1.5fs (ran 100000 steps in 25.17s)
hif2a-rbfe-with-du-dp: N=8840 speed: 386.85ns/day dt: 1.5fs (ran 100000 steps in 33.51s)
hif2a-rbfe-du-dl-interval-0: N=8840 speed: 394.05ns/day dt: 1.5fs (ran 100000 steps in 32.89s)
hif2a-rbfe-du-dl-interval-1: N=8840 speed: 375.34ns/day dt: 1.5fs (ran 100000 steps in 34.53s)
hif2a-rbfe-du-dl-interval-5: N=8840 speed: 388.66ns/day dt: 1.5fs (ran 100000 steps in 33.35s)
solvent-apo: N=6282 speed: 685.69ns/day dt: 1.5fs (ran 100000 steps in 18.91s)
solvent-rbfe-with-du-dp: N=6317 speed: 514.11ns/day dt: 1.5fs (ran 100000 steps in 25.21s)
solvent-rbfe-du-dl-interval-0: N=6317 speed: 515.64ns/day dt: 1.5fs (ran 100000 steps in 25.14s)
solvent-rbfe-du-dl-interval-1: N=6317 speed: 500.53ns/day dt: 1.5fs (ran 100000 steps in 25.90s)
solvent-rbfe-du-dl-interval-5: N=6317 speed: 511.70ns/day dt: 1.5fs (ran 100000 steps in 25.33s)
```