### PR TITLE
Task/write out npz rather than xtc

### DIFF
--- a/fe/model_rabfe.py
+++ b/fe/model_rabfe.py
@@ -151,37 +151,24 @@ class AbsoluteModel(ABC):
 
         dG, dG_err, results = estimator_abfe.deltaG(model, sys_params)
 
-        # uncomment if we want to visualize
+        # Save out the pdb
         combined_topology = model_utils.generate_imaged_topology(
             [self.host_topology, mol],
             x0,
             box0,
-            "initial_"+prefix+".pdb"
+            f"initial_{prefix}.pdb"
         )
 
         for lambda_idx, res in enumerate(results):
-            # used for debugging for now, try to reproduce mdtraj error
-            # outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
-            # pickle.dump((res.xs, res.boxes, combined_topology), outfile)
-            traj = mdtraj.Trajectory(res.xs, mdtraj.Topology.from_openmm(combined_topology))
-            traj.unitcell_vectors = res.boxes
-            traj.save_xtc("initial_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".xtc")
+            np.savez(
+                f"initial_{prefix}_lambda_idx_{lambda_idx}.npz",
+                xs=res.xs,
+                boxes=res.boxes,
+                du_dps=res.du_dps,
+                lambda_us=res.lambda_us,
+            )
     
         return dG, dG_err
-
-        # disabled since image molecules is broken.
-        for idx, result in enumerate(results):
-            traj = mdtraj.Trajectory(result.xs, mdtraj.Topology.from_openmm(combined_topology))
-            unit_cell = np.repeat(self.host_box[None, :], len(result.xs), axis=0)
-            traj.unitcell_vectors = unit_cell
-            traj.image_molecules()
-            traj.save_xtc("complex_lambda_"+str(idx)+".xtc")
-
-        np.savez("results.npz", results=results)
-
-        assert 0
-
-        return dG, results
 
 
 
@@ -304,20 +291,22 @@ class RelativeModel(ABC):
 
         dG, dG_err, results = estimator_abfe.deltaG(model, sys_params)
 
-        # uncomment if we want to visualize.
+        # Save out the pdb
         combined_topology = model_utils.generate_imaged_topology(
             [self.host_topology, mol_a, mol_b],
             x0,
             box0,
-            "initial_"+prefix+".pdb"
+            f"initial_{prefix}.pdb"
         )
 
         for lambda_idx, res in enumerate(results):
-            # outfile = open("pickle_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".pkl", "wb")
-            # pickle.dump((res.xs, res.boxes, combined_topology), outfile)
-            traj = mdtraj.Trajectory(res.xs, mdtraj.Topology.from_openmm(combined_topology))
-            traj.unitcell_vectors = res.boxes
-            traj.save_xtc("initial_"+prefix+"_lambda_idx_" + str(lambda_idx) + ".xtc")
+            np.savez(
+                f"initial_{prefix}_lambda_idx_{lambda_idx}.npz",
+                xs=res.xs,
+                boxes=res.boxes,
+                du_dps=res.du_dps,
+                lambda_us=res.lambda_us,
+            )
 
         return dG, dG_err, results
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,8 +1,11 @@
+import os
 import unittest
 import numpy as np
 import jax
 import jax.numpy as jnp
 import functools
+import contextlib
+from tempfile import TemporaryDirectory
 from timemachine.constants import ONE_4PI_EPS0
 import timemachine
 from pathlib import Path
@@ -16,6 +19,16 @@ from hilbertcurve.hilbertcurve import HilbertCurve
 
 import itertools
 
+
+@contextlib.contextmanager
+def temporary_working_dir():
+    init_dir = os.getcwd()
+    with TemporaryDirectory() as temp:
+        try:
+            os.chdir(temp)
+            yield temp
+        finally:
+            os.chdir(init_dir)
 
 def get_110_ccc_ff():
     root = Path(timemachine.__file__).parent.parent

--- a/tests/test_rabfe.py
+++ b/tests/test_rabfe.py
@@ -1,0 +1,151 @@
+import os
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+import numpy as np
+
+from md import builders, minimizer
+from fe.model_rabfe import RelativeBindingModel, AbsoluteConversionModel
+from fe.free_energy import construct_lambda_schedule
+from fe.free_energy_rabfe import setup_relative_restraints_by_distance, get_romol_conf
+from timemachine.potentials import rmsd
+from testsystems.relative import hif2a_ligand_pair
+
+from parallel.client import CUDAPoolClient
+from parallel.utils import get_gpu_count
+
+from common import temporary_working_dir
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+NUM_GPUS = get_gpu_count()
+
+
+class TestRABFEModels(TestCase):
+
+    def test_predict_complex_decouple(self):
+        """Just to verify that we can handle the most basic complex decoupling RABFE prediction"""
+        complex_system, complex_coords, _, _, complex_box, complex_topology = builders.build_protein_system(
+            os.path.join(DATA_DIR, "hif2a_nowater_min.pdb")
+        )
+
+        # build the water system
+        solvent_system, solvent_coords, solvent_box, _ = builders.build_water_system(4.0)
+
+        temperature = 300.0
+        pressure = 1.0
+        dt = 2.5e-3
+
+        client = CUDAPoolClient(NUM_GPUS)
+
+        model = RelativeBindingModel(
+            client,
+            hif2a_ligand_pair.ff,
+            complex_system,
+            construct_lambda_schedule(2),
+            complex_topology,
+            temperature,
+            pressure,
+            dt,
+            10,
+            50,
+        )
+        mol_a = hif2a_ligand_pair.mol_a
+        mol_b = hif2a_ligand_pair.mol_b
+
+        core_idxs = setup_relative_restraints_by_distance(mol_a, mol_b)
+
+        ref_coords = get_romol_conf(mol_a)
+        mol_coords = get_romol_conf(mol_b) # original coords
+
+        # Align using core_idxs
+        R, t = rmsd.get_optimal_rotation_and_translation(
+            x1=ref_coords[core_idxs[:, 1]], # reference core atoms
+            x2=mol_coords[core_idxs[:, 0]], # mol core atoms
+        )
+
+        aligned_mol_coords = rmsd.apply_rotation_and_translation(mol_coords, R, t)
+        complex_coords = minimizer.minimize_host_4d(
+            [mol_a, mol_b],
+            complex_system,
+            complex_coords,
+            hif2a_ligand_pair.ff,
+            complex_box,
+            [ref_coords, aligned_mol_coords]
+        )
+        complex_x0 = np.concatenate([complex_coords, ref_coords, aligned_mol_coords])
+
+        ordered_params = hif2a_ligand_pair.ff.get_ordered_params()
+        with temporary_working_dir() as temp_dir:
+            dG, dG_err = model.predict(ordered_params, mol_a, mol_b, core_idxs, complex_x0, complex_box, "prefix")
+            self.assertIsInstance(dG, float)
+            self.assertIsInstance(dG_err, float)
+            created_files = os.listdir(temp_dir)
+            # 3 npz, 1 pdb and 1 npy per mol due to a->b and b->a
+            self.assertEqual(len(created_files), 10)
+            self.assertEqual(len([x for x in created_files if x.endswith(".pdb")]), 2)
+            self.assertEqual(len([x for x in created_files if x.endswith(".npy")]), 2)
+            self.assertEqual(len([x for x in created_files if x.endswith(".npz")]), 6)
+
+    def test_predict_complex_conversion(self):
+        """Just to verify that we can handle the most basic complex conversion RABFE prediction"""
+        complex_system, complex_coords, _, _, complex_box, complex_topology = builders.build_protein_system(
+            os.path.join(DATA_DIR, "hif2a_nowater_min.pdb")
+        )
+
+        # build the water system
+        solvent_system, solvent_coords, solvent_box, _ = builders.build_water_system(4.0)
+
+        temperature = 300.0
+        pressure = 1.0
+        dt = 2.5e-3
+
+        client = CUDAPoolClient(NUM_GPUS)
+
+        model = AbsoluteConversionModel(
+            client,
+            hif2a_ligand_pair.ff,
+            complex_system,
+            construct_lambda_schedule(2),
+            complex_topology,
+            temperature,
+            pressure,
+            dt,
+            10,
+            50,
+        )
+        mol_a = hif2a_ligand_pair.mol_a
+        mol_b = hif2a_ligand_pair.mol_b
+
+        core_idxs = setup_relative_restraints_by_distance(mol_a, mol_b)
+
+        ref_coords = get_romol_conf(mol_a)
+        mol_coords = get_romol_conf(mol_b) # original coords
+
+        # Use core_idxs to generate
+        R, t = rmsd.get_optimal_rotation_and_translation(
+            x1=ref_coords[core_idxs[:, 1]], # reference core atoms
+            x2=mol_coords[core_idxs[:, 0]], # mol core atoms
+        )
+
+        aligned_mol_coords = rmsd.apply_rotation_and_translation(mol_coords, R, t)
+        complex_coords = minimizer.minimize_host_4d(
+            [mol_b],
+            complex_system,
+            complex_coords,
+            hif2a_ligand_pair.ff,
+            complex_box,
+            [aligned_mol_coords]
+        )
+        complex_x0 = np.concatenate([complex_coords, aligned_mol_coords])
+
+        ordered_params = hif2a_ligand_pair.ff.get_ordered_params()
+        with temporary_working_dir() as temp_dir:
+            dG, dG_err = model.predict(ordered_params, mol_b, complex_x0, complex_box, "prefix", core_idxs=core_idxs[:, 0])
+            self.assertIsInstance(dG, float)
+            self.assertIsInstance(dG_err, float)
+            created_files = os.listdir(temp_dir)
+            # 2 npz, 1 pdb and 1 npy per mol due to a->b and b->a
+            self.assertEqual(len(created_files), 4)
+            self.assertEqual(len([x for x in created_files if x.endswith(".pdb")]), 1)
+            self.assertEqual(len([x for x in created_files if x.endswith(".npy")]), 1)
+            self.assertEqual(len([x for x in created_files if x.endswith(".npz")]), 2)


### PR DESCRIPTION
Writes out results as NPZ (uncompressed)

Adds tests for the complex RABFE models to verify the change. About 80 seconds, on RTX 2080, will see how long it takes on T4s. Can move to slow tests/ if that seems like a better place.