### PR TITLE
Refactor OE charging

### DIFF
--- a/ff/handlers/nonbonded.py
+++ b/ff/handlers/nonbonded.py
@@ -49,7 +49,6 @@ def convert_to_oe(mol):
     return oemol
 
 
-
 def oe_assign_charges(mol, charge_model='AM1BCCELF10'):
     """assign partial charges, then premultiply by sqrt(ONE_4PI_EPS0)
     as an optimization"""
@@ -342,9 +341,11 @@ class AM1CCCHandler(SerializableMixIn):
             molecule to be parameterized.
 
         """
-        oemol = convert_to_oe(mol)
         # imported here for optional dependency
         from openeye import oechem
+
+        oemol = convert_to_oe(mol)
+        AromaticityModel.assign(oemol)
 
         # check for cache
         cache_key = 'AM1Cache'

--- a/ff/handlers/nonbonded.py
+++ b/ff/handlers/nonbonded.py
@@ -32,6 +32,23 @@ def convert_to_nx(mol):
     return g
 
 
+def convert_to_oe(mol):
+    """Convert an ROMol into an OEMol"""
+
+    # optional import
+    from openeye import oechem
+
+    mb = Chem.MolToMolBlock(mol)
+    ims = oechem.oemolistream()
+    ims.SetFormat(oechem.OEFormat_SDF)
+    ims.openstring(mb)
+
+    for buf_mol in ims.GetOEMols():
+        oemol = oechem.OEMol(buf_mol)
+
+    return oemol
+
+
 def generate_exclusion_idxs(mol, scale12, scale13, scale14):
     """ 
     Generate exclusions for a mol based on the all pairs shortest path.
@@ -223,17 +240,10 @@ class AM1Handler(SerializableMixIn):
             molecule to be parameterized.
 
         """
+        oemol = convert_to_oe(mol)
+
         # imported here for optional dependency
-        from openeye import oechem
         from openeye import oequacpac
-
-        mb = Chem.MolToMolBlock(mol)
-        ims = oechem.oemolistream()
-        ims.SetFormat(oechem.OEFormat_SDF)
-        ims.openstring(mb)
-
-        for buf_mol in ims.GetOEMols():
-            oemol = oechem.OEMol(buf_mol)
 
         result = oequacpac.OEAssignCharges(oemol, oequacpac.OEAM1Charges(symmetrize=True))
 
@@ -275,16 +285,8 @@ class AM1BCCHandler(SerializableMixIn):
 
         """
         # imported here for optional dependency
-        from openeye import oechem
+        oemol = convert_to_oe(mol)
         from openeye import oequacpac
-
-        mb = Chem.MolToMolBlock(mol)
-        ims = oechem.oemolistream()
-        ims.SetFormat(oechem.OEFormat_SDF)
-        ims.openstring(mb)
-
-        for buf_mol in ims.GetOEMols():
-            oemol = oechem.OEMol(buf_mol)
 
         result = oequacpac.OEAssignCharges(oemol, oequacpac.OEAM1BCCELF10Charges())
 
@@ -340,19 +342,9 @@ class AM1CCCHandler(SerializableMixIn):
             molecule to be parameterized.
 
         """
+        oemol = convert_to_oe(mol)
         # imported here for optional dependency
-        from openeye import oechem
-        from openeye import oequacpac
-
-        mb = Chem.MolToMolBlock(mol)
-        ims = oechem.oemolistream()
-        ims.SetFormat(oechem.OEFormat_SDF)
-        ims.openstring(mb)
-
-        for buf_mol in ims.GetOEMols():
-            oemol = oechem.OEMol(buf_mol)
-            # AromaticityModel.assign(oe_molecule, bcc_collection.aromaticity_model)
-            AromaticityModel.assign(oemol)
+        from openeye import oequacpac, oechem
 
         # check for cache
         cache_key = 'AM1Cache'

--- a/scripts/bootstrap_am1.py
+++ b/scripts/bootstrap_am1.py
@@ -7,6 +7,7 @@ from rdkit import Chem
 from openeye import oechem
 from openeye import oequacpac
 from openeye import oeomega
+from ff.handlers.nonbonded import convert_to_oe
 
 ONE_4PI_EPS0 = 138.935456
 
@@ -163,14 +164,7 @@ def score(stds):
 
 
 def prep_structure(rdmol):
-    mb = Chem.MolToMolBlock(rdmol)
-    ims = oechem.oemolistream()
-    ims.SetFormat(oechem.OEFormat_SDF)
-    ims.openstring(mb)
-
-    for buf_mol in ims.GetOEMols():
-        oemol = oechem.OEMol(buf_mol)
-
+    oemol = convert_to_oe(rdmol)
     omega = oeomega.OEOmega()
     # omega.SetIncludeInput(True)
     omega.SetMaxSearchTime(30)


### PR DESCRIPTION
To avoid increasing code duplication when adding a runtime assertion that AM1CCC and AM1BCC are consistent (related to https://github.com/proteneer/timemachine/issues/353), this PR extracts two repeated code fragments into functions:
- [x] Extracts the code fragment used to convert a molecule from RDKit to OE, consolidating 4 duplicates
- [x] Extracts the code fragment used to apply a specified OE charge model to an RDKit molecule, consolidating 3 duplicates (ignoring a 4th near-duplicate)