### PR TITLE
Clean up Parallel Config and Return Float 32

### DIFF
--- a/fe/estimator.py
+++ b/fe/estimator.py
@@ -176,7 +176,7 @@ def simulate(lamb, box, x0, v0, final_potentials, integrator, equil_steps, prod_
     for obs in du_dp_obs:
         grads.append(obs.avg_du_dp())
 
-    result = SimulationResult(xs=xs, du_dls=full_du_dls, du_dps=grads)
+    result = SimulationResult(xs=xs.astype("float32"), du_dls=full_du_dls, du_dps=grads)
     return result
 
 

--- a/fe/estimator_abfe.py
+++ b/fe/estimator_abfe.py
@@ -154,8 +154,8 @@ def simulate(lamb, box, x0, v0, final_potentials, integrator, barostat, equil_st
         grads.append(obs.avg_du_dp())
 
     result = SimulationResult(
-        xs=xs,
-        boxes=boxes,
+        xs=xs.astype("float32"),
+        boxes=boxes.astype("float32"),
         du_dps=grads,
         lambda_us=full_us,
     )

--- a/parallel/client.py
+++ b/parallel/client.py
@@ -9,6 +9,7 @@ import grpc
 
 from parallel import service_pb2_grpc, service_pb2
 from parallel.utils import get_gpu_count
+from parallel.constants import DEFAULT_GRPC_OPTIONS
 
 from concurrent import futures
 
@@ -185,10 +186,7 @@ class GRPCClient(AbstractClient):
         self.hosts = self._prepare_hosts(hosts, default_port)
         self.stubs = []
         if options is None:
-            options = [
-                ('grpc.max_send_message_length', 1024 * 1024 * 1024),
-                ('grpc.max_receive_message_length', 1024 * 1024 * 1024)
-            ]
+            options = DEFAULT_GRPC_OPTIONS
         for host in self.hosts:
             channel = grpc.insecure_channel(
                 host,

--- a/parallel/constants.py
+++ b/parallel/constants.py
@@ -1,0 +1,5 @@
+
+DEFAULT_GRPC_OPTIONS = [
+    ('grpc.max_send_message_length', 1024 * 1024 * 1024),
+    ('grpc.max_receive_message_length', 1024 * 1024 * 1024)
+]

--- a/parallel/worker.py
+++ b/parallel/worker.py
@@ -8,9 +8,9 @@ import logging
 import pickle
 from concurrent import futures
 
-from parallel import service_pb2
-from parallel import service_pb2_grpc
+from parallel import service_pb2, service_pb2_grpc
 from parallel.utils import get_worker_status
+from parallel.constants import DEFAULT_GRPC_OPTIONS
 
 import grpc
 
@@ -33,12 +33,7 @@ class Worker(service_pb2_grpc.WorkerServicer):
 
 def serve(args):
 
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1),
-        options = [
-            ('grpc.max_send_message_length', 1024 * 1024 * 1024),
-            ('grpc.max_receive_message_length', 1024 * 1024 * 1024)
-        ]
-    )
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1), options=DEFAULT_GRPC_OPTIONS)
     service_pb2_grpc.add_WorkerServicer_to_server(Worker(), server)
     server.add_insecure_port('[::]:'+str(args.port))
     server.start()


### PR DESCRIPTION
* Returns float32 from workers, reducing network overhead
* Makes server/client GRPC consistent.