### PR TITLE
Truncate residuals for "bottomed-out" labels

### DIFF
--- a/fe/loss.py
+++ b/fe/loss.py
@@ -96,6 +96,23 @@ def EXP_loss(
     return loss
 
 
+def _scalar_compute_residual(prediction, label, reliable_interval=(-jnp.inf, +jnp.inf)):
+    """prediction - label if label is in the reliable interval"""
+
+    lower, upper = reliable_interval
+
+    if (label >= lower) and (label <= upper):
+        residual = prediction - label
+    elif label < lower:
+        residual = max(0, prediction - lower)
+    elif label > upper:
+        residual = min(0, prediction - upper)
+    else:
+        raise (RuntimeError('unsatisfiable reliable_range'))
+
+    return residual
+
+
 def l1_loss(residual):
     """loss = abs(residual)"""
     return jnp.abs(residual)

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -1,5 +1,5 @@
 import numpy as np
-from fe.loss import l1_loss, pseudo_huber_loss, flat_bottom_loss
+from fe.loss import l1_loss, pseudo_huber_loss, flat_bottom_loss, truncated_residuals
 
 
 def _assert_nonnegative_loss(loss_fxn: callable):
@@ -27,3 +27,35 @@ def test_pseudo_huber_loss():
 
 def test_flat_bottom_loss():
     _assert_basic_loss_properties(flat_bottom_loss)
+
+
+def _scalar_truncated_residual(prediction, label, reliable_interval):
+    lower, upper = reliable_interval
+    assert lower < upper
+
+    if (label >= lower) and (label <= upper):
+        residual = prediction - label
+    elif label < lower:
+        residual = max(0, prediction - lower)
+    elif label > upper:
+        residual = min(0, prediction - upper)
+    else:
+        raise (RuntimeError('unsatisfiable reliable_range'))
+
+    return residual
+
+
+def test_compute_residuals():
+    predictions = np.random.rand(10000) * 4 - 2
+    labels = np.random.rand(10000) * 4 - 2
+
+    reliable_interval = (-1, +1)
+
+    ref = np.array([
+        _scalar_truncated_residual(p, l, reliable_interval)
+        for (p, l) in zip(predictions, labels)
+    ])
+
+    test = truncated_residuals(predictions, labels, reliable_interval)
+
+    np.testing.assert_allclose(ref, test)

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -45,12 +45,7 @@ def _scalar_truncated_residual(prediction, label, reliable_interval):
     return residual
 
 
-def test_compute_residuals():
-    predictions = np.random.rand(10000) * 4 - 2
-    labels = np.random.rand(10000) * 4 - 2
-
-    reliable_interval = (-1, +1)
-
+def assert_consistency_with_scalar_version(predictions, labels, reliable_interval):
     ref = np.array([
         _scalar_truncated_residual(p, l, reliable_interval)
         for (p, l) in zip(predictions, labels)
@@ -59,3 +54,21 @@ def test_compute_residuals():
     test = truncated_residuals(predictions, labels, reliable_interval)
 
     np.testing.assert_allclose(ref, test)
+
+
+def test_compute_residuals_finite_interval():
+    predictions = np.random.rand(10000) * 4 - 2
+    labels = np.random.rand(10000) * 4 - 2
+
+    reliable_interval = (-1, +1)
+
+    assert_consistency_with_scalar_version(predictions, labels, reliable_interval)
+
+
+def test_compute_residuals_infinite_interval():
+    predictions = np.random.rand(10000) * 4 - 2
+    labels = np.random.rand(10000) * 4 - 2
+
+    reliable_interval = (-np.inf, +np.inf)
+
+    assert_consistency_with_scalar_version(predictions, labels, reliable_interval)

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -73,3 +73,17 @@ def test_compute_residuals_infinite_interval():
     reliable_interval = (-np.inf, +np.inf)
 
     assert_consistency_with_scalar_version(predictions, labels, reliable_interval)
+
+
+def test_compute_residuals_sanity_check():
+    reliable_interval = (-10, +np.inf)
+    predictions = np.array([-100.0, 0.0])
+
+    # assays bottom'd out
+    labels = np.array([-15, -15])
+
+    # if we predict -100, but our label of -15 bottomed out at -10, residual should be 0
+    # if we predict    0, and our label of -15 bottomed out at -10, residual should be >=10
+    expected_residual = np.array([0, 10])
+    test_residual = truncated_residuals(predictions, labels, reliable_interval)
+    np.testing.assert_array_equal(expected_residual, test_residual)  # passes

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -1,5 +1,6 @@
 import numpy as np
 from fe.loss import l1_loss, pseudo_huber_loss, flat_bottom_loss, truncated_residuals
+np.random.seed(2021)
 
 
 def _assert_nonnegative_loss(loss_fxn: callable):


### PR DESCRIPTION
Ad hoc patch for comparing absolute predictions to absolute labels, if the labels are only considered reliable in some specified interval (aka fitting to "bottomed-out" assays, as in https://github.com/MCompChem/fep-benchmark/issues/6 ).

Where we compute `loss(predictions - labels)`, we can instead compute `loss(truncated_residuals(predictions, labels))`:
* If the label is in the reliable interval, compute the residual `predictions - labels` normally.
* If the label is outside the interval, truncate the residual to reflect that the label is only providing a `true_value <= some_threshold` signal, rather than a `true_value == label` signal.

Examples of this behavior: https://github.com/proteneer/timemachine/blob/1fccf1636a65489549f1815622918f5b73fe8d5e/fe/loss.py#L105-L109

Further elaborations might:
* add a similar patch, but for relative predictions -- `truncated_relative_residuals(rel_preds_ij, abs_labels_i, abs_labels_j)`
* consider using the `- log_likelihood(predictions, labels)` of an explicit model