### PR TITLE
Bugfix/correctly rebuild nblist#497

### DIFF
--- a/slow_tests/test_benchmark.py
+++ b/slow_tests/test_benchmark.py
@@ -59,7 +59,7 @@ def benchmark(
 
     seed = 1234
     dt = 1.5e-3
-    temperature =300
+    temperature = 300
     pressure = 1.0
     seconds_per_day = 86400
 

--- a/slow_tests/test_determinism.py
+++ b/slow_tests/test_determinism.py
@@ -1,0 +1,113 @@
+import numpy as np
+
+from ff.handlers import openmm_deserializer
+from ff.handlers.deserialize import deserialize_handlers
+from ff import Forcefield
+
+from timemachine.lib import custom_ops, LangevinIntegrator, MonteCarloBarostat
+
+from fe import free_energy
+from fe.topology import SingleTopology
+
+from md import builders, minimizer
+from md.barostat.utils import get_bond_list, get_group_indices
+from testsystems.relative import hif2a_ligand_pair as testsystem
+
+def FIXED_TO_FLOAT(v):
+    FIXED_EXPONENT = 0x1000000000
+    return np.float64(np.int64(v))/FIXED_EXPONENT
+
+def test_deterministic_energies():
+    """Verify that recomputing the energies of frames that have already had energies computed
+    before, will produce the same bitwise identical energy.
+    """
+    seed = 1234
+    dt = 1.5e-3
+    temperature = 300
+    pressure = 1.0
+    barostat_interval = 25
+    mol_a, mol_b, core = testsystem.mol_a, testsystem.mol_b, testsystem.core
+
+    ff_handlers = deserialize_handlers(open('ff/params/smirnoff_1_1_0_sc.py').read())
+    ff = Forcefield(ff_handlers)
+
+    single_topology = SingleTopology(mol_a, mol_b, core, ff)
+    rfe = free_energy.RelativeFreeEnergy(single_topology)
+
+    ff_params = ff.get_ordered_params()
+
+    # build the protein system.
+    complex_system, complex_coords, _, _, complex_box, _ = builders.build_protein_system('tests/data/hif2a_nowater_min.pdb')
+    host_fns, host_masses = openmm_deserializer.deserialize_system(
+        complex_system,
+        cutoff=1.0
+    )
+
+
+    # resolve host clashes
+    min_coords = minimizer.minimize_host_4d([mol_a, mol_b], complex_system, complex_coords, ff, complex_box)
+
+    x0 = min_coords
+    v0 = np.zeros_like(x0)
+
+    harmonic_bond_potential = host_fns[0]
+    bond_list = get_bond_list(harmonic_bond_potential)
+    group_idxs = get_group_indices(bond_list)
+    baro = MonteCarloBarostat(
+        x0.shape[0],
+        pressure,
+        temperature,
+        group_idxs,
+        barostat_interval,
+        seed,
+    )
+
+    intg = LangevinIntegrator(
+        temperature,
+        dt,
+        1.0,
+        np.array(host_masses),
+        seed
+    ).impl()
+
+    for precision, decimals in [(np.float32, 4), (np.float64, 8)]:
+        bps = []
+        unbound_bps = []
+
+        for potential in host_fns:
+            bps.append(potential.bound_impl(precision=precision)) # get the bound implementation
+            unbound_bps.append(potential.unbound_impl(precision))
+
+        for barostat in [None, baro.impl(bps)]:
+            ctxt = custom_ops.Context(
+                x0,
+                v0,
+                complex_box,
+                intg,
+                bps,
+                barostat=barostat
+            )
+            for lamb in [0.0, 0.4, 1.0]:
+                us, xs, boxes = ctxt.multiple_steps_U(
+                    lamb,
+                    200,
+                    np.array([lamb]),
+                    10,
+                    10
+                )
+
+                for ref_U, x, b in zip(us, xs, boxes):
+                    test_u = 0.0
+                    test_u_selective = 0.0
+                    test_U_fixed = np.uint64(0)
+                    for fn, unbound, bp in zip(host_fns, unbound_bps, bps):
+                        U_fixed = bp.execute_fixed(x, b, lamb)
+                        test_U_fixed += U_fixed
+                        _, _, U = bp.execute(x, b, lamb)
+                        test_u += U
+                        _, _, _, U_selective = unbound.execute_selective(x, fn.params, b, lamb, False, False, False, True)
+                        test_u_selective += U_selective
+                    assert ref_U == FIXED_TO_FLOAT(test_U_fixed)
+                    assert test_u == test_u_selective
+                    np.testing.assert_almost_equal(ref_U, test_u, decimal=decimals)
+                    np.testing.assert_almost_equal(ref_U, test_u_selective, decimal=decimals)

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -4,7 +4,6 @@
 #define TILESIZE 32
 #define WARPSIZE 32
 
-
 template<typename RealType>
 void __global__ k_find_block_bounds(
     const int N, // Number of atoms
@@ -13,16 +12,12 @@ void __global__ k_find_block_bounds(
     const double * __restrict__ coords, // [N*3]
     const double * __restrict__ box, // [D*3]
     double *block_bounds_ctr, // [T*3]
-    double *block_bounds_ext, // [T*3]
-    unsigned int * __restrict__ ixn_count, // [1] set to zero if rebuild
-    const int * __restrict__ rebuild // [1]
+    double *block_bounds_ext // [T*3]
 ) {
 
-    if (rebuild[0] <= 0) {
-        return;
-    }
     // Algorithm taken from https://github.com/openmm/openmm/blob/master/platforms/cuda/src/kernels/findInteractingBlocks.cu#L7
     // Computes smaller bounding boxes than simpler form by accounting for periodic box conditions
+
     // each thread processes one tile
     const int index = blockIdx.x*blockDim.x+threadIdx.x;
     if(index >= T) {
@@ -80,9 +75,6 @@ void __global__ k_find_block_bounds(
     block_bounds_ext[index*3+0] = static_cast<RealType>(0.5)*(maxPos_x-minPos_x);
     block_bounds_ext[index*3+1] = static_cast<RealType>(0.5)*(maxPos_y-minPos_y);
     block_bounds_ext[index*3+2] = static_cast<RealType>(0.5)*(maxPos_z-minPos_z);
-
-    // A safe race condition
-    ixn_count[0] = 0;
 }
 
 void __global__ k_compact_trim_atoms(
@@ -91,13 +83,8 @@ void __global__ k_compact_trim_atoms(
     unsigned int* __restrict__ trim_atoms,
     unsigned int* __restrict__ interactionCount,
     int* __restrict__ interactingTiles,
-    unsigned int* __restrict__ interactingAtoms,
-    const int * __restrict__ rebuild // [1]
-) {
+    unsigned int* __restrict__ interactingAtoms) {
 
-    if (rebuild[0] <= 0) {
-        return;
-    }
     __shared__ int ixn_j_buffer[64]; // we can probably get away with using only 32 if we do some fancier remainder tricks, but this isn't a huge save
     ixn_j_buffer[threadIdx.x] = N;
     ixn_j_buffer[WARPSIZE+threadIdx.x] = N;
@@ -179,12 +166,8 @@ void __global__ k_find_blocks_with_ixns(
     int* __restrict__ interactingTiles, // the row block idx of the tile that is interacting
     unsigned int* __restrict__ interactingAtoms, // the col block of the atoms that are interacting
     unsigned int* __restrict__ trim_atoms, // the left-over trims that will later be compacted
-    const double cutoff,
-    const int * __restrict__ rebuild // [1]
-) {
-    if (rebuild[0] <= 0) {
-        return;
-    }
+    const double cutoff) {
+
     const int indexInWarp = threadIdx.x%WARPSIZE;
     const int warpMask = (1<<indexInWarp)-1;
 

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -75,11 +75,11 @@ void __global__ k_check_rebuild_box(
 template <typename RealType>
 void __global__ k_check_rebuild_coords_and_box(
     const int N,
-    const double *new_coords,
-    const double *old_coords,
-    const double *new_box,
-    const double *old_box,
-    double padding,
+    const double * __restrict__ new_coords,
+    const double * __restrict__ old_coords,
+    const double * __restrict__ new_box,
+    const double * __restrict__ old_box,
+    const double padding,
     int *rebuild) {
 
     const int idx = blockIdx.x*blockDim.x + threadIdx.x;
@@ -115,7 +115,32 @@ void __global__ k_check_rebuild_coords_and_box(
         rebuild[0] = 1;
     }
 
+}
 
+template<typename RealType>
+void __global__ k_copy_nblist_coords_and_box(
+    const int N,
+    const int * __restrict__ rebuild,
+    const double * __restrict__ new_coords,
+    const double * __restrict__ new_box,
+    double * __restrict__ nblist_coords,
+    double * __restrict__ nblist_box
+) {
+    if (rebuild[0] <= 0) {
+        return;
+    }
+    const int idx = blockIdx.x*blockDim.x + threadIdx.x;
+
+    if(idx >= N) {
+        return;
+    }
+    if(idx < 9) {
+        nblist_box[idx] = new_box[idx];
+    }
+    #pragma unroll 3
+    for(int i = 0; i < 3; i++) {
+        nblist_coords[idx*3+i] = new_coords[idx*3+i];
+    }
 }
 
 template <typename RealType>

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -89,7 +89,6 @@ void __global__ k_check_rebuild_coords_and_box(
         // we can probably derive a looser bound later on.
         if(old_box[idx] != new_box[idx]) {
             rebuild[0] = 1;
-            return;
         }
     }
 
@@ -448,7 +447,6 @@ template <
 >
 // void __device__ __forceinline__ v_nonbonded_unified(
 void __device__ v_nonbonded_unified(
-    const int tile_idx,
     const int N,
     const double * __restrict__ coords,
     const double * __restrict__ params, // [N]
@@ -467,6 +465,8 @@ void __device__ v_nonbonded_unified(
     unsigned long long * __restrict__ du_dp,
     unsigned long long * __restrict__ du_dl_buffer,
     unsigned long long * __restrict__ u_buffer) {
+
+    int tile_idx = blockIdx.x;
 
     RealType box_x = box[0*3+0];
     RealType box_y = box[1*3+1];
@@ -734,7 +734,6 @@ template <
     bool COMPUTE_DU_DP
 >
 void __global__ k_nonbonded_unified(
-    const unsigned int * ixn_count,
     const int N,
     const double * __restrict__ coords,
     const double * __restrict__ params, // [N]
@@ -750,85 +749,76 @@ void __global__ k_nonbonded_unified(
     unsigned long long * __restrict__ du_dx,
     unsigned long long * __restrict__ du_dp,
     unsigned long long * __restrict__ du_dl_buffer,
-    unsigned long long * __restrict__ u_buffer
-) {
-    const int stride = gridDim.x;
+    unsigned long long * __restrict__ u_buffer) {
+
     int tile_idx = blockIdx.x;
-    const unsigned int interactions = ixn_count[0];
-    while (tile_idx < interactions) {
-        int row_block_idx = ixn_tiles[tile_idx];
-        int atom_i_idx = row_block_idx*32 + threadIdx.x;
+    int row_block_idx = ixn_tiles[tile_idx];
+    int atom_i_idx = row_block_idx*32 + threadIdx.x;
 
-        RealType dq_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+0] : 0;
-        RealType dsig_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+1] : 0;
-        RealType deps_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+2] : 0;
-        RealType cw_i = atom_i_idx < N ? coords_w[atom_i_idx] : 0;
+    RealType dq_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+0] : 0;
+    RealType dsig_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+1] : 0;
+    RealType deps_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+2] : 0;
+    RealType cw_i = atom_i_idx < N ? coords_w[atom_i_idx] : 0;
 
-        int atom_j_idx = ixn_atoms[tile_idx*32 + threadIdx.x];
+    int atom_j_idx = ixn_atoms[tile_idx*32 + threadIdx.x];
 
-        RealType dq_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+0] : 0;
-        RealType dsig_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+1] : 0;
-        RealType deps_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+2] : 0;
-        RealType cw_j = atom_j_idx < N ? coords_w[atom_j_idx] : 0;
+    RealType dq_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+0] : 0;
+    RealType dsig_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+1] : 0;
+    RealType deps_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+2] : 0;
+    RealType cw_j = atom_j_idx < N ? coords_w[atom_j_idx] : 0;
 
-        int is_vanilla = (
-            cw_i == 0 &&
-            dq_dl_i == 0 &&
-            dsig_dl_i == 0 &&
-            deps_dl_i == 0 &&
-            cw_j == 0 &&
-            dq_dl_j == 0 &&
-            dsig_dl_j == 0 &&
-            deps_dl_j == 0
+    int is_vanilla = (
+        cw_i == 0 &&
+        dq_dl_i == 0 &&
+        dsig_dl_i == 0 &&
+        deps_dl_i == 0 &&
+        cw_j == 0 &&
+        dq_dl_j == 0 &&
+        dsig_dl_j == 0 &&
+        deps_dl_j == 0
+    );
+
+    bool tile_is_vanilla = __all_sync(0xffffffff, is_vanilla);
+
+    if(tile_is_vanilla) {
+        v_nonbonded_unified<RealType, 0, COMPUTE_U, COMPUTE_DU_DX, COMPUTE_DU_DL, COMPUTE_DU_DP>(
+            N,
+            coords,
+            params,
+            box,
+            dp_dl,
+            coords_w,
+            dw_dl,
+            lambda,
+            beta,
+            cutoff,
+            ixn_tiles,
+            ixn_atoms,
+            du_dx,
+            du_dp,
+            du_dl_buffer,
+            u_buffer
         );
-
-        bool tile_is_vanilla = __all_sync(0xffffffff, is_vanilla);
-
-        if(tile_is_vanilla) {
-            v_nonbonded_unified<RealType, 0, COMPUTE_U, COMPUTE_DU_DX, COMPUTE_DU_DL, COMPUTE_DU_DP>(
-                tile_idx,
-                N,
-                coords,
-                params,
-                box,
-                dp_dl,
-                coords_w,
-                dw_dl,
-                lambda,
-                beta,
-                cutoff,
-                // ixn_count,
-                ixn_tiles,
-                ixn_atoms,
-                du_dx,
-                du_dp,
-                du_dl_buffer,
-                u_buffer
-            );
-        } else {
-            v_nonbonded_unified<RealType, 1, COMPUTE_U, COMPUTE_DU_DX, COMPUTE_DU_DL, COMPUTE_DU_DP>(
-                tile_idx,
-                N,
-                coords,
-                params,
-                box,
-                dp_dl,
-                coords_w,
-                dw_dl,
-                lambda,
-                beta,
-                cutoff,
-                // ixn_count,
-                ixn_tiles,
-                ixn_atoms,
-                du_dx,
-                du_dp,
-                du_dl_buffer,
-                u_buffer
-            );
-        };
-        tile_idx += stride;
-    }
+    } else {
+        v_nonbonded_unified<RealType, 1, COMPUTE_U, COMPUTE_DU_DX, COMPUTE_DU_DL, COMPUTE_DU_DP>(
+            N,
+            coords,
+            params,
+            box,
+            dp_dl,
+            coords_w,
+            dw_dl,
+            lambda,
+            beta,
+            cutoff,
+            ixn_tiles,
+            ixn_atoms,
+            du_dx,
+            du_dp,
+            du_dl_buffer,
+            u_buffer
+        );
+    };
 
 
 }

