### PR TITLE
Improvements to the RABFE protocol

### DIFF
--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -15,7 +15,7 @@ import argparse
 import numpy as np
 from jax import numpy as jnp
 
-from fe.free_energy_rabfe import construct_absolute_lambda_schedule, construct_conversion_lambda_schedule, get_romol_conf, setup_relative_restraints
+from fe.free_energy_rabfe import construct_absolute_lambda_schedule, construct_conversion_lambda_schedule, get_romol_conf, setup_relative_restraints_using_smarts
 from fe.utils import convert_uIC50_to_kJ_per_mole
 # from fe import model_abfe, model_rabfe, model_conversion
 from fe import model_rabfe
@@ -250,10 +250,12 @@ if __name__ == "__main__":
     ordered_params = forcefield.get_ordered_params()
     ordered_handles = forcefield.get_ordered_handles()
 
+    core_smarts = "*1~*~*~*~*~*~1~O~*1~*~*~*~*~*~1"
+
     def pred_fn(params, mol, mol_ref):
 
         # generate the core_idxs
-        core_idxs = setup_relative_restraints(mol, mol_ref)
+        core_idxs = setup_relative_restraints_using_smarts(mol, mol_ref, core_smarts)
         mol_coords = get_romol_conf(mol) # original coords
         
         num_complex_atoms = complex_coords.shape[0]

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -299,26 +299,24 @@ if __name__ == "__main__":
         # effective free energy of removing from complex
         dG_complex = dG_complex_conversion + dG_complex_decouple
 
-        return 0.0, 0.0
-
         # solvent
-        # min_solvent_coords = minimizer.minimize_host_4d([mol], solvent_system, solvent_coords, forcefield, solvent_box)
-        # solvent_x0 = np.concatenate([min_solvent_coords, mol_coords])
-        # solvent_box0 = solvent_box
-        # dG_solvent_conversion, dG_solvent_conversion_error = binding_model_solvent_conversion.predict(
-        #     params,
-        #     mol,
-        #     solvent_x0,
-        #     solvent_box0,
-        #     prefix='solvent_conversion_'+str(epoch)
-        # )
-        # dG_solvent_decouple, dG_solvent_decouple_error = binding_model_solvent_decouple.predict(
-        #     params,
-        #     mol,
-        #     solvent_x0,
-        #     solvent_box0,
-        #     prefix='solvent_decouple_'+str(epoch),
-        # )
+        min_solvent_coords = minimizer.minimize_host_4d([mol], solvent_system, solvent_coords, forcefield, solvent_box)
+        solvent_x0 = np.concatenate([min_solvent_coords, mol_coords])
+        solvent_box0 = solvent_box
+        dG_solvent_conversion, dG_solvent_conversion_error = binding_model_solvent_conversion.predict(
+            params,
+            mol,
+            solvent_x0,
+            solvent_box0,
+            prefix='solvent_conversion_'+str(epoch)
+        )
+        dG_solvent_decouple, dG_solvent_decouple_error = binding_model_solvent_decouple.predict(
+            params,
+            mol,
+            solvent_x0,
+            solvent_box0,
+            prefix='solvent_decouple_'+str(epoch),
+        )
 
         # effective free energy of removing from solvent
         dG_solvent = dG_solvent_conversion + dG_solvent_decouple

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -281,6 +281,8 @@ if __name__ == "__main__":
             complex_box0,
             prefix='complex_conversion_'+str(epoch))
 
+        return 0.0, 0.0
+
         # compute the free energy of swapping an interacting mol with a non-interacting reference mol
         complex_decouple_x0 = minimizer.minimize_host_4d([mol, mol_ref], complex_system, complex_host_coords, forcefield, complex_box0, [aligned_mol_coords, ref_coords])
         complex_decouple_x0 = np.concatenate([complex_decouple_x0, aligned_mol_coords, ref_coords])

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -270,7 +270,6 @@ if __name__ == "__main__":
 
         ref_coords = complex_ref_x0[num_complex_atoms:]
         complex_host_coords = complex_ref_x0[:num_complex_atoms]
-
         complex_box0 = complex_ref_box0
 
         # compute the free energy of conversion in complex
@@ -281,7 +280,9 @@ if __name__ == "__main__":
             mol,
             complex_conversion_x0,
             complex_box0,
-            prefix='complex_conversion_'+str(epoch))
+            prefix='complex_conversion_'+str(epoch),
+            core_idxs=core_idxs[:, 0]
+        )
 
         return 0.0, 0.0
 

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -407,10 +407,10 @@ if __name__ == "__main__":
         # effective free energy of removing from solvent
         dG_solvent = dG_solvent_conversion + dG_solvent_decouple
         print("stage summary for mol:", mol_name,
-            "dG_complex_conversion", dG_complex_conversion,
-            "dG_complex_decouple", dG_complex_decouple,
-            "dG_solvent_conversion", dG_solvent_conversion,
-            "dG_solvent_decouple", dG_solvent_decouple
+            "dG_complex_conversion (K complex)", dG_complex_conversion,
+            "dG_complex_decouple (E0 + A0 + A1 + E1)", dG_complex_decouple,
+            "dG_solvent_conversion (K complex)", dG_solvent_conversion,
+            "dG_solvent_decouple (D)", dG_solvent_decouple
         )
 
         dG_err = np.sqrt(dG_complex_conversion_error**2 + dG_complex_decouple_error**2 + dG_solvent_conversion_error**2 + dG_solvent_decouple_error**2)

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -51,7 +51,6 @@ def convert_nMKi_to_kJ_per_mole(amount_in_nM):
     """
     return 0.593 * np.log(amount_in_nM * 1e-9) * 4.18
 
-
 class CompareDist(rdFMCS.MCSAtomCompare):
 
     def __init__(self, *args, **kwargs):
@@ -253,6 +252,7 @@ if __name__ == "__main__":
         with open("equil.pickle", "wb") as ofs:
             pickle.dump((complex_ref_x0, complex_ref_box0), ofs)
     else:
+        print("Loading existing pickle from cache")
         with open("equil.pickle", "rb") as ifs:
             complex_ref_x0, complex_ref_box0 = pickle.load(ifs)
     # complex models.

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -302,23 +302,23 @@ if __name__ == "__main__":
         return 0.0, 0.0
 
         # solvent
-        min_solvent_coords = minimizer.minimize_host_4d([mol], solvent_system, solvent_coords, forcefield, solvent_box)
-        solvent_x0 = np.concatenate([min_solvent_coords, mol_coords])
-        solvent_box0 = solvent_box
-        dG_solvent_conversion, dG_solvent_conversion_error = binding_model_solvent_conversion.predict(
-            params,
-            mol,
-            solvent_x0,
-            solvent_box0,
-            prefix='solvent_conversion_'+str(epoch)
-        )
-        dG_solvent_decouple, dG_solvent_decouple_error = binding_model_solvent_decouple.predict(
-            params,
-            mol,
-            solvent_x0,
-            solvent_box0,
-            prefix='solvent_decouple_'+str(epoch),
-        )
+        # min_solvent_coords = minimizer.minimize_host_4d([mol], solvent_system, solvent_coords, forcefield, solvent_box)
+        # solvent_x0 = np.concatenate([min_solvent_coords, mol_coords])
+        # solvent_box0 = solvent_box
+        # dG_solvent_conversion, dG_solvent_conversion_error = binding_model_solvent_conversion.predict(
+        #     params,
+        #     mol,
+        #     solvent_x0,
+        #     solvent_box0,
+        #     prefix='solvent_conversion_'+str(epoch)
+        # )
+        # dG_solvent_decouple, dG_solvent_decouple_error = binding_model_solvent_decouple.predict(
+        #     params,
+        #     mol,
+        #     solvent_x0,
+        #     solvent_box0,
+        #     prefix='solvent_decouple_'+str(epoch),
+        # )
 
         # effective free energy of removing from solvent
         dG_solvent = dG_solvent_conversion + dG_solvent_decouple

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -284,8 +284,6 @@ if __name__ == "__main__":
             core_idxs=core_idxs[:, 0]
         )
 
-        return 0.0, 0.0
-
         # compute the free energy of swapping an interacting mol with a non-interacting reference mol
         complex_decouple_x0 = minimizer.minimize_host_4d([mol, mol_ref], complex_system, complex_host_coords, forcefield, complex_box0, [aligned_mol_coords, ref_coords])
         complex_decouple_x0 = np.concatenate([complex_decouple_x0, aligned_mol_coords, ref_coords])
@@ -300,6 +298,8 @@ if __name__ == "__main__":
 
         # effective free energy of removing from complex
         dG_complex = dG_complex_conversion + dG_complex_decouple
+
+        return 0.0, 0.0
 
         # solvent
         min_solvent_coords = minimizer.minimize_host_4d([mol], solvent_system, solvent_coords, forcefield, solvent_box)

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -299,9 +299,9 @@ if __name__ == "__main__":
 
         result = rdFMCS.FindMCS(
             [mol, mol_ref],
-            ringMatchesRingOnly=True,
-            completeRingsOnly=True,
-            matchChiralTag=True,
+            ringMatchesRingOnly=False,
+            completeRingsOnly=False,
+            matchChiralTag=False,
             atomCompare=rdFMCS.AtomCompare.CompareAny,
             bondCompare=rdFMCS.BondCompare.CompareAny
         )

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -45,12 +45,6 @@ from md import builders, minimizer
 
 from rdkit.Chem import rdFMCS
 
-# def convert_nMKi_to_kJ_per_mole(amount_in_nM):
-#     """
-#     TODO: more sig figs
-#     """
-#     return 0.593 * np.log(amount_in_nM * 1e-9) * 4.18
-
 class CompareDist(rdFMCS.MCSAtomCompare):
 
     def __init__(self, *args, **kwargs):

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -47,6 +47,13 @@ from rdkit.Chem import rdFMCS
 
 class CompareDist(rdFMCS.MCSAtomCompare):
 
