### PR TITLE
Context::set_x_t

### DIFF
--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -2,9 +2,8 @@ import unittest
 from itertools import product
 
 import numpy as np
-from jax.config import config
 
-config.update("jax_enable_x64", True)
+from jax.config import config; config.update("jax_enable_x64", True)
 import jax
 from jax import grad, numpy as jnp, jit
 
@@ -14,8 +13,8 @@ from timemachine.integrator import langevin_coefficients, LangevinIntegrator
 
 from common import prepare_nb_system
 
-
 class TestContext(unittest.TestCase):
+
     def test_set_and_get(self):
         """
         This test the setters and getters in the context.
@@ -79,7 +78,7 @@ class TestContext(unittest.TestCase):
         N = 8
         D = 3
 
-        x0 = np.random.rand(N, D).astype(dtype=np.float64) * 2
+        x0 = np.random.rand(N,D).astype(dtype=np.float64)*2
 
         E = 2
 
@@ -92,7 +91,8 @@ class TestContext(unittest.TestCase):
             lambda_plane_idxs,
             lambda_offset_idxs,
             p_scale=3.0,
-            cutoff=1.0,
+            # cutoff=0.5,
+            cutoff=1.0
         )
 
         masses = np.random.rand(N)
@@ -109,9 +109,14 @@ class TestContext(unittest.TestCase):
         assert (ccs == 0).all()
 
         lamb = np.random.rand()
-        lambda_windows = np.array([lamb + 0.05, lamb, lamb - 0.05])
+        lambda_us = []
+        lambda_windows = np.array([lamb+0.05, lamb, lamb-0.05])
 
-        def integrate_once_through(x_t, v_t, box, params):
+        def integrate_once_through(
+            x_t,
+            v_t,
+            box,
+            params):
 
             dU_dx_fn = jax.grad(ref_nrg_fn, argnums=(0,))
             dU_dp_fn = jax.grad(ref_nrg_fn, argnums=(1,))
@@ -149,24 +154,34 @@ class TestContext(unittest.TestCase):
                 # note that we do not calculate the du_dl of the last frame.
             return all_xs, all_du_dxs, all_du_dps, all_du_dls, all_us, all_lambda_us
 
-        box = np.eye(3) * 3.0
+        box = np.eye(3)*3.0
 
         # when we have multiple parameters, we need to set this up correctly
-        (
-            ref_all_xs,
-            ref_all_du_dxs,
-            ref_all_du_dps,
-            ref_all_du_dls,
-            _,
-            ref_all_lambda_us,
-        ) = integrate_once_through(x0, v0, box, params)
+        ref_all_xs, ref_all_du_dxs, ref_all_du_dps, ref_all_du_dls, ref_all_us, ref_all_lambda_us = integrate_once_through(
+            x0,
+            v0,
+            box,
+            params
+        )
 
-        intg = custom_ops.LangevinIntegrator(dt, ca, cbs, ccs, 1234)
+        intg = custom_ops.LangevinIntegrator(
+            dt,
+            ca,
+            cbs,
+            ccs,
+            1234
+        )
 
         bp = test_nrg.bind(params).bound_impl(precision=np.float64)
         bps = [bp]
 
-        ctxt = custom_ops.Context(x0, v0, box, intg, bps)
+        ctxt = custom_ops.Context(
+            x0,
+            v0,
+            box,
+            intg,
+            bps
+        )
 
         test_obs = custom_ops.AvgPartialUPartialParam(bp, 1)
         test_obs_f2 = custom_ops.AvgPartialUPartialParam(bp, 2)
@@ -187,23 +202,19 @@ class TestContext(unittest.TestCase):
                 # Until we have run 3 steps, std is 0
                 test_std_du_dp = test_obs.std_du_dp()
 
-                np.testing.assert_array_equal(
-                    test_std_du_dp[:, 0], ref_init_du_dps[:, 0]
-                )
-                np.testing.assert_array_equal(
-                    test_std_du_dp[:, 1], ref_init_du_dps[:, 1]
-                )
-                np.testing.assert_array_equal(
-                    test_std_du_dp[:, 2], ref_init_du_dps[:, 2]
-                )
+                np.testing.assert_array_equal(test_std_du_dp[:, 0], ref_init_du_dps[:, 0])
+                np.testing.assert_array_equal(test_std_du_dp[:, 1], ref_init_du_dps[:, 1])
+                np.testing.assert_array_equal(test_std_du_dp[:, 2], ref_init_du_dps[:, 2])
             print("comparing step", step)
             test_x_t = ctxt.get_x_t()
             np.testing.assert_allclose(test_x_t, ref_all_xs[step])
             ctxt.step(lamb)
+            test_v_t = ctxt.get_v_t()
             test_du_dx_t = ctxt._get_du_dx_t_minus_1()
             # test_u_t = ctxt._get_u_t_minus_1()
             # np.testing.assert_allclose(test_u_t, ref_all_us[step])
             np.testing.assert_allclose(test_du_dx_t, ref_all_du_dxs[step])
+
 
         ref_avg_du_dps = np.mean(ref_all_du_dps, axis=0)
         ref_std_du_dps = np.std(ref_all_du_dps, axis=0)
@@ -211,42 +222,40 @@ class TestContext(unittest.TestCase):
         # the fixed point accumulator makes it hard to converge some of these
         # if the derivative is super small - in which case they probably don't matter
         # anyways
-        np.testing.assert_allclose(
-            test_obs.avg_du_dp()[:, 0], ref_avg_du_dps[:, 0], 1.5e-6
-        )
-        np.testing.assert_allclose(
-            test_obs.avg_du_dp()[:, 1], ref_avg_du_dps[:, 1], 1.5e-6
-        )
-        np.testing.assert_allclose(
-            test_obs.avg_du_dp()[:, 2], ref_avg_du_dps[:, 2], 5e-5
-        )
+        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 0], ref_avg_du_dps[:, 0], 1.5e-6)
+        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 1], ref_avg_du_dps[:, 1], 1.5e-6)
+        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 2], ref_avg_du_dps[:, 2], 5e-5)
 
-        np.testing.assert_allclose(
-            test_obs.std_du_dp()[:, 0], ref_std_du_dps[:, 0], 1.5e-6
-        )
-        np.testing.assert_allclose(
-            test_obs.std_du_dp()[:, 1], ref_std_du_dps[:, 1], 1.5e-6
-        )
-        np.testing.assert_allclose(
-            test_obs.std_du_dp()[:, 2], ref_std_du_dps[:, 2], 5e-5
-        )
+        np.testing.assert_allclose(test_obs.std_du_dp()[:, 0], ref_std_du_dps[:, 0], 1.5e-6)
+        np.testing.assert_allclose(test_obs.std_du_dp()[:, 1], ref_std_du_dps[:, 1], 1.5e-6)
+        np.testing.assert_allclose(test_obs.std_du_dp()[:, 2], ref_std_du_dps[:, 2], 5e-5)
 
         # test the multiple_steps method
-        ctxt_2 = custom_ops.Context(x0, v0, box, intg, bps)
+        ctxt_2 = custom_ops.Context(
+            x0,
+            v0,
+            box,
+            intg,
+            bps
+        )
 
-        lambda_schedule = np.ones(num_steps) * lamb
+        lambda_schedule = np.ones(num_steps)*lamb
 
         du_dl_interval = 3
         x_interval = 2
         start_box = ctxt_2.get_box()
-        test_du_dls, test_xs, test_boxes = ctxt_2.multiple_steps(
-            lambda_schedule, du_dl_interval, x_interval
-        )
+        test_du_dls, test_xs, test_boxes = ctxt_2.multiple_steps(lambda_schedule, du_dl_interval, x_interval)
         end_box = ctxt_2.get_box()
 
-        np.testing.assert_allclose(test_du_dls, ref_all_du_dls[::du_dl_interval])
+        np.testing.assert_allclose(
+            test_du_dls,
+            ref_all_du_dls[::du_dl_interval]
+        )
 
-        np.testing.assert_allclose(test_xs, ref_all_xs[::x_interval])
+        np.testing.assert_allclose(
+            test_xs,
+            ref_all_xs[::x_interval]
+        )
         np.testing.assert_array_equal(start_box, end_box)
         for i in range(test_boxes.shape[0]):
             np.testing.assert_array_equal(start_box, test_boxes[i])
@@ -255,60 +264,93 @@ class TestContext(unittest.TestCase):
         self.assertEqual(test_boxes.shape[2], test_xs.shape[2])
 
         # test the multiple_steps_U method
-        ctxt_3 = custom_ops.Context(x0, v0, box, intg, bps)
-
-        u_interval = 3
-
-        test_us, test_xs, test_boxes = ctxt_3.multiple_steps_U(
-            lamb, num_steps, lambda_windows, u_interval, x_interval
+        ctxt_3 = custom_ops.Context(
+            x0,
+            v0,
+            box,
+            intg,
+            bps
         )
 
-        np.testing.assert_array_almost_equal(ref_all_lambda_us[::u_interval], test_us)
+        u_interval = 3
+ 
+        test_us, test_xs, test_boxes = ctxt_3.multiple_steps_U(
+            lamb,
+            num_steps,
+            lambda_windows,
+            u_interval,
+            x_interval)
 
-        np.testing.assert_array_almost_equal(ref_all_xs[::x_interval], test_xs)
+        np.testing.assert_array_almost_equal(
+            ref_all_lambda_us[::u_interval],
+            test_us
+        )
+
+        np.testing.assert_array_almost_equal(
+            ref_all_xs[::x_interval],
+            test_xs
+        )
 
         test_us, test_xs, test_boxes = ctxt_3.multiple_steps_U(
-            lamb, num_steps, np.array([], dtype=np.float64), u_interval, x_interval
+            lamb,
+            num_steps,
+            np.array([], dtype=np.float64),
+            u_interval,
+            x_interval
         )
 
         assert test_us.shape == (2, 0)
 
-
 class TestObservable(unittest.TestCase):
+
     def test_avg_potential_param_sizes_is_zero(self):
         np.random.seed(814)
 
         N = 8
         D = 3
 
-        x0 = np.random.rand(N, D).astype(dtype=np.float64) * 2
+        x0 = np.random.rand(N,D).astype(dtype=np.float64)*2
 
         masses = np.random.rand(N)
 
         v0 = np.random.rand(x0.shape[0], x0.shape[1])
 
         num_steps = 3
+        lambda_schedule = np.random.rand(num_steps)
         ca = np.random.rand()
-        cbs = -np.random.rand(len(masses)) / 1
+        cbs = -np.random.rand(len(masses))/1
         ccs = np.zeros_like(cbs)
 
         dt = 2e-3
         lamb = np.random.rand()
-        box = np.eye(3) * 1.5
+        box = np.eye(3)*1.5
 
-        intg = custom_ops.LangevinIntegrator(dt, ca, cbs, ccs, 814)
+        intg = custom_ops.LangevinIntegrator(
+            dt,
+            ca,
+            cbs,
+            ccs,
+            814
+        )
 
         # Construct a 'bad' centroid restraint
         potential = potentials.CentroidRestraint(
             np.random.randint(N, size=5, dtype=np.int32),
             np.random.randint(N, size=5, dtype=np.int32),
             10.0,
-            0.0,
+            0.0
         )
         # Bind to empty params
         bp = potential.bind(np.zeros(0)).bound_impl(precision=np.float64)
 
-        ctxt = custom_ops.Context(x0, v0, box, intg, [bp])
+        ctxt = custom_ops.Context(
+            x0,
+            v0,
+            box,
+            intg,
+            [bp]
+        )
+
 
         du_dp_obs = custom_ops.AvgPartialUPartialParam(bp, 1)
         ctxt.add_observable(du_dp_obs)
@@ -334,7 +376,7 @@ def test_reference_langevin_integrator(threshold=1e-4):
     np.random.seed(2021)
 
     potential_fxn = lambda x: x ** 4
-    force_fxn = lambda x: -4 * x ** 3
+    force_fxn = lambda x: - 4 * x ** 3
 
     # loop over settings
     temperatures = [200, 300]
@@ -343,8 +385,8 @@ def test_reference_langevin_integrator(threshold=1e-4):
     masses = [1.0, 2.0]
 
     settings = list(product(temperatures, frictions, dts, masses))
-    print(f"testing reference integrator for {len(settings)} combinations of settings:")
-    print("(temperature, friction, dt, mass) -> histogram_mse")
+    print(f'testing reference integrator for {len(settings)} combinations of settings:')
+    print('(temperature, friction, dt, mass) -> histogram_mse')
 
     for (temperature, friction, dt, mass) in settings:
         # generate n_production_steps * n_copies samples
@@ -356,9 +398,7 @@ def test_reference_langevin_integrator(threshold=1e-4):
         samples = xs[10:].flatten()
 
         # summarize using histogram
-        y_empirical, edges = np.histogram(
-            samples, bins=100, range=(-2, +2), density=True
-        )
+        y_empirical, edges = np.histogram(samples, bins=100, range=(-2, +2), density=True)
         x_grid = (edges[1:] + edges[:-1]) / 2
 
         # compare with e^{-U(x) / kB T} / Z
@@ -366,7 +406,7 @@ def test_reference_langevin_integrator(threshold=1e-4):
         y_ref = y / np.trapz(y, x_grid)
 
         histogram_mse = np.mean((y_ref - y_empirical) ** 2)
-        print(f"{(temperature, friction, dt, mass)}".ljust(33), "->", histogram_mse)
+        print(f'{(temperature, friction, dt, mass)}'.ljust(33), '->', histogram_mse)
 
         assert histogram_mse < threshold
 
@@ -381,23 +421,15 @@ def test_reference_langevin_integrator_with_custom_ops():
     # define a force fxn using a mix of optimized custom_ops and prototype-friendly Jax
 
     from testsystems.relative import hif2a_ligand_pair
-
     ff_params = hif2a_ligand_pair.ff.get_ordered_params()
-    (
-        unbound_potentials,
-        sys_params,
-        masses,
-        coords,
-    ) = hif2a_ligand_pair.prepare_vacuum_edge(ff_params)
-    bound_potentials = [
-        ubp.bind(params).bound_impl(np.float32)
-        for (ubp, params) in zip(unbound_potentials, sys_params)
-    ]
+    unbound_potentials, sys_params, masses, coords = hif2a_ligand_pair.prepare_vacuum_edge(ff_params)
+    bound_potentials = [ubp.bind(params).bound_impl(np.float32) for (ubp, params) in
+                        zip(unbound_potentials, sys_params)]
     box = 100 * np.eye(3)
 
     def custom_op_force_component(coords):
         du_dxs = np.array([bp.execute(coords, box, 0.5)[0] for bp in bound_potentials])
-        return -np.sum(du_dxs, 0)
+        return - np.sum(du_dxs, 0)
 
     def jax_restraint(coords):
         center = jnp.mean(coords, 0)
@@ -405,7 +437,7 @@ def test_reference_langevin_integrator_with_custom_ops():
 
     @jit
     def jax_force_component(coords):
-        return -grad(jax_restraint)(coords)
+        return - grad(jax_restraint)(coords)
 
     def force(coords):
         return custom_op_force_component(coords) + jax_force_component(coords)

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -2,8 +2,9 @@ import unittest
 from itertools import product
 
 import numpy as np
+from jax.config import config
 
-from jax.config import config; config.update("jax_enable_x64", True)
+config.update("jax_enable_x64", True)
 import jax
 from jax import grad, numpy as jnp, jit
 
@@ -13,7 +14,58 @@ from timemachine.integrator import langevin_coefficients, LangevinIntegrator
 
 from common import prepare_nb_system
 
+
 class TestContext(unittest.TestCase):
+    def test_set_and_get(self):
+        """
+        This test the setters and getters in the context.
+        """
+
+        np.random.seed(4321)
+
+        N = 8
+        D = 3
+
+        x0 = np.random.rand(N, D).astype(dtype=np.float64) * 2
+
+        E = 2
+
+        lambda_plane_idxs = np.random.randint(low=0, high=2, size=N, dtype=np.int32)
+        lambda_offset_idxs = np.random.randint(low=0, high=2, size=N, dtype=np.int32)
+
+        params, _, test_nrg = prepare_nb_system(
+            x0,
+            E,
+            lambda_plane_idxs,
+            lambda_offset_idxs,
+            p_scale=3.0,
+            cutoff=1.0,
+        )
+
+        masses = np.random.rand(N)
+        v0 = np.random.rand(x0.shape[0], x0.shape[1])
+
+        temperature = 300
+        dt = 2e-3
+        friction = 0.0
+        ca, cbs, ccs = langevin_coefficients(temperature, dt, friction, masses)
+
+        box = np.eye(3) * 3.0
+        intg = custom_ops.LangevinIntegrator(dt, ca, cbs, ccs, 1234)
+
+        bp = test_nrg.bind(params).bound_impl(precision=np.float64)
+        bps = [bp]
+
+        ctxt = custom_ops.Context(x0, v0, box, intg, bps)
+
+        np.testing.assert_equal(ctxt.get_x_t(), x0)
+        np.testing.assert_equal(ctxt.get_v_t(), v0)
+        np.testing.assert_equal(ctxt.get_box(), box)
+
+        new_x = np.random.rand(N, 3)
+        ctxt.set_x_t(new_x)
+
+        np.testing.assert_equal(ctxt.get_x_t(), new_x)
 
     def test_fwd_mode(self):
         """
