### PR TITLE
Improve Conversion Protocol

### DIFF
--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -15,7 +15,7 @@ import argparse
 import numpy as np
 from jax import numpy as jnp
 
-from fe.free_energy_rabfe import construct_absolute_lambda_schedule, construct_conversion_lambda_schedule, get_romol_conf, setup_relative_restraints
+from fe.free_energy_rabfe import construct_absolute_lambda_schedule, construct_conversion_lambda_schedule, get_romol_conf, setup_relative_restraints_using_smarts
 from fe.utils import convert_uIC50_to_kJ_per_mole
 # from fe import model_abfe, model_rabfe, model_conversion
 from fe import model_rabfe
@@ -250,10 +250,12 @@ if __name__ == "__main__":
     ordered_params = forcefield.get_ordered_params()
     ordered_handles = forcefield.get_ordered_handles()
 
+    core_smarts = "*1~*~*~*~*~*~1~O~*1~*~*~*~*~*~1"
+
     def pred_fn(params, mol, mol_ref):
 
         # generate the core_idxs
-        core_idxs = setup_relative_restraints(mol, mol_ref)
+        core_idxs = setup_relative_restraints_using_smarts(mol, mol_ref, core_smarts)
         mol_coords = get_romol_conf(mol) # original coords
         
         num_complex_atoms = complex_coords.shape[0]

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -299,26 +299,24 @@ if __name__ == "__main__":
         # effective free energy of removing from complex
         dG_complex = dG_complex_conversion + dG_complex_decouple
 
-        return 0.0, 0.0
-
         # solvent
-        # min_solvent_coords = minimizer.minimize_host_4d([mol], solvent_system, solvent_coords, forcefield, solvent_box)
-        # solvent_x0 = np.concatenate([min_solvent_coords, mol_coords])
-        # solvent_box0 = solvent_box
-        # dG_solvent_conversion, dG_solvent_conversion_error = binding_model_solvent_conversion.predict(
-        #     params,
-        #     mol,
-        #     solvent_x0,
-        #     solvent_box0,
-        #     prefix='solvent_conversion_'+str(epoch)
-        # )
-        # dG_solvent_decouple, dG_solvent_decouple_error = binding_model_solvent_decouple.predict(
-        #     params,
-        #     mol,
-        #     solvent_x0,
-        #     solvent_box0,
-        #     prefix='solvent_decouple_'+str(epoch),
-        # )
+        min_solvent_coords = minimizer.minimize_host_4d([mol], solvent_system, solvent_coords, forcefield, solvent_box)
+        solvent_x0 = np.concatenate([min_solvent_coords, mol_coords])
+        solvent_box0 = solvent_box
+        dG_solvent_conversion, dG_solvent_conversion_error = binding_model_solvent_conversion.predict(
+            params,
+            mol,
+            solvent_x0,
+            solvent_box0,
+            prefix='solvent_conversion_'+str(epoch)
+        )
+        dG_solvent_decouple, dG_solvent_decouple_error = binding_model_solvent_decouple.predict(
+            params,
+            mol,
+            solvent_x0,
+            solvent_box0,
+            prefix='solvent_decouple_'+str(epoch),
+        )
 
         # effective free energy of removing from solvent
         dG_solvent = dG_solvent_conversion + dG_solvent_decouple

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -281,6 +281,8 @@ if __name__ == "__main__":
             complex_box0,
             prefix='complex_conversion_'+str(epoch))
 
+        return 0.0, 0.0
+
         # compute the free energy of swapping an interacting mol with a non-interacting reference mol
         complex_decouple_x0 = minimizer.minimize_host_4d([mol, mol_ref], complex_system, complex_host_coords, forcefield, complex_box0, [aligned_mol_coords, ref_coords])
         complex_decouple_x0 = np.concatenate([complex_decouple_x0, aligned_mol_coords, ref_coords])

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -270,7 +270,6 @@ if __name__ == "__main__":
 
         ref_coords = complex_ref_x0[num_complex_atoms:]
         complex_host_coords = complex_ref_x0[:num_complex_atoms]