+    """
+    Custom comparator used in the FMCS code.
+    This allows two atoms to match if:
+        1. Neither atom is a terminal atom (H, F, Cl, Halogens etc.)
+        2. They are within 1 angstrom of each other.
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -165,7 +172,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--blocker_name",
         type=str,
-        help='Smarts pattern to use for the core',
+        help='Name of the ligand the sdf file to be used as a blocker',
         required=True
     )
 

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -438,4 +438,5 @@ if __name__ == "__main__":
 
             pred_dG = pred_fn(ordered_params, mol, blocker_mol)
             print("epoch", epoch, "mol", mol.GetProp("_Name"), "pred", pred_dG, "label", label_dG)
-            break
+
+            # break

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -352,16 +352,16 @@ if __name__ == "__main__":
         mol_name = mol.GetProp("_Name")
 
         # compute the free energy of conversion in complex
-        # complex_conversion_x0 = minimizer.minimize_host_4d([mol], complex_system, complex_host_coords, forcefield, complex_box0, [aligned_mol_coords])
-        # complex_conversion_x0 = np.concatenate([complex_conversion_x0, aligned_mol_coords])
-        # dG_complex_conversion, dG_complex_conversion_error = binding_model_complex_conversion.predict(
-        #     params,
-        #     mol,
-        #     complex_conversion_x0,
-        #     complex_box0,
-        #     prefix='complex_conversion_'+str(epoch),
-        #     core_idxs=core_idxs[:, 0]
-        # )
+        complex_conversion_x0 = minimizer.minimize_host_4d([mol], complex_system, complex_host_coords, forcefield, complex_box0, [aligned_mol_coords])
+        complex_conversion_x0 = np.concatenate([complex_conversion_x0, aligned_mol_coords])
+        dG_complex_conversion, dG_complex_conversion_error = binding_model_complex_conversion.predict(
+            params,
+            mol,
+            complex_conversion_x0,
+            complex_box0,
+            prefix='complex_conversion_'+str(epoch),
+            core_idxs=core_idxs[:, 0]
+        )
 
         # compute the free energy of swapping an interacting mol with a non-interacting reference mol
         complex_decouple_x0 = minimizer.minimize_host_4d([mol, mol_ref], complex_system, complex_host_coords, forcefield, complex_box0, [aligned_mol_coords, ref_coords])
@@ -374,8 +374,6 @@ if __name__ == "__main__":
             complex_decouple_x0,
             complex_box0,
             prefix='complex_decouple_'+mol_name+"_"+str(epoch))
-
-        return 0.0, 0.0
 
         # effective free energy of removing from complex
         dG_complex = dG_complex_conversion + dG_complex_decouple

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -17,7 +17,7 @@ import argparse
 import numpy as np
 from jax import numpy as jnp
 
-from fe.free_energy_rabfe import construct_absolute_lambda_schedule, construct_conversion_lambda_schedule, get_romol_conf, setup_relative_restraints_using_smarts
+from fe.free_energy_rabfe import construct_absolute_lambda_schedule_complex, construct_absolute_lambda_schedule_solvent, construct_conversion_lambda_schedule, get_romol_conf, setup_relative_restraints_using_smarts
 from fe.utils import convert_uIC50_to_kJ_per_mole
 # from fe import model_abfe, model_rabfe, model_conversion
 from fe import model_rabfe
@@ -61,7 +61,8 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--property_field",
-        help="Property field to convert to kcals/mols"
+        help="Property field to convert to kcals/mols",
+        required=True
     )
 
     parser.add_argument(
@@ -188,8 +189,8 @@ if __name__ == "__main__":
     dataset = Dataset(mols)
 
     # construct lambda schedules for complex and solvent
-    complex_absolute_schedule = construct_absolute_lambda_schedule(cmd_args.num_complex_windows)
-    solvent_absolute_schedule = construct_absolute_lambda_schedule(cmd_args.num_solvent_windows)
+    complex_absolute_schedule = construct_absolute_lambda_schedule_complex(cmd_args.num_complex_windows)
+    solvent_absolute_schedule = construct_absolute_lambda_schedule_solvent(cmd_args.num_solvent_windows)
 
     # build the protein system.
     complex_system, complex_coords, _, _, complex_box, complex_topology = builders.build_protein_system(

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -378,11 +378,11 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
         overlap = endpoint_correction.overlap_from_cdf(lhs_du, rhs_du)
         lhs_mean = np.mean(lhs_du)
         rhs_mean = np.mean(rhs_du)
-        print(f"{model.prefix} dG_tibar {tibar_dG:.3f} dG_ti {dG_ti:.3f} exact_bar {bar_dG:.3f} exact_bar_err {bar_dG_err:.3f} dG_endpoint {dG_endpoint:.3f} dG_endpoint_err {endpoint_err:.3f} dG_ssc_translation {dG_ssc_translation:.3f} dG_ssc_rotation {dG_ssc_rotation:.3f} overlap {overlap:.3f} lhs_mean {lhs_mean:.3f} rhs_mean {rhs_mean:.3f} lhs_n {len(lhs_du)} rhs_n {len(rhs_du)} | time: {time.time()-start:.3f}s")
+        print(f"{model.prefix} dG_tibar {tibar_dG:.3f} dG_ti {dG_ti:.3f} exact_bar (A) {bar_dG:.3f} exact_bar_err {bar_dG_err:.3f} dG_endpoint (E) {dG_endpoint:.3f} dG_endpoint_err {endpoint_err:.3f} dG_ssc_translation {dG_ssc_translation:.3f} dG_ssc_rotation {dG_ssc_rotation:.3f} overlap {overlap:.3f} lhs_mean {lhs_mean:.3f} rhs_mean {rhs_mean:.3f} lhs_n {len(lhs_du)} rhs_n {len(rhs_du)} | time: {time.time()-start:.3f}s")
         dG += dG_endpoint + dG_ssc_translation + dG_ssc_rotation
         bar_dG_err = np.sqrt(bar_dG_err**2 + endpoint_err**2)
     else:
-        print(f"{model.prefix} dG_tibar {tibar_dG:.3f} dG_ti {dG_ti:.3f} exact_bar {bar_dG:.3f} exact_bar_err {bar_dG_err:.3f} ")
+        print(f"{model.prefix} dG_tibar {tibar_dG:.3f} dG_ti {dG_ti:.3f} exact_bar (A) {bar_dG:.3f} exact_bar_err {bar_dG_err:.3f} ")
 
     return (dG, bar_dG_err, results), dG_grad
 

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -240,9 +240,9 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
     for lamb_idx, lamb in enumerate(model.lambda_schedule):
 
         if model.endpoint_correct and lamb_idx == len(model.lambda_schedule) - 1:
-            x_interval = 200
+            x_interval = 1000
         else:
-            x_interval = 200
+            x_interval = 1000
 
         if lamb_idx == 0:
             lambda_left = None
@@ -265,7 +265,7 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
             model.equil_steps,
             model.prod_steps,
             x_interval, # x_interval
-            200,        # du_dl_interval
+            1000,        # du_dl_interval
             lambda_left,
             lambda_right
         ))
@@ -281,8 +281,8 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
             model.barostat,
             model.equil_steps,
             model.prod_steps,
-            200,       # x_interval
-            200,       # du_dl_interval
+            1000,       # x_interval
+            1000,       # du_dl_interval
             None,
             None
         ))

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -167,10 +167,10 @@ def construct_absolute_lambda_schedule_complex(num_windows):
 
     # assert len(lambda_schedule) == num_windows
 
-    lambda_schedule = np.concatenate([
-        np.linspace(0.15, 0.20, num_windows-1, endpoint=False),
-        np.array([1.0])
-    ])
+    # lambda_schedule = np.concatenate([
+        # np.linspace(0.15, 0.20, num_windows-1, endpoint=False),
+        # np.array([1.0])
+    # ])
 
 
     return lambda_schedule

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -267,8 +267,25 @@ def setup_relative_restraints_using_smarts(
     mol_b,
     smarts):
     """