@@ -27,7 +79,7 @@ class TestContext(unittest.TestCase):
         N = 8
         D = 3
 
-        x0 = np.random.rand(N,D).astype(dtype=np.float64)*2
+        x0 = np.random.rand(N, D).astype(dtype=np.float64) * 2
 
         E = 2
 
@@ -40,8 +92,7 @@ class TestContext(unittest.TestCase):
             lambda_plane_idxs,
             lambda_offset_idxs,
             p_scale=3.0,
-            # cutoff=0.5,
-            cutoff=1.0
+            cutoff=1.0,
         )
 
         masses = np.random.rand(N)
@@ -58,14 +109,9 @@ class TestContext(unittest.TestCase):
         assert (ccs == 0).all()
 
         lamb = np.random.rand()
-        lambda_us = []
-        lambda_windows = np.array([lamb+0.05, lamb, lamb-0.05])
+        lambda_windows = np.array([lamb + 0.05, lamb, lamb - 0.05])
 
-        def integrate_once_through(
-            x_t,
-            v_t,
-            box,
-            params):
+        def integrate_once_through(x_t, v_t, box, params):
 
             dU_dx_fn = jax.grad(ref_nrg_fn, argnums=(0,))
             dU_dp_fn = jax.grad(ref_nrg_fn, argnums=(1,))
