### PR TITLE
Task/optimize barostat

### DIFF
--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import numpy as np
 from simtk import unit
@@ -87,6 +88,19 @@ def test_barostat_zero_interval():
     with pytest.raises(RuntimeError):
         baro.set_interval(0)
 
+def get_platform_version() -> str:
+    release_path = "/etc/os-release"
+    if os.path.isfile(release_path):
+        # AWS Ubuntu 20.04 doesn't have version in uname...
+        with open(release_path, "r") as ifs:
+            for line in ifs.readlines():
+                if line.startswith("PRETTY_NAME="):
+                    platform_version = line.strip()
+    else:
+        platform_version = platform.version()
+    return platform_version.lower()
+
+
 def test_barostat_partial_group_idxs():
     """Verify that the barostat can handle a subset of the molecules
     rather than all of them. This test only verify that it runs, not the behavior"""
@@ -155,7 +169,7 @@ def test_barostat_partial_group_idxs():
     ctxt.multiple_steps(np.ones(1000)*lam)
 
 def test_barostat_varying_pressure():
-    platform_version = platform.version().lower()
+    platform_version = get_platform_version()
     temperature = 300.0 * unit.kelvin
     initial_waterbox_width = 2.0 * unit.nanometer
     timestep = 1.5 * unit.femtosecond
@@ -170,8 +184,8 @@ def test_barostat_varying_pressure():
     if "ubuntu" not in platform_version:
         print("Test expected to run under ubuntu 20.04 or 18.04")
     if "20.04" in platform_version:
-        box_vol = 7.722300793290474
-        box_diff = 0.23923388075982022
+        box_vol = 7.80127358754933
+        box_diff = 1.6621367141041832
         lig_charge_vals[3] = -4.920284514559682
 
     # Start out with a very large pressure

--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -168,8 +168,14 @@ def test_barostat_partial_group_idxs():
     ctxt = custom_ops.Context(coords, v_0, complex_box, integrator_impl, u_impls, barostat=baro)
     ctxt.multiple_steps(np.ones(1000)*lam)
 
-def test_barostat_varying_pressure():
+
+def test_barostat_is_deterministic():
+    """Verify that the barostat results in the same box size shift after 1000
+    steps. This is important to debugging as well as providing the ability to replicate
+    simulations
+    """
     platform_version = get_platform_version()
+    lam = 1.0
     temperature = 300.0 * unit.kelvin
     initial_waterbox_width = 2.0 * unit.nanometer
     timestep = 1.5 * unit.femtosecond
@@ -178,18 +184,18 @@ def test_barostat_varying_pressure():
     seed = 2021
     np.random.seed(seed)
 
-    box_vol = 7.584418174042398
-    box_diff = 0.4723854602575077
+    # OpenEye's AM1 Charging values are OS platform dependent. To ensure that we have deterministic values
+    # we check against our two most common OS versions, Ubuntu 18.04 and 20.04.
+    box_vol = 8.01086504373106
     lig_charge_vals = np.array([1.4572377542719206, -0.37011462071257184, 1.1478267014520305, -4.920166483601927, 0.16985194917937935])
     if "ubuntu" not in platform_version:
-        print("Test expected to run under ubuntu 20.04 or 18.04")
+        print(f"Test expected to run under ubuntu 20.04 or 18.04, got {platform_version}")
     if "20.04" in platform_version:
-        box_vol = 7.824647141563986
-        box_diff = 0.5287400036790046
+        box_vol = 7.864905556101201
         lig_charge_vals[3] = -4.920284514559682
 
-    # Start out with a very large pressure
-    pressure = 1000. * unit.atmosphere
+    pressure = 1. * unit.atmosphere
+
     mol_a = hif2a_ligand_pair.mol_a
     ff = hif2a_ligand_pair.ff
     complex_system, complex_coords, complex_box, complex_top = build_water_system(
@@ -202,27 +208,17 @@ def test_barostat_varying_pressure():
         ff.get_ordered_params(), complex_system, min_complex_coords
     )
 
-
     # get list of molecules for barostat by looking at bond table
     harmonic_bond_potential = unbound_potentials[0]
     bond_list = get_bond_list(harmonic_bond_potential)
     group_indices = get_group_indices(bond_list)
 
-    trajs = []
-    volume_trajs = []
-
-    lam = 1.0
-
-    bound_potentials = []
+    u_impls = []
     # Look at the first five atoms and their assigned charges
     ligand_charges = sys_params[-1][:, 0][len(min_complex_coords):][:5]
     np.testing.assert_array_almost_equal(lig_charge_vals, ligand_charges, decimal=5)
     for params, unbound_pot in zip(sys_params, unbound_potentials):
         bp = unbound_pot.bind(np.asarray(params))
-        bound_potentials.append(bp)
-
-    u_impls = []
-    for bp in bound_potentials:
         bp_impl = bp.bound_impl(precision=np.float32)
         u_impls.append(bp_impl)
 
@@ -248,24 +244,84 @@ def test_barostat_varying_pressure():
     )
 
     ctxt = custom_ops.Context(coords, v_0, complex_box, integrator_impl, u_impls, barostat=baro)