-    Setup restraints between ring atoms in two molecules using
+    Setup restraints between atoms in two molecules using
     a pre-defined SMARTS pattern.
+
+    Parameters
+    ----------
+    mol_a: Chem.Mol
+        First molecule
+
+    mol_b: Chem.Mol
+        Second molecule
+
+    smarts: string
+        Smarts pattern defining the common core.
+
+    Returns
+    -------
+    np.array (N, 2)
+        Atom mapping between atoms in mol_a to atoms in mol_b.
+
     """
 
     # check to ensure the core is connected
@@ -279,8 +296,13 @@ def setup_relative_restraints_using_smarts(
     core = Chem.MolFromSmarts(smarts)
 
     # we want *all* possible combinations.
-    all_core_idxs_a = np.array(mol_a.GetSubstructMatches(core, uniquify=False))
-    all_core_idxs_b = np.array(mol_b.GetSubstructMatches(core, uniquify=False))
+    limit = 1000
+    all_core_idxs_a = np.array(mol_a.GetSubstructMatches(core, uniquify=False, maxMatches=limit))
+    all_core_idxs_b = np.array(mol_b.GetSubstructMatches(core, uniquify=False, maxMatches=limit))
+
+    assert len(all_core_idxs_a) < limit
+    assert len(all_core_idxs_b) < limit
+
     best_rmsd = np.inf
     best_core_idxs_a = None
     best_core_idxs_b = None

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -145,7 +145,32 @@ def construct_conversion_lambda_schedule(num_windows):
     return np.linspace(0, 1, num_windows)
 
 
-def construct_absolute_lambda_schedule(num_windows):
+def construct_absolute_lambda_schedule_complex(num_windows):
+    """Generate a length-num_windows list of lambda values from 0.0 up to 1.0
+
+    Notes
+    -----
+    manually optimized by YTZ
+    """
+
+    A = int(.20 * num_windows)
+    B = int(.66 * num_windows)
+    C = num_windows - A - B
+
+    # optimizing the overlap based on eyeballing absolute hydration free energies
+    # there's probably some better way to deal with this by inspecting the curvature
+    lambda_schedule = np.concatenate([
+        np.linspace(0.0,  0.10, A, endpoint=False),
+        np.linspace(0.10, 0.40, B, endpoint=False),
+        np.linspace(0.40, 1.0,  C, endpoint=True)
+    ])
+
+    assert len(lambda_schedule) == num_windows
+
+    return lambda_schedule
+
+
+def construct_absolute_lambda_schedule_solvent(num_windows):
     """Generate a length-num_windows list of lambda values from 0.0 up to 1.0
 
     Notes