@@ -103,34 +149,24 @@ class TestContext(unittest.TestCase):
                 # note that we do not calculate the du_dl of the last frame.
             return all_xs, all_du_dxs, all_du_dps, all_du_dls, all_us, all_lambda_us
 
-        box = np.eye(3)*3.0
+        box = np.eye(3) * 3.0
 
         # when we have multiple parameters, we need to set this up correctly
-        ref_all_xs, ref_all_du_dxs, ref_all_du_dps, ref_all_du_dls, ref_all_us, ref_all_lambda_us = integrate_once_through(
-            x0,
-            v0,
-            box,
-            params
-        )
+        (
+            ref_all_xs,
+            ref_all_du_dxs,
+            ref_all_du_dps,
+            ref_all_du_dls,
+            _,
+            ref_all_lambda_us,
+        ) = integrate_once_through(x0, v0, box, params)
 
-        intg = custom_ops.LangevinIntegrator(
-            dt,
-            ca,
-            cbs,
-            ccs,
-            1234
-        )
+        intg = custom_ops.LangevinIntegrator(dt, ca, cbs, ccs, 1234)
 
         bp = test_nrg.bind(params).bound_impl(precision=np.float64)
         bps = [bp]
 
-        ctxt = custom_ops.Context(
-            x0,
-            v0,
-            box,
-            intg,
-            bps
-        )
+        ctxt = custom_ops.Context(x0, v0, box, intg, bps)
 
         test_obs = custom_ops.AvgPartialUPartialParam(bp, 1)
         test_obs_f2 = custom_ops.AvgPartialUPartialParam(bp, 2)