-
         complex_box0 = complex_ref_box0
 
         # compute the free energy of conversion in complex
@@ -281,7 +280,9 @@ if __name__ == "__main__":
             mol,
             complex_conversion_x0,
             complex_box0,
-            prefix='complex_conversion_'+str(epoch))
+            prefix='complex_conversion_'+str(epoch),
+            core_idxs=core_idxs[:, 0]
+        )
 
         return 0.0, 0.0
 

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -302,23 +302,23 @@ if __name__ == "__main__":
         return 0.0, 0.0
 
         # solvent
-        min_solvent_coords = minimizer.minimize_host_4d([mol], solvent_system, solvent_coords, forcefield, solvent_box)
-        solvent_x0 = np.concatenate([min_solvent_coords, mol_coords])
-        solvent_box0 = solvent_box
-        dG_solvent_conversion, dG_solvent_conversion_error = binding_model_solvent_conversion.predict(
-            params,
-            mol,
-            solvent_x0,
-            solvent_box0,
-            prefix='solvent_conversion_'+str(epoch)
-        )
-        dG_solvent_decouple, dG_solvent_decouple_error = binding_model_solvent_decouple.predict(
-            params,
-            mol,
-            solvent_x0,
-            solvent_box0,
-            prefix='solvent_decouple_'+str(epoch),
-        )
+        # min_solvent_coords = minimizer.minimize_host_4d([mol], solvent_system, solvent_coords, forcefield, solvent_box)
+        # solvent_x0 = np.concatenate([min_solvent_coords, mol_coords])
+        # solvent_box0 = solvent_box
+        # dG_solvent_conversion, dG_solvent_conversion_error = binding_model_solvent_conversion.predict(
+        #     params,
+        #     mol,
+        #     solvent_x0,
+        #     solvent_box0,
+        #     prefix='solvent_conversion_'+str(epoch)
+        # )
+        # dG_solvent_decouple, dG_solvent_decouple_error = binding_model_solvent_decouple.predict(
+        #     params,
+        #     mol,
+        #     solvent_x0,
+        #     solvent_box0,
+        #     prefix='solvent_decouple_'+str(epoch),
+        # )
 
         # effective free energy of removing from solvent
         dG_solvent = dG_solvent_conversion + dG_solvent_decouple

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -284,8 +284,6 @@ if __name__ == "__main__":
             core_idxs=core_idxs[:, 0]
         )
 
-        return 0.0, 0.0
-
         # compute the free energy of swapping an interacting mol with a non-interacting reference mol
         complex_decouple_x0 = minimizer.minimize_host_4d([mol, mol_ref], complex_system, complex_host_coords, forcefield, complex_box0, [aligned_mol_coords, ref_coords])
         complex_decouple_x0 = np.concatenate([complex_decouple_x0, aligned_mol_coords, ref_coords])
@@ -300,6 +298,8 @@ if __name__ == "__main__":
 
         # effective free energy of removing from complex
         dG_complex = dG_complex_conversion + dG_complex_decouple
+
+        return 0.0, 0.0
 
         # solvent
         min_solvent_coords = minimizer.minimize_host_4d([mol], solvent_system, solvent_coords, forcefield, solvent_box)

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -17,7 +17,7 @@ import argparse
 import numpy as np
 from jax import numpy as jnp
 
-from fe.free_energy_rabfe import construct_absolute_lambda_schedule, construct_conversion_lambda_schedule, get_romol_conf, setup_relative_restraints_using_smarts
+from fe.free_energy_rabfe import construct_absolute_lambda_schedule_complex, construct_absolute_lambda_schedule_solvent, construct_conversion_lambda_schedule, get_romol_conf, setup_relative_restraints_using_smarts
 from fe.utils import convert_uIC50_to_kJ_per_mole
 # from fe import model_abfe, model_rabfe, model_conversion
 from fe import model_rabfe
