### PR TITLE
Add tests for estimator_abfe and fix a bug.

### DIFF
--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -361,7 +361,7 @@ def deltaG_fwd(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
 def deltaG_bwd(model, residual, grad) -> Tuple[np.array]:
     """Note: nondiff args must appear first here, even though one of them appears last in the original function's signature!
     """
-     # residual are the partial dG / partial dparams for each term
+    # residual are the partial dG / partial dparams for each term
     # grad[0] is the adjoint of dG w.r.t. loss: partial L/partial dG
     # grad[1] is the adjoint of dG_err w.r.t. loss: which we don't use
     # grad[2] is the adjoint of simulation results w.r.t. loss: which we don't use

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -325,6 +325,7 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
         dG_grad.append(rhs - lhs)
 
     if model.endpoint_correct:
+        assert len(results[0].du_dps) - len(results[-1].du_dps) == 1
         # (ytz): Fill in missing derivatives since zip() from above loops
         # over the shorter array.
         lhs = results[0].du_dps[-1]

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -326,9 +326,10 @@ def _deltaG(model, sys_params) -> Tuple[Tuple[float, List], np.array]:
 
     if model.endpoint_correct:
         # (ytz): Fill in missing derivatives since zip() from above loops
-        # over the shorter array. The "rhs" from results[-1] is identically
-        # zero as the energies do not depend the core restraints.
-        dG_grad.append(-results[0].du_dps[-1])
+        # over the shorter array.
+        lhs = results[0].du_dps[-1]
+        rhs = 0 # zero as the energies do not depend the core restraints.
+        dG_grad.append(rhs - lhs)
 
         core_restr = bound_potentials[-1]
         # (ytz): tbd, automatically find optimal k_translation/k_rotation such that

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -218,3 +218,4 @@ def test_free_energy_estimator_with_endpoint_correction():
         assert len(grad) == 3
         assert grad[0].shape == sys_params[0].shape
         assert grad[1].shape == sys_params[1].shape
+        assert grad[2].shape == sys_params[2].shape

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -135,6 +135,12 @@ def test_free_energy_estimator():
 
 
 def test_free_energy_estimator_with_endpoint_correction():
+    """
+    Test that we generate correctly shaped derivatives in the estimator code
+    when the endpoint correction is turned on. We expected that f([a,b,c,...])
+    to generate derivatives df/da, df/db, df/dc, df/d... such that
+    df/da.shape == a.shape, df/db.shape == b.shape, df/dc == c.shape, and etc.
+    """
 
     n_atoms = 15
     x0 = np.random.rand(n_atoms, 3)

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -3,7 +3,7 @@ import jax
 import numpy as np
 
 
-from fe import estimator
+from fe import estimator_abfe
 from timemachine.lib import LangevinIntegrator, potentials, MonteCarloBarostat
 from parallel.client import CUDAPoolClient
 from md.barostat.utils import get_bond_list, get_group_indices
@@ -30,6 +30,25 @@ def get_harmonic_angle(n_atoms, n_bonds):
     lamb_mult = np.random.randint(-5, 5, size=n_bonds, dtype=np.int32)
     lamb_offset = np.random.randint(-5, 5, size=n_bonds, dtype=np.int32)
     return potentials.HarmonicAngle(bond_idxs, lamb_mult, lamb_offset), params
+
+
+def get_harmonic_restraints(n_atoms, n_restraints):
+    assert n_restraints*2 <= n_atoms
+    params = np.random.rand(n_restraints, 2).astype(np.float64)
+    bond_idxs_src = []
+    bond_idxs_dst = []
+
+    atom_idxs_src = np.arange(n_atoms//2)
+    atom_idxs_dst = np.arange(n_atoms//2) + n_atoms//2
+    
+    bond_idxs_src = np.random.choice(atom_idxs_src, size=n_restraints, replace=False)
+    bond_idxs_dst = np.random.choice(atom_idxs_dst, size=n_restraints, replace=False)
+
+    bond_idxs = np.array([bond_idxs_src, bond_idxs_dst], dtype=np.int32).T
+    lamb_mult = np.random.randint(-5, 5, size=n_restraints, dtype=np.int32)
+    lamb_offset = np.random.randint(-5, 5, size=n_restraints, dtype=np.int32)
+    return potentials.HarmonicBond(bond_idxs, lamb_mult, lamb_offset), params
+
 
 def test_free_energy_estimator():
 
@@ -74,29 +93,128 @@ def test_free_energy_estimator():
         seed
     )
 
+    beta = 0.125
+
     lambda_schedule = np.linspace(0, 1.0, 4)
 
-    for client in [None, CUDAPoolClient(1)]:
+    def loss_fn(sys_params):
 
-        mdl = estimator.FreeEnergyModel(
+        endpoint_correct = False
+        mdl = estimator_abfe.FreeEnergyModel(
             unbound_potentials,
+            endpoint_correct,
             client,
             box,
             x0,
             v0,
             integrator,
+            barostat,
             lambda_schedule,
             100,
             100,
-            barostat
+            beta,
+            "test"
         )
 
-        value_and_grad_fn = jax.value_and_grad(estimator.deltaG, argnums=1, has_aux=True)
-        (dG, _), sys_grad = value_and_grad_fn(mdl, sys_params) # run fwd, store result, and run bwd
+        dG, bar_dG_err, results = estimator_abfe.deltaG(mdl, sys_params)
 
-        grad_fn = jax.grad(estimator.deltaG, argnums=1, has_aux=True)
-        grad, _ = grad_fn(mdl, sys_params)
+        return dG**2
+
+
+    for client in [None, CUDAPoolClient(1)]:
+        
+        value_and_grad_fn = jax.value_and_grad(loss_fn)
+        dG, sys_grad = value_and_grad_fn(sys_params) # run fwd, store result, and run bwd
+
+        grad_fn = jax.grad(loss_fn)
+        grad = grad_fn(sys_params)
 
         assert len(grad) == 2
+        assert grad[0].shape == sys_params[0].shape
+        assert grad[1].shape == sys_params[1].shape
+
+
+def test_free_energy_estimator_with_endpoint_correction():
+
+    n_atoms = 15
+    x0 = np.random.rand(n_atoms, 3)
+    v0 = np.zeros_like(x0)
+
+    n_bonds = 3
+    n_angles = 4
+    n_restraints = 5
+
+    hb_pot, hb_params = get_harmonic_bond(n_atoms, n_bonds)
+    ha_pot, ha_params = get_harmonic_angle(n_atoms, n_angles)
+    rs_pot, rs_params = get_harmonic_restraints(n_atoms, n_restraints)
+
+    sys_params = [hb_params, ha_params, rs_params]
+    unbound_potentials = [hb_pot, ha_pot, rs_pot]
+
+    masses = np.random.rand(n_atoms)
+
+    box = np.eye(3, dtype=np.float64)
+
+    seed = 2021
+
+    group_idxs = get_group_indices(get_bond_list(hb_pot))
+
+    temperature = 300.0
+    pressure = 1.0
+
+    integrator = LangevinIntegrator(
+        temperature,
+        1.5e-3,
+        1.0,
+        masses,
+        seed
+    )
+
+    barostat = MonteCarloBarostat(
+        x0.shape[0],
+        pressure,
+        temperature,
+        group_idxs,
+        25,
+        seed
+    )
+
+    beta = 0.125
+
+    lambda_schedule = np.linspace(0, 1.0, 4)
+
+    def loss_fn(sys_params):
+
+        endpoint_correct = True
+        mdl = estimator_abfe.FreeEnergyModel(
+            unbound_potentials,
+            endpoint_correct,
+            client,
+            box,
+            x0,
+            v0,
+            integrator,
+            barostat,
+            lambda_schedule,
+            100,
+            100,
+            beta,
+            "test"
+        )
+
+        dG, bar_dG_err, results = estimator_abfe.deltaG(mdl, sys_params)
+
+        return dG**2
+
+
+    for client in [None, CUDAPoolClient(1)]:
+        
+        value_and_grad_fn = jax.value_and_grad(loss_fn)
+        dG, sys_grad = value_and_grad_fn(sys_params) # run fwd, store result, and run bwd
+
+        grad_fn = jax.grad(loss_fn)
+        grad = grad_fn(sys_params)
+
+        assert len(grad) == 3
         assert grad[0].shape == sys_params[0].shape
         assert grad[1].shape == sys_params[1].shape


### PR DESCRIPTION
This PR replaces the old tests for estimator.py (which will soon be deprecated) for estimator_abfe.py instead. This also helped me catch a minor bug in the computation of the derivatives when the endpoint correction is turned on.