@@ -151,19 +187,23 @@ class TestContext(unittest.TestCase):
                 # Until we have run 3 steps, std is 0
                 test_std_du_dp = test_obs.std_du_dp()
 
-                np.testing.assert_array_equal(test_std_du_dp[:, 0], ref_init_du_dps[:, 0])
-                np.testing.assert_array_equal(test_std_du_dp[:, 1], ref_init_du_dps[:, 1])
-                np.testing.assert_array_equal(test_std_du_dp[:, 2], ref_init_du_dps[:, 2])
+                np.testing.assert_array_equal(
+                    test_std_du_dp[:, 0], ref_init_du_dps[:, 0]
+                )
+                np.testing.assert_array_equal(
+                    test_std_du_dp[:, 1], ref_init_du_dps[:, 1]
+                )
+                np.testing.assert_array_equal(
+                    test_std_du_dp[:, 2], ref_init_du_dps[:, 2]
+                )
             print("comparing step", step)
             test_x_t = ctxt.get_x_t()
             np.testing.assert_allclose(test_x_t, ref_all_xs[step])
             ctxt.step(lamb)
-            test_v_t = ctxt.get_v_t()
             test_du_dx_t = ctxt._get_du_dx_t_minus_1()
             # test_u_t = ctxt._get_u_t_minus_1()
             # np.testing.assert_allclose(test_u_t, ref_all_us[step])
             np.testing.assert_allclose(test_du_dx_t, ref_all_du_dxs[step])