@@ -61,7 +61,8 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--property_field",
-        help="Property field to convert to kcals/mols"
+        help="Property field to convert to kcals/mols",
+        required=True
     )
 
     parser.add_argument(
@@ -188,8 +189,8 @@ if __name__ == "__main__":
     dataset = Dataset(mols)
 
     # construct lambda schedules for complex and solvent
-    complex_absolute_schedule = construct_absolute_lambda_schedule(cmd_args.num_complex_windows)
-    solvent_absolute_schedule = construct_absolute_lambda_schedule(cmd_args.num_solvent_windows)
+    complex_absolute_schedule = construct_absolute_lambda_schedule_complex(cmd_args.num_complex_windows)
+    solvent_absolute_schedule = construct_absolute_lambda_schedule_solvent(cmd_args.num_solvent_windows)
 
     # build the protein system.
     complex_system, complex_coords, _, _, complex_box, complex_topology = builders.build_protein_system(

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -240,9 +240,9 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
     for lamb_idx, lamb in enumerate(model.lambda_schedule):
 
         if model.endpoint_correct and lamb_idx == len(model.lambda_schedule) - 1:
-            x_interval = 200
+            x_interval = 1000
         else:
-            x_interval = 200
+            x_interval = 1000
 
         if lamb_idx == 0:
             lambda_left = None
@@ -265,7 +265,7 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
             model.equil_steps,
             model.prod_steps,
             x_interval, # x_interval
-            200,        # du_dl_interval
+            1000,        # du_dl_interval
             lambda_left,
             lambda_right
         ))
@@ -281,8 +281,8 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
             model.barostat,
             model.equil_steps,
             model.prod_steps,
-            200,       # x_interval
-            200,       # du_dl_interval
+            1000,       # x_interval
+            1000,       # du_dl_interval
             None,
             None
         ))

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -145,7 +145,32 @@ def construct_conversion_lambda_schedule(num_windows):
     return np.linspace(0, 1, num_windows)
 
 
-def construct_absolute_lambda_schedule(num_windows):
+def construct_absolute_lambda_schedule_complex(num_windows):
+    """Generate a length-num_windows list of lambda values from 0.0 up to 1.0
+
+    Notes
+    -----
+    manually optimized by YTZ
+    """
+
+    A = int(.20 * num_windows)
+    B = int(.66 * num_windows)
+    C = num_windows - A - B
+
+    # optimizing the overlap based on eyeballing absolute hydration free energies
+    # there's probably some better way to deal with this by inspecting the curvature
+    lambda_schedule = np.concatenate([
+        np.linspace(0.0,  0.10, A, endpoint=False),
+        np.linspace(0.10, 0.40, B, endpoint=False),
+        np.linspace(0.40, 1.0,  C, endpoint=True)
+    ])
+
+    assert len(lambda_schedule) == num_windows
+
+    return lambda_schedule
+
+
+def construct_absolute_lambda_schedule_solvent(num_windows):
     """Generate a length-num_windows list of lambda values from 0.0 up to 1.0
 
     Notes
@@ -163,7 +188,7 @@ def construct_absolute_lambda_schedule(num_windows):
     lambda_schedule = np.concatenate([
         np.linspace(0.0,  0.08,  A, endpoint=False),
         np.linspace(0.08,  0.27, B, endpoint=False),
-        np.linspace(0.27, 0.6,  C, endpoint=True),
+        np.linspace(0.27, 0.50,  C, endpoint=True),
         [1.0],
     ])
 

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -144,6 +144,7 @@ class RelativeFreeEnergy(BaseFreeEnergy):
 def construct_conversion_lambda_schedule(num_windows):
     return np.linspace(0, 1, num_windows)
 
+
 def construct_absolute_lambda_schedule(num_windows):
     """Generate a length-num_windows list of lambda values from 0.0 up to 1.0
 
@@ -162,7 +163,7 @@ def construct_absolute_lambda_schedule(num_windows):
     lambda_schedule = np.concatenate([
         np.linspace(0.0,  0.08,  A, endpoint=False),
         np.linspace(0.08,  0.27, B, endpoint=False),
-        np.linspace(0.27, 0.46,  C, endpoint=True),
+        np.linspace(0.27, 0.6,  C, endpoint=True),
         [1.0],
     ])
 
