### PR TITLE
Makes Fixed Point fix broader

### DIFF
--- a/timemachine/cpp/src/kernels/k_fixed_point.cuh
+++ b/timemachine/cpp/src/kernels/k_fixed_point.cuh
@@ -17,7 +17,7 @@ RealType __device__ __forceinline__ FIXED_TO_FLOAT_DU_DP(unsigned long long v) {
 // (ytz): courtesy of @scottlegrand/NVIDIA, even faster conversion
 // This was original a hack to improve perf on Maxwell, that is now needed for Ampere
 long long __device__ __forceinline__ real_to_int64(float x) {
-#if __CUDA_ARCH__ == 860 || __CUDA_ARCH__ == 750
+#if __CUDA_ARCH__ >= 750
   float z = x * (float)0x1.00000p-32;
   int hi = __float2int_rz( z );                         // First convert high bits
   float delta = x - ((float)0x1.00000p32*((float)hi));  // Check remainder sign


### PR DESCRIPTION
* In testing from 7.5 -> 8.6 this fix is crucial for performance.


Please make sure to test this on your machine to ensure you don't see a performance loss. This real to int64 change has been important on the following GPUs I have tested:

* T4
* RTX 2080
* A4000
* RTX 3090
* A10G