### PR TITLE
Swap default and override OS-dependent parameter values in barostat test

### DIFF
--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -187,15 +187,15 @@ def test_barostat_is_deterministic():
 
     # OpenEye's AM1 Charging values are OS platform dependent. To ensure that we have deterministic values
     # we check against our two most common OS versions, Ubuntu 18.04 and 20.04.
-    box_vol = 26.711716908713402
+    box_vol = 26.869380588831582
     lig_charge_vals = np.array(
-        [1.4572377542719206, -0.37011462071257184, 1.1478267014520305, -4.920166483601927, 0.16985194917937935]
+        [1.4572377542719206, -0.37011462071257184, 1.1478267014520305, -4.920284514559682, 0.16985194917937935]
     )
     if "ubuntu" not in platform_version:
         print(f"Test expected to run under ubuntu 20.04 or 18.04, got {platform_version}")
-    if "20.04" in platform_version:
-        box_vol = 26.869380588831582
-        lig_charge_vals[3] = -4.920284514559682
+    if "18.04" in platform_version:
+        box_vol = 26.711716908713402
+        lig_charge_vals[3] = -4.920166483601927
 
     pressure = 1.0 * unit.atmosphere
 


### PR DESCRIPTION
Currently, we use parameter values that allow tests to pass on Ubuntu 18.04 in `test_barostat_is_deterministic`, with an override exception triggered when the OS is Ubuntu 20.04.

This PR swaps the default and override values so that if the OS is unrecognized, we use the defaults for Ubuntu 20.04. This allows tests to pass (with a warning) on some other recent OSes (e.g. NixOS 21.11).