### PR TITLE
Relative Hydration Improvements

### DIFF
--- a/examples/validate_relative_hydration.py
+++ b/examples/validate_relative_hydration.py
@@ -152,14 +152,15 @@ if __name__ == "__main__":
                 mol_a = dataset.data[i]
                 mol_b = dataset.data[j]
 
-                ddG_ab = model_relative.predict(
+                ddG_ab, ddG_ab_err = model_relative.predict(
                     ordered_params,
                     mol_a,
                     mol_b,
                     prefix='epoch_'+str(epoch)+'_solvent_relative_'+mol_a.GetProp('_Name')+'_'+mol_b.GetProp('_Name')
                 )
 
-                dG_a = model_absolute.predict(ordered_params, mol_a, prefix='solvent_absolute_'+mol_a.GetProp('_Name'))
-                dG_b = model_absolute.predict(ordered_params, mol_b, prefix='solvent_absolute_'+mol_b.GetProp('_Name'))
+                dG_a, dG_a_err = model_absolute.predict(ordered_params, mol_a, prefix='solvent_absolute_'+mol_a.GetProp('_Name'))
+                dG_b, dG_b_err = model_absolute.predict(ordered_params, mol_b, prefix='solvent_absolute_'+mol_b.GetProp('_Name'))
+                dG_ab_err = np.sqrt(dG_a_err**2 + dG_b_err**2)
 
-                print("mol_i", i, mol_a.GetProp("_Name"), "mol_j", j, mol_b.GetProp("_Name"), "ddG_ab", ddG_ab, "dG_a-dG_b", dG_a-dG_b)
+                print(f"mol_i {i} {mol_a.GetProp('_Name')} mol_j {j} {mol_b.GetProp('_Name')} ddG_ab {ddG_ab:.3f} +- {ddG_ab_err:.3f} dG_a-dG_b {dG_a-dG_b:.3f} +- {dG_ab_err:3f}")

--- a/examples/validate_relative_hydration.py
+++ b/examples/validate_relative_hydration.py
@@ -163,4 +163,4 @@ if __name__ == "__main__":
                 dG_b, dG_b_err = model_absolute.predict(ordered_params, mol_b, prefix='solvent_absolute_'+mol_b.GetProp('_Name'))
                 dG_ab_err = np.sqrt(dG_a_err**2 + dG_b_err**2)
 
-                print(f"mol_i {i} {mol_a.GetProp('_Name')} mol_j {j} {mol_b.GetProp('_Name')} ddG_ab {ddG_ab:.3f} +- {ddG_ab_err:.3f} dG_a-dG_b {dG_a-dG_b:.3f} +- {dG_ab_err:3f}")
+                print(f"mol_i {i} {mol_a.GetProp('_Name')} mol_j {j} {mol_b.GetProp('_Name')} ddG_ab {ddG_ab:.3f} +- {ddG_ab_err:.3f} dG_a-dG_b {dG_a-dG_b:.3f} +- {dG_ab_err:.3f}")

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -380,12 +380,11 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
         rhs_mean = np.mean(rhs_du)
         print(f"{model.prefix} dG_tibar {tibar_dG:.3f} dG_ti {dG_ti:.3f} exact_bar {bar_dG:.3f} exact_bar_err {bar_dG_err:.3f} dG_endpoint {dG_endpoint:.3f} dG_endpoint_err {endpoint_err:.3f} dG_ssc_translation {dG_ssc_translation:.3f} dG_ssc_rotation {dG_ssc_rotation:.3f} overlap {overlap:.3f} lhs_mean {lhs_mean:.3f} rhs_mean {rhs_mean:.3f} lhs_n {len(lhs_du)} rhs_n {len(rhs_du)} | time: {time.time()-start:.3f}s")
         dG += dG_endpoint + dG_ssc_translation + dG_ssc_rotation
-        bar_dG_err += endpoint_err**2
-        bar_dG_err = np.sqrt(bar_dG_err)
+        bar_dG_err = np.sqrt(bar_dG_err**2 + endpoint_err**2)
     else:
         print(f"{model.prefix} dG_tibar {tibar_dG:.3f} dG_ti {dG_ti:.3f} exact_bar {bar_dG:.3f} exact_bar_err {bar_dG_err:.3f} ")
 
-    return (dG, results), dG_grad
+    return (dG, bar_dG_err, results), dG_grad
 
 @functools.partial(jax.custom_vjp, nondiff_argnums=(0,))
 def deltaG(model, sys_params) -> Tuple[float, List]:
@@ -400,7 +399,8 @@ def deltaG_bwd(model, residual, grad) -> Tuple[np.array]:
     """
     # residual are the partial dG / partial dparams for each term
     # grad[0] is the adjoint of dG w.r.t. loss: partial L/partial dG
-    # grad[1] is the adjoint of dG w.r.t. simulation result, which we don't use
+    # grad[1] is the adjoint of dG_err w.r.t. loss: which we don't use
+    # grad[2] is the adjoint of simulation results w.r.t. loss: which we don't use
     return ([grad[0]*r for r in residual],)
 
 deltaG.defvjp(deltaG_fwd, deltaG_bwd)

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -310,7 +310,7 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
 
     for lambda_idx, (lambda_window, result) in enumerate(zip(model.lambda_schedule, ti_results)):
         # (ytz): figure out what to do with stddev(du_dl) later
-        print(f"{model.prefix} index {lambda_idx} lambda {lambda_window:.5f} <du/dl> {np.mean(result.du_dls):.5f} med(du/dl) {np.median(result.du_dls):.5f}  o(du/dl) {np.std(result.du_dls):.5f}")
+        # print(f"{model.prefix} index {lambda_idx} lambda {lambda_window:.5f} <du/dl> {np.mean(result.du_dls):.5f} med(du/dl) {np.median(result.du_dls):.5f}  o(du/dl) {np.std(result.du_dls):.5f}")
         mean_du_dls.append(np.mean(result.du_dls))
         all_grads.append(result.du_dps)
 

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -62,7 +62,7 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
         """
         self.mol = mol
         self.ff = ff
-        self.top = topology.BaseTopology(mol, ff)
+        self.top = topology.BaseTopologyRHFE(mol, ff)
 
     def prepare_host_edge(self, ff_params, host_system):
         """

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -130,6 +130,9 @@ class AbsoluteModel(ABC):
         mol: Chem.Mol
             Molecule we want to decouple
 
+        prefix: str
+            String to prepend to print out statements
+
         Returns
         -------
         float
@@ -214,8 +217,8 @@ class AbsoluteModel(ABC):
 
         return dG, dG_err
 
+        # disabled since image molecules is broken.
         for idx, result in enumerate(results):
-            # print(result.xs.shape)
             traj = mdtraj.Trajectory(result.xs, mdtraj.Topology.from_openmm(combined_topology))
             unit_cell = np.repeat(self.host_box[None, :], len(result.xs), axis=0)
             traj.unitcell_vectors = unit_cell

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -116,8 +116,29 @@ class AbsoluteModel(ABC):
     def predict(self,
         ff_params,
         mol,
-        prefix,
-        standardize=False):
+        prefix):
+        """ Compute the absolute free of energy of decoupling mol_a.
+
+        This function is differentiable w.r.t. ff_params.
+
+        Parameters
+        ----------
+
+        ff_params: list of np.ndarray
+            This should match the ordered params returned by the forcefield
+
+        mol: Chem.Mol
+            Molecule we want to decouple
+
+        Returns
+        -------
+        float
+            delta G in kJ/mol
+
+        float
+            BAR error in the delta G in kJ/mol
+
+        """
 
         print(f"Minimizing the host structure to remove clashes.")
         minimized_host_coords = minimizer.minimize_host_4d(
@@ -128,10 +149,6 @@ class AbsoluteModel(ABC):
             self.host_box
         )
 
-        # if standardize:
-            # top = topology.BaseTopologyStandardDecoupling(mol, self.ff)
-        # else:
-            # top = topology.BaseTopology(mol, self.ff)
         top = self.setup_topology(mol)
 
         afe = free_energy_rabfe.AbsoluteFreeEnergy(mol, self.ff)
@@ -193,9 +210,9 @@ class AbsoluteModel(ABC):
             prefix
         )
 
-        dG, results = estimator_abfe.deltaG(model, sys_params)
+        dG, dG_err, results = estimator_abfe.deltaG(model, sys_params)
 
-        return dG
+        return dG, dG_err
 
         for idx, result in enumerate(results):
             # print(result.xs.shape)
@@ -254,8 +271,7 @@ class RelativeModel(ABC):
         mol_b,
         core_idxs,
         combined_coords,
-        prefix,
-        standardize):
+        prefix):
 
         dual_topology = self.setup_topology(mol_a, mol_b)
         rfe = free_energy_rabfe.RelativeFreeEnergy(dual_topology)
@@ -342,15 +358,16 @@ class RelativeModel(ABC):
             prefix
         )
 
-        dG, results = estimator_abfe.deltaG(model, sys_params)
+        dG, dG_err, results = estimator_abfe.deltaG(model, sys_params)
 
-        for idx, result in enumerate(results):
-            traj = mdtraj.Trajectory(result.xs, mdtraj.Topology.from_openmm(combined_topology))
-            traj.unitcell_vectors = result.boxes
-            traj.image_molecules()
-            traj.save_xtc(prefix+"_complex_lambda_"+str(idx)+".xtc")
+        # disable this for now since image_molecules() is unstable.
+        # for idx, result in enumerate(results):
+        #     traj = mdtraj.Trajectory(result.xs, mdtraj.Topology.from_openmm(combined_topology))
+        #     traj.unitcell_vectors = result.boxes
+        #     traj.image_molecules()
+        #     traj.save_xtc(prefix+"_complex_lambda_"+str(idx)+".xtc")
 
-        return dG, results
+        return dG, dG_err, results
 
     def predict(self, ff_params: list, mol_a: Chem.Mol, mol_b: Chem.Mol, prefix: str):
         """
@@ -364,15 +381,22 @@ class RelativeModel(ABC):
         ff_params: list of np.ndarray
             This should match the ordered params returned by the forcefield
 
-        mol: Chem.Mol
-            Molecule we want to decouple
+        mol_a: Chem.Mol
+            Starting molecule
+
+        mol_b: Chem.Mol
+            Resulting molecule
+
+        prefix: str
+            Auxiliary string to prepend print-outs
 
         Returns
         -------
         float
-            delta delta G in kJ/mol
-        aux
-            list of TI results
+            delta delta G in kJ/mol of morphing mol_a into mol_b
+
+        float
+            BAR error in the delta delta G in kJ/mol
 
         """
 
@@ -404,14 +428,13 @@ class RelativeModel(ABC):
             mol_a_coords,
             mol_b_coords
         ])
-        dG_0, results_0 = self._predict_a_to_b(
+        dG_0, dG_0_err, results_0 = self._predict_a_to_b(
             ff_params,
             mol_a,
             mol_b,
             combined_core_idxs,
             combined_coords,
-            prefix+"_ref_to_mol",
-            standardize=None)
+            prefix+"_ref_to_mol")
 
         # pull out mol_a from combined state
         combined_core_idxs = np.copy(core_idxs)
@@ -425,21 +448,22 @@ class RelativeModel(ABC):
             mol_b_coords,
             mol_a_coords
         ])
-        dG_1, results_1 = self._predict_a_to_b(
+        dG_1, dG_1_err, results_1 = self._predict_a_to_b(
             ff_params,
             mol_b,
             mol_a,
             combined_core_idxs,
             combined_coords,
-            prefix+"_mol_to_ref",
-            standardize=None)
+            prefix+"_mol_to_ref")
 
         # dG_0 is the free energy of moving X-B-A into X-B+A
         # dG_1 is the free energy of moving X-A-B into X-A+B
         # -dG_1 + dG_0 is the free energy of moving X-A+B -> X-B+A
         # i.e. the free energy of "unbinding" A
 
-        return -dG_0 + dG_1
+        dG_err = np.sqrt(dG_0_err**2 + dG_1_err**2)
+
+        return -dG_0 + dG_1, dG_err
 
 
 class RelativeHydrationModel(RelativeModel):

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -141,6 +141,10 @@ class AbsoluteModel(ABC):
         float
             BAR error in the delta G in kJ/mol
 
+        Note that the error estimate is likely to be biased for two reasons: we don't
+            know the true decorrelation time, and by re-using intermediate windows
+            to compute delta_Us, the BAR estimates themselves become correlated.
+
         """
 
         print(f"Minimizing the host structure to remove clashes.")
@@ -400,6 +404,10 @@ class RelativeModel(ABC):
 
         float
             BAR error in the delta delta G in kJ/mol
+
+        Note that the error estimate is likely to be biased for two reasons: we don't
+            know the true decorrelation time, and by re-using intermediate windows
+            to compute delta_Us, the BAR estimates themselves become correlated.
 
         """
 

--- a/fe/topology.py
+++ b/fe/topology.py
@@ -571,6 +571,28 @@ class DualTopology(ABC):
     def parameterize_improper_torsion(self, ff_params):
         return self._parameterize_bonded_term(ff_params, self.ff.it_handle, potentials.PeriodicTorsion)
 
+# (ytz): for hydration free energy tests, we turn off the torsions between non-ring atoms to improve
+# sampling.
+class BaseTopologyRHFE(BaseTopology):
+
+    def parameterize_proper_torsion(self, ff_params):
+        # alchemically turn off proper torsions.
+        torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
+        membership = get_ring_membership(self.mol)
+
+        num_torsions = torsion_params.shape[0]
+
+        lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
+        lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
+
+        for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
+            if membership[b] != membership[c]:
+                lambda_offset_idxs[torsion_idx] = 0
+
+        torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
+
+        return torsion_params, torsion_potential
+
 
 class DualTopologyRHFE(DualTopology):
     """
@@ -578,6 +600,28 @@ class DualTopologyRHFE(DualTopology):
     from 0 to 1, while ligand A is fully coupled. At the same time, at lambda=0, ligand B and ligand A
     have their charges and epsilons reduced by half.
     """
+
+    def parameterize_proper_torsion(self, ff_params):
+
+        torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
+
+        mol_c = Chem.CombineMols(self.mol_a, self.mol_b)
+        membership = get_ring_membership(mol_c)
+
+        num_torsions = torsion_params.shape[0]
+
+        lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
+        lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
+
+        for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
+            if membership[b] != membership[c]:
+                lambda_offset_idxs[torsion_idx] = 0
+
+        torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
+
+        return torsion_params, torsion_potential
+
+
     def parameterize_nonbonded(self,
         ff_q_params,
         ff_lj_params):


### PR DESCRIPTION
This PR makes two major changes:

1) The estimator_rabfe code now returns the BAR error, and the final error is properly accumulated all the way to the final value.
2) For the purposes of correctness testing, and to avoid sampling problems, we turn off the non-ring torsions for *both* the absolute calculation and the relative calculation. This helps improve the overlap of the endpoint correction and removes one source of sampling problems. In binding free energies, we do a similar procedure (except we explicitly compute the deltaG of turning off the torsions). This isn't needed for this particular test case because we're mainly testing for consistency of the restraints themselves.
