### PR TITLE
nblist_debug

### DIFF
--- a/slow_tests/test_benchmark.py
+++ b/slow_tests/test_benchmark.py
@@ -154,7 +154,7 @@ def benchmark(
                 U_fixed = bp.execute_fixed(x, b, lamb)
                 # print(type(U_fixed[0]), U_fixed[0])
                 test_U_fixed += U_fixed
-            print(ref_U[0], FIXED_TO_FLOAT(test_U_fixed), np.abs(ref_U[0] - FIXED_TO_FLOAT(test_U_fixed)), test_U)
+            print(ref_U[0], FIXED_TO_FLOAT(test_U_fixed), np.abs(ref_U[0] - FIXED_TO_FLOAT(test_U_fixed)))
 
         assert 0
         batch_end = time.time()
@@ -291,5 +291,5 @@ def test_hif2a():
 
 if __name__ == "__main__":
 
-    benchmark_dhfr(verbose=False, num_batches=2, steps_per_batch=10000)
+    benchmark_dhfr(verbose=False, num_batches=2, steps_per_batch=1000)
     # benchmark_hif2a(verbose=False, num_batches=100)

--- a/slow_tests/test_benchmark.py
+++ b/slow_tests/test_benchmark.py
@@ -136,10 +136,6 @@ def benchmark(
 
         print(len(us), len(xs), len(boxes))
 
-# template<typename RealType>
-# RealType __host__ __device__ __forceinline__ FIXED_TO_FLOAT(unsigned long long v) {
-    # return static_cast<RealType>(static_cast<long long>(v))/FIXED_EXPONENT;
-# }
         def FIXED_TO_FLOAT(v):
             FIXED_EXPONENT = 0x1000000000
             # print(v, type(v))
@@ -154,7 +150,7 @@ def benchmark(
                 U_fixed = bp.execute_fixed(x, b, lamb)
                 # print(type(U_fixed[0]), U_fixed[0])
                 test_U_fixed += U_fixed
-            print(ref_U[0], FIXED_TO_FLOAT(test_U_fixed), np.abs(ref_U[0] - FIXED_TO_FLOAT(test_U_fixed)))
+            print(ref_U[0], FIXED_TO_FLOAT(test_U_fixed), ref_U[0] == FIXED_TO_FLOAT(test_U_fixed), ref_U[0] == test_U,  FIXED_TO_FLOAT(test_U_fixed) == test_U)
 
         assert 0
         batch_end = time.time()
@@ -291,5 +287,5 @@ def test_hif2a():
 
 if __name__ == "__main__":
 
-    benchmark_dhfr(verbose=False, num_batches=2, steps_per_batch=1000)
+    benchmark_dhfr(verbose=False, num_batches=2, steps_per_batch=10000)
     # benchmark_hif2a(verbose=False, num_batches=100)

--- a/timemachine/cpp/src/context.cu
+++ b/timemachine/cpp/src/context.cu
@@ -220,7 +220,8 @@ std::array<std::vector<double>, 3> Context::multiple_steps_U(
                 for(int w=0; w < n_windows; w++) {
                     // reset buffers on each pass.
                     gpuErrchk(cudaMemsetAsync(d_u_buffer_, 0, N_*sizeof(*d_u_buffer_), stream));
-                    for(int i=0; i < bps_.size(); i++) {
+                    // for(int i=0; i < bps_.size(); i++) {
+                    for(int i=3; i < 4; i++) {
                         bps_[i]->execute_device(
                             N_,
                             d_x_t_,

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -82,7 +82,7 @@ void __global__ k_check_rebuild_coords_and_box(
     double padding,
     int *rebuild) {
 
-    rebuild[0] = 1;
+    // rebuild[0] = 1;
 
     const int idx = blockIdx.x*blockDim.x + threadIdx.x;
 

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -46,7 +46,7 @@ void __global__ k_coords_to_kv(
 
     keys[atom_idx] = bin_to_idx[bin_x*256*256+bin_y*256+bin_z];
     // uncomment below if you want to preserve the atom ordering
-    // keys[atom_idx] = atom_idx;
+    keys[atom_idx] = atom_idx;
     vals[atom_idx] = atom_idx;
 
 }
@@ -82,6 +82,8 @@ void __global__ k_check_rebuild_coords_and_box(
     double padding,
     int *rebuild) {
 
+    rebuild[0] = 1;
+
     const int idx = blockIdx.x*blockDim.x + threadIdx.x;
 
     if(idx < 9) {
@@ -114,6 +116,8 @@ void __global__ k_check_rebuild_coords_and_box(
         // (ytz): this is *safe* but technically is a race condition
         rebuild[0] = 1;
     }
+
+
 
 
 }


### PR DESCRIPTION
run `python slow_tests/test_benchmark` with the following change:

`# rebuild[0] = 1`

Results in:

```
20:58 $ python slow_tests/test_benchmark.py 
10 10 10
-296410.23126922693 -296410.23126922693 0.0
-351723.4265386751 -351723.4265386751 0.0
-354495.6966231485 -354495.6966231485 0.0
-358570.56889335 -358570.56889335 0.0
-354156.2046588351 -354156.2046588351 0.0
-346692.1250566134 -346692.1250566134 0.0
-339979.0699788562 -339979.0699788562 0.0
-337174.4063756148 -337174.4063756148 0.0
-338117.268503869 -338117.268503869 0.0
-339676.1849502132 -339676.1849502132 0.0
```

If we turn off the forced rebuild, we get an entirely different trajectory, and inconsisten results:

```
-296410.23126922693 -296410.23126922693 0.0
-351721.6626151853 -351721.6626151853 0.0
-354506.1504299764 -354506.1504299764 0.0
-358539.97117179225 -358539.97117179225 0.0
-354179.2921922471 -354179.2921922471 0.0
-346548.2187939928 -346548.2187939928 0.0
-339992.23063213256 -339992.23063213256 0.0
-336569.0883504798 -336568.84441707033 0.24393340945243835
-338176.4288818252 -338176.0416050565 0.3872767686843872
-339240.1838250231 -339239.3900046047 0.7938204184174538
```