@@ -240,8 +241,6 @@ def setup_relative_restraints(
     return core_idxs
 
 
-
-
 def setup_relative_restraints_using_smarts(
     mol_a,
     mol_b,
@@ -275,7 +274,6 @@ def setup_relative_restraints_using_smarts(
     row_idxs, col_idxs = linear_sum_assignment(rij)
 
     core_idxs = []
-
 
     for core_a, core_b in zip(row_idxs, col_idxs):
         core_idxs.append((

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -257,8 +257,8 @@ def setup_relative_restraints_using_smarts(
     assert "." not in smarts
 
     core = Chem.MolFromSmarts(smarts)
-    core_idxs_a = mol_a.GetSubstructMatch(core)
-    core_idxs_b = mol_b.GetSubstructMatch(core)
+    core_idxs_a = np.array(mol_a.GetSubstructMatch(core))
+    core_idxs_b = np.array(mol_b.GetSubstructMatch(core))
     # setup relative orientational restraints
     # rough sketch of algorithm:
     # find core atoms in mol_a
@@ -275,6 +275,7 @@ def setup_relative_restraints_using_smarts(
     row_idxs, col_idxs = linear_sum_assignment(rij)
 
     core_idxs = []
+
 
     for core_a, core_b in zip(row_idxs, col_idxs):
         core_idxs.append((

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -444,14 +444,8 @@ class AbsoluteHydrationModel(AbsoluteModel):
 
 class RelativeHydrationModel(RelativeModel):
 
-    def setup_topology(self, mol_a, mol_b, core_idxs):
-        top = topology.DualTopologyRHFE(mol_a, mol_b, self.ff)
-        top.parameterize_proper_torsion = functools.partial(
-            top.parameterize_proper_torsion,
-            core_idxs_a=core_idxs[:, 0],
-            core_idxs_b=core_idxs[:, 1]
-        )
-        return top
+    def setup_topology(self, mol_a, mol_b, _):
+        return topology.DualTopologyRHFE(mol_a, mol_b, self.ff)
 
 class AbsoluteConversionModel(AbsoluteModel):
 

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -152,23 +152,22 @@ class AbsoluteModel(ABC):
         dG, dG_err, results = estimator_abfe.deltaG(model, sys_params)
 
         # uncomment if we want to visualize
-        # combined_topology = model_utils.generate_imaged_topology(
-        #     [self.host_topology, mol],
-        #     x0,
-        #     box0,
-        #     "initial_"+prefix+".pdb"
-        # )
+        combined_topology = model_utils.generate_imaged_topology(
+            [self.host_topology, mol],
+            x0,
+            box0,
+            "initial_"+prefix+".pdb"
+        )
 
-        # for lambda_idx, res in enumerate(results):
-        #     # used for debugging for now, try to reproduce mdtraj error
-        #     outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
-        #     pickle.dump((res.xs, res.boxes, combined_topology), outfile)
-        #     print("dumping", outfile)
-        #     # pickle.dump((res.xs[:100], res.boxes[:100], combined_topology), outfile)
-        #     traj = mdtraj.Trajectory(res.xs, mdtraj.Topology.from_openmm(combined_topology))
-        #     traj.unitcell_vectors = res.boxes
-        #     traj.image_molecules()
-        #     traj.save_xtc("initial_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".xtc")
+        for lambda_idx, res in enumerate(results):
+            # used for debugging for now, try to reproduce mdtraj error
+            outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
+            pickle.dump((res.xs, res.boxes, combined_topology), outfile)
+            print("dumping", outfile)
+            # pickle.dump((res.xs[:100], res.boxes[:100], combined_topology), outfile)
+            traj = mdtraj.Trajectory(res.xs, mdtraj.Topology.from_openmm(combined_topology))
+            traj.unitcell_vectors = res.boxes
+            traj.save_xtc("initial_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".xtc")
     
         return dG, dG_err
 
@@ -307,21 +306,20 @@ class RelativeModel(ABC):
         dG, dG_err, results = estimator_abfe.deltaG(model, sys_params)
 
         # uncomment if we want to visualize.
-        # combined_topology = model_utils.generate_imaged_topology(
-        #     [self.host_topology, mol_a, mol_b],
-        #     x0,
-        #     box0,
-        #     "initial_"+prefix+".pdb"
-        # )
+        combined_topology = model_utils.generate_imaged_topology(
+            [self.host_topology, mol_a, mol_b],
+            x0,
+            box0,
+            "initial_"+prefix+".pdb"
+        )
 
-        # for lambda_idx, res in enumerate(results):
-        #     outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
-        #     pickle.dump((res.xs, res.boxes, combined_topology), outfile)
-        #     print("dumping", outfile)
-        #     traj = mdtraj.Trajectory(res.xs, mdtraj.Topology.from_openmm(combined_topology))
-        #     traj.unitcell_vectors = res.boxes
-        #     traj.image_molecules() # don't do this in prod
-        #     traj.save_xtc("initial_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".xtc")
+        for lambda_idx, res in enumerate(results):
+            outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
+            pickle.dump((res.xs, res.boxes, combined_topology), outfile)
+            print("dumping", outfile)
+            traj = mdtraj.Trajectory(res.xs, mdtraj.Topology.from_openmm(combined_topology))
+            traj.unitcell_vectors = res.boxes
+            traj.save_xtc("initial_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".xtc")
 
         return dG, dG_err, results
 

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -163,7 +163,6 @@ class AbsoluteModel(ABC):
             # used for debugging for now, try to reproduce mdtraj error
             outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
             pickle.dump((res.xs, res.boxes, combined_topology), outfile)
-            print("dumping", outfile)
             # pickle.dump((res.xs[:100], res.boxes[:100], combined_topology), outfile)
             traj = mdtraj.Trajectory(res.xs, mdtraj.Topology.from_openmm(combined_topology))
             traj.unitcell_vectors = res.boxes

--- a/fe/topology.py
+++ b/fe/topology.py
@@ -342,23 +342,23 @@ class BaseTopologyConversion(BaseTopology):
     FastFindRings or SSSRs (ring basis), of which neither is what we want.
     """
 
-    def parameterize_proper_torsion(self, ff_params):
-        # alchemically turn off proper torsions.
-        torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
-        membership = get_ring_membership(self.mol)
+    # def parameterize_proper_torsion(self, ff_params):
+    #     # alchemically turn off proper torsions.
+    #     torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
+    #     membership = get_ring_membership(self.mol)
 
-        num_torsions = torsion_params.shape[0]
+    #     num_torsions = torsion_params.shape[0]
 
-        lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
-        lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
+    #     lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
+    #     lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
 
-        for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
-            if membership[b] != membership[c]:
-                lambda_mult_idxs[torsion_idx] = -1
+    #     for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
+    #         if membership[b] != membership[c]:
+    #             lambda_mult_idxs[torsion_idx] = -1
 
-        torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
+    #     torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
 
-        return torsion_params, torsion_potential
+    #     return torsion_params, torsion_potential
 
 
     def parameterize_nonbonded(self,

--- a/fe/topology.py
+++ b/fe/topology.py
@@ -361,6 +361,7 @@ class BaseTopologyConversion(BaseTopology):
                 continue
 
             if membership[b] != membership[c]:
+                print("disabling torsion between", b, c)
                 lambda_mult_idxs[torsion_idx] = -1
 
         torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
@@ -614,7 +615,10 @@ class DualTopologyRHFE(DualTopology):
     have their charges and epsilons reduced by half.
     """
 
-    def parameterize_proper_torsion(self, ff_params):
+    def parameterize_proper_torsion(self, ff_params, core_idxs):
+
+        if core_idxs is None:
+            core_idxs = []
 
         torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
 
@@ -627,6 +631,10 @@ class DualTopologyRHFE(DualTopology):
         lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
 
         for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
+            # skip entirely if we're not in the core
+            if b not in core_idxs or c not in core_idxs:
+                continue
+
             if membership[b] != membership[c]:
                 lambda_offset_idxs[torsion_idx] = 0
 

--- a/parallel/client.py
+++ b/parallel/client.py
@@ -186,8 +186,8 @@ class GRPCClient(AbstractClient):
         self.stubs = []
         if options is None:
             options = [
-                ('grpc.max_send_message_length', 500 * 1024 * 1024),
-                ('grpc.max_receive_message_length', 500 * 1024 * 1024)
+                ('grpc.max_send_message_length', 1024 * 1024 * 1024),
+                ('grpc.max_receive_message_length', 1024 * 1024 * 1024)
             ]
         for host in self.hosts:
             channel = grpc.insecure_channel(

--- a/parallel/worker.py
+++ b/parallel/worker.py
@@ -29,8 +29,8 @@ def serve(args):
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1),
         options = [
-            ('grpc.max_send_message_length', 500 * 1024 * 1024),
-            ('grpc.max_receive_message_length', 500 * 1024 * 1024)
+            ('grpc.max_send_message_length', 1024 * 1024 * 1024),
+            ('grpc.max_receive_message_length', 1024 * 1024 * 1024)
         ]
     )
     service_pb2_grpc.add_WorkerServicer_to_server(Worker(), server)

--- a/tests/test_rabfe_topology.py
+++ b/tests/test_rabfe_topology.py
@@ -54,52 +54,7 @@ def test_base_topology_conversion_ring_torsion():
     np.testing.assert_array_equal(vanilla_qlj_params, src_qlj_params)
     np.testing.assert_array_equal(topology.standard_qlj_typer(mol), dst_qlj_params)
 
-
     
-
-# def test_base_topology_conversion_ring_torsion():
-
-#     # test that the conversion protocol behaves as intended on a
-#     # simple linked cycle.
-
-#     ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_sc.py').read())
-#     ff = Forcefield(ff_handlers)
-#     mol = Chem.MolFromSmiles("C1CC1C1CC1")
-#     vanilla_mol_top = topology.BaseTopology(mol, ff)
-
-#     vanilla_torsion_params, _ = vanilla_mol_top.parameterize_proper_torsion(ff.pt_handle.params)
-
-#     mol_top = topology.BaseTopologyConversion(mol, ff)
-#     core_idxs = [0,1,2,3,4,5]
-#     conversion_torsion_params, torsion_potential = mol_top.parameterize_proper_torsion(ff.pt_handle.params, core_idxs)
-
-#     np.testing.assert_array_equal(vanilla_torsion_params, conversion_torsion_params)
-
-#     # in the conversion phase, torsions that bridge the two rings should be set to
-#     # be alchemically turned off.
-#     ring_group = [0,0,0,1,1,1]
-
-#     for torsion_idxs, mult, offset in zip(torsion_potential.get_idxs(), torsion_potential.get_lambda_mult(), torsion_potential.get_lambda_offset()):
-#         _, b, c, _ = torsion_idxs
-#         assert offset == 1
-#         if ring_group[b] != ring_group[c]:
-#             assert mult == -1
-#         else:
-#             assert mult == 0
-
-#     vanilla_qlj_params, _ = vanilla_mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
-#     qlj_params, nonbonded_potential = mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
-
-#     assert isinstance(nonbonded_potential, potentials.NonbondedInterpolated)
-
-#     src_qlj_params = qlj_params[:len(qlj_params)//2]
-#     dst_qlj_params = qlj_params[len(qlj_params)//2:]
-
-#     np.testing.assert_array_equal(vanilla_qlj_params, src_qlj_params)
-#     np.testing.assert_array_equal(topology.standard_qlj_typer(mol), dst_qlj_params)
-
-
-
 def test_base_topology_conversion_r_group():
 
     # check that phenol torsions are turned off if they're defined in the core


### PR DESCRIPTION
This PR turns off the non-ring torsions within the core region only. Previously we turned off all non-ring torsions in the conversion stage, regardless of whether or not it was part of the core. We noticed this introduces more error than we'd like. This PR also requires the user to pre-specify a SMARTS pattern to define the core (and checks to make sure that it's connected). 


