### PR TITLE
Revert "Ensure that clients queue messages for GRPC"

### DIFF
--- a/parallel/worker.py
+++ b/parallel/worker.py
@@ -33,11 +33,7 @@ class Worker(service_pb2_grpc.WorkerServicer):
 
 def serve(args):
 
-    server = grpc.server(
-        futures.ThreadPoolExecutor(max_workers=1),
-        options=DEFAULT_GRPC_OPTIONS,
-        maximum_concurrent_rpcs=1
-    )
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1), options=DEFAULT_GRPC_OPTIONS)
     service_pb2_grpc.add_WorkerServicer_to_server(Worker(), server)
     server.add_insecure_port('[::]:'+str(args.port))
     server.start()


### PR DESCRIPTION
This reverts commit a04df76aa4ee6a4c4562ec46208ada14621506b9.


Does not trigger queuing on the client side as I had misinterpreted. Verified this works using a hif2a simulation