--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -76,29 +76,24 @@ void Neighborlist<RealType>::compute_block_bounds_host(
 
     assert(N == N_);
     assert(D == 3);
-    int h_rebuild = 1;
 
     double *d_coords = gpuErrchkCudaMallocAndCopy(h_coords, N*3*sizeof(double));
-    double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3*3*sizeof(double));
-    int *d_rebuild = gpuErrchkCudaMallocAndCopy(&h_rebuild, 1*sizeof(int));
-    cudaStream_t stream = static_cast<cudaStream_t>(0);
+    double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3*3*sizeof(double));  
+   
     this->compute_block_bounds_device(
         N,
         D,
         d_coords,
         d_box,
-        d_rebuild,
-        stream
+        static_cast<cudaStream_t>(0)
     );
-
-    cudaStreamSynchronize(stream);
+    gpuErrchk(cudaDeviceSynchronize());
 
     gpuErrchk(cudaMemcpy(h_bb_ctrs, d_block_bounds_ctr_, this->B()*3*sizeof(*d_block_bounds_ctr_), cudaMemcpyDeviceToHost));
     gpuErrchk(cudaMemcpy(h_bb_exts, d_block_bounds_ext_, this->B()*3*sizeof(*d_block_bounds_ext_), cudaMemcpyDeviceToHost));
 
     gpuErrchk(cudaFree(d_coords));
     gpuErrchk(cudaFree(d_box));