-    ctxt.multiple_steps(np.ones(2000)*lam)
+    ctxt.multiple_steps(np.ones(1000)*lam)
+    atm_box = ctxt.get_box()
+    np.testing.assert_almost_equal(compute_box_volume(atm_box), box_vol, decimal=5)
+
+
+def test_barostat_varying_pressure():
+    temperature = 300.0 * unit.kelvin
+    initial_waterbox_width = 2.0 * unit.nanometer
+    timestep = 1.5 * unit.femtosecond
+    barostat_interval = 3
+    collision_rate = 1.0 / unit.picosecond
+    seed = 2021
+    np.random.seed(seed)
+
+    # Start out with a very large pressure
+    pressure = 1000. * unit.atmosphere
+    mol_a = hif2a_ligand_pair.mol_a
+    ff = hif2a_ligand_pair.ff
+    complex_system, complex_coords, complex_box, complex_top = build_water_system(
+        initial_waterbox_width.value_in_unit(unit.nanometer))
+
+    min_complex_coords = minimize_host_4d([mol_a], complex_system, complex_coords, ff, complex_box)
+    afe = AbsoluteFreeEnergy(mol_a, ff)
+
+    unbound_potentials, sys_params, masses, coords = afe.prepare_host_edge(
+        ff.get_ordered_params(), complex_system, min_complex_coords
+    )
+
+    # get list of molecules for barostat by looking at bond table
+    harmonic_bond_potential = unbound_potentials[0]
+    bond_list = get_bond_list(harmonic_bond_potential)
+    group_indices = get_group_indices(bond_list)
+
+    lam = 1.0
+
+    u_impls = []
+    for params, unbound_pot in zip(sys_params, unbound_potentials):
+        bp = unbound_pot.bind(np.asarray(params))
+        bp_impl = bp.bound_impl(precision=np.float32)
+        u_impls.append(bp_impl)
+
+    integrator = LangevinIntegrator(
+        temperature.value_in_unit(unit.kelvin),
+        timestep.value_in_unit(unit.picosecond),
+        collision_rate.value_in_unit(unit.picosecond**-1),
+        masses,
+        seed
+    )
+    integrator_impl = integrator.impl()
+
+    v_0 = sample_velocities(masses * unit.amu, temperature)
+
+    baro = custom_ops.MonteCarloBarostat(
+        coords.shape[0],
+        pressure.value_in_unit(unit.bar),
+        temperature.value_in_unit(unit.kelvin),
+        group_indices,
+        barostat_interval,
+        u_impls,
+        seed
+    )
+
+    ctxt = custom_ops.Context(coords, v_0, complex_box, integrator_impl, u_impls, barostat=baro)
+    ctxt.multiple_steps(np.ones(1000)*lam)
     ten_atm_box = ctxt.get_box()
     ten_atm_box_vol = compute_box_volume(ten_atm_box)
     # Expect the box to shrink thanks to the barostat
-    assert ten_atm_box_vol < compute_box_volume(complex_box)
+    assert compute_box_volume(complex_box) - ten_atm_box_vol > 0.4
 
     # Set the pressure to 1 bar
     baro.set_pressure((1 * unit.atmosphere).value_in_unit(unit.bar))
     # Changing the barostat interval resets the barostat step.
     baro.set_interval(2)
 
-    ctxt.multiple_steps(np.ones(5000)*lam)
+    ctxt.multiple_steps(np.ones(2000)*lam)
     atm_box = ctxt.get_box()
-    # OpenEye's AM1 Charging values are OS platform dependent. To ensure that we have deterministic values
-    # we check against our two most common OS versions, Ubuntu 18.04 and 20.04.
-    np.testing.assert_almost_equal(compute_box_volume(atm_box), box_vol, decimal=5)
     # Box will grow thanks to the lower pressure
-    np.testing.assert_almost_equal(compute_box_volume(atm_box) - ten_atm_box_vol, box_diff, decimal=5)
+    assert compute_box_volume(atm_box) > ten_atm_box_vol
 
 def test_molecular_ideal_gas():
     """

--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -178,14 +178,14 @@ def test_barostat_varying_pressure():
     seed = 2021
     np.random.seed(seed)
 
-    box_vol = 7.8336338769085809
-    box_diff = 0.5439182266135552
+    box_vol = 7.584418174042398
+    box_diff = 0.4723854602575077
     lig_charge_vals = np.array([1.4572377542719206, -0.37011462071257184, 1.1478267014520305, -4.920166483601927, 0.16985194917937935])
     if "ubuntu" not in platform_version:
         print("Test expected to run under ubuntu 20.04 or 18.04")
     if "20.04" in platform_version:
-        box_vol = 7.80127358754933
-        box_diff = 1.6621367141041832
+        box_vol = 7.824647141563986
+        box_diff = 0.5287400036790046
         lig_charge_vals[3] = -4.920284514559682
 
     # Start out with a very large pressure
@@ -265,7 +265,7 @@ def test_barostat_varying_pressure():
     # we check against our two most common OS versions, Ubuntu 18.04 and 20.04.
     np.testing.assert_almost_equal(compute_box_volume(atm_box), box_vol, decimal=5)
     # Box will grow thanks to the lower pressure
-    np.testing.assert_almost_equal(np.abs(ten_atm_box_vol - compute_box_volume(atm_box)), box_diff, decimal=5)
+    np.testing.assert_almost_equal(compute_box_volume(atm_box) - ten_atm_box_vol, box_diff, decimal=5)
 
 def test_molecular_ideal_gas():
     """

