### PR TITLE
Extract some definitions from RABFE example script

### DIFF
--- a/fe/atom_mapping.py
+++ b/fe/atom_mapping.py
@@ -28,6 +28,31 @@ class CompareDist(rdFMCS.MCSAtomCompare):
         return bool(np.linalg.norm(x_i - x_j) <= self.threshold)  # must convert from np.bool_ to Python bool!
 
 
+class CompareDistNonterminal(rdFMCS.MCSAtomCompare):
+    """
+    Custom comparator used in the FMCS code.
+    This allows two atoms to match if:
+        1. Neither atom is a terminal atom (H, F, Cl, Halogens etc.)
+        2. They are within 1 angstrom of each other.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def compare(self, p, mol1, atom1, mol2, atom2):
+
+        if mol1.GetAtomWithIdx(atom1).GetDegree() == 1:
+            return False
+        if mol2.GetAtomWithIdx(atom2).GetDegree() == 1:
+            return False
+
+        x_i = mol1.GetConformer(0).GetPositions()[atom1]
+        x_j = mol2.GetConformer(0).GetPositions()[atom2]
+        if np.linalg.norm(x_i - x_j) > 1.0:  # angstroms
+            return False
+        else:
+            return True
+
 def mcs_map(a, b, threshold: float = 0.5, timeout: int = 5, smarts: Optional[str] = None):
     """Find the MCS map of going from A to B"""
     params = rdFMCS.MCSParameters()

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -60,13 +60,6 @@ class RABFEResult():
         from the solvent into the complex"""
         return self.dG_solvent - self.dG_complex
 
-    #@property
-    #def dG_err(self):
-    #    stage_errors = np.array([
-    #        self.dG_complex_conversion_error, self.dG_complex_decouple_error,
-    #        self.dG_solvent_conversion_error, self.dG_solvent_decouple_error])
-    #    return np.sqrt(stage_errors**2)
-
 
 class UnsupportedTopology(Exception):
     pass

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -27,7 +27,7 @@ class RABFEResult():
         print("stage summary for mol:", self.mol_name,
               "dG_complex_conversion (K complex)", self.dG_complex_conversion,
               "dG_complex_decouple (E0 + A0 + A1 + E1)", self.dG_complex_decouple,
-              "dG_solvent_conversion (K complex)", self.dG_solvent_conversion,
+              "dG_solvent_conversion (K solvent)", self.dG_solvent_conversion,
               "dG_solvent_decouple (D)", self.dG_solvent_decouple
               )
 

--- a/tests/test_free_energy_rabfe.py
+++ b/tests/test_free_energy_rabfe.py
@@ -1,0 +1,25 @@
+import io
+from contextlib import redirect_stdout
+from fe.free_energy_rabfe import RABFEResult
+
+
+def capture_print(closure):
+    """capture anything printed when we call closure()"""
+
+    f = io.StringIO()
+    with redirect_stdout(f):
+        closure()
+    printed = f.getvalue()
+    return printed
+
+
+def test_rabfe_result_to_from_log():
+    """assert equality after round-trip to/from preferred terminal log format"""
+
+    result = RABFEResult('my mol', 1.0, 2.0, 3.0, 4.0)
+
+    printed = capture_print(result.log)
+    first_line = printed.splitlines()[0]
+
+    reconstructed = RABFEResult.from_log(first_line)
+    assert result == reconstructed


### PR DESCRIPTION
Context and motivation: Aiming to add an RABFE training example based on [`examples/validate_relative_binding.py`](https://github.com/proteneer/timemachine/blob/7df21182fd0076030860d7ec3c6847161ba061e1/examples/validate_relative_binding.py). This new script should run in training mode (i.e.  load the expensive cached results and run only the cheaper conversion steps), while duplicating as little as possible of the original script. 

In this PR, two important definitions are extracted to the `fe` module, and a new function `RABFEResult.from_log` is added/tested.
- [x] Extract RABFE thermodynamic cycle definition
- [x] Extract preferred terminal log format for RABFE results
- [x] Add (and test) function to parse terminal log
- [x] Extract custom atom comparison to `fe.atom_mapping`

Further refactoring of the RABFE example script is in progress on the [`rabfe-training`](https://github.com/proteneer/timemachine/tree/rabfe-training) branch 