-    gpuErrchk(cudaFree(d_rebuild));
 
 }
 
@@ -111,33 +106,27 @@ std::vector<std::vector<int> > Neighborlist<RealType>::get_nblist_host(
 
     // assert(N==N_);
 
-    int h_rebuild = 1;
-
     double *d_coords = gpuErrchkCudaMallocAndCopy(h_coords, N*3*sizeof(double));
-    double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3*3*sizeof(double));
-    int *d_rebuild = gpuErrchkCudaMallocAndCopy(&h_rebuild, 1*sizeof(int));
+    double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3*3*sizeof(double));    
 
-    cudaStream_t stream = static_cast<cudaStream_t>(0);
     this->build_nblist_device(
         N,
         d_coords,
         d_box,
         cutoff,
-        d_rebuild,
-        stream
+        static_cast<cudaStream_t>(0)
     );
 
-    cudaStreamSynchronize(stream);
-
+    cudaDeviceSynchronize();
     const int B = this->B(); //(N+32-1)/32;
 
     unsigned long long MAX_TILE_BUFFER = B*B;
     unsigned long long MAX_ATOM_BUFFER = B*B*32;
 
     unsigned int h_ixn_count;
+    gpuErrchk(cudaMemcpy(&h_ixn_count, d_ixn_count_, 1*sizeof(*d_ixn_count_), cudaMemcpyDeviceToHost));
     std::vector<int> h_ixn_tiles(MAX_TILE_BUFFER);
     std::vector<unsigned int> h_ixn_atoms(MAX_ATOM_BUFFER);