--- a/timemachine/cpp/src/barostat.cu
+++ b/timemachine/cpp/src/barostat.cu
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <stdio.h>
 #include <set>
+#include <cub/cub.cuh>
 
 #include "kernels/k_fixed_point.cuh"
 
@@ -14,7 +15,7 @@ namespace timemachine {
 
 MonteCarloBarostat::MonteCarloBarostat(
     const int N,
-    const double pressure,  // Expected in Bar
+    const double pressure, // Expected in Bar
     const double temperature, // Kelvin
     const std::vector<std::vector<int> > group_idxs,
     const int interval,
@@ -27,9 +28,8 @@ MonteCarloBarostat::MonteCarloBarostat(
     bps_(bps),
     group_idxs_(group_idxs),
     num_grouped_atoms_(0),
-    volume_scale_(0),
-    num_attempted_(0),
-    num_accepted_(0),
+    d_sum_storage_(nullptr),
+    d_sum_storage_bytes_(0),
     seed_(seed),
     step_(0) {
 
@@ -45,18 +45,29 @@ MonteCarloBarostat::MonteCarloBarostat(
         std::cout << "warning pressure more than 10bar" << std::endl;
     }
 
-    mt_ = std::mt19937(seed_);
-    dist_ = std::uniform_real_distribution<double>(0.0, 1.0);
-
-    //gpuErrchk(cudaMalloc(&d_group_idxs_, group_idxs_.size()*sizeof(*d_group_idxs_)));
+    curandErrchk(curandCreateGenerator(&cr_rng_, CURAND_RNG_PSEUDO_DEFAULT));
+    gpuErrchk(cudaMalloc(&d_rand_, 2*sizeof(double)));
+    curandErrchk(curandSetPseudoRandomGeneratorSeed(cr_rng_, seed_));
 
     const int num_mols = group_idxs_.size();
 
     gpuErrchk(cudaMalloc(&d_x_after_, N_*3*sizeof(*d_x_after_)));
     gpuErrchk(cudaMalloc(&d_box_after_, 3*3*sizeof(*d_box_after_)));
+    gpuErrchk(cudaMalloc(&d_u_buffer_, N_*sizeof(*d_u_buffer_)));
+    gpuErrchk(cudaMalloc(&d_u_after_buffer_, N_*sizeof(*d_u_after_buffer_)));
 
-    gpuErrchk(cudaMalloc(&d_u_before_, N_*sizeof(*d_u_before_)));
-    gpuErrchk(cudaMalloc(&d_u_after_, N_*sizeof(*d_u_after_)));
+    gpuErrchk(cudaMalloc(&d_init_u_, 1*sizeof(*d_init_u_)));
+    gpuErrchk(cudaMalloc(&d_final_u_, 1*sizeof(*d_final_u_)));
+
+    gpuErrchk(cudaMalloc(&d_num_accepted_, 1*sizeof(*d_num_accepted_)));
+    gpuErrchk(cudaMalloc(&d_num_attempted_, 1*sizeof(*d_num_attempted_)));
+
+    gpuErrchk(cudaMalloc(&d_volume_, 1*sizeof(*d_volume_)));
+    gpuErrchk(cudaMalloc(&d_length_scale_, 1*sizeof(*d_length_scale_)));
+    gpuErrchk(cudaMalloc(&d_volume_scale_, 1*sizeof(*d_volume_scale_)));
+    gpuErrchk(cudaMalloc(&d_volume_delta_, 1*sizeof(*d_volume_delta_)));
+
+    gpuErrchk(cudaMemset(d_volume_scale_, 0, 1*sizeof(*d_volume_scale_)));
 
 
     std::set<int> group_set;
@@ -101,6 +112,16 @@ MonteCarloBarostat::MonteCarloBarostat(
     gpuErrchk(cudaMemcpy(d_atom_idxs_, atom_idxs, num_grouped_atoms_*sizeof(*d_atom_idxs_), cudaMemcpyHostToDevice));
     gpuErrchk(cudaMemcpy(d_mol_offsets_, mol_offsets, (num_mols+1)*sizeof(*d_mol_offsets_), cudaMemcpyHostToDevice));
 
+    // Use a typed nullptr so cub can calculate space needed to reduce
+    unsigned long long *d_in_tmp = nullptr; // dummy
+    unsigned long long *d_out_tmp = nullptr; // dummy
+
+    // Compute amount of space to reduce energies
+    cub::DeviceReduce::Sum(d_sum_storage_, d_sum_storage_bytes_, d_in_tmp, d_out_tmp, N_);
+    gpuErrchk(cudaPeekAtLastError());
+    gpuErrchk(cudaMalloc(&d_sum_storage_, d_sum_storage_bytes_));
+    this->reset_counters();
+
 };
 
 MonteCarloBarostat::~MonteCarloBarostat() {
@@ -110,15 +131,24 @@ MonteCarloBarostat::~MonteCarloBarostat() {
     gpuErrchk(cudaFree(d_mol_idxs_));
     gpuErrchk(cudaFree(d_mol_offsets_));
     gpuErrchk(cudaFree(d_box_after_));
-    gpuErrchk(cudaFree(d_u_before_));
-    gpuErrchk(cudaFree(d_u_after_));
+    gpuErrchk(cudaFree(d_u_after_buffer_));
+    gpuErrchk(cudaFree(d_u_buffer_));
+    gpuErrchk(cudaFree(d_init_u_));
+    gpuErrchk(cudaFree(d_final_u_));
+    gpuErrchk(cudaFree(d_rand_))
+    gpuErrchk(cudaFree(d_length_scale_));
+    gpuErrchk(cudaFree(d_volume_scale_));
+    gpuErrchk(cudaFree(d_volume_delta_));
+    gpuErrchk(cudaFree(d_num_accepted_));
+    gpuErrchk(cudaFree(d_num_attempted_));
+    curandErrchk(curandDestroyGenerator(cr_rng_));
 };
 
 
 void __global__ rescale_positions(
     const int N, // Number of atoms to shift
     double * __restrict__ coords, // Cordinates
-    const double length_scale,
+    const double * __restrict__ length_scale, // [1]
     const double * __restrict__ box, // [9]
     double * __restrict__ scaled_box, // [9]
     const int * __restrict__ atom_idxs, // [N]
@@ -133,9 +163,9 @@ void __global__ rescale_positions(
     const int atom_idx = atom_idxs[idx];
     const int mol_idx = mol_idxs[idx];
 
-    double center_x = box[0*3+0] * 0.5;
-    double center_y = box[1*3+1] * 0.5;
-    double center_z = box[2*3+2] * 0.5;
+    const double center_x = box[0*3+0] * 0.5;
+    const double center_y = box[1*3+1] * 0.5;
+    const double center_z = box[2*3+2] * 0.5;
 
     const double num_atoms = static_cast<double>(mol_offsets[mol_idx+1] - mol_offsets[mol_idx]);
 
@@ -143,17 +173,17 @@ void __global__ rescale_positions(
     const double centroid_y = FIXED_TO_FLOAT<double>(centroids[mol_idx*3+1]) / num_atoms;
     const double centroid_z = FIXED_TO_FLOAT<double>(centroids[mol_idx*3+2]) / num_atoms;
 
-    const double displacement_x = ((centroid_x - center_x) * length_scale) + center_x - centroid_x;
-    const double displacement_y = ((centroid_y - center_y) * length_scale) + center_y - centroid_y;
-    const double displacement_z = ((centroid_z - center_z) * length_scale) + center_z - centroid_z;
+    const double displacement_x = ((centroid_x - center_x) * length_scale[0]) + center_x - centroid_x;
+    const double displacement_y = ((centroid_y - center_y) * length_scale[0]) + center_y - centroid_y;
+    const double displacement_z = ((centroid_z - center_z) * length_scale[0]) + center_z - centroid_z;
 
     coords[atom_idx*3+0] += displacement_x;
     coords[atom_idx*3+1] += displacement_y;
     coords[atom_idx*3+2] += displacement_z;
     if (atom_idx == 0) {
-        scaled_box[0*3+0] *= length_scale;
-        scaled_box[1*3+1] *= length_scale;
-        scaled_box[2*3+2] *= length_scale;
+        scaled_box[0*3+0] *= length_scale[0];
+        scaled_box[1*3+1] *= length_scale[0];
+        scaled_box[2*3+2] *= length_scale[0];
     }
 }
 
@@ -175,41 +205,115 @@ void __global__ find_group_centroids(
     atomicAdd(centroids + mol_idx*3+2, FLOAT_TO_FIXED<double>(coords[atom_idx*3+2]));
 }
 
-void MonteCarloBarostat::reset_counters() {
-    num_attempted_ = 0;
-    num_accepted_ = 0;
+void __global__ k_setup_barostat_move(
+    const double * __restrict__ rand, // [2], use first value, second value is metropolis condition
+    double * __restrict__ d_box, // [3*3]
+    double * __restrict__ d_volume_delta, // [1]
+    double * __restrict__ d_volume_scale, // [1]
+    double * __restrict__ d_length_scale // [1]
+) {
+    const int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    if (idx >= 1) {
+        return; // Only a single thread needs to perform this operation
+    }
+    const double volume = d_box[0*3+0] * d_box[1*3+1] * d_box[2*3+2];
+    if(d_volume_scale[0] == 0) {
+        d_volume_scale[0] = 0.01 * volume;
+    }
+    const double delta_volume = d_volume_scale[0]*2*(rand[0]-0.5);
+    const double new_volume = volume+delta_volume;
+    d_volume_delta[0] = delta_volume;
+    d_length_scale[0] = cbrt(new_volume/volume);
+}
+
+void __global__ k_decide_move(
+    const int N,
+    const int num_molecules,
+    const double kt,
+    const double pressure,
+    const double * __restrict__ rand, // [2] Use second value
+    double * __restrict__ d_volume_delta,
+    double * __restrict__ d_volume_scale,
+    const unsigned long long * __restrict__ d_init_u,
+    const unsigned long long * __restrict__ d_final_u,
+    double * __restrict__ d_box,
+    const double * __restrict__ d_box_output,
+    double * __restrict__ d_x,
+    const double * __restrict__ d_x_output,
+    int * __restrict__ num_accepted,
+    int * __restrict__ num_attempted
+) {
+    const int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    if (idx >= N) {
+        return;
+    }
+
+    const double volume = d_box[0*3+0] * d_box[1*3+1] * d_box[2*3+2];
+    const double new_volume = volume+d_volume_delta[0];
+    const double energy_delta = FIXED_TO_FLOAT<double>(d_final_u[0] - d_init_u[0]);
+    const double w = energy_delta + pressure*d_volume_delta[0] - num_molecules * kt * std::log(new_volume/volume);
+
+    const bool rejected = w > 0 && rand[1] > std::exp(-w/kt);
+    if(idx == 0) {
+        if (!rejected) {
+            num_accepted[0]++;
+        }
+        num_attempted[0]++;
+        if(num_attempted[0] >= 10) {
+            if (num_accepted[0] < 0.25*num_attempted[0]) {
+                d_volume_scale[0] /= 1.1;
+                // Reset the counters
+                num_attempted[0] = 0;
+                num_accepted[0] = 0;
+            } else if (num_accepted[0] > 0.75*num_attempted[0]) {
+                d_volume_scale[0] = min(d_volume_scale[0]*1.1, volume*0.3);
+                // Reset the counters
+                num_attempted[0] = 0;
+                num_accepted[0] = 0;
+            }
+        }
+    }
+    if (rejected) {
+        return;
+    }
+    // If the mc move was accepted copy all of the data into place
+
+    if (idx < 9) {
+        d_box[idx] = d_box_output[idx];
+    }
+
+    #pragma unroll
+    for (int i = 0; i < 3; i ++) {
+        d_x[idx*3+i] = d_x_output[idx*3+i];
+    }
+}
+
+
+
+void MonteCarloBarostat::reset_counters(){
+    gpuErrchk(cudaMemset(d_num_accepted_, 0, sizeof(*d_num_accepted_)));
+    gpuErrchk(cudaMemset(d_num_attempted_, 0, sizeof(*d_num_attempted_)));
 }
 
 void MonteCarloBarostat::inplace_move(
-    double *d_x,
-    double *d_box,
-    const double lambda
-    ) {
-
+    double *d_x, // [N*3]
+    double *d_box, // [3*3]
+    const double lambda,
+    cudaStream_t stream
+) {
     step_++;
     if (step_ % interval_ != 0) {
         return;
     }
-    std::vector<double> h_box(9);
-    gpuErrchk(cudaMemcpy(&h_box[0], d_box, 9*sizeof(d_box), cudaMemcpyDeviceToHost));
 
-    double volume = h_box[0*3+0]*h_box[1*3+1]*h_box[2*3+2];
+    curandErrchk(curandSetStream(cr_rng_, stream));
+    // Generate scaling and metropolis conditions in one pass
+    curandErrchk(curandGenerateUniformDouble(cr_rng_, d_rand_, 2));
 
-    if(volume_scale_ == 0) {
-        volume_scale_ = 0.01*volume;
-    }
-
-    const int num_molecules = group_idxs_.size();
-
-    const int tpb = 32;
-    const int blocks = (num_grouped_atoms_ + tpb - 1) / tpb;
-
-    // Compute the energy of the modified system.
-
-    cudaStream_t stream = static_cast<cudaStream_t>(0);
-    gpuErrchk(cudaMemsetAsync(d_u_before_, 0, N_*sizeof(*d_u_before_), stream));
-    gpuErrchk(cudaMemsetAsync(d_u_after_, 0, N_*sizeof(*d_u_after_), stream));
-    gpuErrchk(cudaMemsetAsync(d_centroids_, 0, num_molecules*3*sizeof(*d_centroids_), stream));
+    gpuErrchk(cudaMemsetAsync(d_init_u_, 0, sizeof(*d_init_u_), stream));
+    gpuErrchk(cudaMemsetAsync(d_final_u_, 0, sizeof(*d_final_u_), stream));
+    gpuErrchk(cudaMemsetAsync(d_u_buffer_, 0, N_*sizeof(*d_u_buffer_), stream));
+    gpuErrchk(cudaMemsetAsync(d_u_after_buffer_, 0, N_*sizeof(*d_u_after_buffer_), stream));
 
     for(int i=0; i < bps_.size(); i++) {
         bps_[i]->execute_device(
@@ -220,31 +324,55 @@ void MonteCarloBarostat::inplace_move(
             nullptr,
             nullptr,
             nullptr,
-            d_u_before_,
-            stream // TBD: parallelize me!
+            d_u_buffer_,
+            stream
         );
     }
 
+    cub::DeviceReduce::Sum(
+        d_sum_storage_,
+        d_sum_storage_bytes_,
+        d_u_buffer_,
+        d_init_u_,
+        N_,
+        stream
+    );
+    gpuErrchk(cudaPeekAtLastError());
+
+    k_setup_barostat_move<<<1, 1, 0, stream>>>(
+        d_rand_,
+        d_box,
+        d_volume_delta_,
+        d_volume_scale_,
+        d_length_scale_
+    );
+    gpuErrchk(cudaPeekAtLastError());
+
+    const int num_molecules = group_idxs_.size();
+    gpuErrchk(cudaMemsetAsync(d_centroids_, 0, num_molecules*3*sizeof(*d_centroids_), stream));
+
+    // Create duplicates of the coords/box that we can modify
     gpuErrchk(cudaMemcpyAsync(d_x_after_, d_x, N_*3*sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
-    gpuErrchk(cudaMemcpyAsync(d_box_after_, d_box, 3*3*sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
+    gpuErrchk(cudaMemcpyAsync(d_box_after_, d_box, 3*3*sizeof(*d_box_after_), cudaMemcpyDeviceToDevice, stream));
+
+    const int tpb = 32;
+    const int blocks = (num_grouped_atoms_ + tpb - 1) / tpb;
 
     find_group_centroids<<<blocks, tpb, 0, stream>>>(
         num_grouped_atoms_,
-        d_x_after_,
+        d_x,
         d_atom_idxs_,
         d_mol_idxs_,
         d_centroids_
     );
 
-    double delta_volume = volume_scale_*2*(dist_(mt_)-0.5);
-    double new_volume = volume+delta_volume;
-    double length_scale = std::pow(new_volume/volume, 1.0/3.0);
+    gpuErrchk(cudaPeekAtLastError());
 
     // Scale centroids
     rescale_positions<<<blocks, tpb, 0, stream>>>(
         num_grouped_atoms_,
         d_x_after_,
-        length_scale,
+        d_length_scale_,
         d_box,
         d_box_after_, // Box will be rescaled by length_scale
         d_atom_idxs_,
@@ -253,6 +381,7 @@ void MonteCarloBarostat::inplace_move(
         d_centroids_
     );
     gpuErrchk(cudaPeekAtLastError());
+
 
     for(int i=0; i < bps_.size(); i++) {
         bps_[i]->execute_device(
@@ -263,57 +392,45 @@ void MonteCarloBarostat::inplace_move(
             nullptr,
             nullptr,
             nullptr,
-            d_u_after_,
-            stream // TBD: parallelize me!
+            d_u_after_buffer_,
+            stream
         );
     }
+
+    cub::DeviceReduce::Sum(
+        d_sum_storage_,
+        d_sum_storage_bytes_,
+        d_u_after_buffer_,
+        d_final_u_,
+        N_,
+        stream
+    );
+    gpuErrchk(cudaPeekAtLastError());
 
     double pressure = pressure_*AVOGADRO*1e-25;
     const double kT = BOLTZ*temperature_;
 
-    unsigned long long u_init_agg = 0;
-    unsigned long long u_final_agg = 0;
+    const int move_blocks = (N_ + tpb - 1) / tpb;
 
-    unsigned long long initial_energy[N_];
-    unsigned long long final_energy[N_];
+    k_decide_move<<<move_blocks, tpb, 0, stream>>>(
+        N_,
+        num_molecules,
+        kT,
+        pressure,
+        d_rand_,
+        d_volume_delta_,
+        d_volume_scale_,
+        d_init_u_,
+        d_final_u_,
+        d_box,
+        d_box_after_,
+        d_x,
+        d_x_after_,
+        d_num_accepted_,
+        d_num_attempted_
+    );
 
-    gpuErrchk(cudaMemcpyAsync(initial_energy, d_u_before_, N_*sizeof(*d_u_before_), cudaMemcpyDeviceToHost, stream));
-    gpuErrchk(cudaMemcpyAsync(final_energy, d_u_after_, N_*sizeof(*d_u_after_), cudaMemcpyDeviceToHost, stream));
-
-    gpuErrchk(cudaStreamSynchronize(stream));
-
-    for (int i = 0; i < N_; i++) {
-        u_init_agg += initial_energy[i];
-        u_final_agg += final_energy[i];
-    }
-
-    double u_init = FIXED_TO_FLOAT<double>(u_init_agg);
-    double u_final = FIXED_TO_FLOAT<double>(u_final_agg);
-
-    double w = u_final-u_init + pressure*delta_volume - num_molecules*kT*std::log(new_volume/volume);
-
-    if (w > 0 && dist_(mt_) > std::exp(-w/kT)) {
-        // Reject the step.
-        // Don't modify the coords, keep box the same
-        volume = new_volume;
-    }
-    else {
-        num_accepted_++;
-        // Replace the coords and box if step accepted
-        gpuErrchk(cudaMemcpyAsync(d_x, d_x_after_, N_*3*sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
-        gpuErrchk(cudaMemcpyAsync(d_box, d_box_after_, 3*3*sizeof(*d_box), cudaMemcpyDeviceToDevice, stream));
-    }
-    num_attempted_++;
-    if (num_attempted_ >= 10) {
-        if (num_accepted_ < 0.25*num_attempted_) {
-            volume_scale_ /= 1.1;
-            this->reset_counters();
-        }
-        else if (num_accepted_ > 0.75*num_attempted_) {
-            volume_scale_ = std::min(volume_scale_*1.1, volume*0.3);
-            this->reset_counters();
-        }
-    }
+    gpuErrchk(cudaPeekAtLastError())
 };
 
 void MonteCarloBarostat::set_interval(const int interval){

--- a/timemachine/cpp/src/barostat.hpp
+++ b/timemachine/cpp/src/barostat.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <random>
 #include "bound_potential.hpp"
+#include "curand.h"
 
 namespace timemachine {
 
@@ -41,7 +42,8 @@ public:
     void inplace_move(
         double *d_x,
         double *d_box,
-        const double lambda
+        const double lambda,
+        cudaStream_t stream
     );
 
     void set_interval(const int interval);
@@ -65,26 +67,36 @@ private:
     const std::vector<std::vector<int> > group_idxs_;
 
     // stuff that deals with RNG
-    std::mt19937 mt_; // Expected to be seeded with seed_
-    std::uniform_real_distribution<double> dist_; // guaranteed unbiased
+    double *d_rand_;
+    curandGenerator_t  cr_rng_;
 
     // internals
     int step_;
-    double volume_scale_;
-    int num_attempted_;
-    int num_accepted_;
     int num_grouped_atoms_;
 
-    unsigned long long *d_u_before_;
-    unsigned long long *d_u_after_;
+    int *d_num_attempted_;
+    int *d_num_accepted_;
+
+    unsigned long long *d_u_buffer_;
+    unsigned long long *d_u_after_buffer_;
+
+    unsigned long long *d_init_u_;
+    unsigned long long *d_final_u_;
+
+    double *d_volume_;
+    double *d_volume_delta_;
+    double *d_length_scale_;
+    double *d_volume_scale_;
 
     double *d_x_after_;
-
     double *d_box_after_;
 
     int *d_atom_idxs_; // grouped index to atom coords
     int *d_mol_idxs_; // grouped index to molecule index
     int *d_mol_offsets_; // Offset of molecules to determine size of mols
+
+    double *d_sum_storage_;
+    size_t d_sum_storage_bytes_;
 
     unsigned long long *d_centroids_; // Accumulate centroids in fix point to ensure deterministic behavior
 

--- a/timemachine/cpp/src/integrator.cu
+++ b/timemachine/cpp/src/integrator.cu
@@ -80,7 +80,8 @@ void LangevinIntegrator::step_fwd(
     double *d_x_t,
     double *d_v_t,
     unsigned long long *d_du_dx_t,
-    double *d_box_t_) {
+    double *d_box_t_,
+    cudaStream_t stream) {
 
     const int D = 3;
     size_t tpb = 32;
@@ -89,7 +90,7 @@ void LangevinIntegrator::step_fwd(
 
     curandErrchk(templateCurandNormal(cr_rng_, d_noise_, round_up_even(N_*D), 0.0, 1.0));
 
-    update_forward<double><<<dimGrid_dx, tpb>>>(
+    update_forward<double><<<dimGrid_dx, tpb, 0, stream>>>(
         N_,
         D,
         ca_,

--- a/timemachine/cpp/src/integrator.hpp
+++ b/timemachine/cpp/src/integrator.hpp
@@ -14,7 +14,8 @@ public:
         double *d_x_t,
         double *d_v_t,
         unsigned long long *d_du_dx_t,
-        double *d_box_t_
+        double *d_box_t_,
+        cudaStream_t stream
     ) = 0;
 
 };
@@ -49,7 +50,8 @@ public:
         double *d_x_t,
         double *d_v_t,
         unsigned long long *d_du_dx_t,
-        double *d_box_t_
+        double *d_box_t_,
+        cudaStream_t stream
     ) override;
 
 };


### PR DESCRIPTION
Moves the MonteCarloBarostat onto the GPU, without any need to do a stream synchronize or copy things from the device to the host.

Fundamentally this does not speed things up that much. In the case where the interval is 1, you see a ~40% improvement in speed (DHFR 53 ns/day -> 67ns/day), however as the interval gets up to 25 it falls off to being negligible (189ns/day -> 186,  which I attribute to the benchmarks not converging).

The reason for this lack of a speed up due to every barostat move triggering up to 2 rebuilds of the neighborlist. The first when you shift the box and if that shift failed, it has to recompute the original neighborlist. At this point the most obvious solution is to speed up the neighborlist construction, though that will be left to a separate issue.

Barostat on CPU
--------------
dhfr-apo: N=23558 speed: 221.51ns/day dt: 1.5fs (ran 100000 steps in 58.52s)
dhfr-apo-barostat-1: N=23558 speed: 53.88ns/day dt: 1.5fs (ran 100000 steps in 240.55s)
dhfr-apo-barostat-3: N=23558 speed: 107.31ns/day dt: 1.5fs (ran 100000 steps in 120.78s)
dhfr-apo-barostat-5: N=23558 speed: 133.62ns/day dt: 1.5fs (ran 100000 steps in 97.00s)
dhfr-apo-barostat-8: N=23558 speed: 155.03ns/day dt: 1.5fs (ran 100000 steps in 83.61s)
dhfr-apo-barostat-13: N=23558 speed: 173.17ns/day dt: 1.5fs (ran 100000 steps in 74.85s)
dhfr-apo-barostat-25: N=23558 speed: 189.13ns/day dt: 1.5fs (ran 100000 steps in 68.54s)

hif2a-apo: N=8805 speed: 523.49ns/day dt: 1.5fs (ran 100000 steps in 24.77s)
hif2a-apo-barostat-1: N=8805 speed: 124.37ns/day dt: 1.5fs (ran 100000 steps in 104.21s)
hif2a-apo-barostat-3: N=8805 speed: 247.54ns/day dt: 1.5fs (ran 100000 steps in 52.36s)
hif2a-apo-barostat-5: N=8805 speed: 312.12ns/day dt: 1.5fs (ran 100000 steps in 41.53s)
hif2a-apo-barostat-8: N=8805 speed: 360.81ns/day dt: 1.5fs (ran 100000 steps in 35.93s)
hif2a-apo-barostat-13: N=8805 speed: 404.20ns/day dt: 1.5fs (ran 100000 steps in 32.07s)
hif2a-apo-barostat-25: N=8805 speed: 444.05ns/day dt: 1.5fs (ran 100000 steps in 29.19s)

solvent-apo: N=6282 speed: 716.43ns/day dt: 1.5fs (ran 100000 steps in 18.10s)
solvent-apo-barostat-1: N=6282 speed: 170.79ns/day dt: 1.5fs (ran 100000 steps in 75.89s)
solvent-apo-barostat-3: N=6282 speed: 349.49ns/day dt: 1.5fs (ran 100000 steps in 37.09s)
solvent-apo-barostat-5: N=6282 speed: 442.20ns/day dt: 1.5fs (ran 100000 steps in 29.32s)
solvent-apo-barostat-8: N=6282 speed: 518.82ns/day dt: 1.5fs (ran 100000 steps in 24.99s)
solvent-apo-barostat-13: N=6282 speed: 582.11ns/day dt: 1.5fs (ran 100000 steps in 22.27s)
solvent-apo-barostat-25: N=6282 speed: 643.30ns/day dt: 1.5fs (ran 100000 steps in 20.15s)


Barostat on GPU
---------------
dhfr-apo-barostat-1: N=23558 speed: 67.88ns/day dt: 1.5fs (ran 100000 steps in 190.95s)
dhfr-apo-barostat-3: N=23558 speed: 124.60ns/day dt: 1.5fs (ran 100000 steps in 104.03s)
dhfr-apo-barostat-5: N=23558 speed: 147.50ns/day dt: 1.5fs (ran 100000 steps in 87.88s)
dhfr-apo-barostat-8: N=23558 speed: 166.01ns/day dt: 1.5fs (ran 100000 steps in 78.08s)
dhfr-apo-barostat-13: N=23558 speed: 176.18ns/day dt: 1.5fs (ran 100000 steps in 73.57s)
dhfr-apo-barostat-25: N=23558 speed: 186.06ns/day dt: 1.5fs (ran 100000 steps in 69.67s)

hif2a-apo-barostat-1: N=8805 speed: 152.60ns/day dt: 1.5fs (ran 100000 steps in 84.94s)
hif2a-apo-barostat-3: N=8805 speed: 284.69ns/day dt: 1.5fs (ran 100000 steps in 45.53s)
hif2a-apo-barostat-5: N=8805 speed: 344.05ns/day dt: 1.5fs (ran 100000 steps in 37.68s)
hif2a-apo-barostat-8: N=8805 speed: 389.65ns/day dt: 1.5fs (ran 100000 steps in 33.27s)
hif2a-apo-barostat-13: N=8805 speed: 423.85ns/day dt: 1.5fs (ran 100000 steps in 30.58s)
hif2a-apo-barostat-25: N=8805 speed: 456.82ns/day dt: 1.5fs (ran 100000 steps in 28.38s)

solvent-apo-barostat-1: N=6282 speed: 220.51ns/day dt: 1.5fs (ran 100000 steps in 58.78s)
solvent-apo-barostat-3: N=6282 speed: 408.79ns/day dt: 1.5fs (ran 100000 steps in 31.71s)
solvent-apo-barostat-5: N=6282 speed: 494.27ns/day dt: 1.5fs (ran 100000 steps in 26.23s)
solvent-apo-barostat-8: N=6282 speed: 565.67ns/day dt: 1.5fs (ran 100000 steps in 22.92s)
solvent-apo-barostat-13: N=6282 speed: 617.43ns/day dt: 1.5fs (ran 100000 steps in 21.00s)
solvent-apo-barostat-25: N=6282 speed: 664.89ns/day dt: 1.5fs (ran 100000 steps in 19.50s)