-
 
         ref_avg_du_dps = np.mean(ref_all_du_dps, axis=0)
         ref_std_du_dps = np.std(ref_all_du_dps, axis=0)
@@ -171,40 +211,42 @@ class TestContext(unittest.TestCase):
         # the fixed point accumulator makes it hard to converge some of these
         # if the derivative is super small - in which case they probably don't matter
         # anyways
-        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 0], ref_avg_du_dps[:, 0], 1.5e-6)
-        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 1], ref_avg_du_dps[:, 1], 1.5e-6)
-        np.testing.assert_allclose(test_obs.avg_du_dp()[:, 2], ref_avg_du_dps[:, 2], 5e-5)
-
-        np.testing.assert_allclose(test_obs.std_du_dp()[:, 0], ref_std_du_dps[:, 0], 1.5e-6)
-        np.testing.assert_allclose(test_obs.std_du_dp()[:, 1], ref_std_du_dps[:, 1], 1.5e-6)
-        np.testing.assert_allclose(test_obs.std_du_dp()[:, 2], ref_std_du_dps[:, 2], 5e-5)
-
-        # test the multiple_steps method
-        ctxt_2 = custom_ops.Context(
-            x0,
-            v0,
-            box,
-            intg,
-            bps
+        np.testing.assert_allclose(
+            test_obs.avg_du_dp()[:, 0], ref_avg_du_dps[:, 0], 1.5e-6
+        )
+        np.testing.assert_allclose(
+            test_obs.avg_du_dp()[:, 1], ref_avg_du_dps[:, 1], 1.5e-6
+        )
+        np.testing.assert_allclose(
+            test_obs.avg_du_dp()[:, 2], ref_avg_du_dps[:, 2], 5e-5
         )
 
-        lambda_schedule = np.ones(num_steps)*lamb
+        np.testing.assert_allclose(
+            test_obs.std_du_dp()[:, 0], ref_std_du_dps[:, 0], 1.5e-6
+        )
+        np.testing.assert_allclose(
+            test_obs.std_du_dp()[:, 1], ref_std_du_dps[:, 1], 1.5e-6
+        )
+        np.testing.assert_allclose(
+            test_obs.std_du_dp()[:, 2], ref_std_du_dps[:, 2], 5e-5
+        )
+
+        # test the multiple_steps method
+        ctxt_2 = custom_ops.Context(x0, v0, box, intg, bps)
+
+        lambda_schedule = np.ones(num_steps) * lamb
 
         du_dl_interval = 3
         x_interval = 2
         start_box = ctxt_2.get_box()
-        test_du_dls, test_xs, test_boxes = ctxt_2.multiple_steps(lambda_schedule, du_dl_interval, x_interval)
+        test_du_dls, test_xs, test_boxes = ctxt_2.multiple_steps(
+            lambda_schedule, du_dl_interval, x_interval
+        )
         end_box = ctxt_2.get_box()
 
-        np.testing.assert_allclose(
-            test_du_dls,
-            ref_all_du_dls[::du_dl_interval]
-        )
+        np.testing.assert_allclose(test_du_dls, ref_all_du_dls[::du_dl_interval])
 
-        np.testing.assert_allclose(
-            test_xs,
-            ref_all_xs[::x_interval]
-        )
+        np.testing.assert_allclose(test_xs, ref_all_xs[::x_interval])
         np.testing.assert_array_equal(start_box, end_box)
         for i in range(test_boxes.shape[0]):
             np.testing.assert_array_equal(start_box, test_boxes[i])
@@ -213,93 +255,60 @@ class TestContext(unittest.TestCase):
         self.assertEqual(test_boxes.shape[2], test_xs.shape[2])
 
         # test the multiple_steps_U method
-        ctxt_3 = custom_ops.Context(
-            x0,
-            v0,
-            box,
-            intg,
-            bps
-        )
+        ctxt_3 = custom_ops.Context(x0, v0, box, intg, bps)
 
         u_interval = 3
- 
-        test_us, test_xs, test_boxes = ctxt_3.multiple_steps_U(
-            lamb,
-            num_steps,
-            lambda_windows,
-            u_interval,
-            x_interval)
-
-        np.testing.assert_array_almost_equal(
-            ref_all_lambda_us[::u_interval],
-            test_us
-        )
-
-        np.testing.assert_array_almost_equal(
-            ref_all_xs[::x_interval],
-            test_xs
-        )
 
         test_us, test_xs, test_boxes = ctxt_3.multiple_steps_U(
-            lamb,
-            num_steps,
-            np.array([], dtype=np.float64),
-            u_interval,
-            x_interval
+            lamb, num_steps, lambda_windows, u_interval, x_interval
+        )
+
+        np.testing.assert_array_almost_equal(ref_all_lambda_us[::u_interval], test_us)
+
+        np.testing.assert_array_almost_equal(ref_all_xs[::x_interval], test_xs)
+
+        test_us, test_xs, test_boxes = ctxt_3.multiple_steps_U(
+            lamb, num_steps, np.array([], dtype=np.float64), u_interval, x_interval
         )
 
         assert test_us.shape == (2, 0)
 
-class TestObservable(unittest.TestCase):
 
+class TestObservable(unittest.TestCase):
     def test_avg_potential_param_sizes_is_zero(self):
         np.random.seed(814)
 
         N = 8
         D = 3
 
-        x0 = np.random.rand(N,D).astype(dtype=np.float64)*2
+        x0 = np.random.rand(N, D).astype(dtype=np.float64) * 2
 
         masses = np.random.rand(N)
 
         v0 = np.random.rand(x0.shape[0], x0.shape[1])
 
         num_steps = 3
-        lambda_schedule = np.random.rand(num_steps)
         ca = np.random.rand()
-        cbs = -np.random.rand(len(masses))/1
+        cbs = -np.random.rand(len(masses)) / 1
         ccs = np.zeros_like(cbs)
 
         dt = 2e-3
         lamb = np.random.rand()
-        box = np.eye(3)*1.5
+        box = np.eye(3) * 1.5
 
-        intg = custom_ops.LangevinIntegrator(
-            dt,
-            ca,
-            cbs,
-            ccs,
-            814
-        )
+        intg = custom_ops.LangevinIntegrator(dt, ca, cbs, ccs, 814)
 
         # Construct a 'bad' centroid restraint
         potential = potentials.CentroidRestraint(
             np.random.randint(N, size=5, dtype=np.int32),
             np.random.randint(N, size=5, dtype=np.int32),
             10.0,
-            0.0
+            0.0,
         )
         # Bind to empty params
         bp = potential.bind(np.zeros(0)).bound_impl(precision=np.float64)
 
-        ctxt = custom_ops.Context(
-            x0,
-            v0,
-            box,
-            intg,
-            [bp]
-        )
-
+        ctxt = custom_ops.Context(x0, v0, box, intg, [bp])
 
         du_dp_obs = custom_ops.AvgPartialUPartialParam(bp, 1)
         ctxt.add_observable(du_dp_obs)
@@ -325,7 +334,7 @@ def test_reference_langevin_integrator(threshold=1e-4):
     np.random.seed(2021)
 
     potential_fxn = lambda x: x ** 4
-    force_fxn = lambda x: - 4 * x ** 3
+    force_fxn = lambda x: -4 * x ** 3
 
     # loop over settings
     temperatures = [200, 300]
@@ -334,8 +343,8 @@ def test_reference_langevin_integrator(threshold=1e-4):
     masses = [1.0, 2.0]
 
     settings = list(product(temperatures, frictions, dts, masses))
-    print(f'testing reference integrator for {len(settings)} combinations of settings:')
-    print('(temperature, friction, dt, mass) -> histogram_mse')
+    print(f"testing reference integrator for {len(settings)} combinations of settings:")
+    print("(temperature, friction, dt, mass) -> histogram_mse")
 
     for (temperature, friction, dt, mass) in settings:
         # generate n_production_steps * n_copies samples
@@ -347,7 +356,9 @@ def test_reference_langevin_integrator(threshold=1e-4):
         samples = xs[10:].flatten()
 
         # summarize using histogram
-        y_empirical, edges = np.histogram(samples, bins=100, range=(-2, +2), density=True)
+        y_empirical, edges = np.histogram(
+            samples, bins=100, range=(-2, +2), density=True
+        )
         x_grid = (edges[1:] + edges[:-1]) / 2
 
         # compare with e^{-U(x) / kB T} / Z
@@ -355,7 +366,7 @@ def test_reference_langevin_integrator(threshold=1e-4):
         y_ref = y / np.trapz(y, x_grid)
 
         histogram_mse = np.mean((y_ref - y_empirical) ** 2)
-        print(f'{(temperature, friction, dt, mass)}'.ljust(33), '->', histogram_mse)
+        print(f"{(temperature, friction, dt, mass)}".ljust(33), "->", histogram_mse)
 
         assert histogram_mse < threshold
 
@@ -370,15 +381,23 @@ def test_reference_langevin_integrator_with_custom_ops():
     # define a force fxn using a mix of optimized custom_ops and prototype-friendly Jax
 
     from testsystems.relative import hif2a_ligand_pair
+
     ff_params = hif2a_ligand_pair.ff.get_ordered_params()
-    unbound_potentials, sys_params, masses, coords = hif2a_ligand_pair.prepare_vacuum_edge(ff_params)
-    bound_potentials = [ubp.bind(params).bound_impl(np.float32) for (ubp, params) in
-                        zip(unbound_potentials, sys_params)]
+    (
+        unbound_potentials,
+        sys_params,
+        masses,
+        coords,
+    ) = hif2a_ligand_pair.prepare_vacuum_edge(ff_params)
+    bound_potentials = [
+        ubp.bind(params).bound_impl(np.float32)
+        for (ubp, params) in zip(unbound_potentials, sys_params)
+    ]
     box = 100 * np.eye(3)
 
     def custom_op_force_component(coords):
         du_dxs = np.array([bp.execute(coords, box, 0.5)[0] for bp in bound_potentials])
-        return - np.sum(du_dxs, 0)
+        return -np.sum(du_dxs, 0)
 
     def jax_restraint(coords):
         center = jnp.mean(coords, 0)
@@ -386,7 +405,7 @@ def test_reference_langevin_integrator_with_custom_ops():
 
     @jit
     def jax_force_component(coords):
-        return - grad(jax_restraint)(coords)
+        return -grad(jax_restraint)(coords)
 
     def force(coords):
         return custom_op_force_component(coords) + jax_force_component(coords)

--- a/timemachine/cpp/src/context.cu
+++ b/timemachine/cpp/src/context.cu
@@ -395,6 +395,10 @@ void Context::get_v_t(double *out_buffer) const {
     gpuErrchk(cudaMemcpy(out_buffer, d_v_t_, N_*3*sizeof(*out_buffer), cudaMemcpyDeviceToHost));
 }
 
+void Context::set_x_t(const double *in_buffer) {
+    gpuErrchk(cudaMemcpy(d_x_t_, in_buffer, N_ * 3 * sizeof(*in_buffer), cudaMemcpyHostToDevice));
+}
+
 void Context::get_box(double *out_buffer) const {
     gpuErrchk(cudaMemcpy(out_buffer, d_box_t_, 3*3*sizeof(*out_buffer), cudaMemcpyDeviceToHost));
 }

--- a/timemachine/cpp/src/context.hpp
+++ b/timemachine/cpp/src/context.hpp
@@ -43,6 +43,8 @@ public:
 
     void get_du_dx_t_minus_1(unsigned long long *out_buffer) const;
 
+    void set_x_t(const double *in_buffer);
+
     void get_x_t(double *out_buffer) const;
 
     void get_v_t(double *out_buffer) const;

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -180,6 +180,10 @@ void declare_context(py::module &m) {
         ctxt.get_x_t(buffer.mutable_data());
         return buffer;
     })
+    .def("set_x_t", [](timemachine::Context &ctxt,
+        const py::array_t<double, py::array::c_style> new_x_t) {
+        ctxt.set_x_t(new_x_t.data());
+    })
     .def("multiple_steps_U", [](timemachine::Context &ctxt,
         const double lambda,
         const int n_steps,


### PR DESCRIPTION
This PR adds the ability to set the coordinates in the Context in preparation for enhanced sampling. It also adds additional tests for other getters in the `Context`.