-    gpuErrchk(cudaMemcpy(&h_ixn_count, d_ixn_count_, 1*sizeof(*d_ixn_count_), cudaMemcpyDeviceToHost));
     gpuErrchk(cudaMemcpy(&h_ixn_tiles[0], d_ixn_tiles_, MAX_TILE_BUFFER*sizeof(int), cudaMemcpyDeviceToHost));
     gpuErrchk(cudaMemcpy(&h_ixn_atoms[0], d_ixn_atoms_, MAX_ATOM_BUFFER*sizeof(unsigned int), cudaMemcpyDeviceToHost));
 
@@ -155,7 +144,6 @@ std::vector<std::vector<int> > Neighborlist<RealType>::get_nblist_host(
 
     gpuErrchk(cudaFree(d_coords));
     gpuErrchk(cudaFree(d_box));
-    gpuErrchk(cudaFree(d_rebuild));
 
     return ixn_list;
 
@@ -167,10 +155,12 @@ void Neighborlist<RealType>::build_nblist_device(
     const double *d_coords,
     const double *d_box,
     const double cutoff,
-    int *d_rebuild_nblist,
     cudaStream_t stream) {
 
     // assert(N == N_);
+
+    // reset the interaction count
+    gpuErrchk(cudaMemsetAsync(d_ixn_count_, 0, 1*sizeof(*d_ixn_count_), stream));
 
     const int D = 3;
     this->compute_block_bounds_device(
@@ -178,11 +168,10 @@ void Neighborlist<RealType>::build_nblist_device(
         D,
         d_coords,
         d_box,
-        d_rebuild_nblist,
         stream
     );
 
-    const int tpb = 32;
+    int tpb = 32;
     const int B = this->B(); // (N+32-1)/32;
     const int Y = this->Y(); // (B+32-1)/32;
 
@@ -199,8 +188,7 @@ void Neighborlist<RealType>::build_nblist_device(
         d_ixn_tiles_,
         d_ixn_atoms_,
         d_trim_atoms_,
-        cutoff,
-        d_rebuild_nblist
+        cutoff
     );
 
     gpuErrchk(cudaPeekAtLastError());
@@ -211,8 +199,7 @@ void Neighborlist<RealType>::build_nblist_device(
         d_trim_atoms_,
         d_ixn_count_,
         d_ixn_tiles_,
-        d_ixn_atoms_,
-        d_rebuild_nblist
+        d_ixn_atoms_
     );
 
     gpuErrchk(cudaPeekAtLastError());
@@ -225,7 +212,6 @@ void Neighborlist<RealType>::compute_block_bounds_device(
     const int D, // Box dimensions
     const double *d_coords, // [N*3]
     const double *d_box, // [D*3]
-    const int * d_rebuild_nblist,
     cudaStream_t stream) {
 
     assert(N == N_);
@@ -241,10 +227,8 @@ void Neighborlist<RealType>::compute_block_bounds_device(
         d_coords,
         d_box,
         d_block_bounds_ctr_,
-        d_block_bounds_ext_,
-        d_ixn_count_,
-        d_rebuild_nblist
-    );	
+        d_block_bounds_ext_
+    );
 
     gpuErrchk(cudaPeekAtLastError());
 

--- a/timemachine/cpp/src/neighborlist.hpp
+++ b/timemachine/cpp/src/neighborlist.hpp
@@ -41,7 +41,6 @@ public:
         const double *d_coords,
         const double *d_box,
         const double cutoff,
-        int *d_rebuild_nblist,
         cudaStream_t stream
     );
 
@@ -83,9 +82,9 @@ private:
         int D,
         const double *coords,
         const double *box,
-        const int *rebuild,
         cudaStream_t stream
     );
+
 
 };
 