@@ -163,7 +188,7 @@ def construct_absolute_lambda_schedule(num_windows):
     lambda_schedule = np.concatenate([
         np.linspace(0.0,  0.08,  A, endpoint=False),
         np.linspace(0.08,  0.27, B, endpoint=False),
-        np.linspace(0.27, 0.6,  C, endpoint=True),
+        np.linspace(0.27, 0.50,  C, endpoint=True),
         [1.0],
     ])
 

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -307,8 +307,6 @@ def setup_relative_restraints_using_smarts(
 
     for core_idxs_a in all_core_idxs_a:
         for core_idxs_b in all_core_idxs_b:
-            # print("A", core_idxs_a)
-            # print("B", core_idxs_b)
 
             ri = np.expand_dims(ligand_coords_a[core_idxs_a], 1)
             rj = np.expand_dims(ligand_coords_b[core_idxs_b], 0)
@@ -325,24 +323,5 @@ def setup_relative_restraints_using_smarts(
                 best_core_idxs_b = core_idxs_b
 
     core_idxs = np.stack([best_core_idxs_a, best_core_idxs_b], axis=1).astype(np.int32)
-
-    # print(core_idxs)
-
-    # assert 0
-
-    # core_idxs_a = best_core_idxs_a
-    # core_idxs_b = best_core_idxs_b
-
-    # # assert 0
-
-    # core_idxs = []
-
-    # for core_a, core_b in zip(row_idxs, col_idxs):
-    #     core_idxs.append((
-    #         core_idxs_a[core_a],
-    #         core_idxs_b[core_b]
-    #     ))
-
-    # core_idxs = np.array(core_idxs, dtype=np.int32)
 
     return core_idxs

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -154,24 +154,14 @@ def construct_absolute_lambda_schedule_complex(num_windows):
     """
 
     A = int(.20 * num_windows)
-    B = int(.66 * num_windows)
+    B = int(.50 * num_windows)
     C = num_windows - A - B
 
-    # optimizing the overlap based on eyeballing absolute hydration free energies
-    # there's probably some better way to deal with this by inspecting the curvature
     lambda_schedule = np.concatenate([
-        np.linspace(0.0,  0.10, A, endpoint=False),
-        np.linspace(0.10, 0.40, B, endpoint=False),
-        np.linspace(0.40, 1.0,  C, endpoint=True)
+        np.linspace(0.0, 0.1, A, endpoint=False),
+        np.linspace(0.1, 0.3, B, endpoint=False),
+        np.linspace(0.3, 1.0, C, endpoint=True)
     ])
-
-    # assert len(lambda_schedule) == num_windows
-
-    # lambda_schedule = np.concatenate([
-        # np.linspace(0.15, 0.20, num_windows-1, endpoint=False),
-        # np.array([1.0])
-    # ])
-
 
     return lambda_schedule
 

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -144,6 +144,7 @@ class RelativeFreeEnergy(BaseFreeEnergy):
 def construct_conversion_lambda_schedule(num_windows):
     return np.linspace(0, 1, num_windows)
 
+
 def construct_absolute_lambda_schedule(num_windows):
     """Generate a length-num_windows list of lambda values from 0.0 up to 1.0
 
@@ -162,7 +163,7 @@ def construct_absolute_lambda_schedule(num_windows):
     lambda_schedule = np.concatenate([
         np.linspace(0.0,  0.08,  A, endpoint=False),
         np.linspace(0.08,  0.27, B, endpoint=False),
-        np.linspace(0.27, 0.46,  C, endpoint=True),
+        np.linspace(0.27, 0.6,  C, endpoint=True),
         [1.0],
     ])
 
@@ -240,8 +241,6 @@ def setup_relative_restraints(
     return core_idxs
 
 
-
-
 def setup_relative_restraints_using_smarts(
     mol_a,
     mol_b,
@@ -275,7 +274,6 @@ def setup_relative_restraints_using_smarts(
     row_idxs, col_idxs = linear_sum_assignment(rij)
 
     core_idxs = []
-
 
     for core_a, core_b in zip(row_idxs, col_idxs):
         core_idxs.append((

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -257,8 +257,8 @@ def setup_relative_restraints_using_smarts(
     assert "." not in smarts
 
     core = Chem.MolFromSmarts(smarts)
-    core_idxs_a = mol_a.GetSubstructMatch(core)
-    core_idxs_b = mol_b.GetSubstructMatch(core)
+    core_idxs_a = np.array(mol_a.GetSubstructMatch(core))
+    core_idxs_b = np.array(mol_b.GetSubstructMatch(core))
     # setup relative orientational restraints
     # rough sketch of algorithm:
     # find core atoms in mol_a
@@ -275,6 +275,7 @@ def setup_relative_restraints_using_smarts(
     row_idxs, col_idxs = linear_sum_assignment(rij)
 
     core_idxs = []
+
 
     for core_a, core_b in zip(row_idxs, col_idxs):
         core_idxs.append((

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -277,6 +277,8 @@ def setup_relative_restraints_using_smarts(
     assert "." not in smarts
 
     core = Chem.MolFromSmarts(smarts)
+
+    # we want *all* possible combinations.
     all_core_idxs_a = np.array(mol_a.GetSubstructMatches(core, uniquify=False))
     all_core_idxs_b = np.array(mol_b.GetSubstructMatches(core, uniquify=False))
     best_rmsd = np.inf
@@ -308,10 +310,10 @@ def setup_relative_restraints_using_smarts(
 
             if rmsd < best_rmsd:
                 best_rmsd = rmsd
-                print("best rmsd:", rmsd)
                 best_core_idxs_a = core_idxs_a
                 best_core_idxs_b = core_idxs_b
 
+    print("core_idxs", core_idxs, "rmsd", best_rmsd)
     core_idxs = np.stack([best_core_idxs_a, best_core_idxs_b], axis=1).astype(np.int32)
 
     return core_idxs

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -313,7 +313,8 @@ def setup_relative_restraints_using_smarts(
                 best_core_idxs_a = core_idxs_a
                 best_core_idxs_b = core_idxs_b
 
-    print("core_idxs", core_idxs, "rmsd", best_rmsd)
+
     core_idxs = np.stack([best_core_idxs_a, best_core_idxs_b], axis=1).astype(np.int32)
+    print("core_idxs", core_idxs, "rmsd", best_rmsd)
 
     return core_idxs

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -165,7 +165,13 @@ def construct_absolute_lambda_schedule_complex(num_windows):
         np.linspace(0.40, 1.0,  C, endpoint=True)
     ])
 
-    assert len(lambda_schedule) == num_windows
+    # assert len(lambda_schedule) == num_windows
+
+    lambda_schedule = np.concatenate([
+        np.linspace(0.15, 0.20, num_windows-1, endpoint=False),
+        np.array([1.0])
+    ])
+
 
     return lambda_schedule
 

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -242,7 +242,7 @@ class RelativeModel(ABC):
             self.host_system
         )
 
-        k_core = 75.0
+        k_core = 30.0
         core_params = np.zeros_like(combined_core_idxs).astype(np.float64)
         core_params[:, 0] = k_core
 

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -444,14 +444,8 @@ class AbsoluteHydrationModel(AbsoluteModel):
 
 class RelativeHydrationModel(RelativeModel):
 
-    def setup_topology(self, mol_a, mol_b, core_idxs):
-        top = topology.DualTopologyRHFE(mol_a, mol_b, self.ff)
-        top.parameterize_proper_torsion = functools.partial(
-            top.parameterize_proper_torsion,
-            core_idxs_a=core_idxs[:, 0],
-            core_idxs_b=core_idxs[:, 1]
-        )
-        return top
+    def setup_topology(self, mol_a, mol_b, _):
+        return topology.DualTopologyRHFE(mol_a, mol_b, self.ff)
 
 class AbsoluteConversionModel(AbsoluteModel):
 

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -152,23 +152,22 @@ class AbsoluteModel(ABC):
         dG, dG_err, results = estimator_abfe.deltaG(model, sys_params)
 
         # uncomment if we want to visualize
-        # combined_topology = model_utils.generate_imaged_topology(
-        #     [self.host_topology, mol],
-        #     x0,
-        #     box0,
-        #     "initial_"+prefix+".pdb"
-        # )
+        combined_topology = model_utils.generate_imaged_topology(
+            [self.host_topology, mol],
+            x0,
+            box0,
+            "initial_"+prefix+".pdb"
+        )
 
-        # for lambda_idx, res in enumerate(results):
-        #     # used for debugging for now, try to reproduce mdtraj error
-        #     outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
-        #     pickle.dump((res.xs, res.boxes, combined_topology), outfile)
-        #     print("dumping", outfile)
-        #     # pickle.dump((res.xs[:100], res.boxes[:100], combined_topology), outfile)
-        #     traj = mdtraj.Trajectory(res.xs, mdtraj.Topology.from_openmm(combined_topology))
-        #     traj.unitcell_vectors = res.boxes
-        #     traj.image_molecules()
-        #     traj.save_xtc("initial_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".xtc")
+        for lambda_idx, res in enumerate(results):
+            # used for debugging for now, try to reproduce mdtraj error
+            outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
+            pickle.dump((res.xs, res.boxes, combined_topology), outfile)
+            print("dumping", outfile)
+            # pickle.dump((res.xs[:100], res.boxes[:100], combined_topology), outfile)
+            traj = mdtraj.Trajectory(res.xs, mdtraj.Topology.from_openmm(combined_topology))
+            traj.unitcell_vectors = res.boxes
+            traj.save_xtc("initial_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".xtc")
     
         return dG, dG_err
 
@@ -307,21 +306,20 @@ class RelativeModel(ABC):
         dG, dG_err, results = estimator_abfe.deltaG(model, sys_params)
 
         # uncomment if we want to visualize.
-        # combined_topology = model_utils.generate_imaged_topology(
-        #     [self.host_topology, mol_a, mol_b],
-        #     x0,
-        #     box0,
-        #     "initial_"+prefix+".pdb"
-        # )
+        combined_topology = model_utils.generate_imaged_topology(
+            [self.host_topology, mol_a, mol_b],
+            x0,
+            box0,
+            "initial_"+prefix+".pdb"
+        )
 
-        # for lambda_idx, res in enumerate(results):
-        #     outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
-        #     pickle.dump((res.xs, res.boxes, combined_topology), outfile)
-        #     print("dumping", outfile)
-        #     traj = mdtraj.Trajectory(res.xs, mdtraj.Topology.from_openmm(combined_topology))
-        #     traj.unitcell_vectors = res.boxes
-        #     traj.image_molecules() # don't do this in prod
-        #     traj.save_xtc("initial_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".xtc")
+        for lambda_idx, res in enumerate(results):
+            outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
+            pickle.dump((res.xs, res.boxes, combined_topology), outfile)
+            print("dumping", outfile)
+            traj = mdtraj.Trajectory(res.xs, mdtraj.Topology.from_openmm(combined_topology))
+            traj.unitcell_vectors = res.boxes
+            traj.save_xtc("initial_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".xtc")
 
         return dG, dG_err, results
 

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -95,7 +95,7 @@ class AbsoluteModel(ABC):
             to compute delta_Us, the BAR estimates themselves become correlated.
 
         """
-        top = self.setup_topology(mol, core_idxs)
+        top = self.setup_topology(mol)
 
         afe = free_energy_rabfe.AbsoluteFreeEnergy(mol, top)
 
@@ -234,7 +234,7 @@ class RelativeModel(ABC):
         core_idxs = combined_core_idxs - num_host_atoms
         core_idxs[:, 1] -= mol_a.GetNumAtoms()
 
-        dual_topology = self.setup_topology(mol_a, mol_b, core_idxs)
+        dual_topology = self.setup_topology(mol_a, mol_b)
         rfe = free_energy_rabfe.RelativeFreeEnergy(dual_topology)
 
         unbound_potentials, sys_params, masses = rfe.prepare_host_edge(
@@ -438,28 +438,28 @@ class RelativeModel(ABC):
 
 class AbsoluteHydrationModel(AbsoluteModel):
 
-    def setup_topology(self, mol, _):
+    def setup_topology(self, mol):
         return topology.BaseTopologyRHFE(mol, self.ff)
 
 class RelativeHydrationModel(RelativeModel):
 
-    def setup_topology(self, mol_a, mol_b, _):
+    def setup_topology(self, mol_a, mol_b):
         return topology.DualTopologyRHFE(mol_a, mol_b, self.ff)
 
 class AbsoluteConversionModel(AbsoluteModel):
 
-    def setup_topology(self, mol, core_idxs):
+    def setup_topology(self, mol):
         top = topology.BaseTopologyConversion(mol, self.ff)
         return top
 
 class AbsoluteStandardHydrationModel(AbsoluteModel):
 
-    def setup_topology(self, mol, core_idxs):
+    def setup_topology(self, mol):
         top = topology.BaseTopologyStandardDecoupling(mol, self.ff)
         return top
 
 class RelativeBindingModel(RelativeModel):
 
-    def setup_topology(self, mol_a, mol_b, core_idxs):
+    def setup_topology(self, mol_a, mol_b):
         top = topology.DualTopologyStandardDecoupling(mol_a, mol_b, self.ff)
         return top

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -315,7 +315,6 @@ class RelativeModel(ABC):
         for lambda_idx, res in enumerate(results):
             outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
             pickle.dump((res.xs, res.boxes, combined_topology), outfile)
-            print("dumping", outfile)
             traj = mdtraj.Trajectory(res.xs, mdtraj.Topology.from_openmm(combined_topology))
             traj.unitcell_vectors = res.boxes
             traj.save_xtc("initial_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".xtc")
@@ -401,6 +400,8 @@ class RelativeModel(ABC):
             box0,
             prefix+"_ref_to_mol")
 
+        return dG_0, dG_0_err
+
         # pull out mol_a from combined state
         combined_core_idxs = np.copy(core_idxs)
         # swap the ligand coordinates in the reverse direction
@@ -448,29 +449,29 @@ class AbsoluteConversionModel(AbsoluteModel):
 
     def setup_topology(self, mol, core_idxs):
         top = topology.BaseTopologyConversion(mol, self.ff)
-        top.parameterize_proper_torsion = functools.partial(
-            top.parameterize_proper_torsion,
-            core_idxs=core_idxs
-        )
+        # top.parameterize_proper_torsion = functools.partial(
+        #     top.parameterize_proper_torsion,
+        #     core_idxs=core_idxs
+        # )
         return top
 
 class AbsoluteStandardHydrationModel(AbsoluteModel):
 
     def setup_topology(self, mol, core_idxs):
         top = topology.BaseTopologyStandardDecoupling(mol, self.ff)
-        top.parameterize_proper_torsion = functools.partial(
-            top.parameterize_proper_torsion,
-            core_idxs=core_idxs
-        )
+        # top.parameterize_proper_torsion = functools.partial(
+        #     top.parameterize_proper_torsion,
+        #     core_idxs=core_idxs
+        # )
         return top
 
 class RelativeBindingModel(RelativeModel):
 
     def setup_topology(self, mol_a, mol_b, core_idxs):
         top = topology.DualTopologyStandardDecoupling(mol_a, mol_b, self.ff)
-        top.parameterize_proper_torsion = functools.partial(
-            top.parameterize_proper_torsion,
-            core_idxs_a=core_idxs[:, 0],
-            core_idxs_b=core_idxs[:, 1]
-        )
+        # top.parameterize_proper_torsion = functools.partial(
+        #     top.parameterize_proper_torsion,
+        #     core_idxs_a=core_idxs[:, 0],
+        #     core_idxs_b=core_idxs[:, 1]
+        # )
         return top

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -450,29 +450,16 @@ class AbsoluteConversionModel(AbsoluteModel):
 
     def setup_topology(self, mol, core_idxs):
         top = topology.BaseTopologyConversion(mol, self.ff)
-        # top.parameterize_proper_torsion = functools.partial(
-        #     top.parameterize_proper_torsion,
-        #     core_idxs=core_idxs
-        # )
         return top
 
 class AbsoluteStandardHydrationModel(AbsoluteModel):
 
     def setup_topology(self, mol, core_idxs):
         top = topology.BaseTopologyStandardDecoupling(mol, self.ff)
-        # top.parameterize_proper_torsion = functools.partial(
-        #     top.parameterize_proper_torsion,
-        #     core_idxs=core_idxs
-        # )
         return top
 
 class RelativeBindingModel(RelativeModel):
 
     def setup_topology(self, mol_a, mol_b, core_idxs):
         top = topology.DualTopologyStandardDecoupling(mol_a, mol_b, self.ff)
-        # top.parameterize_proper_torsion = functools.partial(
-        #     top.parameterize_proper_torsion,
-        #     core_idxs_a=core_idxs[:, 0],
-        #     core_idxs_b=core_idxs[:, 1]
-        # )
         return top

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -163,7 +163,6 @@ class AbsoluteModel(ABC):
             # used for debugging for now, try to reproduce mdtraj error
             outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
             pickle.dump((res.xs, res.boxes, combined_topology), outfile)
-            print("dumping", outfile)
             # pickle.dump((res.xs[:100], res.boxes[:100], combined_topology), outfile)
             traj = mdtraj.Trajectory(res.xs, mdtraj.Topology.from_openmm(combined_topology))
             traj.unitcell_vectors = res.boxes

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -400,8 +400,6 @@ class RelativeModel(ABC):
             box0,
             prefix+"_ref_to_mol")
 
-        return dG_0, dG_0_err
-
         # pull out mol_a from combined state
         combined_core_idxs = np.copy(core_idxs)
         # swap the ligand coordinates in the reverse direction

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -161,9 +161,8 @@ class AbsoluteModel(ABC):
 
         for lambda_idx, res in enumerate(results):
             # used for debugging for now, try to reproduce mdtraj error
-            outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
-            pickle.dump((res.xs, res.boxes, combined_topology), outfile)
-            # pickle.dump((res.xs[:100], res.boxes[:100], combined_topology), outfile)
+            # outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
+            # pickle.dump((res.xs, res.boxes, combined_topology), outfile)
             traj = mdtraj.Trajectory(res.xs, mdtraj.Topology.from_openmm(combined_topology))
             traj.unitcell_vectors = res.boxes
             traj.save_xtc("initial_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".xtc")
@@ -314,8 +313,8 @@ class RelativeModel(ABC):
         )
 
         for lambda_idx, res in enumerate(results):
-            outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
-            pickle.dump((res.xs, res.boxes, combined_topology), outfile)
+            # outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
+            # pickle.dump((res.xs, res.boxes, combined_topology), outfile)
             traj = mdtraj.Trajectory(res.xs, mdtraj.Topology.from_openmm(combined_topology))
             traj.unitcell_vectors = res.boxes
             traj.save_xtc("initial_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".xtc")

--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -243,6 +243,7 @@ class RelativeModel(ABC):
         )
 
         k_core = 30.0
+
         core_params = np.zeros_like(combined_core_idxs).astype(np.float64)
         core_params[:, 0] = k_core
 

--- a/fe/topology.py
+++ b/fe/topology.py
@@ -342,23 +342,23 @@ class BaseTopologyConversion(BaseTopology):
     FastFindRings or SSSRs (ring basis), of which neither is what we want.
     """
 
-    def parameterize_proper_torsion(self, ff_params):
-        # alchemically turn off proper torsions.
-        torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
-        membership = get_ring_membership(self.mol)
+    # def parameterize_proper_torsion(self, ff_params):
+    #     # alchemically turn off proper torsions.
+    #     torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
+    #     membership = get_ring_membership(self.mol)
 
-        num_torsions = torsion_params.shape[0]
+    #     num_torsions = torsion_params.shape[0]
 
-        lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
-        lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
+    #     lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
+    #     lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
 
-        for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
-            if membership[b] != membership[c]:
-                lambda_mult_idxs[torsion_idx] = -1
+    #     for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
+    #         if membership[b] != membership[c]:
+    #             lambda_mult_idxs[torsion_idx] = -1
 
-        torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
+    #     torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
 
-        return torsion_params, torsion_potential
+    #     return torsion_params, torsion_potential
 
 
     def parameterize_nonbonded(self,

--- a/fe/topology.py
+++ b/fe/topology.py
@@ -53,8 +53,11 @@ def standard_qlj_typer(mol):
             val = (0.0, 0.37, 0.9)
         elif a_num == 16:
             val = (0.0, 0.35, 1.0)
+        elif a_num == 17:
+            val = (0.0, 0.35, 1.0)
         else:
-            assert 0
+            # print("Unknown a_num", a_num)
+            assert 0, "Unknown a_num "+str(a_num)
 
         # sigmas need to be halved
         standard_qlj.append((val[0], val[1]/2, val[2]))

--- a/fe/topology.py
+++ b/fe/topology.py
@@ -361,6 +361,7 @@ class BaseTopologyConversion(BaseTopology):
                 continue
 
             if membership[b] != membership[c]:
+                print("disabling torsion between", b, c)
                 lambda_mult_idxs[torsion_idx] = -1
 
         torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
@@ -614,7 +615,10 @@ class DualTopologyRHFE(DualTopology):
     have their charges and epsilons reduced by half.
     """
 
-    def parameterize_proper_torsion(self, ff_params):
+    def parameterize_proper_torsion(self, ff_params, core_idxs):
+
+        if core_idxs is None:
+            core_idxs = []
 
         torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
 
@@ -627,6 +631,10 @@ class DualTopologyRHFE(DualTopology):
         lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
 
         for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
+            # skip entirely if we're not in the core
+            if b not in core_idxs or c not in core_idxs:
+                continue
+
             if membership[b] != membership[c]:
                 lambda_offset_idxs[torsion_idx] = 0
 

--- a/fe/topology.py
+++ b/fe/topology.py
@@ -343,33 +343,33 @@ class BaseTopologyConversion(BaseTopology):
     FastFindRings or SSSRs (ring basis), of which neither is what we want.
     """
 
-    def parameterize_proper_torsion(self, ff_params, core_idxs=None):
-        if core_idxs is None:
-            core_idxs = []
+    # def parameterize_proper_torsion(self, ff_params, core_idxs=None):
+    #     if core_idxs is None:
+    #         core_idxs = []
 
-        for idx in core_idxs:
-            assert idx < self.mol.GetNumAtoms()
+    #     for idx in core_idxs:
+    #         assert idx < self.mol.GetNumAtoms()
 
-        # alchemically turn off proper torsions.
-        torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
-        membership = get_ring_membership(self.mol)
+    #     # alchemically turn off proper torsions.
+    #     torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
+    #     membership = get_ring_membership(self.mol)
 
-        num_torsions = torsion_params.shape[0]
+    #     num_torsions = torsion_params.shape[0]
 
-        lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
-        lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
+    #     lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
+    #     lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
 
-        for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
-            # skip entirely if we're not in the core
-            if b not in core_idxs or c not in core_idxs:
-                continue
+    #     for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
+    #         # skip entirely if we're not in the core
+    #         if b not in core_idxs or c not in core_idxs:
+    #             continue
 
-            if membership[b] != membership[c]:
-                lambda_mult_idxs[torsion_idx] = -1
+    #         if membership[b] != membership[c]:
+    #             lambda_mult_idxs[torsion_idx] = -1
 
-        torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
+    #     torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
 
-        return torsion_params, torsion_potential
+    #     return torsion_params, torsion_potential
 
 
     def parameterize_nonbonded(self,
@@ -400,33 +400,33 @@ class BaseTopologyStandardDecoupling(BaseTopology):
     lambda=0 fully interacting
     lambda=1 fully non-interacting.
     """
-    def parameterize_proper_torsion(self, ff_params, core_idxs=None):
+    # def parameterize_proper_torsion(self, ff_params, core_idxs=None):
 
-        if core_idxs is None:
-            core_idxs = []
+    #     if core_idxs is None:
+    #         core_idxs = []
 
-        for idx in core_idxs:
-            assert idx < self.mol.GetNumAtoms()
+    #     for idx in core_idxs:
+    #         assert idx < self.mol.GetNumAtoms()
 
-        torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
-        membership = get_ring_membership(self.mol)
+    #     torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
+    #     membership = get_ring_membership(self.mol)
 
-        num_torsions = torsion_params.shape[0]
+    #     num_torsions = torsion_params.shape[0]
 
-        lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
-        lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
+    #     lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
+    #     lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
 
-        for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
-            # skip entirely if we're not in the core
-            if b not in core_idxs or c not in core_idxs:
-                continue
+    #     for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
+    #         # skip entirely if we're not in the core
+    #         if b not in core_idxs or c not in core_idxs:
+    #             continue
 
-            if membership[b] != membership[c]:
-                lambda_offset_idxs[torsion_idx] = 0
+    #         if membership[b] != membership[c]:
+    #             lambda_offset_idxs[torsion_idx] = 0
 
-        torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
+    #     torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
 
-        return torsion_params, torsion_potential
+    #     return torsion_params, torsion_potential
 
     def parameterize_nonbonded(self,
         ff_q_params,
@@ -599,53 +599,55 @@ class DualTopology(ABC):
 # free energy test
 class BaseTopologyRHFE(BaseTopology):
 
-    def parameterize_proper_torsion(self, ff_params):
+    pass 
+    # def parameterize_proper_torsion(self, ff_params):
 
-        # alchemically turn off proper torsions.
-        torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
-        membership = get_ring_membership(self.mol)
+    #     # alchemically turn off proper torsions.
+    #     torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
+    #     membership = get_ring_membership(self.mol)
 
-        num_torsions = torsion_params.shape[0]
+    #     num_torsions = torsion_params.shape[0]
 
-        lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
-        lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
+    #     lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
+    #     lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
 
-        for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
-            if membership[b] != membership[c]:
-                lambda_offset_idxs[torsion_idx] = 0
+    #     for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
+    #         if membership[b] != membership[c]:
+    #             lambda_offset_idxs[torsion_idx] = 0
 
-        torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
+    #     torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
 
-        return torsion_params, torsion_potential
+    #     return torsion_params, torsion_potential
 
 # non-ring torsions are just always turned off at the end-states in the hydration
 # free energy test
 class DualTopologyRHFE(DualTopology):
+
     """
     Utility class used for relative hydration free energies. Ligand B is decoupled as lambda goes
     from 0 to 1, while ligand A is fully coupled. At the same time, at lambda=0, ligand B and ligand A
     have their charges and epsilons reduced by half.
     """
 
-    def parameterize_proper_torsion(self, ff_params):
+    # def parameterize_proper_torsion(self, ff_params):
 
-        torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
+    #     torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
 
-        mol_c = Chem.CombineMols(self.mol_a, self.mol_b)
-        membership = get_ring_membership(mol_c)
+    #     mol_c = Chem.CombineMols(self.mol_a, self.mol_b)
+    #     membership = get_ring_membership(mol_c)
 
-        num_torsions = torsion_params.shape[0]
+    #     num_torsions = torsion_params.shape[0]
 
-        lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
-        lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
+    #     lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
+    #     lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
 
-        for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
-            if membership[b] != membership[c]:
-                lambda_offset_idxs[torsion_idx] = 0
+    #     for torsion_idx, (_, b, c, _) in enumerate(torsion_potential.get_idxs()):
+    #         if membership[b] != membership[c]:
+    #             lambda_offset_idxs[torsion_idx] = 0
 
-        torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
+    #     torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
 
-        return torsion_params, torsion_potential
+    #     return torsion_params, torsion_potential
 
 
     def parameterize_nonbonded(self,
@@ -719,60 +721,60 @@ class DualTopologyStandardDecoupling(DualTopology):
     Blocker molecule has all of its torsions turned off throughout
 
     """
-    def parameterize_proper_torsion(self, ff_params, core_idxs_a, core_idxs_b):
-        # (ytz): TBD need to do this for Base Topology as well
+    # def parameterize_proper_torsion(self, ff_params, core_idxs_a, core_idxs_b):
+    #     # (ytz): TBD need to do this for Base Topology as well
 
-        # sanity check
-        for idx in core_idxs_a:
-            assert idx < self.mol_a.GetNumAtoms()
+    #     # sanity check
+    #     for idx in core_idxs_a:
+    #         assert idx < self.mol_a.GetNumAtoms()
 
-        for idx in core_idxs_b:
-            assert idx < self.mol_b.GetNumAtoms()
+    #     for idx in core_idxs_b:
+    #         assert idx < self.mol_b.GetNumAtoms()
 
-        torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
+    #     torsion_params, torsion_potential = super().parameterize_proper_torsion(ff_params)
 
-        membership_a = get_ring_membership(self.mol_a)
-        membership_b = get_ring_membership(self.mol_b)
+    #     membership_a = get_ring_membership(self.mol_a)
+    #     membership_b = get_ring_membership(self.mol_b)
 
-        num_torsions = torsion_params.shape[0]
+    #     num_torsions = torsion_params.shape[0]
 
-        lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
-        lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
+    #     lambda_mult_idxs = np.zeros(num_torsions, dtype=np.int32)
+    #     lambda_offset_idxs = np.ones(num_torsions, dtype=np.int32)
 
-        NA = self.mol_a.GetNumAtoms()
+    #     NA = self.mol_a.GetNumAtoms()
 
 
-        # offset by an equivalent amount
-        for torsion_idx, (i, b, c, j) in enumerate(torsion_potential.get_idxs()):
+    #     # offset by an equivalent amount
+    #     for torsion_idx, (i, b, c, j) in enumerate(torsion_potential.get_idxs()):
 
-            # does this torsion belong to mol_a?
-            if b < NA and c < NA and i < NA and j < NA:
+    #         # does this torsion belong to mol_a?
+    #         if b < NA and c < NA and i < NA and j < NA:
 
-                if b not in core_idxs_a or c not in core_idxs_a:
-                    continue
+    #             if b not in core_idxs_a or c not in core_idxs_a:
+    #                 continue
 
-                if membership_a[b] != membership_a[c]:
-                    print("disabling mol_a", b, c)
-                    lambda_offset_idxs[torsion_idx] = 0
-            # are we in in b?
-            elif b >= NA and c >= NA and i >= NA and j >= NA:
+    #             if membership_a[b] != membership_a[c]:
+    #                 print("disabling mol_a", b, c)
+    #                 lambda_offset_idxs[torsion_idx] = 0
+    #         # are we in in b?
+    #         elif b >= NA and c >= NA and i >= NA and j >= NA:
 
-                # need to compute the old indices since the final torsions have been concatenated.
-                old_b = b - NA
-                old_c = c - NA
+    #             # need to compute the old indices since the final torsions have been concatenated.
+    #             old_b = b - NA
+    #             old_c = c - NA
 
-                if old_b not in core_idxs_b or old_c not in core_idxs_b:
-                    continue
+    #             if old_b not in core_idxs_b or old_c not in core_idxs_b:
+    #                 continue
 
-                if membership_b[old_b] != membership_b[old_c]:
-                    print("disabling mol_b", b, c)
-                    lambda_offset_idxs[torsion_idx] = 0
-            else:
-                assert 0, "torsion spans two different mols"
+    #             if membership_b[old_b] != membership_b[old_c]:
+    #                 print("disabling mol_b", b, c)
+    #                 lambda_offset_idxs[torsion_idx] = 0
+    #         else:
+    #             assert 0, "torsion spans two different mols"
 
-        torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
+    #     torsion_potential.set_lambda_mult_and_offset(lambda_mult_idxs, lambda_offset_idxs)
 
-        return torsion_params, torsion_potential
+    #     return torsion_params, torsion_potential
 
     def parameterize_nonbonded(
         self,

--- a/fe/utils.py
+++ b/fe/utils.py
@@ -47,6 +47,8 @@ def convert_uIC50_to_kJ_per_mole(amount_in_uM):
     """
     return 0.593 * np.log(amount_in_uM * 1e-6) * 4.18
 
+def convert_uM_to_kJ_per_mole(amount_in_uM):
+    return 0.593 * np.log(amount_in_uM * 1e-6) * 4.18
 
 from scipy.spatial.distance import cdist
 import networkx as nx

--- a/fe/utils.py
+++ b/fe/utils.py
@@ -48,6 +48,20 @@ def convert_uIC50_to_kJ_per_mole(amount_in_uM):
     return 0.593 * np.log(amount_in_uM * 1e-6) * 4.18
 
 def convert_uM_to_kJ_per_mole(amount_in_uM):
+    """
+    Convert a potency measurement in uM concentrations.
+
+    Parameters
+    ----------
+    amount_in_uM: float
+        Binding potency in uM concentration.
+
+    Returns
+    -------
+    float
+        Binding potency in kJ/mol.
+
+    """
     return 0.593 * np.log(amount_in_uM * 1e-6) * 4.18
 
 from scipy.spatial.distance import cdist

--- a/parallel/client.py
+++ b/parallel/client.py
@@ -186,8 +186,8 @@ class GRPCClient(AbstractClient):
         self.stubs = []
         if options is None:
             options = [
-                ('grpc.max_send_message_length', 500 * 1024 * 1024),
-                ('grpc.max_receive_message_length', 500 * 1024 * 1024)
+                ('grpc.max_send_message_length', 1024 * 1024 * 1024),
+                ('grpc.max_receive_message_length', 1024 * 1024 * 1024)
             ]
         for host in self.hosts:
             channel = grpc.insecure_channel(

--- a/tests/test_rabfe_topology.py
+++ b/tests/test_rabfe_topology.py
@@ -54,52 +54,7 @@ def test_base_topology_conversion_ring_torsion():
     np.testing.assert_array_equal(vanilla_qlj_params, src_qlj_params)
     np.testing.assert_array_equal(topology.standard_qlj_typer(mol), dst_qlj_params)
 
-
     
-
-# def test_base_topology_conversion_ring_torsion():
-
-#     # test that the conversion protocol behaves as intended on a
-#     # simple linked cycle.
-
-#     ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_sc.py').read())
-#     ff = Forcefield(ff_handlers)
-#     mol = Chem.MolFromSmiles("C1CC1C1CC1")
-#     vanilla_mol_top = topology.BaseTopology(mol, ff)
-
-#     vanilla_torsion_params, _ = vanilla_mol_top.parameterize_proper_torsion(ff.pt_handle.params)
-
-#     mol_top = topology.BaseTopologyConversion(mol, ff)
-#     core_idxs = [0,1,2,3,4,5]
-#     conversion_torsion_params, torsion_potential = mol_top.parameterize_proper_torsion(ff.pt_handle.params, core_idxs)
-
-#     np.testing.assert_array_equal(vanilla_torsion_params, conversion_torsion_params)
-
-#     # in the conversion phase, torsions that bridge the two rings should be set to
-#     # be alchemically turned off.
-#     ring_group = [0,0,0,1,1,1]
-
-#     for torsion_idxs, mult, offset in zip(torsion_potential.get_idxs(), torsion_potential.get_lambda_mult(), torsion_potential.get_lambda_offset()):
-#         _, b, c, _ = torsion_idxs
-#         assert offset == 1
-#         if ring_group[b] != ring_group[c]:
-#             assert mult == -1
-#         else:
-#             assert mult == 0
-
-#     vanilla_qlj_params, _ = vanilla_mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
-#     qlj_params, nonbonded_potential = mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
-
-#     assert isinstance(nonbonded_potential, potentials.NonbondedInterpolated)
-
-#     src_qlj_params = qlj_params[:len(qlj_params)//2]
-#     dst_qlj_params = qlj_params[len(qlj_params)//2:]
-
-#     np.testing.assert_array_equal(vanilla_qlj_params, src_qlj_params)
-#     np.testing.assert_array_equal(topology.standard_qlj_typer(mol), dst_qlj_params)
-
-
-
 def test_base_topology_conversion_r_group():
 
     # check that phenol torsions are turned off if they're defined in the core

--- a/tests/test_rabfe_topology.py
+++ b/tests/test_rabfe_topology.py
@@ -1,5 +1,4 @@
 # test topology classes used in the RABFE protocol.
-import functools
 from jax.config import config; config.update("jax_enable_x64", True)
 from ff import Forcefield
 from ff.handlers.deserialize import deserialize_handlers
@@ -17,31 +16,32 @@ def test_base_topology_conversion_ring_torsion():
 
     ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_sc.py').read())
     ff = Forcefield(ff_handlers)
-
-    # note that this molecule "incomplete", as we do not add graphical hydrogens
-    mol = Chem.MolFromSmiles("CCC1CC1C1CC1")
+    mol = Chem.MolFromSmiles("C1CC1C1CC1")
     vanilla_mol_top = topology.BaseTopology(mol, ff)
     vanilla_torsion_params, _ = vanilla_mol_top.parameterize_proper_torsion(ff.pt_handle.params)
 
     mol_top = topology.BaseTopologyConversion(mol, ff)
-    core_idxs = [2,3,4,5,6,7]
-
-    conversion_torsion_params, torsion_potential = mol_top.parameterize_proper_torsion(ff.pt_handle.params, core_idxs)
+    conversion_torsion_params, torsion_potential = mol_top.parameterize_proper_torsion(ff.pt_handle.params)
 
     np.testing.assert_array_equal(vanilla_torsion_params, conversion_torsion_params)
 
-    ring_group = [0,1,2,2,2,3,3,3]
+    # in the conversion phase, torsions that bridge the two rings should be set to
+    # be alchemically turned off.
 
-    for torsion_idxs, mult, offset in zip(torsion_potential.get_idxs(), torsion_potential.get_lambda_mult(), torsion_potential.get_lambda_offset()):
-        _, b, c, _ = torsion_idxs
-        assert offset == 1
+    # assert torsion_potential.get_idxs() 
+    assert torsion_potential.get_lambda_mult() is None
+    assert torsion_potential.get_lambda_offset() is None
+    # ring_group = [0,0,0,1,1,1]
 
-        if b not in core_idxs or c not in core_idxs:
-            assert mult == 0
-        elif ring_group[b] != ring_group[c]:
-            assert mult == -1
-        else:
-            assert mult == 0
+
+
+    # for torsion_idxs, mult, offset in zip(torsion_potential.get_idxs(), torsion_potential.get_lambda_mult(), torsion_potential.get_lambda_offset()):
+    #     _, b, c, _ = torsion_idxs
+    #     assert offset == 1
+    #     if ring_group[b] != ring_group[c]:
+    #         assert mult == -1
+    #     else:
+    #         assert mult == 0
 
     vanilla_qlj_params, _ = vanilla_mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
     qlj_params, nonbonded_potential = mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
@@ -54,30 +54,19 @@ def test_base_topology_conversion_ring_torsion():
     np.testing.assert_array_equal(vanilla_qlj_params, src_qlj_params)
     np.testing.assert_array_equal(topology.standard_qlj_typer(mol), dst_qlj_params)
 
-    
+
 def test_base_topology_conversion_r_group():
 
-    # check that phenol torsions are turned off if they're defined in the core
+    # check that phenol torsions are turned off
     ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_sc.py').read())
     ff = Forcefield(ff_handlers)
     mol = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1O"))
     mol_top = topology.BaseTopologyConversion(mol, ff)
-
-    core_idxs = np.arange(mol.GetNumAtoms())
-
-    result, potential = mol_top.parameterize_proper_torsion(ff.pt_handle.params, core_idxs)
+    result, potential = mol_top.parameterize_proper_torsion(ff.pt_handle.params)
     # in the conversion phase, torsions that bridge the two rings should be set to
     # be alchemically turned off.
-    is_in_ring = [1,1,1,1,1,1,0,0]
-
-    for torsion_idxs, mult, offset in zip(potential.get_idxs(), potential.get_lambda_mult(), potential.get_lambda_offset()):
-        _, b, c, _ = torsion_idxs
-        assert offset == 1
-        if is_in_ring[b] and is_in_ring[c]:
-            # should be always turned on
-            assert mult == 0
-        elif (not is_in_ring[b]) or (not is_in_ring[c]):
-            assert mult == -1
+    assert potential.get_lambda_mult() is None
+    assert potential.get_lambda_offset() is None
 
 def test_base_topology_standard_decoupling():
 
@@ -86,23 +75,20 @@ def test_base_topology_standard_decoupling():
     # the torsions should be turned off.
     ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_sc.py').read())
     ff = Forcefield(ff_handlers)
-    mol = Chem.AddHs(Chem.MolFromSmiles("CCc1ccccc1O"))
+    mol = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1O"))
     vanilla_mol_top = topology.BaseTopology(mol, ff)
     vanilla_torsion_params, _ = vanilla_mol_top.parameterize_proper_torsion(ff.pt_handle.params)
 
-    core_idxs = [2,3,4,5,6,7,8]
-
     mol_top = topology.BaseTopologyStandardDecoupling(mol, ff)
-
-    mol_top.parameterize_proper_torsion = functools.partial(mol_top.parameterize_proper_torsion, core_idxs=core_idxs)
-
     decouple_torsion_params, torsion_potential = mol_top.parameterize_proper_torsion(ff.pt_handle.params)
 
     np.testing.assert_array_equal(vanilla_torsion_params, decouple_torsion_params)
 
-    is_in_ring = [0,0,1,1,1,1,1,1,0,0]
+    # in the conversion phase, torsions that bridge the two rings should be set to
+    # be alchemically turned off.
+    is_in_ring = [1,1,1,1,1,1,0,0]
 
-    _, combined_torsion_potential = mol_top.parameterize_periodic_torsion(
+    combined_decouple_torsion_params, combined_torsion_potential = mol_top.parameterize_periodic_torsion(
         ff.pt_handle.params,
         ff.it_handle.params
     )
@@ -113,26 +99,8 @@ def test_base_topology_standard_decoupling():
     # impropers should always be turned on.
     num_proper_torsions = len(torsion_potential.get_idxs())
 
-    for idx, (torsion_idxs, mult, offset) in enumerate(zip(
-        combined_torsion_potential.get_idxs(),
-        combined_torsion_potential.get_lambda_mult(),
-        combined_torsion_potential.get_lambda_offset())):
-        _, b, c, _ = torsion_idxs
-
-        if idx < num_proper_torsions:
-            # proper torsion
-            assert mult == 0
-            if b not in core_idxs or c not in core_idxs:
-                assert offset == 1
-            elif is_in_ring[b] and is_in_ring[c]:
-                # ring bond
-                assert offset == 1
-            else:
-                # not ring bond
-                assert offset == 0
-        else:
-            # improper torsion
-            assert offset == 1
+    assert np.all(combined_torsion_potential.get_lambda_mult() == 0)
+    assert np.all(combined_torsion_potential.get_lambda_offset() == 1)
 
     qlj_params, nonbonded_potential = mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
 
@@ -153,68 +121,30 @@ def test_dual_topology_standard_decoupling():
 
     ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_sc.py').read())
     ff = Forcefield(ff_handlers)
-    mol_a = Chem.AddHs(Chem.MolFromSmiles("FOc1ccccc1O"))
-    mol_b = Chem.AddHs(Chem.MolFromSmiles("FOc1ccccc1F"))
+    mol_a = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1O"))
+    mol_b = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1F"))
     mol_c = Chem.CombineMols(mol_a, mol_b)
     mol_top = topology.DualTopologyStandardDecoupling(mol_a, mol_b, ff)
-
-    core_idxs_a = [2,3,4,5,6,7,8]
-    core_idxs_b = [2,3,4,5,6,7]  # note the missing F
-
-    mol_top.parameterize_proper_torsion = functools.partial(mol_top.parameterize_proper_torsion,
-        core_idxs_a=core_idxs_a,
-        core_idxs_b=core_idxs_b
-    )
 
     decouple_torsion_params, torsion_potential = mol_top.parameterize_proper_torsion(ff.pt_handle.params)
 
     # np.testing.assert_array_equal(vanilla_torsion_params, decouple_torsion_params)
-    #             F O C C C C C C O H H H H H H  F O C C C C C C F H H H H H H
-    is_in_ring = [0,0,1,1,1,1,1,1,0,0,0,0,0,0,0, 0,0,1,1,1,1,1,1,0,0,0,0,0,0,0]
-
+    #             C C C C C C O H H H H H H  C C C C C C F H H H H H H
+    is_in_ring = [1,1,1,1,1,1,0,0,0,0,0,0,0, 1,1,1,1,1,1,0,0,0,0,0,0,0]
 
     combined_decouple_torsion_params, combined_torsion_potential = mol_top.parameterize_periodic_torsion(
         ff.pt_handle.params,
-        ff.it_handle.params,
+        ff.it_handle.params
     )
 
     assert len(combined_torsion_potential.get_lambda_mult()) == len(combined_torsion_potential.get_idxs())
     assert len(combined_torsion_potential.get_lambda_mult()) == len(combined_torsion_potential.get_lambda_offset())
 
-    NA = mol_a.GetNumAtoms()
-
-    # impropers should always be turned on. as amides/esters are kept planar with impropers
+    # impropers should always be turned on.
     num_proper_torsions = len(torsion_potential.get_idxs())
 
-    for idx, (torsion_idxs, mult, offset) in enumerate(zip(
-        combined_torsion_potential.get_idxs(),
-        combined_torsion_potential.get_lambda_mult(),
-        combined_torsion_potential.get_lambda_offset())):
-
-        if idx < num_proper_torsions:
-
-            _, b, c, _ = torsion_idxs
-
-            if b < NA and c < NA:
-                if b not in core_idxs_a or c not in core_idxs_a:
-                    continue
-            elif b >= NA and c >= NA:
-                if b not in core_idxs_b or c not in core_idxs_b:
-                    continue
-            else:
-                # bad torsion
-                assert 0
-
-            # we must now be between two core atoms if we're reached this line.
-
-            assert mult == 0
-            if is_in_ring[b] and is_in_ring[c]:
-                assert offset == 1
-            else:
-                assert offset == 0
-
-        else:
-            assert offset == 1
+    assert np.all(combined_torsion_potential.get_lambda_mult() == 0)
+    assert np.all(combined_torsion_potential.get_lambda_offset() == 1)
 
     qlj_params, nonbonded_potential = mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
 

--- a/tests/test_rabfe_topology.py
+++ b/tests/test_rabfe_topology.py
@@ -25,23 +25,8 @@ def test_base_topology_conversion_ring_torsion():
 
     np.testing.assert_array_equal(vanilla_torsion_params, conversion_torsion_params)
 
-    # in the conversion phase, torsions that bridge the two rings should be set to
-    # be alchemically turned off.
-
-    # assert torsion_potential.get_idxs() 
     assert torsion_potential.get_lambda_mult() is None
     assert torsion_potential.get_lambda_offset() is None
-    # ring_group = [0,0,0,1,1,1]
-
-
-
-    # for torsion_idxs, mult, offset in zip(torsion_potential.get_idxs(), torsion_potential.get_lambda_mult(), torsion_potential.get_lambda_offset()):
-    #     _, b, c, _ = torsion_idxs
-    #     assert offset == 1
-    #     if ring_group[b] != ring_group[c]:
-    #         assert mult == -1
-    #     else:
-    #         assert mult == 0
 
     vanilla_qlj_params, _ = vanilla_mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
     qlj_params, nonbonded_potential = mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
@@ -127,10 +112,6 @@ def test_dual_topology_standard_decoupling():
     mol_top = topology.DualTopologyStandardDecoupling(mol_a, mol_b, ff)
 
     decouple_torsion_params, torsion_potential = mol_top.parameterize_proper_torsion(ff.pt_handle.params)
-
-    # np.testing.assert_array_equal(vanilla_torsion_params, decouple_torsion_params)
-    #             C C C C C C O H H H H H H  C C C C C C F H H H H H H
-    is_in_ring = [1,1,1,1,1,1,0,0,0,0,0,0,0, 1,1,1,1,1,1,0,0,0,0,0,0,0]
 
     combined_decouple_torsion_params, combined_torsion_potential = mol_top.parameterize_periodic_torsion(
         ff.pt_handle.params,


### PR DESCRIPTION
This PR adds several improvements and reverts one change to the RABFE protocol.

Minor Improvements
- Label potency and units are now specified via --property_field and --property_units (uM or nM)
- We require specifying a blocker ligand by _Name in the command line via --blocker_name
- core_smarts no longer is needed. We use a MCS algorithm based on distance and non-terminal atoms followed by Hungarian matching.
- To accomodate for bigger cores, the force constants have been reduced to 30kJ/mol from 75kJ/mol
- Complex and solvent legs have different decoupling schedules
- Add standard type for Chlorine in the standard_qlj_typer
- Statistics are collected once every 1000 steps as opposed to 200. This may still be too frequent!

Removed Feature
- We no longer do any sort of torsional rescaling. In the end, it's just too hard to detect when a torsion should be scaled down (ring atoms? core only? not amides? not esters?). And it only moves the extra variance from the endpoint correction to other stages. There are more efficient ways to generate gas-phase samples in the endpoint technique (eg. just running a bunch of simulations in parallel) that I don't think this is truly necessary anymore.