### PR TITLE
Task/optimize barostat

### DIFF
--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import numpy as np
 from simtk import unit
@@ -23,6 +24,19 @@ from timemachine.lib import LangevinIntegrator, custom_ops
 from functools import partial
 
 from timemachine.constants import BOLTZ, ENERGY_UNIT, DISTANCE_UNIT
+
+
+def get_platform_version() -> str:
+    release_path = "/etc/os-release"
+    if os.path.isfile(release_path):
+        # AWS Ubuntu 20.04 doesn't have version in uname...
+        with open(release_path, "r") as ifs:
+            for line in ifs.readlines():
+                if line.startswith("PRETTY_NAME="):
+                    platform_version = line.strip()
+    else:
+        platform_version = platform.version()
+    return platform_version.lower()
 
 
 def test_barostat_partial_group_idxs():
@@ -93,7 +107,7 @@ def test_barostat_partial_group_idxs():
     ctxt.multiple_steps(np.ones(1000)*lam)
 
 def test_barostat_varying_pressure():
-    platform_version = platform.version().lower()
+    platform_version = get_platform_version()
     temperature = 300.0 * unit.kelvin
     initial_waterbox_width = 2.0 * unit.nanometer
     timestep = 1.5 * unit.femtosecond
@@ -108,8 +122,8 @@ def test_barostat_varying_pressure():
     if "ubuntu" not in platform_version:
         print("Test expected to run under ubuntu 20.04 or 18.04")
     if "20.04" in platform_version:
-        box_vol = 7.722300793290474
-        box_diff = 0.23923388075982022
+        box_vol = 7.80127358754933
+        box_diff = 1.6621367141041832
         lig_charge_vals[3] = -4.920284514559682
 
     # Start out with a very large pressure

--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -103,7 +103,7 @@ def test_barostat_varying_pressure():
     np.random.seed(seed)
 
     box_vol = 7.0866907017
-    box_diff = 0.5439182266135552
+    box_diff = 1.0856025048
     lig_charge_vals = np.array([1.4572377542719206, -0.37011462071257184, 1.1478267014520305, -4.920166483601927, 0.16985194917937935])
     if "ubuntu" not in platform_version:
         print("Test expected to run under ubuntu 20.04 or 18.04")

--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -102,7 +102,7 @@ def test_barostat_varying_pressure():
     seed = 2021
     np.random.seed(seed)
 
-    box_vol = 7.8336338769085809
+    box_vol = 7.0866907017
     box_diff = 0.5439182266135552
     lig_charge_vals = np.array([1.4572377542719206, -0.37011462071257184, 1.1478267014520305, -4.920166483601927, 0.16985194917937935])
     if "ubuntu" not in platform_version:

--- a/timemachine/cpp/src/barostat.hpp
+++ b/timemachine/cpp/src/barostat.hpp
@@ -41,7 +41,10 @@ public:
     void inplace_move(
         double *d_x,
         double *d_box,
-        const double lambda
+        unsigned long long *d_du_dx, // [N*3]
+        unsigned long long *d_u,
+        const double lambda,
+        cudaStream_t stream
     );
 
     void set_interval(const int interval);
@@ -49,6 +52,8 @@ public:
     int get_interval();
 
     void set_pressure(const double pressure);
+
+    bool run_next_step();
 
 
 private:
@@ -70,21 +75,31 @@ private:
 
     // internals
     int step_;
-    double volume_scale_;
-    int num_attempted_;
-    int num_accepted_;
     int num_grouped_atoms_;
 
-    unsigned long long *d_u_before_;
-    unsigned long long *d_u_after_;
+    int *d_num_attempted_;
+    int *d_num_accepted_;
+
+    unsigned long long *d_u_after_buffer_;
+    unsigned long long *d_du_dx_after_;
+
+    unsigned long long *d_init_u_;
+    unsigned long long *d_final_u_;
+
+    double *d_volume_;
+    double *d_volume_delta_;
+    double *d_length_scale_;
+    double *d_volume_scale_;
 
     double *d_x_after_;
-
     double *d_box_after_;
 
     int *d_atom_idxs_; // grouped index to atom coords
     int *d_mol_idxs_; // grouped index to molecule index
     int *d_mol_offsets_; // Offset of molecules to determine size of mols
+
+    double *d_sum_storage_;
+    size_t d_sum_storage_bytes_;
 
     unsigned long long *d_centroids_; // Accumulate centroids in fix point to ensure deterministic behavior
 

--- a/timemachine/cpp/src/context.hpp
+++ b/timemachine/cpp/src/context.hpp
@@ -57,6 +57,7 @@ private:
 
     unsigned long long *d_du_dx_t_; // du/dx [N,3]
     unsigned long long *d_du_dl_buffer_; // du/dl [N]
+    unsigned long long *d_u_buffer_; // u [N] // Only used if barostat
     double *d_sum_storage_;
     size_t d_sum_storage_bytes_;
 

--- a/timemachine/cpp/src/integrator.cu
+++ b/timemachine/cpp/src/integrator.cu
@@ -80,7 +80,8 @@ void LangevinIntegrator::step_fwd(
     double *d_x_t,
     double *d_v_t,
     unsigned long long *d_du_dx_t,
-    double *d_box_t_) {
+    double *d_box_t_,
+    cudaStream_t stream) {
 
     const int D = 3;
     size_t tpb = 32;
@@ -89,7 +90,7 @@ void LangevinIntegrator::step_fwd(
 
     curandErrchk(templateCurandNormal(cr_rng_, d_noise_, round_up_even(N_*D), 0.0, 1.0));
 
-    update_forward<double><<<dimGrid_dx, tpb>>>(
+    update_forward<double><<<dimGrid_dx, tpb, 0, stream>>>(
         N_,
         D,
         ca_,

--- a/timemachine/cpp/src/integrator.hpp
+++ b/timemachine/cpp/src/integrator.hpp
@@ -14,7 +14,8 @@ public:
         double *d_x_t,
         double *d_v_t,
         unsigned long long *d_du_dx_t,
-        double *d_box_t_
+        double *d_box_t_,
+        cudaStream_t stream
     ) = 0;
 
 };
@@ -49,7 +50,8 @@ public:
         double *d_x_t,
         double *d_v_t,
         unsigned long long *d_du_dx_t,
-        double *d_box_t_
+        double *d_box_t_,
+        cudaStream_t stream
     ) override;
 
 };


### PR DESCRIPTION
Fundamentally this does not speed things up that much. In the case where the interval is 1, you see a ~40% improvement in speed (DHFR 54 ns/day -> 70ns/day), however as the interval gets up to 25 it falls off to being negligible (193ns/day -> 195, and that is not a meaningful difference). 

The issue is that *every* barostat move triggers up to 2 rebuilds of the neighborlist. The first when you shift the box and if that shift failed, it has to recompute the original neighborlist. At this point the most obvious solution is to speed up the neighborlist construction, though that seems to be a separate issue. Another idea would be to give the Barostat a different set of potentials that could reduce the number of neighborlist reconstructions are needed. This would happen because as the simulation runs longer the number of accepted moves decreases, which means the original neighborlist can be reused more regularly.