--- a/timemachine/cpp/src/nonbonded.cu
+++ b/timemachine/cpp/src/nonbonded.cu
@@ -18,9 +18,6 @@
 #include <fstream>
 #include <streambuf>
 
-#define NONBONDED_KERNEL_BLOCKS 8192
-#define HILBERT_SORT_INTERVAL 100
-
 namespace timemachine {
 
 template <typename RealType, bool Interpolated>
@@ -41,7 +38,6 @@ Nonbonded<RealType, Interpolated>::Nonbonded(
     E_(exclusion_idxs.size()/2),
     nblist_(lambda_offset_idxs.size()),
     beta_(beta),
-    cur_step_(0),
     d_sort_storage_(nullptr),
     d_sort_storage_bytes_(0),
     nblist_padding_(0.1),
@@ -115,11 +111,14 @@ Nonbonded<RealType, Interpolated>::Nonbonded(
     gpuErrchk(cudaMalloc(&d_scales_, E_*2*sizeof(*d_scales_)));
     gpuErrchk(cudaMemcpy(d_scales_, &scales[0], E_*2*sizeof(*d_scales_), cudaMemcpyHostToDevice));
 
+    gpuErrchk(cudaMallocHost(&p_ixn_count_, 1*sizeof(*p_ixn_count_)));
+
     gpuErrchk(cudaMalloc(&d_nblist_x_, N_*3*sizeof(*d_nblist_x_)));
     gpuErrchk(cudaMemset(d_nblist_x_, 0, N_*3*sizeof(*d_nblist_x_))); // set non-sensical positions
     gpuErrchk(cudaMalloc(&d_nblist_box_, 3*3*sizeof(*d_nblist_x_)));
     gpuErrchk(cudaMemset(d_nblist_box_, 0, 3*3*sizeof(*d_nblist_x_)));
     gpuErrchk(cudaMalloc(&d_rebuild_nblist_, 1*sizeof(*d_rebuild_nblist_)));
+    gpuErrchk(cudaMallocHost(&p_rebuild_nblist_, 1*sizeof(*p_rebuild_nblist_)));
 
     gpuErrchk(cudaMalloc(&d_sort_keys_in_, N_*sizeof(d_sort_keys_in_)));
     gpuErrchk(cudaMalloc(&d_sort_keys_out_, N_*sizeof(d_sort_keys_out_)));
@@ -191,9 +190,12 @@ Nonbonded<RealType, Interpolated>::~Nonbonded() {
     gpuErrchk(cudaFree(d_sort_vals_in_));
     gpuErrchk(cudaFree(d_sort_storage_));
 
+    gpuErrchk(cudaFreeHost(p_ixn_count_));
+
     gpuErrchk(cudaFree(d_nblist_x_));
     gpuErrchk(cudaFree(d_nblist_box_));
     gpuErrchk(cudaFree(d_rebuild_nblist_));
+    gpuErrchk(cudaFreeHost(p_rebuild_nblist_));
 };
 
 
@@ -280,8 +282,7 @@ void Nonbonded<RealType, Interpolated>::execute_device(
         std::cout << N << " " << N_ << std::endl;
         throw std::runtime_error("Nonbonded::execute_device() N != N_");
     }
-    bool sort_indices = cur_step_ == 0;
-    cur_step_ = (cur_step_ + 1) % HILBERT_SORT_INTERVAL; // How often to sort
+
     const int M = Interpolated ? 2 : 1;
 
     if(P != M*N_*3) {
@@ -295,54 +296,56 @@ void Nonbonded<RealType, Interpolated>::execute_device(
     const int B = (N+tpb-1)/tpb;
 
     dim3 dimGrid(B, 3, 1);
-    // If we have to sort, we also have to rebuild the neighborlist
-    if (sort_indices) {
+
+    // (ytz) see if we need to rebuild the neighborlist.
+    // (ytz + jfass): note that this logic needs to change if we use NPT later on since a resize in the box
+    // can introduce new interactions.
+    k_check_rebuild_coords_and_box<RealType><<<B, tpb, 0, stream>>>(
+        N,
+        d_x,
+        d_nblist_x_,
+        d_box,
+        d_nblist_box_,
+        nblist_padding_,
+        d_rebuild_nblist_
+    );
+    gpuErrchk(cudaPeekAtLastError());
+
+    // we can optimize this away by doing the check on the GPU directly.
+    gpuErrchk(cudaMemcpyAsync(p_rebuild_nblist_, d_rebuild_nblist_, 1*sizeof(*p_rebuild_nblist_), cudaMemcpyDeviceToHost, stream));
+    gpuErrchk(cudaStreamSynchronize(stream)); // slow!
+
+    if(p_rebuild_nblist_[0] > 0) {
+
+        // (ytz): update the permutation index before building neighborlist, as the neighborlist is tied
+        // to a particular sort order
         if(!disable_hilbert_) {
             this->hilbert_sort(d_x, d_box, stream);
         } else {
             k_arange<<<B, tpb, 0, stream>>>(N, d_perm_);
             gpuErrchk(cudaPeekAtLastError());
         }
-        // Indicate that the neighborlist must be rebuilt
-        gpuErrchk(cudaMemsetAsync(d_rebuild_nblist_, 1, 1*sizeof(*d_rebuild_nblist_), stream));
-    } else {
-        // (ytz) see if we need to rebuild the neighborlist.
-        // (ytz + jfass): note that this logic could be optimized when using NPT is
-        // enabled since a resize in the box can introduce new interactions.
-        k_check_rebuild_coords_and_box<RealType><<<B, tpb, 0, stream>>>(
+
+        // compute new coordinates, new lambda_idxs, new_plane_idxs
+        k_permute<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_x, d_sorted_x_);
+        gpuErrchk(cudaPeekAtLastError());
+        nblist_.build_nblist_device(
             N,
-            d_x,
-            d_nblist_x_,
+            d_sorted_x_,
             d_box,
-            d_nblist_box_,
-            nblist_padding_,
-            d_rebuild_nblist_
+            cutoff_+nblist_padding_,
+            stream
         );
+        gpuErrchk(cudaMemsetAsync(d_rebuild_nblist_, 0, sizeof(*d_rebuild_nblist_), stream));
+        gpuErrchk(cudaMemcpyAsync(p_ixn_count_, nblist_.get_ixn_count(), 1*sizeof(*p_ixn_count_), cudaMemcpyDeviceToHost, stream));
+        gpuErrchk(cudaMemcpyAsync(d_nblist_x_, d_x, N*3*sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
+        gpuErrchk(cudaMemcpyAsync(d_nblist_box_, d_box, 3*3*sizeof(*d_box), cudaMemcpyDeviceToDevice, stream));
+        gpuErrchk(cudaStreamSynchronize(stream));
+
+    } else {
+        k_permute<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_x, d_sorted_x_);
         gpuErrchk(cudaPeekAtLastError());
     }
-
-    // compute new coordinates, new lambda_idxs, new_plane_idxs
-    k_permute<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_x, d_sorted_x_);
-    gpuErrchk(cudaPeekAtLastError());
-    nblist_.build_nblist_device(
-        N,
-        d_sorted_x_,
-        d_box,
-        cutoff_+nblist_padding_,
-        d_rebuild_nblist_,
-        stream
-    );
-    // Cache the nblist coords/box if rebuilt
-    k_copy_nblist_coords_and_box<RealType><<<B, tpb, 0, stream>>>(
-        N,
-        d_rebuild_nblist_,
-        d_x,
-        d_box,
-        d_nblist_x_,
-        d_nblist_box_
-    );
-    gpuErrchk(cudaPeekAtLastError());
-    gpuErrchk(cudaMemsetAsync(d_rebuild_nblist_, 0, sizeof(*d_rebuild_nblist_), stream));
 
     // do parameter interpolation here
     if(Interpolated) {
@@ -364,6 +367,7 @@ void Nonbonded<RealType, Interpolated>::execute_device(
         gpuErrchk(cudaMemsetAsync(d_sorted_dp_dl_, 0, N*3*sizeof(*d_sorted_dp_dl_), stream))
     }
 
+    // this stream needs to be synchronized so we can be sure that p_ixn_count_ is properly set.
     // reset buffers and sorted accumulators
     if(d_du_dx) {
 	    gpuErrchk(cudaMemsetAsync(d_sorted_du_dx_, 0, N*3*sizeof(*d_sorted_du_dx_), stream))
@@ -398,8 +402,8 @@ void Nonbonded<RealType, Interpolated>::execute_device(
     kernel_idx |= d_du_dl ? 1 << 1 : 0;
     kernel_idx |= d_du_dx ? 1 << 2 : 0;
     kernel_idx |= d_u ? 1 << 3 : 0;
-    kernel_ptrs_[kernel_idx]<<<NONBONDED_KERNEL_BLOCKS, tpb, 0, stream>>>(
-        nblist_.get_ixn_count(),
+
+    kernel_ptrs_[kernel_idx]<<<p_ixn_count_[0], tpb, 0, stream>>>(
         N,
         d_sorted_x_,
         d_sorted_p_,

--- a/timemachine/cpp/src/nonbonded.hpp
+++ b/timemachine/cpp/src/nonbonded.hpp
@@ -8,9 +8,7 @@
 
 namespace timemachine {
 
-typedef void (*k_nonbonded_fn)(
-    const unsigned int * ixn_count,
-    const int N,
+typedef void (*k_nonbonded_fn)(const int N,
     const double * __restrict__ coords,
     const double * __restrict__ params, // [N]
     const double * __restrict__ box,
@@ -38,10 +36,10 @@ private:
     double *d_scales_; // [E, 2]
     int *d_lambda_plane_idxs_;
     int *d_lambda_offset_idxs_;
+    int *p_ixn_count_; // pinned memory
 
     double beta_;
     double cutoff_;
-    unsigned int cur_step_;
     Neighborlist<RealType> nblist_;
 
     const int E_;
@@ -51,6 +49,7 @@ private:
     double *d_nblist_x_; // coords which were used to compute the nblist
     double *d_nblist_box_; // box which was used to rebuild the nblist
     int *d_rebuild_nblist_; // whether or not we have to rebuild the nblist
+    int *p_rebuild_nblist_; // pinned
 
     unsigned int *d_perm_; // hilbert curve permutation
 


### PR DESCRIPTION
This reverts the performance 'improvements' previously added. This is due to the improvements being broken and once fixed half the speed of the old implementation.

Benchmarks run on RTX-2080

With Correct NBlist construction
dhfr-apo: N=23558 speed: 94.61ns/day dt: 1.5fs (ran 100000 steps in 136.99s)
dhfr-apo-barostat-interval-25: N=23558 speed: 84.47ns/day dt: 1.5fs (ran 100000 steps in 153.43s)
dhfr-apo-hmr-barostat-interval-25: N=23558 speed: 130.61ns/day dt: 2.5fs (ran 100000 steps in 165.39s)
building a protein system with 1758 protein atoms and 7047 water atoms
WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
hif2a-apo: N=8805 speed: 272.56ns/day dt: 1.5fs (ran 100000 steps in 47.55s)
hif2a-apo-barostat-interval-25: N=8805 speed: 240.92ns/day dt: 1.5fs (ran 100000 steps in 53.80s)
hif2a-rbfe-with-du-dp: N=8840 speed: 208.05ns/day dt: 1.5fs (ran 100000 steps in 62.30s)
hif2a-rbfe-du-dl-interval-0: N=8840 speed: 209.36ns/day dt: 1.5fs (ran 100000 steps in 61.91s)
hif2a-rbfe-du-dl-interval-1: N=8840 speed: 205.70ns/day dt: 1.5fs (ran 100000 steps in 63.01s)
hif2a-rbfe-du-dl-interval-5: N=8840 speed: 206.87ns/day dt: 1.5fs (ran 100000 steps in 62.66s)
solvent-apo: N=6282 speed: 321.25ns/day dt: 1.5fs (ran 100000 steps in 40.35s)
solvent-apo-barostat-interval-25: N=6282 speed: 303.82ns/day dt: 1.5fs (ran 100000 steps in 42.66s)
solvent-rbfe-with-du-dp: N=6317 speed: 248.18ns/day dt: 1.5fs (ran 100000 steps in 52.23s)
solvent-rbfe-du-dl-interval-0: N=6317 speed: 251.27ns/day dt: 1.5fs (ran 100000 steps in 51.58s)
solvent-rbfe-du-dl-interval-1: N=6317 speed: 245.98ns/day dt: 1.5fs (ran 100000 steps in 52.69s)
solvent-rbfe-du-dl-interval-5: N=6317 speed: 250.34ns/day dt: 1.5fs (ran 100000 steps in 51.78s)

With Correct and Revert
dhfr-apo: N=23558 speed: 201.00ns/day dt: 1.5fs (ran 100000 steps in 64.48s)
dhfr-apo-barostat-interval-25: N=23558 speed: 182.92ns/day dt: 1.5fs (ran 100000 steps in 70.86s)
dhfr-apo-hmr-barostat-interval-25: N=23558 speed: 300.64ns/day dt: 2.5fs (ran 100000 steps in 71.85s)
building a protein system with 1758 protein atoms and 7047 water atoms
WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
hif2a-apo: N=8805 speed: 435.90ns/day dt: 1.5fs (ran 100000 steps in 29.74s)
hif2a-apo-barostat-interval-25: N=8805 speed: 380.25ns/day dt: 1.5fs (ran 100000 steps in 34.09s)
hif2a-rbfe-with-du-dp: N=8840 speed: 328.36ns/day dt: 1.5fs (ran 100000 steps in 39.48s)
hif2a-rbfe-du-dl-interval-0: N=8840 speed: 314.36ns/day dt: 1.5fs (ran 100000 steps in 41.23s)
hif2a-rbfe-du-dl-interval-1: N=8840 speed: 322.16ns/day dt: 1.5fs (ran 100000 steps in 40.23s)
hif2a-rbfe-du-dl-interval-5: N=8840 speed: 334.52ns/day dt: 1.5fs (ran 100000 steps in 38.75s)
solvent-apo: N=6282 speed: 557.64ns/day dt: 1.5fs (ran 100000 steps in 23.25s)
solvent-apo-barostat-interval-25: N=6282 speed: 510.07ns/day dt: 1.5fs (ran 100000 steps in 25.41s)
solvent-rbfe-with-du-dp: N=6317 speed: 427.47ns/day dt: 1.5fs (ran 100000 steps in 30.32s)
solvent-rbfe-du-dl-interval-0: N=6317 speed: 426.32ns/day dt: 1.5fs (ran 100000 steps in 30.40s)
solvent-rbfe-du-dl-interval-1: N=6317 speed: 419.75ns/day dt: 1.5fs (ran 100000 steps in 30.88s)
solvent-rbfe-du-dl-interval-5: N=6317 speed: 427.40ns/day dt: 1.5fs (ran 100000 steps in 30.33s)