### PR TITLE
Format cuda source files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
     rev: v13.0.0
     hooks:
     -   id: clang-format
+        types_or: [c, c++, cuda]
         files: '^timemachine/cpp/src/'
 
 exclude: '\.pdb$|\.sdf$|\.proto$|\.xml$|/vendored/|^ff/params/|^parallel/grpc/'

--- a/timemachine/cpp/src/barostat.cu
+++ b/timemachine/cpp/src/barostat.cu
@@ -1,10 +1,10 @@
 #include "barostat.hpp"
-#include "gpu_utils.cuh"
 #include "fixed_point.hpp"
+#include "gpu_utils.cuh"
 #include <algorithm>
-#include <stdio.h>
-#include <set>
 #include <cub/cub.cuh>
+#include <set>
+#include <stdio.h>
 
 #include "kernels/k_fixed_point.cuh"
 
@@ -15,67 +15,57 @@ namespace timemachine {
 
 MonteCarloBarostat::MonteCarloBarostat(
     const int N,
-    const double pressure, // Expected in Bar
+    const double pressure,    // Expected in Bar
     const double temperature, // Kelvin
-    const std::vector<std::vector<int> > group_idxs,
+    const std::vector<std::vector<int>> group_idxs,
     const int interval,
     const std::vector<BoundPotential *> bps,
-    const int seed) :
-    N_(N),
-    pressure_(pressure),
-    temperature_(temperature),
-    interval_(interval),
-    bps_(bps),
-    group_idxs_(group_idxs),
-    num_grouped_atoms_(0),
-    d_sum_storage_(nullptr),
-    d_sum_storage_bytes_(0),
-    seed_(seed),
-    step_(0) {
+    const int seed)
+    : N_(N), pressure_(pressure), temperature_(temperature), interval_(interval), bps_(bps), group_idxs_(group_idxs),
+      num_grouped_atoms_(0), d_sum_storage_(nullptr), d_sum_storage_bytes_(0), seed_(seed), step_(0) {
 
     // Trigger check that interval is valid
     this->set_interval(interval_);
 
     // lets not have another facepalm moment again...
-    if(temperature < 100.0) {
+    if (temperature < 100.0) {
         std::cout << "warning temperature less than 100K" << std::endl;
     }
 
-    if(pressure > 10.0) {
+    if (pressure > 10.0) {
         std::cout << "warning pressure more than 10bar" << std::endl;
     }
 
     curandErrchk(curandCreateGenerator(&cr_rng_, CURAND_RNG_PSEUDO_DEFAULT));
-    gpuErrchk(cudaMalloc(&d_rand_, 2*sizeof(double)));
+    gpuErrchk(cudaMalloc(&d_rand_, 2 * sizeof(double)));
     curandErrchk(curandSetPseudoRandomGeneratorSeed(cr_rng_, seed_));
 
     const int num_mols = group_idxs_.size();
 
-    gpuErrchk(cudaMalloc(&d_x_after_, N_*3*sizeof(*d_x_after_)));
-    gpuErrchk(cudaMalloc(&d_box_after_, 3*3*sizeof(*d_box_after_)));
-    gpuErrchk(cudaMalloc(&d_u_buffer_, N_*sizeof(*d_u_buffer_)));
-    gpuErrchk(cudaMalloc(&d_u_after_buffer_, N_*sizeof(*d_u_after_buffer_)));
+    gpuErrchk(cudaMalloc(&d_x_after_, N_ * 3 * sizeof(*d_x_after_)));
+    gpuErrchk(cudaMalloc(&d_box_after_, 3 * 3 * sizeof(*d_box_after_)));
+    gpuErrchk(cudaMalloc(&d_u_buffer_, N_ * sizeof(*d_u_buffer_)));
+    gpuErrchk(cudaMalloc(&d_u_after_buffer_, N_ * sizeof(*d_u_after_buffer_)));
 
-    gpuErrchk(cudaMalloc(&d_init_u_, 1*sizeof(*d_init_u_)));
-    gpuErrchk(cudaMalloc(&d_final_u_, 1*sizeof(*d_final_u_)));
+    gpuErrchk(cudaMalloc(&d_init_u_, 1 * sizeof(*d_init_u_)));
+    gpuErrchk(cudaMalloc(&d_final_u_, 1 * sizeof(*d_final_u_)));
 
-    gpuErrchk(cudaMalloc(&d_num_accepted_, 1*sizeof(*d_num_accepted_)));
-    gpuErrchk(cudaMalloc(&d_num_attempted_, 1*sizeof(*d_num_attempted_)));
+    gpuErrchk(cudaMalloc(&d_num_accepted_, 1 * sizeof(*d_num_accepted_)));
+    gpuErrchk(cudaMalloc(&d_num_attempted_, 1 * sizeof(*d_num_attempted_)));
 
-    gpuErrchk(cudaMalloc(&d_volume_, 1*sizeof(*d_volume_)));
-    gpuErrchk(cudaMalloc(&d_length_scale_, 1*sizeof(*d_length_scale_)));
-    gpuErrchk(cudaMalloc(&d_volume_scale_, 1*sizeof(*d_volume_scale_)));
-    gpuErrchk(cudaMalloc(&d_volume_delta_, 1*sizeof(*d_volume_delta_)));
+    gpuErrchk(cudaMalloc(&d_volume_, 1 * sizeof(*d_volume_)));
+    gpuErrchk(cudaMalloc(&d_length_scale_, 1 * sizeof(*d_length_scale_)));
+    gpuErrchk(cudaMalloc(&d_volume_scale_, 1 * sizeof(*d_volume_scale_)));
+    gpuErrchk(cudaMalloc(&d_volume_delta_, 1 * sizeof(*d_volume_delta_)));
 
-    gpuErrchk(cudaMemset(d_volume_scale_, 0, 1*sizeof(*d_volume_scale_)));
-
+    gpuErrchk(cudaMemset(d_volume_scale_, 0, 1 * sizeof(*d_volume_scale_)));
 
     std::set<int> group_set;
     for (int i = 0; i < num_mols; i++) {
         std::vector<int> atoms = group_idxs[i];
         const int num_atoms = atoms.size();
         num_grouped_atoms_ += num_atoms;
-        for(int j = 0; j < num_atoms; j++) {
+        for (int j = 0; j < num_atoms; j++) {
             int idx = atoms[j];
             if (idx < 0 || idx >= N_) {
                 throw std::runtime_error("Grouped indices must be between 0 and N");
@@ -88,13 +78,13 @@ MonteCarloBarostat::MonteCarloBarostat(
         throw std::runtime_error("All grouped indices must be unique");
     }
 
-    gpuErrchk(cudaMalloc(&d_centroids_, num_mols*3*sizeof(*d_centroids_)));
-    gpuErrchk(cudaMalloc(&d_atom_idxs_, num_grouped_atoms_*sizeof(*d_atom_idxs_)));
-    gpuErrchk(cudaMalloc(&d_mol_idxs_, num_grouped_atoms_*sizeof(*d_mol_idxs_)));
-    gpuErrchk(cudaMalloc(&d_mol_offsets_, (num_mols+1)*sizeof(*d_mol_offsets_)));
+    gpuErrchk(cudaMalloc(&d_centroids_, num_mols * 3 * sizeof(*d_centroids_)));
+    gpuErrchk(cudaMalloc(&d_atom_idxs_, num_grouped_atoms_ * sizeof(*d_atom_idxs_)));
+    gpuErrchk(cudaMalloc(&d_mol_idxs_, num_grouped_atoms_ * sizeof(*d_mol_idxs_)));
+    gpuErrchk(cudaMalloc(&d_mol_offsets_, (num_mols + 1) * sizeof(*d_mol_offsets_)));
 
     int offset = 0;
-    int mol_offsets[num_mols+1];
+    int mol_offsets[num_mols + 1];
     int mol_idxs[num_grouped_atoms_];
     int atom_idxs[num_grouped_atoms_];
     for (int i = 0; i < num_mols; i++) {
@@ -102,18 +92,19 @@ MonteCarloBarostat::MonteCarloBarostat(
         mol_offsets[i] = offset;
         int num_atoms = atoms.size();
         for (int j = 0; j < num_atoms; j++) {
-            mol_idxs[offset+j] = i;
-            atom_idxs[offset+j] = atoms[j];
+            mol_idxs[offset + j] = i;
+            atom_idxs[offset + j] = atoms[j];
         }
         offset += num_atoms;
     }
     mol_offsets[num_mols] = offset;
-    gpuErrchk(cudaMemcpy(d_mol_idxs_, mol_idxs, num_grouped_atoms_*sizeof(*d_mol_idxs_), cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(d_atom_idxs_, atom_idxs, num_grouped_atoms_*sizeof(*d_atom_idxs_), cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(d_mol_offsets_, mol_offsets, (num_mols+1)*sizeof(*d_mol_offsets_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_mol_idxs_, mol_idxs, num_grouped_atoms_ * sizeof(*d_mol_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_atom_idxs_, atom_idxs, num_grouped_atoms_ * sizeof(*d_atom_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(
+        cudaMemcpy(d_mol_offsets_, mol_offsets, (num_mols + 1) * sizeof(*d_mol_offsets_), cudaMemcpyHostToDevice));
 
     // Use a typed nullptr so cub can calculate space needed to reduce
-    unsigned long long *d_in_tmp = nullptr; // dummy
+    unsigned long long *d_in_tmp = nullptr;  // dummy
     unsigned long long *d_out_tmp = nullptr; // dummy
 
     // Compute amount of space to reduce energies
@@ -121,7 +112,6 @@ MonteCarloBarostat::MonteCarloBarostat(
     gpuErrchk(cudaPeekAtLastError());
     gpuErrchk(cudaMalloc(&d_sum_storage_, d_sum_storage_bytes_));
     this->reset_counters();
-
 };
 
 MonteCarloBarostat::~MonteCarloBarostat() {
@@ -135,8 +125,7 @@ MonteCarloBarostat::~MonteCarloBarostat() {
     gpuErrchk(cudaFree(d_u_buffer_));
     gpuErrchk(cudaFree(d_init_u_));
     gpuErrchk(cudaFree(d_final_u_));
-    gpuErrchk(cudaFree(d_rand_))
-    gpuErrchk(cudaFree(d_length_scale_));
+    gpuErrchk(cudaFree(d_rand_)) gpuErrchk(cudaFree(d_length_scale_));
     gpuErrchk(cudaFree(d_volume_scale_));
     gpuErrchk(cudaFree(d_volume_delta_));
     gpuErrchk(cudaFree(d_num_accepted_));
@@ -144,86 +133,85 @@ MonteCarloBarostat::~MonteCarloBarostat() {
     curandErrchk(curandDestroyGenerator(cr_rng_));
 };
 
-
 void __global__ rescale_positions(
-    const int N, // Number of atoms to shift
-    double * __restrict__ coords, // Cordinates
-    const double * __restrict__ length_scale, // [1]
-    const double * __restrict__ box, // [9]
-    double * __restrict__ scaled_box, // [9]
-    const int * __restrict__ atom_idxs, // [N]
-    const int * __restrict__ mol_idxs, // [N]
-    const int * __restrict__ mol_offsets, // [N]
-    const unsigned long long * __restrict__ centroids // [N*3]
+    const int N,                                     // Number of atoms to shift
+    double *__restrict__ coords,                     // Cordinates
+    const double *__restrict__ length_scale,         // [1]
+    const double *__restrict__ box,                  // [9]
+    double *__restrict__ scaled_box,                 // [9]
+    const int *__restrict__ atom_idxs,               // [N]
+    const int *__restrict__ mol_idxs,                // [N]
+    const int *__restrict__ mol_offsets,             // [N]
+    const unsigned long long *__restrict__ centroids // [N*3]
 ) {
-    const int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= N) {
         return;
     }
     const int atom_idx = atom_idxs[idx];
     const int mol_idx = mol_idxs[idx];
 
-    const double center_x = box[0*3+0] * 0.5;
-    const double center_y = box[1*3+1] * 0.5;
-    const double center_z = box[2*3+2] * 0.5;
+    const double center_x = box[0 * 3 + 0] * 0.5;
+    const double center_y = box[1 * 3 + 1] * 0.5;
+    const double center_z = box[2 * 3 + 2] * 0.5;
 
-    const double num_atoms = static_cast<double>(mol_offsets[mol_idx+1] - mol_offsets[mol_idx]);
+    const double num_atoms = static_cast<double>(mol_offsets[mol_idx + 1] - mol_offsets[mol_idx]);
 
-    const double centroid_x = FIXED_TO_FLOAT<double>(centroids[mol_idx*3+0]) / num_atoms;
-    const double centroid_y = FIXED_TO_FLOAT<double>(centroids[mol_idx*3+1]) / num_atoms;
-    const double centroid_z = FIXED_TO_FLOAT<double>(centroids[mol_idx*3+2]) / num_atoms;
+    const double centroid_x = FIXED_TO_FLOAT<double>(centroids[mol_idx * 3 + 0]) / num_atoms;
+    const double centroid_y = FIXED_TO_FLOAT<double>(centroids[mol_idx * 3 + 1]) / num_atoms;
+    const double centroid_z = FIXED_TO_FLOAT<double>(centroids[mol_idx * 3 + 2]) / num_atoms;
 
     const double displacement_x = ((centroid_x - center_x) * length_scale[0]) + center_x - centroid_x;
     const double displacement_y = ((centroid_y - center_y) * length_scale[0]) + center_y - centroid_y;
     const double displacement_z = ((centroid_z - center_z) * length_scale[0]) + center_z - centroid_z;
 
-    coords[atom_idx*3+0] += displacement_x;
-    coords[atom_idx*3+1] += displacement_y;
-    coords[atom_idx*3+2] += displacement_z;
+    coords[atom_idx * 3 + 0] += displacement_x;
+    coords[atom_idx * 3 + 1] += displacement_y;
+    coords[atom_idx * 3 + 2] += displacement_z;
     if (atom_idx == 0) {
-        scaled_box[0*3+0] *= length_scale[0];
-        scaled_box[1*3+1] *= length_scale[0];
-        scaled_box[2*3+2] *= length_scale[0];
+        scaled_box[0 * 3 + 0] *= length_scale[0];
+        scaled_box[1 * 3 + 1] *= length_scale[0];
+        scaled_box[2 * 3 + 2] *= length_scale[0];
     }
 }
 
 void __global__ find_group_centroids(
-    const int N, // Number of atoms to shift
-    const double * __restrict__ coords, // Coordinates
-    const int * __restrict__ atom_idxs, // [N]
-    const int * __restrict__ mol_idxs, // [N]
-    unsigned long long * __restrict__ centroids // [num_molecules * 3]
+    const int N,                               // Number of atoms to shift
+    const double *__restrict__ coords,         // Coordinates
+    const int *__restrict__ atom_idxs,         // [N]
+    const int *__restrict__ mol_idxs,          // [N]
+    unsigned long long *__restrict__ centroids // [num_molecules * 3]
 ) {
-    const int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= N) {
         return;
     }
     const int atom_idx = atom_idxs[idx];
     const int mol_idx = mol_idxs[idx];
-    atomicAdd(centroids + mol_idx*3+0, FLOAT_TO_FIXED<double>(coords[atom_idx*3+0]));
-    atomicAdd(centroids + mol_idx*3+1, FLOAT_TO_FIXED<double>(coords[atom_idx*3+1]));
-    atomicAdd(centroids + mol_idx*3+2, FLOAT_TO_FIXED<double>(coords[atom_idx*3+2]));
+    atomicAdd(centroids + mol_idx * 3 + 0, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 0]));
+    atomicAdd(centroids + mol_idx * 3 + 1, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 1]));
+    atomicAdd(centroids + mol_idx * 3 + 2, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 2]));
 }
 
 void __global__ k_setup_barostat_move(
-    const double * __restrict__ rand, // [2], use first value, second value is metropolis condition
-    double * __restrict__ d_box, // [3*3]
-    double * __restrict__ d_volume_delta, // [1]
-    double * __restrict__ d_volume_scale, // [1]
-    double * __restrict__ d_length_scale // [1]
+    const double *__restrict__ rand,     // [2], use first value, second value is metropolis condition
+    double *__restrict__ d_box,          // [3*3]
+    double *__restrict__ d_volume_delta, // [1]
+    double *__restrict__ d_volume_scale, // [1]
+    double *__restrict__ d_length_scale  // [1]
 ) {
-    const int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= 1) {
         return; // Only a single thread needs to perform this operation
     }
-    const double volume = d_box[0*3+0] * d_box[1*3+1] * d_box[2*3+2];
-    if(d_volume_scale[0] == 0) {
+    const double volume = d_box[0 * 3 + 0] * d_box[1 * 3 + 1] * d_box[2 * 3 + 2];
+    if (d_volume_scale[0] == 0) {
         d_volume_scale[0] = 0.01 * volume;
     }
-    const double delta_volume = d_volume_scale[0]*2*(rand[0]-0.5);
-    const double new_volume = volume+delta_volume;
+    const double delta_volume = d_volume_scale[0] * 2 * (rand[0] - 0.5);
+    const double new_volume = volume + delta_volume;
     d_volume_delta[0] = delta_volume;
-    d_length_scale[0] = cbrt(new_volume/volume);
+    d_length_scale[0] = cbrt(new_volume / volume);
 }
 
 void __global__ k_decide_move(
@@ -231,42 +219,41 @@ void __global__ k_decide_move(
     const int num_molecules,
     const double kt,
     const double pressure,
-    const double * __restrict__ rand, // [2] Use second value
-    double * __restrict__ d_volume_delta,
-    double * __restrict__ d_volume_scale,
-    const unsigned long long * __restrict__ d_init_u,
-    const unsigned long long * __restrict__ d_final_u,
-    double * __restrict__ d_box,
-    const double * __restrict__ d_box_output,
-    double * __restrict__ d_x,
-    const double * __restrict__ d_x_output,
-    int * __restrict__ num_accepted,
-    int * __restrict__ num_attempted
-) {
-    const int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    const double *__restrict__ rand, // [2] Use second value
+    double *__restrict__ d_volume_delta,
+    double *__restrict__ d_volume_scale,
+    const unsigned long long *__restrict__ d_init_u,
+    const unsigned long long *__restrict__ d_final_u,
+    double *__restrict__ d_box,
+    const double *__restrict__ d_box_output,
+    double *__restrict__ d_x,
+    const double *__restrict__ d_x_output,
+    int *__restrict__ num_accepted,
+    int *__restrict__ num_attempted) {
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= N) {
         return;
     }
 
-    const double volume = d_box[0*3+0] * d_box[1*3+1] * d_box[2*3+2];
-    const double new_volume = volume+d_volume_delta[0];
+    const double volume = d_box[0 * 3 + 0] * d_box[1 * 3 + 1] * d_box[2 * 3 + 2];
+    const double new_volume = volume + d_volume_delta[0];
     const double energy_delta = FIXED_TO_FLOAT<double>(d_final_u[0] - d_init_u[0]);
-    const double w = energy_delta + pressure*d_volume_delta[0] - num_molecules * kt * std::log(new_volume/volume);
+    const double w = energy_delta + pressure * d_volume_delta[0] - num_molecules * kt * std::log(new_volume / volume);
 
-    const bool rejected = w > 0 && rand[1] > std::exp(-w/kt);
-    if(idx == 0) {
+    const bool rejected = w > 0 && rand[1] > std::exp(-w / kt);
+    if (idx == 0) {
         if (!rejected) {
             num_accepted[0]++;
         }
         num_attempted[0]++;
-        if(num_attempted[0] >= 10) {
-            if (num_accepted[0] < 0.25*num_attempted[0]) {
+        if (num_attempted[0] >= 10) {
+            if (num_accepted[0] < 0.25 * num_attempted[0]) {
                 d_volume_scale[0] /= 1.1;
                 // Reset the counters
                 num_attempted[0] = 0;
                 num_accepted[0] = 0;
-            } else if (num_accepted[0] > 0.75*num_attempted[0]) {
-                d_volume_scale[0] = min(d_volume_scale[0]*1.1, volume*0.3);
+            } else if (num_accepted[0] > 0.75 * num_attempted[0]) {
+                d_volume_scale[0] = min(d_volume_scale[0] * 1.1, volume * 0.3);
                 // Reset the counters
                 num_attempted[0] = 0;
                 num_accepted[0] = 0;
@@ -282,25 +269,22 @@ void __global__ k_decide_move(
         d_box[idx] = d_box_output[idx];
     }
 
-    #pragma unroll
-    for (int i = 0; i < 3; i ++) {
-        d_x[idx*3+i] = d_x_output[idx*3+i];
+#pragma unroll
+    for (int i = 0; i < 3; i++) {
+        d_x[idx * 3 + i] = d_x_output[idx * 3 + i];
     }
 }
 
-
-
-void MonteCarloBarostat::reset_counters(){
+void MonteCarloBarostat::reset_counters() {
     gpuErrchk(cudaMemset(d_num_accepted_, 0, sizeof(*d_num_accepted_)));
     gpuErrchk(cudaMemset(d_num_attempted_, 0, sizeof(*d_num_attempted_)));
 }
 
 void MonteCarloBarostat::inplace_move(
-    double *d_x, // [N*3]
+    double *d_x,   // [N*3]
     double *d_box, // [3*3]
     const double lambda,
-    cudaStream_t stream
-) {
+    cudaStream_t stream) {
     step_++;
     if (step_ % interval_ != 0) {
         return;
@@ -312,59 +296,30 @@ void MonteCarloBarostat::inplace_move(
 
     gpuErrchk(cudaMemsetAsync(d_init_u_, 0, sizeof(*d_init_u_), stream));
     gpuErrchk(cudaMemsetAsync(d_final_u_, 0, sizeof(*d_final_u_), stream));
-    gpuErrchk(cudaMemsetAsync(d_u_buffer_, 0, N_*sizeof(*d_u_buffer_), stream));
-    gpuErrchk(cudaMemsetAsync(d_u_after_buffer_, 0, N_*sizeof(*d_u_after_buffer_), stream));
+    gpuErrchk(cudaMemsetAsync(d_u_buffer_, 0, N_ * sizeof(*d_u_buffer_), stream));
+    gpuErrchk(cudaMemsetAsync(d_u_after_buffer_, 0, N_ * sizeof(*d_u_after_buffer_), stream));
 
-    for(int i=0; i < bps_.size(); i++) {
-        bps_[i]->execute_device(
-            N_,
-            d_x,
-            d_box,
-            lambda,
-            nullptr,
-            nullptr,
-            nullptr,
-            d_u_buffer_,
-            stream
-        );
+    for (int i = 0; i < bps_.size(); i++) {
+        bps_[i]->execute_device(N_, d_x, d_box, lambda, nullptr, nullptr, nullptr, d_u_buffer_, stream);
     }
 
-    cub::DeviceReduce::Sum(
-        d_sum_storage_,
-        d_sum_storage_bytes_,
-        d_u_buffer_,
-        d_init_u_,
-        N_,
-        stream
-    );
+    cub::DeviceReduce::Sum(d_sum_storage_, d_sum_storage_bytes_, d_u_buffer_, d_init_u_, N_, stream);
     gpuErrchk(cudaPeekAtLastError());
 
-    k_setup_barostat_move<<<1, 1, 0, stream>>>(
-        d_rand_,
-        d_box,
-        d_volume_delta_,
-        d_volume_scale_,
-        d_length_scale_
-    );
+    k_setup_barostat_move<<<1, 1, 0, stream>>>(d_rand_, d_box, d_volume_delta_, d_volume_scale_, d_length_scale_);
     gpuErrchk(cudaPeekAtLastError());
 
     const int num_molecules = group_idxs_.size();
-    gpuErrchk(cudaMemsetAsync(d_centroids_, 0, num_molecules*3*sizeof(*d_centroids_), stream));
+    gpuErrchk(cudaMemsetAsync(d_centroids_, 0, num_molecules * 3 * sizeof(*d_centroids_), stream));
 
     // Create duplicates of the coords/box that we can modify
-    gpuErrchk(cudaMemcpyAsync(d_x_after_, d_x, N_*3*sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
-    gpuErrchk(cudaMemcpyAsync(d_box_after_, d_box, 3*3*sizeof(*d_box_after_), cudaMemcpyDeviceToDevice, stream));
+    gpuErrchk(cudaMemcpyAsync(d_x_after_, d_x, N_ * 3 * sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
+    gpuErrchk(cudaMemcpyAsync(d_box_after_, d_box, 3 * 3 * sizeof(*d_box_after_), cudaMemcpyDeviceToDevice, stream));
 
     const int tpb = 32;
     const int blocks = (num_grouped_atoms_ + tpb - 1) / tpb;
 
-    find_group_centroids<<<blocks, tpb, 0, stream>>>(
-        num_grouped_atoms_,
-        d_x,
-        d_atom_idxs_,
-        d_mol_idxs_,
-        d_centroids_
-    );
+    find_group_centroids<<<blocks, tpb, 0, stream>>>(num_grouped_atoms_, d_x, d_atom_idxs_, d_mol_idxs_, d_centroids_);
 
     gpuErrchk(cudaPeekAtLastError());
 
@@ -378,37 +333,19 @@ void MonteCarloBarostat::inplace_move(
         d_atom_idxs_,
         d_mol_idxs_,
         d_mol_offsets_,
-        d_centroids_
-    );
+        d_centroids_);
     gpuErrchk(cudaPeekAtLastError());
 
-
-    for(int i=0; i < bps_.size(); i++) {
+    for (int i = 0; i < bps_.size(); i++) {
         bps_[i]->execute_device(
-            N_,
-            d_x_after_,
-            d_box_after_,
-            lambda,
-            nullptr,
-            nullptr,
-            nullptr,
-            d_u_after_buffer_,
-            stream
-        );
+            N_, d_x_after_, d_box_after_, lambda, nullptr, nullptr, nullptr, d_u_after_buffer_, stream);
     }
 
-    cub::DeviceReduce::Sum(
-        d_sum_storage_,
-        d_sum_storage_bytes_,
-        d_u_after_buffer_,
-        d_final_u_,
-        N_,
-        stream
-    );
+    cub::DeviceReduce::Sum(d_sum_storage_, d_sum_storage_bytes_, d_u_after_buffer_, d_final_u_, N_, stream);
     gpuErrchk(cudaPeekAtLastError());
 
-    double pressure = pressure_*AVOGADRO*1e-25;
-    const double kT = BOLTZ*temperature_;
+    double pressure = pressure_ * AVOGADRO * 1e-25;
+    const double kT = BOLTZ * temperature_;
 
     const int move_blocks = (N_ + tpb - 1) / tpb;
 
@@ -427,13 +364,12 @@ void MonteCarloBarostat::inplace_move(
         d_x,
         d_x_after_,
         d_num_accepted_,
-        d_num_attempted_
-    );
+        d_num_attempted_);
 
     gpuErrchk(cudaPeekAtLastError())
 };
 
-void MonteCarloBarostat::set_interval(const int interval){
+void MonteCarloBarostat::set_interval(const int interval) {
     if (interval <= 0) {
         throw std::runtime_error("Barostat interval must be greater than 0");
     }
@@ -442,16 +378,13 @@ void MonteCarloBarostat::set_interval(const int interval){
     step_ = 0;
 }
 
-int MonteCarloBarostat::get_interval(){
-    return interval_;
-}
+int MonteCarloBarostat::get_interval() { return interval_; }
 
-void MonteCarloBarostat::set_pressure(const double pressure){
+void MonteCarloBarostat::set_pressure(const double pressure) {
     pressure_ = pressure;
     // Could have equilibrated and be a large number of steps from shifting volume
     // adjustment, ie num attempted = 300 and num accepted = 150
     this->reset_counters();
 }
 
-
-}
+} // namespace timemachine

--- a/timemachine/cpp/src/bound_potential.cu
+++ b/timemachine/cpp/src/bound_potential.cu
@@ -3,18 +3,13 @@
 
 namespace timemachine {
 
-BoundPotential::BoundPotential(
-    std::shared_ptr<Potential> potential,
-    std::vector<int> shape,
-    const double *h_p
-) : potential(potential),
-    shape(shape) {
+BoundPotential::BoundPotential(std::shared_ptr<Potential> potential, std::vector<int> shape, const double *h_p)
+    : potential(potential), shape(shape) {
 
     int P = this->size();
 
-    gpuErrchk(cudaMalloc(&d_p, P*sizeof(*d_p)));
-    gpuErrchk(cudaMemcpy(d_p, h_p, P*sizeof(*d_p), cudaMemcpyHostToDevice));
-
+    gpuErrchk(cudaMalloc(&d_p, P * sizeof(*d_p)));
+    gpuErrchk(cudaMemcpy(d_p, h_p, P * sizeof(*d_p), cudaMemcpyHostToDevice));
 }
 
 BoundPotential::~BoundPotential() {
@@ -22,12 +17,11 @@ BoundPotential::~BoundPotential() {
     gpuErrchk(cudaFree(d_p));
 }
 
-
 void BoundPotential::execute_host(
     const int N,
-    const double *h_x, // [N,3]
-    const double *h_box, // [3, 3]
-    const double lambda, // [1]
+    const double *h_x,           // [N,3]
+    const double *h_box,         // [3, 3]
+    const double lambda,         // [1]
     unsigned long long *h_du_dx, // [N,3]
     unsigned long long *h_du_dl, //
     unsigned long long *h_u) {
@@ -37,60 +31,47 @@ void BoundPotential::execute_host(
 
     const int D = 3;
 
-    gpuErrchk(cudaMalloc(&d_x, N*D*sizeof(double)));
-    gpuErrchk(cudaMemcpy(d_x, h_x, N*D*sizeof(double), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_x, N * D * sizeof(double)));
+    gpuErrchk(cudaMemcpy(d_x, h_x, N * D * sizeof(double), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_box, D*D*sizeof(double)));
-    gpuErrchk(cudaMemcpy(d_box, h_box, D*D*sizeof(double), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_box, D * D * sizeof(double)));
+    gpuErrchk(cudaMemcpy(d_box, h_box, D * D * sizeof(double), cudaMemcpyHostToDevice));
 
     unsigned long long *d_du_dx; // du/dx
     unsigned long long *d_du_dl; // du/dl
-    unsigned long long *d_u; // u
+    unsigned long long *d_u;     // u
 
     const int P = this->size();
 
     // very important that these are initialized to zero since the kernels themselves just accumulate
-    gpuErrchk(cudaMalloc(&d_du_dx, N*D*sizeof(unsigned long long)));
-    gpuErrchk(cudaMemset(d_du_dx, 0, N*D*sizeof(unsigned long long)));
-    gpuErrchk(cudaMalloc(&d_du_dl, N*sizeof(unsigned long long)));
-    gpuErrchk(cudaMemset(d_du_dl, 0, N*sizeof(unsigned long long)));
-    gpuErrchk(cudaMalloc(&d_u, N*sizeof(unsigned long long)));
-    gpuErrchk(cudaMemset(d_u, 0, N*sizeof(unsigned long long)));
+    gpuErrchk(cudaMalloc(&d_du_dx, N * D * sizeof(unsigned long long)));
+    gpuErrchk(cudaMemset(d_du_dx, 0, N * D * sizeof(unsigned long long)));
+    gpuErrchk(cudaMalloc(&d_du_dl, N * sizeof(unsigned long long)));
+    gpuErrchk(cudaMemset(d_du_dl, 0, N * sizeof(unsigned long long)));
+    gpuErrchk(cudaMalloc(&d_u, N * sizeof(unsigned long long)));
+    gpuErrchk(cudaMemset(d_u, 0, N * sizeof(unsigned long long)));
 
+    this->execute_device(N, d_x, d_box, lambda, d_du_dx, nullptr, d_du_dl, d_u, static_cast<cudaStream_t>(0));
 
-    this->execute_device(
-        N,
-        d_x,
-        d_box,
-        lambda,
-        d_du_dx,
-        nullptr,
-        d_du_dl,
-        d_u,
-        static_cast<cudaStream_t>(0)
-    );
-
-    gpuErrchk(cudaMemcpy(h_du_dx, d_du_dx, N*D*sizeof(*h_du_dx), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(h_du_dx, d_du_dx, N * D * sizeof(*h_du_dx), cudaMemcpyDeviceToHost));
     gpuErrchk(cudaFree(d_du_dx));
-    gpuErrchk(cudaMemcpy(h_du_dl, d_du_dl, N*sizeof(*h_du_dl), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(h_du_dl, d_du_dl, N * sizeof(*h_du_dl), cudaMemcpyDeviceToHost));
     gpuErrchk(cudaFree(d_du_dl));
-    gpuErrchk(cudaMemcpy(h_u, d_u, N*sizeof(*h_u), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(h_u, d_u, N * sizeof(*h_u), cudaMemcpyDeviceToHost));
     gpuErrchk(cudaFree(d_u));
     gpuErrchk(cudaFree(d_x));
     gpuErrchk(cudaFree(d_box));
-
 };
 
-
 int BoundPotential::size() const {
-    if(shape.size() == 0) {
+    if (shape.size() == 0) {
         return 0;
     }
     int total = 1;
-    for(auto s : shape) {
+    for (auto s : shape) {
         total *= s;
     }
     return total;
 }
 
-}
+} // namespace timemachine

--- a/timemachine/cpp/src/centroid_restraint.cu
+++ b/timemachine/cpp/src/centroid_restraint.cu
@@ -1,87 +1,61 @@
-#include <chrono>
-#include <iostream>
-#include <vector>
-#include <complex>
 #include "centroid_restraint.hpp"
 #include "gpu_utils.cuh"
 #include "k_centroid_restraint.cuh"
+#include <chrono>
+#include <complex>
+#include <iostream>
+#include <vector>
 
 namespace timemachine {
 
 template <typename RealType>
 CentroidRestraint<RealType>::CentroidRestraint(
-    const std::vector<int> &group_a_idxs,
-    const std::vector<int> &group_b_idxs,
-    const double kb,
-    const double b0
-) : N_A_(group_a_idxs.size()),
-    N_B_(group_b_idxs.size()),
-    kb_(kb),
-    b0_(b0) {
+    const std::vector<int> &group_a_idxs, const std::vector<int> &group_b_idxs, const double kb, const double b0)
+    : N_A_(group_a_idxs.size()), N_B_(group_b_idxs.size()), kb_(kb), b0_(b0) {
 
-    gpuErrchk(cudaMalloc(&d_group_a_idxs_, N_A_*sizeof(*d_group_a_idxs_)));
-    gpuErrchk(cudaMemcpy(d_group_a_idxs_, &group_a_idxs[0], N_A_*sizeof(*d_group_a_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_group_a_idxs_, N_A_ * sizeof(*d_group_a_idxs_)));
+    gpuErrchk(cudaMemcpy(d_group_a_idxs_, &group_a_idxs[0], N_A_ * sizeof(*d_group_a_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_group_b_idxs_, N_B_*sizeof(*d_group_b_idxs_)));
-    gpuErrchk(cudaMemcpy(d_group_b_idxs_, &group_b_idxs[0], N_B_*sizeof(*d_group_b_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_group_b_idxs_, N_B_ * sizeof(*d_group_b_idxs_)));
+    gpuErrchk(cudaMemcpy(d_group_b_idxs_, &group_b_idxs[0], N_B_ * sizeof(*d_group_b_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_centroid_a_, 3*sizeof(*d_centroid_a_)));
-    gpuErrchk(cudaMalloc(&d_centroid_b_, 3*sizeof(*d_centroid_b_)));
+    gpuErrchk(cudaMalloc(&d_centroid_a_, 3 * sizeof(*d_centroid_a_)));
+    gpuErrchk(cudaMalloc(&d_centroid_b_, 3 * sizeof(*d_centroid_b_)));
 };
 
-template <typename RealType>
-CentroidRestraint<RealType>::~CentroidRestraint() {
+template <typename RealType> CentroidRestraint<RealType>::~CentroidRestraint() {
     gpuErrchk(cudaFree(d_group_a_idxs_));
     gpuErrchk(cudaFree(d_group_b_idxs_));
     gpuErrchk(cudaFree(d_centroid_a_));
     gpuErrchk(cudaFree(d_centroid_b_));
 };
 
-
 template <typename RealType>
 void CentroidRestraint<RealType>::execute_device(
-        const int N,
-        const int P,
-        const double *d_x,
-        const double *d_p,
-        const double *d_box,
-        const double lambda,
-        unsigned long long *d_du_dx,
-        double *d_du_dp,
-        unsigned long long *d_du_dl,
-        unsigned long long *d_u,
-        cudaStream_t stream) {
+    const int N,
+    const int P,
+    const double *d_x,
+    const double *d_p,
+    const double *d_box,
+    const double lambda,
+    unsigned long long *d_du_dx,
+    double *d_du_dp,
+    unsigned long long *d_du_dl,
+    unsigned long long *d_u,
+    cudaStream_t stream) {
 
     int tpb = 32;
 
-    int blocks = (N_B_ + N_A_ + tpb -1)/tpb;
-    gpuErrchk(cudaMemsetAsync(d_centroid_a_, 0.0, 3*sizeof(*d_centroid_a_), stream));
-    gpuErrchk(cudaMemsetAsync(d_centroid_b_, 0.0, 3*sizeof(*d_centroid_b_), stream));
-    k_calc_centroid<RealType><<<blocks, tpb, 0, stream>>>(
-        d_x,
-        d_group_a_idxs_,
-        d_group_b_idxs_,
-        N_A_,
-        N_B_,
-        d_centroid_a_,
-        d_centroid_b_
-    );
+    int blocks = (N_B_ + N_A_ + tpb - 1) / tpb;
+    gpuErrchk(cudaMemsetAsync(d_centroid_a_, 0.0, 3 * sizeof(*d_centroid_a_), stream));
+    gpuErrchk(cudaMemsetAsync(d_centroid_b_, 0.0, 3 * sizeof(*d_centroid_b_), stream));
+    k_calc_centroid<RealType>
+        <<<blocks, tpb, 0, stream>>>(d_x, d_group_a_idxs_, d_group_b_idxs_, N_A_, N_B_, d_centroid_a_, d_centroid_b_);
 
     gpuErrchk(cudaPeekAtLastError());
 
     k_centroid_restraint<RealType><<<blocks, tpb, 0, stream>>>(
-        d_x,
-        d_group_a_idxs_,
-        d_group_b_idxs_,
-        N_A_,
-        N_B_,
-        d_centroid_a_,
-        d_centroid_b_,
-        kb_,
-        b0_,
-        d_du_dx,
-        d_u
-    );
+        d_x, d_group_a_idxs_, d_group_b_idxs_, N_A_, N_B_, d_centroid_a_, d_centroid_b_, kb_, b0_, d_du_dx, d_u);
     gpuErrchk(cudaPeekAtLastError());
 };
 

--- a/timemachine/cpp/src/context.cu
+++ b/timemachine/cpp/src/context.cu
@@ -1,37 +1,29 @@
 #include "context.hpp"
-#include "gpu_utils.cuh"
 #include "fixed_point.hpp"
-#include <iostream>
+#include "gpu_utils.cuh"
 #include <chrono>
 #include <cub/cub.cuh>
+#include <iostream>
 
 namespace timemachine {
-
-
 
 Context::Context(
     int N,
     const double *x_0,
     const double *v_0,
     const double *box_0,
-    Integrator* intg,
+    Integrator *intg,
     std::vector<BoundPotential *> bps,
-    MonteCarloBarostat* barostat) :
-    N_(N),
-    intg_(intg),
-    bps_(bps),
-    step_(0),
-    d_sum_storage_(nullptr),
-    d_sum_storage_bytes_(0),
-    barostat_(barostat) {
-    d_x_t_ = gpuErrchkCudaMallocAndCopy(x_0, N*3);
-    d_v_t_ = gpuErrchkCudaMallocAndCopy(v_0, N*3);
-    d_box_t_ = gpuErrchkCudaMallocAndCopy(box_0, 3*3);
-    gpuErrchk(cudaMalloc(&d_du_dx_t_, N*3*sizeof(*d_du_dx_t_)));
-    gpuErrchk(cudaMalloc(&d_du_dl_buffer_, N*sizeof(*d_du_dl_buffer_)));
-    gpuErrchk(cudaMalloc(&d_u_buffer_, N*sizeof(*d_u_buffer_)));
+    MonteCarloBarostat *barostat)
+    : N_(N), intg_(intg), bps_(bps), step_(0), d_sum_storage_(nullptr), d_sum_storage_bytes_(0), barostat_(barostat) {
+    d_x_t_ = gpuErrchkCudaMallocAndCopy(x_0, N * 3);
+    d_v_t_ = gpuErrchkCudaMallocAndCopy(v_0, N * 3);
+    d_box_t_ = gpuErrchkCudaMallocAndCopy(box_0, 3 * 3);
+    gpuErrchk(cudaMalloc(&d_du_dx_t_, N * 3 * sizeof(*d_du_dx_t_)));
+    gpuErrchk(cudaMalloc(&d_du_dl_buffer_, N * sizeof(*d_du_dl_buffer_)));
+    gpuErrchk(cudaMalloc(&d_u_buffer_, N * sizeof(*d_u_buffer_)));
 
-    unsigned long long *d_in_tmp = nullptr; // dummy
+    unsigned long long *d_in_tmp = nullptr;  // dummy
     unsigned long long *d_out_tmp = nullptr; // dummy
 
     // Compute the storage size necessary to reduce du_dl
@@ -40,12 +32,10 @@ Context::Context(
     gpuErrchk(cudaMalloc(&d_sum_storage_, d_sum_storage_bytes_));
 
     // for(int i=0; i < bps.size(); i++) {
-        // cudaStream_t stream;
-        // gpuErrchk(cudaStreamCreate(&stream));
-        // streams_.push_back(stream);
+    // cudaStream_t stream;
+    // gpuErrchk(cudaStreamCreate(&stream));
+    // streams_.push_back(stream);
     // }
-
-
 };
 
 Context::~Context() {
@@ -58,55 +48,54 @@ Context::~Context() {
     gpuErrchk(cudaFree(d_sum_storage_));
 
     // for(int i=0; i < streams_.size(); i++) {
-        // gpuErrchk(cudaStreamDestroy(streams_[i]));
+    // gpuErrchk(cudaStreamDestroy(streams_[i]));
     // }
 };
 
-void Context::add_observable(Observable *obs) {
-    this->observables_.push_back(obs);
-}
+void Context::add_observable(Observable *obs) { this->observables_.push_back(obs); }
 
-std::array<std::vector<double>, 3> Context::multiple_steps(
-    const std::vector<double> &lambda_schedule,
-    int store_du_dl_interval,
-    int store_x_interval) {
+std::array<std::vector<double>, 3>
+Context::multiple_steps(const std::vector<double> &lambda_schedule, int store_du_dl_interval, int store_x_interval) {
     unsigned long long *d_du_dl_buffer = nullptr;
     double *d_box_buffer = nullptr;
     // try catch block is to deal with leaks in d_du_dl_buffer
-    if(store_du_dl_interval <= 0) {
+    if (store_du_dl_interval <= 0) {
         throw std::runtime_error("store_du_dl_interval <= 0");
     }
-    if(store_x_interval <= 0) {
+    if (store_x_interval <= 0) {
         throw std::runtime_error("store_x_interval <= 0");
     }
     int du_dl_buffer_size = (lambda_schedule.size() + store_du_dl_interval - 1) / store_du_dl_interval;
     int x_buffer_size = (lambda_schedule.size() + store_x_interval - 1) / store_x_interval;
-    int box_buffer_size = x_buffer_size*3*3;
+    int box_buffer_size = x_buffer_size * 3 * 3;
 
-    std::vector<double> h_x_buffer(x_buffer_size*N_*3);
+    std::vector<double> h_x_buffer(x_buffer_size * N_ * 3);
 
     try {
-        gpuErrchk(cudaMalloc(&d_box_buffer, box_buffer_size*sizeof(*d_box_buffer)));
+        gpuErrchk(cudaMalloc(&d_box_buffer, box_buffer_size * sizeof(*d_box_buffer)));
         // indicator so we can set it to a default arg.
-        gpuErrchk(cudaMalloc(&d_du_dl_buffer, du_dl_buffer_size*sizeof(*d_du_dl_buffer)));
-        gpuErrchk(cudaMemset(d_du_dl_buffer, 0, du_dl_buffer_size*sizeof(*d_du_dl_buffer)));
+        gpuErrchk(cudaMalloc(&d_du_dl_buffer, du_dl_buffer_size * sizeof(*d_du_dl_buffer)));
+        gpuErrchk(cudaMemset(d_du_dl_buffer, 0, du_dl_buffer_size * sizeof(*d_du_dl_buffer)));
 
-        for(int i=0; i < lambda_schedule.size(); i++) {
+        for (int i = 0; i < lambda_schedule.size(); i++) {
             // decide if we need to store the du_dl for this step
             unsigned long long *du_dl_ptr = nullptr;
-            if(i % store_du_dl_interval == 0) {
+            if (i % store_du_dl_interval == 0) {
                 // pemdas but just to make it clear we're doing pointer arithmetic
                 du_dl_ptr = d_du_dl_buffer + (i / store_du_dl_interval);
             }
 
-            if(i % store_x_interval == 0) {
+            if (i % store_x_interval == 0) {
                 gpuErrchk(cudaMemcpy(
-                    &h_x_buffer[0] + (i / store_x_interval)*N_*3,
+                    &h_x_buffer[0] + (i / store_x_interval) * N_ * 3,
                     d_x_t_,
-                    N_*3*sizeof(double),
-                    cudaMemcpyDeviceToHost)
-                );
-                gpuErrchk(cudaMemcpy(&d_box_buffer[0] + (i / store_x_interval)*3*3, d_box_t_, 3*3*sizeof(*d_box_buffer), cudaMemcpyDeviceToDevice));
+                    N_ * 3 * sizeof(double),
+                    cudaMemcpyDeviceToHost));
+                gpuErrchk(cudaMemcpy(
+                    &d_box_buffer[0] + (i / store_x_interval) * 3 * 3,
+                    d_box_t_,
+                    3 * 3 * sizeof(*d_box_buffer),
+                    cudaMemcpyDeviceToDevice));
             }
 
             double lambda = lambda_schedule[i];
@@ -119,27 +108,26 @@ std::array<std::vector<double>, 3> Context::multiple_steps(
         gpuErrchk(cudaMemcpy(
             &h_du_dl_buffer_ull[0],
             d_du_dl_buffer,
-            du_dl_buffer_size*sizeof(*d_du_dl_buffer),
-            cudaMemcpyDeviceToHost)
-        );
+            du_dl_buffer_size * sizeof(*d_du_dl_buffer),
+            cudaMemcpyDeviceToHost));
 
         std::vector<double> h_du_dl_buffer_double(du_dl_buffer_size);
-        for(int i=0; i < h_du_dl_buffer_ull.size(); i++) {
+        for (int i = 0; i < h_du_dl_buffer_ull.size(); i++) {
             h_du_dl_buffer_double[i] = FIXED_TO_FLOAT<double>(h_du_dl_buffer_ull[i]);
         }
         std::vector<double> h_box_buffer(box_buffer_size);
-        gpuErrchk(cudaMemcpy(&h_box_buffer[0], d_box_buffer, box_buffer_size*sizeof(*d_box_buffer), cudaMemcpyDeviceToHost));
+        gpuErrchk(cudaMemcpy(
+            &h_box_buffer[0], d_box_buffer, box_buffer_size * sizeof(*d_box_buffer), cudaMemcpyDeviceToHost));
 
         gpuErrchk(cudaFree(d_du_dl_buffer));
         gpuErrchk(cudaFree(d_box_buffer));
         return std::array<std::vector<double>, 3>({h_du_dl_buffer_double, h_x_buffer, h_box_buffer});
 
-    } catch(...) {
+    } catch (...) {
         gpuErrchk(cudaFree(d_du_dl_buffer));
         gpuErrchk(cudaFree(d_box_buffer));
         throw;
     }
-
 }
 
 std::array<std::vector<double>, 3> Context::multiple_steps_U(
@@ -153,54 +141,51 @@ std::array<std::vector<double>, 3> Context::multiple_steps_U(
     double *d_box_traj = nullptr;
 
     // try catch block is to deal with leaks in d_u_buffer
-    if(store_u_interval <= 0) {
+    if (store_u_interval <= 0) {
         throw std::runtime_error("store_u_interval <= 0");
     }
 
-    if(store_x_interval <= 0) {
+    if (store_x_interval <= 0) {
         throw std::runtime_error("store_x_interval <= 0");
     }
 
     int n_windows = lambda_windows.size();
-    int u_traj_size = ((n_steps + store_u_interval - 1) / store_u_interval)*n_windows;
+    int u_traj_size = ((n_steps + store_u_interval - 1) / store_u_interval) * n_windows;
     int x_traj_size = (n_steps + store_x_interval - 1) / store_x_interval;
-    int box_traj_size = x_traj_size*3*3;
+    int box_traj_size = x_traj_size * 3 * 3;
 
-    std::vector<double> h_x_traj(x_traj_size*N_*3);
+    std::vector<double> h_x_traj(x_traj_size * N_ * 3);
 
     try {
-        gpuErrchk(cudaMalloc(&d_box_traj, box_traj_size*sizeof(*d_box_traj)));
-        gpuErrchk(cudaMalloc(&d_u_traj, u_traj_size*sizeof(*d_u_traj)));
-        gpuErrchk(cudaMemset(d_u_traj, 0, u_traj_size*sizeof(*d_u_traj)));
+        gpuErrchk(cudaMalloc(&d_box_traj, box_traj_size * sizeof(*d_box_traj)));
+        gpuErrchk(cudaMalloc(&d_u_traj, u_traj_size * sizeof(*d_u_traj)));
+        gpuErrchk(cudaMemset(d_u_traj, 0, u_traj_size * sizeof(*d_u_traj)));
 
-        for(int step=0; step < n_steps; step++) {
+        for (int step = 0; step < n_steps; step++) {
 
-            if(step % store_x_interval == 0) {
+            if (step % store_x_interval == 0) {
                 gpuErrchk(cudaMemcpy(
-                    &h_x_traj[0] + (step / store_x_interval)*N_*3,
+                    &h_x_traj[0] + (step / store_x_interval) * N_ * 3,
                     d_x_t_,
-                    N_*3*sizeof(double),
-                    cudaMemcpyDeviceToHost)
-                );
-                gpuErrchk(cudaMemcpy(&d_box_traj[0] + (step / store_x_interval)*3*3, d_box_t_, 3*3*sizeof(*d_box_traj), cudaMemcpyDeviceToDevice));
+                    N_ * 3 * sizeof(double),
+                    cudaMemcpyDeviceToHost));
+                gpuErrchk(cudaMemcpy(
+                    &d_box_traj[0] + (step / store_x_interval) * 3 * 3,
+                    d_box_t_,
+                    3 * 3 * sizeof(*d_box_traj),
+                    cudaMemcpyDeviceToDevice));
             }
 
             cudaStream_t stream = static_cast<cudaStream_t>(0);
 
-            for(int i=0; i < observables_.size(); i++) {
-                observables_[i]->observe(
-                    step,
-                    N_,
-                    d_x_t_,
-                    d_box_t_,
-                    lambda
-                );
+            for (int i = 0; i < observables_.size(); i++) {
+                observables_[i]->observe(step, N_, d_x_t_, d_box_t_, lambda);
             }
 
-            gpuErrchk(cudaMemsetAsync(d_du_dx_t_, 0, N_*3*sizeof(*d_du_dx_t_), stream));
+            gpuErrchk(cudaMemsetAsync(d_du_dx_t_, 0, N_ * 3 * sizeof(*d_du_dx_t_), stream));
 
             // first pass generate the forces
-            for(int i=0; i < bps_.size(); i++) {
+            for (int i = 0; i < bps_.size(); i++) {
                 bps_[i]->execute_device(
                     N_,
                     d_x_t_,
@@ -210,89 +195,53 @@ std::array<std::vector<double>, 3> Context::multiple_steps_U(
                     nullptr,
                     nullptr,
                     nullptr,
-                    stream
-                );
+                    stream);
             }
 
             // we need to compute aggregate energies on this step
-            if(step % store_u_interval == 0) {
-                unsigned long long *u_ptr = d_u_traj + (step / store_u_interval)*n_windows;
-                for(int w=0; w < n_windows; w++) {
+            if (step % store_u_interval == 0) {
+                unsigned long long *u_ptr = d_u_traj + (step / store_u_interval) * n_windows;
+                for (int w = 0; w < n_windows; w++) {
                     // reset buffers on each pass.
-                    gpuErrchk(cudaMemsetAsync(d_u_buffer_, 0, N_*sizeof(*d_u_buffer_), stream));
-                    for(int i=0; i < bps_.size(); i++) {
+                    gpuErrchk(cudaMemsetAsync(d_u_buffer_, 0, N_ * sizeof(*d_u_buffer_), stream));
+                    for (int i = 0; i < bps_.size(); i++) {
                         bps_[i]->execute_device(
-                            N_,
-                            d_x_t_,
-                            d_box_t_,
-                            lambda_windows[w],
-                            nullptr,
-                            nullptr,
-                            nullptr,
-                            d_u_buffer_,
-                            stream
-                        );
+                            N_, d_x_t_, d_box_t_, lambda_windows[w], nullptr, nullptr, nullptr, d_u_buffer_, stream);
                     }
-                    cub::DeviceReduce::Sum(
-                        d_sum_storage_,
-                        d_sum_storage_bytes_,
-                        d_u_buffer_,
-                        u_ptr+w,
-                        N_,
-                        stream
-                    );
+                    cub::DeviceReduce::Sum(d_sum_storage_, d_sum_storage_bytes_, d_u_buffer_, u_ptr + w, N_, stream);
                     gpuErrchk(cudaPeekAtLastError());
                 }
-
             }
 
-            intg_->step_fwd(
-                d_x_t_,
-                d_v_t_,
-                d_du_dx_t_,
-                d_box_t_,
-                stream
-            );
+            intg_->step_fwd(d_x_t_, d_v_t_, d_du_dx_t_, d_box_t_, stream);
 
-            if(barostat_) {
+            if (barostat_) {
                 // May modify coords, du_dx and box size
-                barostat_->inplace_move(
-                    d_x_t_,
-                    d_box_t_,
-                    lambda,
-                    stream
-                );
+                barostat_->inplace_move(d_x_t_, d_box_t_, lambda, stream);
             }
-
         }
 
         cudaDeviceSynchronize();
 
         std::vector<unsigned long long> h_u_traj_ull(u_traj_size);
-        gpuErrchk(cudaMemcpy(
-            &h_u_traj_ull[0],
-            d_u_traj,
-            u_traj_size*sizeof(*d_u_traj),
-            cudaMemcpyDeviceToHost)
-        );
+        gpuErrchk(cudaMemcpy(&h_u_traj_ull[0], d_u_traj, u_traj_size * sizeof(*d_u_traj), cudaMemcpyDeviceToHost));
 
         std::vector<double> h_u_traj_double(u_traj_size);
-        for(int i=0; i < h_u_traj_ull.size(); i++) {
+        for (int i = 0; i < h_u_traj_ull.size(); i++) {
             h_u_traj_double[i] = FIXED_TO_FLOAT<double>(h_u_traj_ull[i]);
         }
         std::vector<double> h_box_traj(box_traj_size);
-        gpuErrchk(cudaMemcpy(&h_box_traj[0], d_box_traj, box_traj_size*sizeof(*d_box_traj), cudaMemcpyDeviceToHost));
+        gpuErrchk(cudaMemcpy(&h_box_traj[0], d_box_traj, box_traj_size * sizeof(*d_box_traj), cudaMemcpyDeviceToHost));
 
         gpuErrchk(cudaFree(d_u_traj));
         gpuErrchk(cudaFree(d_box_traj));
         return std::array<std::vector<double>, 3>({h_u_traj_double, h_x_traj, h_box_traj});
 
-    } catch(...) {
+    } catch (...) {
         gpuErrchk(cudaFree(d_u_traj));
         gpuErrchk(cudaFree(d_box_traj));
         throw;
     }
-
 }
 
 void Context::step(double lambda) {
@@ -307,23 +256,17 @@ void Context::_step(double lambda, unsigned long long *du_dl_out) {
 
     cudaStream_t stream = static_cast<cudaStream_t>(0);
 
-    for(int i=0; i < observables_.size(); i++) {
-        observables_[i]->observe(
-            step_,
-            N_,
-            d_x_t_,
-            d_box_t_,
-            lambda
-        );
+    for (int i = 0; i < observables_.size(); i++) {
+        observables_[i]->observe(step_, N_, d_x_t_, d_box_t_, lambda);
     }
 
-    gpuErrchk(cudaMemsetAsync(d_du_dx_t_, 0, N_*3*sizeof(*d_du_dx_t_), stream));
+    gpuErrchk(cudaMemsetAsync(d_du_dx_t_, 0, N_ * 3 * sizeof(*d_du_dx_t_), stream));
 
-    if(du_dl_out) {
-        gpuErrchk(cudaMemsetAsync(d_du_dl_buffer_, 0, N_*sizeof(*d_du_dl_buffer_), stream));
+    if (du_dl_out) {
+        gpuErrchk(cudaMemsetAsync(d_du_dl_buffer_, 0, N_ * sizeof(*d_du_dl_buffer_), stream));
     }
 
-    for(int i=0; i < bps_.size(); i++) {
+    for (int i = 0; i < bps_.size(); i++) {
         bps_[i]->execute_device(
             N_,
             d_x_t_,
@@ -333,74 +276,48 @@ void Context::_step(double lambda, unsigned long long *du_dl_out) {
             nullptr,
             du_dl_out ? d_du_dl_buffer_ : nullptr,
             nullptr,
-            stream
-        );
+            stream);
     }
 
     // compute du_dl
-    if(du_dl_out) {
-        cub::DeviceReduce::Sum(
-            d_sum_storage_,
-            d_sum_storage_bytes_,
-            d_du_dl_buffer_,
-            du_dl_out,
-            N_,
-            stream
-        );
+    if (du_dl_out) {
+        cub::DeviceReduce::Sum(d_sum_storage_, d_sum_storage_bytes_, d_du_dl_buffer_, du_dl_out, N_, stream);
         gpuErrchk(cudaPeekAtLastError());
     }
 
-
     // for(int i=0; i < streams_.size(); i++) {
-        // gpuErrchk(cudaStreamSynchronize(streams_[i]));
+    // gpuErrchk(cudaStreamSynchronize(streams_[i]));
     // }
-    intg_->step_fwd(
-        d_x_t_,
-        d_v_t_,
-        d_du_dx_t_,
-        d_box_t_,
-        stream
-    );
+    intg_->step_fwd(d_x_t_, d_v_t_, d_du_dx_t_, d_box_t_, stream);
 
-    if(barostat_) {
+    if (barostat_) {
         // May modify coords, du_dx and box size
-        barostat_->inplace_move(
-            d_x_t_,
-            d_box_t_,
-            lambda,
-            stream
-        );
+        barostat_->inplace_move(d_x_t_, d_box_t_, lambda, stream);
     }
 
-
-
     step_ += 1;
-
 };
 
-
-int Context::num_atoms() const {
-    return N_;
-}
+int Context::num_atoms() const { return N_; }
 
 void Context::set_x_t(const double *in_buffer) {
     gpuErrchk(cudaMemcpy(d_x_t_, in_buffer, N_ * 3 * sizeof(*in_buffer), cudaMemcpyHostToDevice));
 }
 
 void Context::get_du_dx_t_minus_1(unsigned long long *out_buffer) const {
-    gpuErrchk(cudaMemcpy(out_buffer, d_du_dx_t_, N_*3*sizeof(*out_buffer), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(out_buffer, d_du_dx_t_, N_ * 3 * sizeof(*out_buffer), cudaMemcpyDeviceToHost));
 }
 
 void Context::get_x_t(double *out_buffer) const {
-    gpuErrchk(cudaMemcpy(out_buffer, d_x_t_, N_*3*sizeof(*out_buffer), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(out_buffer, d_x_t_, N_ * 3 * sizeof(*out_buffer), cudaMemcpyDeviceToHost));
 }
 
 void Context::get_v_t(double *out_buffer) const {
-    gpuErrchk(cudaMemcpy(out_buffer, d_v_t_, N_*3*sizeof(*out_buffer), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(out_buffer, d_v_t_, N_ * 3 * sizeof(*out_buffer), cudaMemcpyDeviceToHost));
 }
 
 void Context::get_box(double *out_buffer) const {
-    gpuErrchk(cudaMemcpy(out_buffer, d_box_t_, 3*3*sizeof(*out_buffer), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(out_buffer, d_box_t_, 3 * 3 * sizeof(*out_buffer), cudaMemcpyDeviceToHost));
 }
 
-}
+} // namespace timemachine

--- a/timemachine/cpp/src/electrostatics.cu
+++ b/timemachine/cpp/src/electrostatics.cu
@@ -1,14 +1,14 @@
-#include <chrono>
-#include <iostream>
-#include <vector>
-#include <complex>
-#include <sstream>
-#include <numeric>
 #include <algorithm>
+#include <chrono>
+#include <complex>
+#include <iostream>
+#include <numeric>
+#include <sstream>
+#include <vector>
 
-#include "vendored/hilbert.h"
 #include "electrostatics.hpp"
 #include "gpu_utils.cuh"
+#include "vendored/hilbert.h"
 
 #include "k_electrostatics.cuh"
 #include "k_electrostatics_jvp.cuh"
@@ -17,40 +17,35 @@ namespace timemachine {
 
 template <typename RealType>
 Electrostatics<RealType>::Electrostatics(
-    const std::vector<int> &exclusion_idxs, // [E,2]
-    const std::vector<double> &charge_scales, // [E]
+    const std::vector<int> &exclusion_idxs,     // [E,2]
+    const std::vector<double> &charge_scales,   // [E]
     const std::vector<int> &lambda_offset_idxs, // [N]
     double beta,
-    double cutoff
-) :  N_(lambda_offset_idxs.size()),
-    beta_(beta),
-    cutoff_(cutoff),
-    E_(exclusion_idxs.size()/2),
-    nblist_(lambda_offset_idxs.size()),
-    d_perm_(nullptr) {
+    double cutoff)
+    : N_(lambda_offset_idxs.size()), beta_(beta), cutoff_(cutoff), E_(exclusion_idxs.size() / 2),
+      nblist_(lambda_offset_idxs.size()), d_perm_(nullptr) {
 
-    if(lambda_offset_idxs.size() != N_) {
+    if (lambda_offset_idxs.size() != N_) {
         throw std::runtime_error("lambda offset idxs need to have size N");
     }
 
-    if(charge_scales.size()*2 != exclusion_idxs.size()) {
+    if (charge_scales.size() * 2 != exclusion_idxs.size()) {
         throw std::runtime_error("charge scale idxs size not half of exclusion size!");
     }
 
-    gpuErrchk(cudaMalloc(&d_lambda_offset_idxs_, N_*sizeof(*d_lambda_offset_idxs_)));
-    gpuErrchk(cudaMemcpy(d_lambda_offset_idxs_, &lambda_offset_idxs[0], N_*sizeof(*d_lambda_offset_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_lambda_offset_idxs_, N_ * sizeof(*d_lambda_offset_idxs_)));
+    gpuErrchk(cudaMemcpy(
+        d_lambda_offset_idxs_, &lambda_offset_idxs[0], N_ * sizeof(*d_lambda_offset_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_exclusion_idxs_, E_*2*sizeof(*d_exclusion_idxs_)));
-    gpuErrchk(cudaMemcpy(d_exclusion_idxs_, &exclusion_idxs[0], E_*2*sizeof(*d_exclusion_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_exclusion_idxs_, E_ * 2 * sizeof(*d_exclusion_idxs_)));
+    gpuErrchk(
+        cudaMemcpy(d_exclusion_idxs_, &exclusion_idxs[0], E_ * 2 * sizeof(*d_exclusion_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_charge_scales_, E_*sizeof(*d_charge_scales_)));
-    gpuErrchk(cudaMemcpy(d_charge_scales_, &charge_scales[0], E_*sizeof(*d_charge_scales_), cudaMemcpyHostToDevice));
-
-
+    gpuErrchk(cudaMalloc(&d_charge_scales_, E_ * sizeof(*d_charge_scales_)));
+    gpuErrchk(cudaMemcpy(d_charge_scales_, &charge_scales[0], E_ * sizeof(*d_charge_scales_), cudaMemcpyHostToDevice));
 };
 
-template <typename RealType>
-Electrostatics<RealType>::~Electrostatics() {
+template <typename RealType> Electrostatics<RealType>::~Electrostatics() {
     gpuErrchk(cudaFree(d_exclusion_idxs_));
     gpuErrchk(cudaFree(d_charge_scales_));
     gpuErrchk(cudaFree(d_lambda_offset_idxs_));
@@ -61,13 +56,9 @@ struct Vec3 {
 
     double x, y, z;
 
-    Vec3(double x, double y, double z) : x(x), y(y), z(z) {};
+    Vec3(double x, double y, double z) : x(x), y(y), z(z){};
 
-    Vec3 operator*(double a) {
-        return Vec3(x*a, y*a, z*a);
-    }
-
-
+    Vec3 operator*(double a) { return Vec3(x * a, y * a, z * a); }
 };
 
 template <typename RealType>
@@ -84,22 +75,20 @@ void Electrostatics<RealType>::execute_device(
     double *d_u,
     cudaStream_t stream) {
 
-    if(N != N_) {
+    if (N != N_) {
         std::ostringstream err_msg;
         err_msg << "N != N_ " << N << " " << N_;
         throw std::runtime_error(err_msg.str());
     }
 
     int WSIZE = 32;
-    const int B = (N_+WSIZE-1)/WSIZE;
+    const int B = (N_ + WSIZE - 1) / WSIZE;
     const int D = 3;
-
-
 
     // add conditional for flipping a random number.
     bool sort = 0;
-    if(d_perm_ == nullptr) {
-        gpuErrchk(cudaMalloc(&d_perm_, N_*sizeof(*d_perm_)));
+    if (d_perm_ == nullptr) {
+        gpuErrchk(cudaMalloc(&d_perm_, N_ * sizeof(*d_perm_)));
         sort = true;
     }
 
@@ -109,18 +98,16 @@ void Electrostatics<RealType>::execute_device(
 
     // can probably be turned into a float for speed, since the nblist is approximate anyways
 
-
-    std::vector<double> centered_coords(N_*3);
+    std::vector<double> centered_coords(N_ * 3);
     std::vector<int> perm(N_);
-
 
     // tbd switch with asyncversions
     std::vector<double> box(9);
-    gpuErrchk(cudaMemcpy(&box[0], d_box, 9*sizeof(double), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(&box[0], d_box, 9 * sizeof(double), cudaMemcpyDeviceToHost));
 
     // 1. copy over coordinates
-    std::vector<double> coords(N_*3);
-    gpuErrchk(cudaMemcpy(&coords[0], d_x, N_*3*sizeof(double), cudaMemcpyDeviceToHost));
+    std::vector<double> coords(N_ * 3);
+    gpuErrchk(cudaMemcpy(&coords[0], d_x, N_ * 3 * sizeof(double), cudaMemcpyDeviceToHost));
 
     // nblist_.build_nblist_cpu(
     //     N,
@@ -130,26 +117,26 @@ void Electrostatics<RealType>::execute_device(
 
     throw std::runtime_error("break");
 
-    if(sort) {
-        double bx = box[0*3+0];
-        double by = box[1*3+1];
-        double bz = box[2*3+2];
+    if (sort) {
+        double bx = box[0 * 3 + 0];
+        double by = box[1 * 3 + 1];
+        double bz = box[2 * 3 + 2];
 
         // 2. apply periodic centering
-        for(int i=0; i < N_; i++) {
+        for (int i = 0; i < N_; i++) {
 
-            double x = coords[i*3+0];
-            double y = coords[i*3+1];
-            double z = coords[i*3+2];
+            double x = coords[i * 3 + 0];
+            double y = coords[i * 3 + 1];
+            double z = coords[i * 3 + 2];
 
             // only if periodic
-            x -= bx*floor(x/bx);
-            y -= by*floor(y/by);
-            z -= bz*floor(z/bz);
+            x -= bx * floor(x / bx);
+            y -= by * floor(y / by);
+            z -= bz * floor(z / bz);
 
-            centered_coords[i*3+0] = x;
-            centered_coords[i*3+1] = y;
-            centered_coords[i*3+2] = z;
+            centered_coords[i * 3 + 0] = x;
+            centered_coords[i * 3 + 1] = y;
+            centered_coords[i * 3 + 2] = z;
         }
 
         // 3. build the hilbert curve
@@ -162,50 +149,51 @@ void Electrostatics<RealType>::execute_device(
         // double maxz = bz;
 
         // always use this to generate the bounding box
-        double minx = centered_coords[0*3+0], maxx = centered_coords[0*3+0];
-        double miny = centered_coords[0*3+1], maxy = centered_coords[0*3+1];
-        double minz = centered_coords[0*3+2], maxz = centered_coords[0*3+2];
+        double minx = centered_coords[0 * 3 + 0], maxx = centered_coords[0 * 3 + 0];
+        double miny = centered_coords[0 * 3 + 1], maxy = centered_coords[0 * 3 + 1];
+        double minz = centered_coords[0 * 3 + 2], maxz = centered_coords[0 * 3 + 2];
         for (int i = 1; i < N_; i++) {
             // const Real4& pos = oldPosq[i];
-            minx = min(minx, centered_coords[i*3+0]);
-            maxx = max(maxx, centered_coords[i*3+0]);
-            miny = min(miny, centered_coords[i*3+1]);
-            maxy = max(maxy, centered_coords[i*3+1]);
-            minz = min(minz, centered_coords[i*3+2]);
-            maxz = max(maxz, centered_coords[i*3+2]);
+            minx = min(minx, centered_coords[i * 3 + 0]);
+            maxx = max(maxx, centered_coords[i * 3 + 0]);
+            miny = min(miny, centered_coords[i * 3 + 1]);
+            maxy = max(maxy, centered_coords[i * 3 + 1]);
+            minz = min(minz, centered_coords[i * 3 + 2]);
+            maxz = max(maxz, centered_coords[i * 3 + 2]);
         }
 
-        double binWidth = max(max(maxx-minx, maxy-miny), maxz-minz)/255.0;
-        double invBinWidth = 1.0/binWidth;
-        std::vector<std::pair<int, int> > molBins(N_);
+        double binWidth = max(max(maxx - minx, maxy - miny), maxz - minz) / 255.0;
+        double invBinWidth = 1.0 / binWidth;
+        std::vector<std::pair<int, int>> molBins(N_);
 
-        for(int i = 0; i < N_; i++) {
-            int x = (centered_coords[i*3+0]-minx)*invBinWidth;
-            int y = (centered_coords[i*3+1]-miny)*invBinWidth;
-            int z = (centered_coords[i*3+2]-minz)*invBinWidth;
+        for (int i = 0; i < N_; i++) {
+            int x = (centered_coords[i * 3 + 0] - minx) * invBinWidth;
+            int y = (centered_coords[i * 3 + 1] - miny) * invBinWidth;
+            int z = (centered_coords[i * 3 + 2] - minz) * invBinWidth;
 
             bitmask_t hilbert_coords[3];
             hilbert_coords[0] = x;
             hilbert_coords[1] = y;
             hilbert_coords[2] = z;
-            int bin = (int) hilbert_c2i(3, 8, hilbert_coords);
+            int bin = (int)hilbert_c2i(3, 8, hilbert_coords);
 
             molBins[i] = std::pair<int, int>(bin, i);
         }
         std::sort(molBins.begin(), molBins.end());
         // 4. generate a new ordering
 
-        for(int i=0; i < N_; i++) {
+        for (int i = 0; i < N_; i++) {
             // perm[i] = i;
             perm[i] = molBins[i].second;
         }
-        gpuErrchk(cudaMemcpy(d_perm_, &perm[0], N*sizeof(*d_perm_), cudaMemcpyHostToDevice));
+        gpuErrchk(cudaMemcpy(d_perm_, &perm[0], N * sizeof(*d_perm_), cudaMemcpyHostToDevice));
     }
 
     auto end_sort = std::chrono::high_resolution_clock::now();
 
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_sort - start_sort).count();
-    std::cout << duration << "us to re-sort" << std::endl;;
+    std::cout << duration << "us to re-sort" << std::endl;
+    ;
 
     // its safe for us to build a neighborlist in a lower dimension.
     // nblist_.compute_block_bounds(
@@ -217,8 +205,8 @@ void Electrostatics<RealType>::execute_device(
     //     stream
     // );
 
-    std::vector<double> bb_ctr(B*3);
-    std::vector<double> bb_ext(B*3);
+    std::vector<double> bb_ctr(B * 3);
+    std::vector<double> bb_ext(B * 3);
 
     // gpuErrchk(cudaMemcpy(&bb_ctr[0], nblist_.get_block_bounds_ctr(), B*3*sizeof(double), cudaMemcpyDeviceToHost));
     // gpuErrchk(cudaMemcpy(&bb_ext[0], nblist_.get_block_bounds_ext(), B*3*sizeof(double), cudaMemcpyDeviceToHost));
@@ -229,21 +217,19 @@ void Electrostatics<RealType>::execute_device(
     // std::vector<double> box(9);
     // gpuErrchk(cudaMemcpy(&box[0], d_box, 9*sizeof(double), cudaMemcpyDeviceToHost));
 
-    double bx[3] = {box[0*3+0], box[1*3+1], box[2*3+2]};
+    double bx[3] = {box[0 * 3 + 0], box[1 * 3 + 1], box[2 * 3 + 2]};
 
     std::vector<double> bv;
 
-
-    for(int x=0; x < B; x++) {
+    for (int x = 0; x < B; x++) {
 
         double vol = 1;
 
-        for(int d=0; d < 3; d++) {
-            double block_row_ext = bb_ext[x*3+d];
-            vol *= 2*block_row_ext*2*block_row_ext;
+        for (int d = 0; d < 3; d++) {
+            double block_row_ext = bb_ext[x * 3 + d];
+            vol *= 2 * block_row_ext * 2 * block_row_ext;
         }
         bv.push_back(vol);
-
     }
 
     double box_sum = std::accumulate(bv.begin(), bv.end(), 0.0);
@@ -256,37 +242,35 @@ void Electrostatics<RealType>::execute_device(
 
     // throw std::runtime_error("debug");
 
-
     // check bounding box deltas
-    for(int x=0; x < B; x++) {
+    for (int x = 0; x < B; x++) {
 
-        for(int y=0; y < B; y++) {
+        for (int y = 0; y < B; y++) {
 
-            if(y > x) {
+            if (y > x) {
                 continue;
             }
 
             double block_d2ij = 0;
 
-            for(int d=0; d < 3; d++) {
-                double block_row_ctr = bb_ctr[x*3+d];
-                double block_row_ext = bb_ext[x*3+d];
-                double block_col_ctr = bb_ctr[y*3+d];
-                double block_col_ext = bb_ext[y*3+d];
+            for (int d = 0; d < 3; d++) {
+                double block_row_ctr = bb_ctr[x * 3 + d];
+                double block_row_ext = bb_ext[x * 3 + d];
+                double block_col_ctr = bb_ctr[y * 3 + d];
+                double block_col_ext = bb_ext[y * 3 + d];
 
                 double dx = block_row_ctr - block_col_ctr;
-                dx -= bx[d]*floor(dx/bx[d]+static_cast<double>(0.5));
+                dx -= bx[d] * floor(dx / bx[d] + static_cast<double>(0.5));
                 dx = max(static_cast<double>(0.0), fabs(dx) - (block_row_ext + block_col_ext));
-                block_d2ij += dx*dx;
+                block_d2ij += dx * dx;
             }
 
-            if(block_d2ij < cutoff_*cutoff_) {
+            if (block_d2ij < cutoff_ * cutoff_) {
                 tiles_x.push_back(x);
                 tiles_y.push_back(y);
-            } else{
+            } else {
                 // std::cout << "skipping: " << x << " " << y << std::endl;
             }
-
         }
     }
 
@@ -297,74 +281,62 @@ void Electrostatics<RealType>::execute_device(
 
     // test fully compact tiles
 
-
     std::vector<int> interacting_y_offsets;
     std::vector<int> all_interacting_ys;
 
-
     int compact_tile_size = 0;
-    for(int bi=0; bi < B; bi++) {
+    for (int bi = 0; bi < B; bi++) {
 
         std::vector<int> interacting_ys;
         std::vector<int> interacting_y_counts;
 
-        for(int j=0; j < N_; j++) {
+        for (int j = 0; j < N_; j++) {
 
             // skip upper right triangular parts
-            if(j > bi*32) {
+            if (j > bi * 32) {
                 continue;
             }
 
-            double cj[3] = {
-                coords[perm[j]*3+0],
-                coords[perm[j]*3+1],
-                coords[perm[j]*3+2]
-            };
+            double cj[3] = {coords[perm[j] * 3 + 0], coords[perm[j] * 3 + 1], coords[perm[j] * 3 + 2]};
 
             int j_ixns = 0;
 
-            for(int i = bi*32; i < min((bi+1)*32, N_); i++) {
+            for (int i = bi * 32; i < min((bi + 1) * 32, N_); i++) {
 
-                double ci[3] = {
-                    coords[perm[i]*3+0],
-                    coords[perm[i]*3+1],
-                    coords[perm[i]*3+2]
-                };
+                double ci[3] = {coords[perm[i] * 3 + 0], coords[perm[i] * 3 + 1], coords[perm[i] * 3 + 2]};
 
                 double dij = 0;
 
-                for(int d=0; d < 3; d++) {
+                for (int d = 0; d < 3; d++) {
                     double delta = ci[d] - cj[d];
-                    delta -= box[d*3+d]*floor(delta/box[d*3+d]+0.5);
-                    dij += delta*delta;
+                    delta -= box[d * 3 + d] * floor(delta / box[d * 3 + d] + 0.5);
+                    dij += delta * delta;
                 }
 
                 dij = sqrt(dij);
 
-                if(dij < cutoff_) {
+                if (dij < cutoff_) {
                     j_ixns += 1;
                 }
-
             }
 
-            if(j_ixns > 0) {
+            if (j_ixns > 0) {
                 interacting_ys.push_back(j);
                 interacting_y_counts.push_back(j_ixns);
             }
 
             ref_total_ixns += j_ixns;
-
         }
 
         interacting_y_offsets.push_back(interacting_ys.size()); // needs to get prefix summ'd
 
-        for(int j=0; j < interacting_ys.size(); j++) {
+        for (int j = 0; j < interacting_ys.size(); j++) {
             all_interacting_ys.push_back(interacting_ys[j]);
         }
 
         interacting_y_offsets.push_back(interacting_ys.size());
 
-        compact_tile_size += interacting_ys.size()/32;
+        compact_tile_size += interacting_ys.size() / 32;
 
         // std::cout << "block " << bi << " interacts with " << interacting_ys.size() << " neighbors " << std::endl;
 
@@ -378,32 +350,26 @@ void Electrostatics<RealType>::execute_device(
 
         //     throw std::runtime_error("debug");
         // }
-
-
     }
 
     std::cout << "compact tile size: " << compact_tile_size << std::endl;
     // throw std::runtime_error("debug");
 
-
-    std::cout << "num_tiles: " << tiles_x.size() << " out of " << (N_/32)*(N_/32) << std::endl;
+    std::cout << "num_tiles: " << tiles_x.size() << " out of " << (N_ / 32) * (N_ / 32) << std::endl;
 
     gpuErrchk(cudaPeekAtLastError());
 
     // remove me later
     cudaDeviceSynchronize();
 
-
-
     auto start = std::chrono::high_resolution_clock::now();
-
 
     // these can be ran in two streams later on
     int *total_ixns;
-    gpuErrchk(cudaMallocManaged(&total_ixns, 1*sizeof(int)));
+    gpuErrchk(cudaMallocManaged(&total_ixns, 1 * sizeof(int)));
 
     int *total_empty_tiles;
-    gpuErrchk(cudaMallocManaged(&total_empty_tiles, 1*sizeof(int)));
+    gpuErrchk(cudaMallocManaged(&total_empty_tiles, 1 * sizeof(int)));
 
     // const int TILES = (tiles_x.size()+tpb-1)/tpb;
     const int TILES = tiles_x.size();
@@ -411,8 +377,8 @@ void Electrostatics<RealType>::execute_device(
     std::cout << "NUM TILES: " << TILES << std::endl;
 
     const int tpb = 32;
-    const int div = tpb/32;
-    const int NBLOCKS = (TILES + div - 1)/div;
+    const int div = tpb / 32;
+    const int NBLOCKS = (TILES + div - 1) / div;
 
     // dim3 dimGrid(B, B, 1); // x, y, z dims
     dim3 dimGrid(NBLOCKS, 1, 1); // x, y, z dims
@@ -437,24 +403,22 @@ void Electrostatics<RealType>::execute_device(
         d_du_dl,
         d_u,
         total_ixns,
-        total_empty_tiles
-    );
+        total_empty_tiles);
 
     cudaDeviceSynchronize();
 
-    std::cout << "total ixns: " << *total_ixns << "/" << TILES*(32*32) << std::endl;
+    std::cout << "total ixns: " << *total_ixns << "/" << TILES * (32 * 32) << std::endl;
 
-    std::cout << "compact ixns: " << *total_ixns << "/" << compact_tile_size*32*32 << std::endl;
+    std::cout << "compact ixns: " << *total_ixns << "/" << compact_tile_size * 32 * 32 << std::endl;
 
     std::cout << "total empty tiles: " << *total_empty_tiles << "/" << tiles_x.size() << std::endl;
 
     // cudaDeviceSynchronize();
     gpuErrchk(cudaPeekAtLastError());
 
-    if(E_ > 0) {
+    if (E_ > 0) {
 
-
-        dim3 dimGridExclusions((E_+tpb-1)/tpb, 1, 1);
+        dim3 dimGridExclusions((E_ + tpb - 1) / tpb, 1, 1);
 
         // k_electrostatics_exclusion_inference<RealType><<<dimGridExclusions, tpb, 0, stream>>>(
         //     E_,

--- a/timemachine/cpp/src/fast_nonbonded.cu
+++ b/timemachine/cpp/src/fast_nonbonded.cu
@@ -4,13 +4,13 @@
 #include "fast_nonbonded.hpp"
 #include "k_nonbonded_deterministic.cuh"
 
-#include <vector>
 #include "gpu_utils.cuh"
 #include "surreal.cuh"
+#include <vector>
 
 #include "assert.h"
 
-template<typename RealType, int D>
+template <typename RealType, int D>
 void fast_nonbonded_normal(
     const RealType *coords,
     const RealType *coords_tangents,
@@ -28,36 +28,28 @@ void fast_nonbonded_normal(
 
     int *d_param_idxs;
 
-    int ND = N*D;
+    int ND = N * D;
 
-    gpuErrchk(cudaMalloc(&d_coords, sizeof(RealType)*ND));
-    gpuErrchk(cudaMalloc(&d_params, sizeof(RealType)*P));
-    gpuErrchk(cudaMalloc(&d_param_idxs, sizeof(int)*N));
+    gpuErrchk(cudaMalloc(&d_coords, sizeof(RealType) * ND));
+    gpuErrchk(cudaMalloc(&d_params, sizeof(RealType) * P));
+    gpuErrchk(cudaMalloc(&d_param_idxs, sizeof(int) * N));
 
-    gpuErrchk(cudaMemcpy(d_coords, coords, sizeof(RealType)*ND, cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(d_params, params, sizeof(RealType)*P, cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(d_param_idxs, param_idxs, sizeof(int)*N, cudaMemcpyHostToDevice));
-
+    gpuErrchk(cudaMemcpy(d_coords, coords, sizeof(RealType) * ND, cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_params, params, sizeof(RealType) * P, cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_param_idxs, param_idxs, sizeof(int) * N, cudaMemcpyHostToDevice));
 
     int tpb = 32;
-    int n_blocks = (N+tpb-1)/tpb;
+    int n_blocks = (N + tpb - 1) / tpb;
 
     RealType *block_bounds_ctr;
     RealType *block_bounds_ext;
 
-    gpuErrchk(cudaMalloc(&block_bounds_ctr, sizeof(*block_bounds_ctr)*n_blocks*D));
-    gpuErrchk(cudaMalloc(&block_bounds_ext, sizeof(*block_bounds_ctr)*n_blocks*D));
-    gpuErrchk(cudaMemset(block_bounds_ctr, 0, sizeof(*block_bounds_ctr)*n_blocks*D));
-    gpuErrchk(cudaMemset(block_bounds_ext, 0, sizeof(*block_bounds_ctr)*n_blocks*D));
+    gpuErrchk(cudaMalloc(&block_bounds_ctr, sizeof(*block_bounds_ctr) * n_blocks * D));
+    gpuErrchk(cudaMalloc(&block_bounds_ext, sizeof(*block_bounds_ctr) * n_blocks * D));
+    gpuErrchk(cudaMemset(block_bounds_ctr, 0, sizeof(*block_bounds_ctr) * n_blocks * D));
+    gpuErrchk(cudaMemset(block_bounds_ext, 0, sizeof(*block_bounds_ctr) * n_blocks * D));
 
-    k_find_block_bounds<RealType><<<1, n_blocks>>>(
-        N,
-        D,
-        n_blocks,
-        d_coords,
-        block_bounds_ctr,
-        block_bounds_ext
-    );
+    k_find_block_bounds<RealType><<<1, n_blocks>>>(N, D, n_blocks, d_coords, block_bounds_ctr, block_bounds_ext);
 
     cudaDeviceSynchronize();
 
@@ -65,27 +57,19 @@ void fast_nonbonded_normal(
 
     dim3 dimGrid(n_blocks, n_blocks, 1); // x, y, z dims
 
-    if(coords_tangents == nullptr) {
+    if (coords_tangents == nullptr) {
 
         assert(out_coords != nullptr);
         assert(out_coords_tangents == nullptr);
         assert(out_params_tangents == nullptr);
 
         unsigned long long *d_out_coords;
-        gpuErrchk(cudaMalloc(&d_out_coords, sizeof(unsigned long long)*ND));
-        gpuErrchk(cudaMemset(d_out_coords, 0, sizeof(unsigned long long)*ND));
+        gpuErrchk(cudaMalloc(&d_out_coords, sizeof(unsigned long long) * ND));
+        gpuErrchk(cudaMemset(d_out_coords, 0, sizeof(unsigned long long) * ND));
 
         auto start = std::chrono::high_resolution_clock::now();
         k_nonbonded_inference<RealType, D><<<dimGrid, tpb>>>(
-            N,
-            d_coords,
-            d_params,
-            d_param_idxs,
-            cutoff,
-            block_bounds_ctr,
-            block_bounds_ext,
-            d_out_coords
-        );
+            N, d_coords, d_params, d_param_idxs, cutoff, block_bounds_ctr, block_bounds_ext, d_out_coords);
 
         gpuErrchk(cudaPeekAtLastError());
         cudaDeviceSynchronize();
@@ -94,10 +78,11 @@ void fast_nonbonded_normal(
         std::chrono::duration<double> elapsed = finish - start;
         std::cout << "Nonbonded Elapsed time: " << elapsed.count() << " s\n";
 
-        std::vector<unsigned long long> h_host_coords(N*D);
-        gpuErrchk(cudaMemcpy(&h_host_coords[0], d_out_coords, sizeof(unsigned long long)*ND, cudaMemcpyDeviceToHost));
-        for(int i=0; i<h_host_coords.size(); i++) {
-            out_coords[i] = static_cast<RealType>(static_cast<signed long long>(h_host_coords[i]))/0x100000000;;
+        std::vector<unsigned long long> h_host_coords(N * D);
+        gpuErrchk(cudaMemcpy(&h_host_coords[0], d_out_coords, sizeof(unsigned long long) * ND, cudaMemcpyDeviceToHost));
+        for (int i = 0; i < h_host_coords.size(); i++) {
+            out_coords[i] = static_cast<RealType>(static_cast<signed long long>(h_host_coords[i])) / 0x100000000;
+            ;
         }
 
     } else {
@@ -110,14 +95,13 @@ void fast_nonbonded_normal(
         RealType *d_out_coords_tangents;
         RealType *d_out_params_tangents;
 
-        gpuErrchk(cudaMalloc(&d_in_coords_tangents, sizeof(RealType)*ND));
-        gpuErrchk(cudaMalloc(&d_out_coords_tangents, sizeof(RealType)*ND));
-        gpuErrchk(cudaMalloc(&d_out_params_tangents, sizeof(RealType)*ND));
+        gpuErrchk(cudaMalloc(&d_in_coords_tangents, sizeof(RealType) * ND));
+        gpuErrchk(cudaMalloc(&d_out_coords_tangents, sizeof(RealType) * ND));
+        gpuErrchk(cudaMalloc(&d_out_params_tangents, sizeof(RealType) * ND));
 
-        gpuErrchk(cudaMemcpy(d_in_coords_tangents, coords_tangents, sizeof(RealType)*ND, cudaMemcpyHostToDevice));
-        gpuErrchk(cudaMemset(d_out_coords_tangents, 0, sizeof(RealType)*ND));
-        gpuErrchk(cudaMemset(d_out_params_tangents, 0, sizeof(RealType)*P));
-
+        gpuErrchk(cudaMemcpy(d_in_coords_tangents, coords_tangents, sizeof(RealType) * ND, cudaMemcpyHostToDevice));
+        gpuErrchk(cudaMemset(d_out_coords_tangents, 0, sizeof(RealType) * ND));
+        gpuErrchk(cudaMemset(d_out_params_tangents, 0, sizeof(RealType) * P));
 
         auto start = std::chrono::high_resolution_clock::now();
         k_nonbonded_jvp<RealType, D><<<dimGrid, tpb>>>(
@@ -130,8 +114,7 @@ void fast_nonbonded_normal(
             block_bounds_ctr,
             block_bounds_ext,
             d_out_coords_tangents,
-            d_out_params_tangents
-        );
+            d_out_params_tangents);
 
         gpuErrchk(cudaPeekAtLastError());
         cudaDeviceSynchronize();
@@ -140,11 +123,10 @@ void fast_nonbonded_normal(
         std::chrono::duration<double> elapsed = finish - start;
         std::cout << "Nonbonded JVP Elapsed time: " << elapsed.count() << " s\n";
 
-        gpuErrchk(cudaMemcpy(out_coords_tangents, d_out_coords_tangents, sizeof(RealType)*ND, cudaMemcpyDeviceToHost));
-        gpuErrchk(cudaMemcpy(out_params_tangents, d_out_params_tangents, sizeof(RealType)*P, cudaMemcpyDeviceToHost));
-
+        gpuErrchk(
+            cudaMemcpy(out_coords_tangents, d_out_coords_tangents, sizeof(RealType) * ND, cudaMemcpyDeviceToHost));
+        gpuErrchk(cudaMemcpy(out_params_tangents, d_out_params_tangents, sizeof(RealType) * P, cudaMemcpyDeviceToHost));
     }
-
 }
 
 template void fast_nonbonded_normal<double, 3>(
@@ -158,7 +140,6 @@ template void fast_nonbonded_normal<double, 3>(
     double *out_coords,
     double *out_coords_tangents,
     double *out_params_tangents);
-
 
 template void fast_nonbonded_normal<double, 4>(
     const double *coords,

--- a/timemachine/cpp/src/gbsa.cu
+++ b/timemachine/cpp/src/gbsa.cu
@@ -1,21 +1,21 @@
-#include <stdexcept>
-#include <iostream>
-#include <chrono>
 #include "fixed_point.hpp"
 #include "gbsa.hpp"
 #include "gbsa_jvp.cuh"
 #include "gpu_utils.cuh"
-#include "math_utils.cuh"
 #include "k_gbsa.cuh"
 #include "k_gbsa_jvp.cuh"
+#include "math_utils.cuh"
+#include <chrono>
+#include <iostream>
+#include <stdexcept>
 
 namespace timemachine {
 
 template <typename RealType>
 GBSA<RealType>::GBSA(
-    const std::vector<double> &charge_params, // [N]
-    const std::vector<double> &gb_params, // [N, 2]
-    const std::vector<int> &lambda_plane_idxs, // [N]
+    const std::vector<double> &charge_params,   // [N]
+    const std::vector<double> &gb_params,       // [N, 2]
+    const std::vector<int> &lambda_plane_idxs,  // [N]
     const std::vector<int> &lambda_offset_idxs, // [N]
     double alpha,
     double beta,
@@ -26,115 +26,100 @@ GBSA<RealType>::GBSA(
     double solvent_dielectric,
     double probe_radius,
     double cutoff_radii,
-    double cutoff_force
-) : N_(charge_params.size()),
-    alpha_(alpha),
-    beta_(beta),
-    gamma_(gamma),
-    dielectric_offset_(dielectric_offset),
-    surface_tension_(surface_tension),
-    solute_dielectric_(solute_dielectric),
-    solvent_dielectric_(solvent_dielectric),
-    probe_radius_(probe_radius),
-    cutoff_radii_(cutoff_radii),
-    cutoff_force_(cutoff_force),
-    nblist_(charge_params.size(), 3) {
+    double cutoff_force)
+    : N_(charge_params.size()), alpha_(alpha), beta_(beta), gamma_(gamma), dielectric_offset_(dielectric_offset),
+      surface_tension_(surface_tension), solute_dielectric_(solute_dielectric), solvent_dielectric_(solvent_dielectric),
+      probe_radius_(probe_radius), cutoff_radii_(cutoff_radii), cutoff_force_(cutoff_force),
+      nblist_(charge_params.size(), 3) {
 
-    if(gb_params.size() != N_*2) {
+    if (gb_params.size() != N_ * 2) {
         throw std::runtime_error("Fatal: gb parameters != N*2");
     }
 
-    if(cutoff_radii != cutoff_force) {
-      throw std::runtime_error("GB currently requires that cutoff_radii be equal to cutoff_force!");
+    if (cutoff_radii != cutoff_force) {
+        throw std::runtime_error("GB currently requires that cutoff_radii be equal to cutoff_force!");
     }
 
-    gpuErrchk(cudaMalloc(&d_lambda_plane_idxs_, N_*sizeof(*d_lambda_plane_idxs_)));
-    gpuErrchk(cudaMemcpy(d_lambda_plane_idxs_, &lambda_plane_idxs[0], N_*sizeof(*d_lambda_plane_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_lambda_plane_idxs_, N_ * sizeof(*d_lambda_plane_idxs_)));
+    gpuErrchk(cudaMemcpy(
+        d_lambda_plane_idxs_, &lambda_plane_idxs[0], N_ * sizeof(*d_lambda_plane_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_lambda_offset_idxs_, N_*sizeof(*d_lambda_offset_idxs_)));
-    gpuErrchk(cudaMemcpy(d_lambda_offset_idxs_, &lambda_offset_idxs[0], N_*sizeof(*d_lambda_offset_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_lambda_offset_idxs_, N_ * sizeof(*d_lambda_offset_idxs_)));
+    gpuErrchk(cudaMemcpy(
+        d_lambda_offset_idxs_, &lambda_offset_idxs[0], N_ * sizeof(*d_lambda_offset_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_charge_params_, N_*sizeof(*d_charge_params_)));
-    gpuErrchk(cudaMalloc(&d_gb_params_, N_*2*sizeof(*d_gb_params_)));
+    gpuErrchk(cudaMalloc(&d_charge_params_, N_ * sizeof(*d_charge_params_)));
+    gpuErrchk(cudaMalloc(&d_gb_params_, N_ * 2 * sizeof(*d_gb_params_)));
 
-    gpuErrchk(cudaMemcpy(d_charge_params_, &charge_params[0], N_*sizeof(*d_charge_params_), cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(d_gb_params_, &gb_params[0], N_*2*sizeof(*d_gb_params_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_charge_params_, &charge_params[0], N_ * sizeof(*d_charge_params_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_gb_params_, &gb_params[0], N_ * 2 * sizeof(*d_gb_params_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_du_dcharge_primals_, N_*sizeof(*d_du_dcharge_primals_)));
-    gpuErrchk(cudaMalloc(&d_du_dgb_primals_, N_*2*sizeof(*d_du_dgb_primals_)));
+    gpuErrchk(cudaMalloc(&d_du_dcharge_primals_, N_ * sizeof(*d_du_dcharge_primals_)));
+    gpuErrchk(cudaMalloc(&d_du_dgb_primals_, N_ * 2 * sizeof(*d_du_dgb_primals_)));
 
-    gpuErrchk(cudaMemset(d_du_dcharge_primals_, 0, N_*sizeof(*d_du_dcharge_primals_)));
-    gpuErrchk(cudaMemset(d_du_dgb_primals_, 0, N_*2*sizeof(*d_du_dgb_primals_)));
+    gpuErrchk(cudaMemset(d_du_dcharge_primals_, 0, N_ * sizeof(*d_du_dcharge_primals_)));
+    gpuErrchk(cudaMemset(d_du_dgb_primals_, 0, N_ * 2 * sizeof(*d_du_dgb_primals_)));
 
-    gpuErrchk(cudaMalloc(&d_du_dcharge_tangents_, N_*sizeof(*d_du_dcharge_tangents_)));
-    gpuErrchk(cudaMalloc(&d_du_dgb_tangents_, N_*2*sizeof(*d_du_dgb_tangents_)));
+    gpuErrchk(cudaMalloc(&d_du_dcharge_tangents_, N_ * sizeof(*d_du_dcharge_tangents_)));
+    gpuErrchk(cudaMalloc(&d_du_dgb_tangents_, N_ * 2 * sizeof(*d_du_dgb_tangents_)));
 
-    gpuErrchk(cudaMemset(d_du_dcharge_tangents_, 0, N_*sizeof(*d_du_dcharge_tangents_)));
-    gpuErrchk(cudaMemset(d_du_dgb_tangents_, 0, N_*2*sizeof(*d_du_dgb_tangents_)));
-
+    gpuErrchk(cudaMemset(d_du_dcharge_tangents_, 0, N_ * sizeof(*d_du_dcharge_tangents_)));
+    gpuErrchk(cudaMemset(d_du_dgb_tangents_, 0, N_ * 2 * sizeof(*d_du_dgb_tangents_)));
 
     // we probaly don't need *all* these buffers if we do just one pass, but they take up only
     // O(N) ram so we don't really care and just pre-allocate everything to keep things simple.
     // it also ensures that we can RAII properly.
 
-    gpuErrchk(cudaMalloc(&d_born_psi_buffer_, N_*sizeof(*d_born_psi_buffer_)));
-    gpuErrchk(cudaMalloc(&d_born_radii_buffer_, N_*sizeof(*d_born_radii_buffer_)));
-    gpuErrchk(cudaMalloc(&d_obc_buffer_, N_*sizeof(*d_obc_buffer_)));
-    gpuErrchk(cudaMalloc(&d_born_forces_buffer_, N_*sizeof(*d_born_forces_buffer_)));
+    gpuErrchk(cudaMalloc(&d_born_psi_buffer_, N_ * sizeof(*d_born_psi_buffer_)));
+    gpuErrchk(cudaMalloc(&d_born_radii_buffer_, N_ * sizeof(*d_born_radii_buffer_)));
+    gpuErrchk(cudaMalloc(&d_obc_buffer_, N_ * sizeof(*d_obc_buffer_)));
+    gpuErrchk(cudaMalloc(&d_born_forces_buffer_, N_ * sizeof(*d_born_forces_buffer_)));
 
-    gpuErrchk(cudaMalloc(&d_born_radii_buffer_jvp_, N_*sizeof(*d_born_radii_buffer_jvp_)));
-    gpuErrchk(cudaMalloc(&d_obc_buffer_jvp_, N_*sizeof(*d_obc_buffer_jvp_)));
-    gpuErrchk(cudaMalloc(&d_obc_ri_buffer_jvp_, N_*sizeof(*d_obc_ri_buffer_jvp_)));
-    gpuErrchk(cudaMalloc(&d_born_forces_buffer_jvp_, N_*sizeof(*d_born_forces_buffer_jvp_)));
-
-
+    gpuErrchk(cudaMalloc(&d_born_radii_buffer_jvp_, N_ * sizeof(*d_born_radii_buffer_jvp_)));
+    gpuErrchk(cudaMalloc(&d_obc_buffer_jvp_, N_ * sizeof(*d_obc_buffer_jvp_)));
+    gpuErrchk(cudaMalloc(&d_obc_ri_buffer_jvp_, N_ * sizeof(*d_obc_ri_buffer_jvp_)));
+    gpuErrchk(cudaMalloc(&d_born_forces_buffer_jvp_, N_ * sizeof(*d_born_forces_buffer_jvp_)));
 }
 
-template <typename RealType>
-GBSA<RealType>::~GBSA() {
+template <typename RealType> GBSA<RealType>::~GBSA() {
 
-  gpuErrchk(cudaFree(d_charge_params_));
-  gpuErrchk(cudaFree(d_gb_params_));
+    gpuErrchk(cudaFree(d_charge_params_));
+    gpuErrchk(cudaFree(d_gb_params_));
 
-  gpuErrchk(cudaFree(d_du_dcharge_primals_));
-  gpuErrchk(cudaFree(d_du_dgb_primals_));
+    gpuErrchk(cudaFree(d_du_dcharge_primals_));
+    gpuErrchk(cudaFree(d_du_dgb_primals_));
 
-  gpuErrchk(cudaFree(d_du_dcharge_tangents_));
-  gpuErrchk(cudaFree(d_du_dgb_tangents_));
+    gpuErrchk(cudaFree(d_du_dcharge_tangents_));
+    gpuErrchk(cudaFree(d_du_dgb_tangents_));
 
-  gpuErrchk(cudaFree(d_lambda_plane_idxs_));
-  gpuErrchk(cudaFree(d_lambda_offset_idxs_));
+    gpuErrchk(cudaFree(d_lambda_plane_idxs_));
+    gpuErrchk(cudaFree(d_lambda_offset_idxs_));
 
-  gpuErrchk(cudaFree(d_born_psi_buffer_));
-  gpuErrchk(cudaFree(d_born_radii_buffer_));
-  gpuErrchk(cudaFree(d_obc_buffer_));
-  gpuErrchk(cudaFree(d_born_forces_buffer_));
+    gpuErrchk(cudaFree(d_born_psi_buffer_));
+    gpuErrchk(cudaFree(d_born_radii_buffer_));
+    gpuErrchk(cudaFree(d_obc_buffer_));
+    gpuErrchk(cudaFree(d_born_forces_buffer_));
 
-  gpuErrchk(cudaFree(d_born_radii_buffer_jvp_));
-  gpuErrchk(cudaFree(d_obc_buffer_jvp_));
-  gpuErrchk(cudaFree(d_obc_ri_buffer_jvp_));
-  gpuErrchk(cudaFree(d_born_forces_buffer_jvp_));
-
+    gpuErrchk(cudaFree(d_born_radii_buffer_jvp_));
+    gpuErrchk(cudaFree(d_obc_buffer_jvp_));
+    gpuErrchk(cudaFree(d_obc_ri_buffer_jvp_));
+    gpuErrchk(cudaFree(d_born_forces_buffer_jvp_));
 };
 
-template <typename RealType>
-void GBSA<RealType>::get_du_dcharge_primals(double *buf) {
-    gpuErrchk(cudaMemcpy(buf, d_du_dcharge_primals_, N_*sizeof(*d_du_dcharge_primals_), cudaMemcpyDeviceToHost));
+template <typename RealType> void GBSA<RealType>::get_du_dcharge_primals(double *buf) {
+    gpuErrchk(cudaMemcpy(buf, d_du_dcharge_primals_, N_ * sizeof(*d_du_dcharge_primals_), cudaMemcpyDeviceToHost));
 }
 
-template <typename RealType>
-void GBSA<RealType>::get_du_dcharge_tangents(double *buf) {
-    gpuErrchk(cudaMemcpy(buf, d_du_dcharge_tangents_, N_*sizeof(*d_du_dcharge_tangents_), cudaMemcpyDeviceToHost));
+template <typename RealType> void GBSA<RealType>::get_du_dcharge_tangents(double *buf) {
+    gpuErrchk(cudaMemcpy(buf, d_du_dcharge_tangents_, N_ * sizeof(*d_du_dcharge_tangents_), cudaMemcpyDeviceToHost));
 }
 
-template <typename RealType>
-void GBSA<RealType>::get_du_dgb_primals(double *buf) {
-    gpuErrchk(cudaMemcpy(buf, d_du_dgb_primals_, N_*2*sizeof(*d_du_dgb_primals_), cudaMemcpyDeviceToHost));
+template <typename RealType> void GBSA<RealType>::get_du_dgb_primals(double *buf) {
+    gpuErrchk(cudaMemcpy(buf, d_du_dgb_primals_, N_ * 2 * sizeof(*d_du_dgb_primals_), cudaMemcpyDeviceToHost));
 }
 
-template <typename RealType>
-void GBSA<RealType>::get_du_dgb_tangents(double *buf) {
-    gpuErrchk(cudaMemcpy(buf, d_du_dgb_tangents_, N_*2*sizeof(*d_du_dgb_tangents_), cudaMemcpyDeviceToHost));
+template <typename RealType> void GBSA<RealType>::get_du_dgb_tangents(double *buf) {
+    gpuErrchk(cudaMemcpy(buf, d_du_dgb_tangents_, N_ * 2 * sizeof(*d_du_dgb_tangents_), cudaMemcpyDeviceToHost));
 }
 
 template <typename RealType>
@@ -148,14 +133,14 @@ void GBSA<RealType>::execute_lambda_inference_device(
     cudaStream_t stream) {
 
     int tpb = 32;
-    int B = (N_+tpb-1)/tpb;
+    int B = (N_ + tpb - 1) / tpb;
     const int D = 3;
 
     dim3 dimGrid(B, B, 1); // x, y, z dims
 
     double prefactor;
     if (solute_dielectric_ != 0.0 && solvent_dielectric_ != 0.0) {
-        prefactor = -((1.0/solute_dielectric_) - (1.0/solvent_dielectric_));
+        prefactor = -((1.0 / solute_dielectric_) - (1.0 / solvent_dielectric_));
     } else {
         // this seems ill defined, we probably want to just assert instead?
         prefactor = 0.0;
@@ -165,100 +150,94 @@ void GBSA<RealType>::execute_lambda_inference_device(
 
     auto start = std::chrono::high_resolution_clock::now();
 
-    gpuErrchk(cudaMemsetAsync(d_born_psi_buffer_, 0, N*sizeof(*d_born_psi_buffer_), stream));
-    gpuErrchk(cudaMemsetAsync(d_born_radii_buffer_, 0, N*sizeof(*d_born_radii_buffer_), stream));
-    gpuErrchk(cudaMemsetAsync(d_obc_buffer_, 0, N*sizeof(*d_obc_buffer_), stream));
-    gpuErrchk(cudaMemsetAsync(d_born_forces_buffer_, 0, N*sizeof(*d_born_forces_buffer_), stream));
+    gpuErrchk(cudaMemsetAsync(d_born_psi_buffer_, 0, N * sizeof(*d_born_psi_buffer_), stream));
+    gpuErrchk(cudaMemsetAsync(d_born_radii_buffer_, 0, N * sizeof(*d_born_radii_buffer_), stream));
+    gpuErrchk(cudaMemsetAsync(d_obc_buffer_, 0, N * sizeof(*d_obc_buffer_), stream));
+    gpuErrchk(cudaMemsetAsync(d_born_forces_buffer_, 0, N * sizeof(*d_born_forces_buffer_), stream));
 
     k_compute_born_radii<RealType><<<dimGrid, tpb, 0, stream>>>(
-      N_,
-      d_coords,
-      lambda,
-      d_lambda_plane_idxs_,
-      d_lambda_offset_idxs_,
-      d_gb_params_,
-      dielectric_offset_,
-      cutoff_radii_,
-      nblist_.get_block_bounds_ctr(),
-      nblist_.get_block_bounds_ext(),
-      d_born_psi_buffer_
-    );
+        N_,
+        d_coords,
+        lambda,
+        d_lambda_plane_idxs_,
+        d_lambda_offset_idxs_,
+        d_gb_params_,
+        dielectric_offset_,
+        cutoff_radii_,
+        nblist_.get_block_bounds_ctr(),
+        nblist_.get_block_bounds_ext(),
+        d_born_psi_buffer_);
 
     // cudaDeviceSynchronize();
     gpuErrchk(cudaPeekAtLastError());
 
     k_reduce_born_radii<<<B, tpb, 0, stream>>>(
-      N_,
-      d_gb_params_,
-      dielectric_offset_,
-      alpha_,
-      beta_,
-      gamma_,
-      d_born_psi_buffer_,
-      d_born_radii_buffer_,
-      d_obc_buffer_
-    );
+        N_,
+        d_gb_params_,
+        dielectric_offset_,
+        alpha_,
+        beta_,
+        gamma_,
+        d_born_psi_buffer_,
+        d_born_radii_buffer_,
+        d_obc_buffer_);
 
     // cudaDeviceSynchronize();
     gpuErrchk(cudaPeekAtLastError());
 
     k_compute_born_first_loop_gpu<RealType><<<dimGrid, tpb, 0, stream>>>(
-      N_,
-      d_coords,
-      lambda,
-      d_lambda_plane_idxs_,
-      d_lambda_offset_idxs_,
-      d_charge_params_,
-      d_born_radii_buffer_,
-      prefactor,
-      cutoff_force_,
-      nblist_.get_block_bounds_ctr(),
-      nblist_.get_block_bounds_ext(),
-      d_born_forces_buffer_, // output
-      d_out_coords,
-      d_out_lambda, // output
-      d_out_energy
-    );
+        N_,
+        d_coords,
+        lambda,
+        d_lambda_plane_idxs_,
+        d_lambda_offset_idxs_,
+        d_charge_params_,
+        d_born_radii_buffer_,
+        prefactor,
+        cutoff_force_,
+        nblist_.get_block_bounds_ctr(),
+        nblist_.get_block_bounds_ext(),
+        d_born_forces_buffer_, // output
+        d_out_coords,
+        d_out_lambda, // output
+        d_out_energy);
 
     // cudaDeviceSynchronize();
     gpuErrchk(cudaPeekAtLastError());
 
     k_reduce_born_forces<<<B, tpb, 0, stream>>>(
-      N_,
-      d_gb_params_,
-      d_born_radii_buffer_,
-      d_obc_buffer_,
-      surface_tension_,
-      probe_radius_,
-      d_born_forces_buffer_,
-      d_out_energy
-    );
+        N_,
+        d_gb_params_,
+        d_born_radii_buffer_,
+        d_obc_buffer_,
+        surface_tension_,
+        probe_radius_,
+        d_born_forces_buffer_,
+        d_out_energy);
 
     // // cudaDeviceSynchronize();
     gpuErrchk(cudaPeekAtLastError());
 
     k_compute_born_energy_and_forces<RealType><<<dimGrid, tpb, 0, stream>>>(
-      N_,
-      d_coords,
-      // d_params,
-      lambda,
-      d_lambda_plane_idxs_,
-      d_lambda_offset_idxs_,
-      d_gb_params_,
-      d_born_radii_buffer_,
-      d_obc_buffer_,
-      dielectric_offset_,
-      cutoff_force_,
-      nblist_.get_block_bounds_ctr(),
-      nblist_.get_block_bounds_ext(),
-      d_born_forces_buffer_,
-      d_out_coords,
-      d_out_lambda
-    );
+        N_,
+        d_coords,
+        // d_params,
+        lambda,
+        d_lambda_plane_idxs_,
+        d_lambda_offset_idxs_,
+        d_gb_params_,
+        d_born_radii_buffer_,
+        d_obc_buffer_,
+        dielectric_offset_,
+        cutoff_force_,
+        nblist_.get_block_bounds_ctr(),
+        nblist_.get_block_bounds_ext(),
+        d_born_forces_buffer_,
+        d_out_coords,
+        d_out_lambda);
 
     // cudaDeviceSynchronize();
     gpuErrchk(cudaPeekAtLastError());
-
 }
 
 template <typename RealType>
@@ -273,14 +252,14 @@ void GBSA<RealType>::execute_lambda_jvp_device(
     cudaStream_t stream) {
 
     int tpb = 32;
-    int B = (N_+tpb-1)/tpb;
+    int B = (N_ + tpb - 1) / tpb;
     const int D = 3;
 
     dim3 dimGrid(B, B, 1); // x, y, z dims
 
     double prefactor;
     if (solute_dielectric_ != 0.0 && solvent_dielectric_ != 0.0) {
-        prefactor = -((1.0/solute_dielectric_) - (1.0/solvent_dielectric_));
+        prefactor = -((1.0 / solute_dielectric_) - (1.0 / solvent_dielectric_));
     } else {
         prefactor = 0.0;
     }
@@ -289,10 +268,10 @@ void GBSA<RealType>::execute_lambda_jvp_device(
 
     auto start = std::chrono::high_resolution_clock::now();
 
-    gpuErrchk(cudaMemsetAsync(d_born_radii_buffer_jvp_, 0, N*sizeof(*d_born_radii_buffer_jvp_), stream));
-    gpuErrchk(cudaMemsetAsync(d_obc_buffer_jvp_, 0, N*sizeof(*d_obc_buffer_jvp_), stream));
-    gpuErrchk(cudaMemsetAsync(d_obc_ri_buffer_jvp_, 0, N*sizeof(*d_obc_ri_buffer_jvp_), stream));
-    gpuErrchk(cudaMemsetAsync(d_born_forces_buffer_jvp_, 0, N*sizeof(*d_born_forces_buffer_jvp_), stream));
+    gpuErrchk(cudaMemsetAsync(d_born_radii_buffer_jvp_, 0, N * sizeof(*d_born_radii_buffer_jvp_), stream));
+    gpuErrchk(cudaMemsetAsync(d_obc_buffer_jvp_, 0, N * sizeof(*d_obc_buffer_jvp_), stream));
+    gpuErrchk(cudaMemsetAsync(d_obc_ri_buffer_jvp_, 0, N * sizeof(*d_obc_ri_buffer_jvp_), stream));
+    gpuErrchk(cudaMemsetAsync(d_born_forces_buffer_jvp_, 0, N * sizeof(*d_born_forces_buffer_jvp_), stream));
 
     k_compute_born_radii_gpu_jvp<RealType><<<dimGrid, tpb, 0, stream>>>(
         N_,
@@ -307,23 +286,21 @@ void GBSA<RealType>::execute_lambda_jvp_device(
         cutoff_radii_,
         nblist_.get_block_bounds_ctr(),
         nblist_.get_block_bounds_ext(),
-        d_born_radii_buffer_jvp_
-    );
+        d_born_radii_buffer_jvp_);
 
     // cudaDeviceSynchronize();
     gpuErrchk(cudaPeekAtLastError());
 
     k_reduce_born_radii_jvp<<<B, tpb, 0, stream>>>(
-      N_,
-      d_gb_params_,
-      dielectric_offset_,
-      alpha_,
-      beta_,
-      gamma_,
-      d_born_radii_buffer_jvp_,
-      d_obc_buffer_jvp_,
-      d_obc_ri_buffer_jvp_
-    );
+        N_,
+        d_gb_params_,
+        dielectric_offset_,
+        alpha_,
+        beta_,
+        gamma_,
+        d_born_radii_buffer_jvp_,
+        d_obc_buffer_jvp_,
+        d_obc_ri_buffer_jvp_);
 
     // cudaDeviceSynchronize();
     gpuErrchk(cudaPeekAtLastError());
@@ -343,10 +320,10 @@ void GBSA<RealType>::execute_lambda_jvp_device(
         nblist_.get_block_bounds_ctr(),
         nblist_.get_block_bounds_ext(),
         d_born_forces_buffer_jvp_, // output
-        d_out_coords_primals, // output
-        d_out_coords_tangents, // output
-        d_du_dcharge_primals_, // output
-        d_du_dcharge_tangents_ // output
+        d_out_coords_primals,      // output
+        d_out_coords_tangents,     // output
+        d_du_dcharge_primals_,     // output
+        d_du_dcharge_tangents_     // output
     );
 
     // cudaDeviceSynchronize();
@@ -364,12 +341,10 @@ void GBSA<RealType>::execute_lambda_jvp_device(
         probe_radius_,
         d_born_forces_buffer_jvp_,
         d_du_dgb_primals_,
-        d_du_dgb_tangents_
-    );
+        d_du_dgb_tangents_);
 
     // cudaDeviceSynchronize();
     gpuErrchk(cudaPeekAtLastError());
-
 
     // auto start = std::chrono::high_resolution_clock::now();
     k_compute_born_energy_and_forces_jvp<RealType, D><<<dimGrid, tpb, 0, stream>>>(
@@ -389,19 +364,16 @@ void GBSA<RealType>::execute_lambda_jvp_device(
         nblist_.get_block_bounds_ctr(),
         nblist_.get_block_bounds_ext(),
         d_born_forces_buffer_jvp_,
-        d_out_coords_primals, // output
+        d_out_coords_primals,  // output
         d_out_coords_tangents, // output
         d_du_dgb_primals_,
-        d_du_dgb_tangents_
-    );
+        d_du_dgb_tangents_);
 
     // cudaDeviceSynchronize();
     gpuErrchk(cudaPeekAtLastError());
-
 }
 
 template class GBSA<double>;
 template class GBSA<float>;
 
-
-}
+} // namespace timemachine

--- a/timemachine/cpp/src/gbsa_jvp.cuh
+++ b/timemachine/cpp/src/gbsa_jvp.cuh
@@ -1,165 +1,160 @@
-#include <stdexcept>
-#include <iostream>
 #include "fixed_point.hpp"
-#include "surreal.cuh"
 #include "kernel_utils.cuh"
 #include "math_utils.cuh"
+#include "surreal.cuh"
+#include <iostream>
+#include <stdexcept>
 
 namespace timemachine {
 
-
 template <int D>
 double reduce_born_forces_jvp(
-    const std::vector<Surreal<double> >& coords,
-    const std::vector<double>& params,
-    const std::vector<int>& atomic_radii_idxs,
-    const std::vector<Surreal<double> >& born_radii,
-    const std::vector<Surreal<double> >& obc_chain,
-    const std::vector<Surreal<double> >& obc_chain_ri,
+    const std::vector<Surreal<double>> &coords,
+    const std::vector<double> &params,
+    const std::vector<int> &atomic_radii_idxs,
+    const std::vector<Surreal<double>> &born_radii,
+    const std::vector<Surreal<double>> &obc_chain,
+    const std::vector<Surreal<double>> &obc_chain_ri,
     const double surface_tension, // surface area factor
     const double probe_radius,
-    std::vector<Surreal<double> > &bornForces, // dU/Ri
-    std::vector<double> &out_MvP
-) {
+    std::vector<Surreal<double>> &bornForces, // dU/Ri
+    std::vector<double> &out_MvP) {
 
     // constants
     const int numberOfAtoms = atomic_radii_idxs.size();
     const int N = numberOfAtoms;
 
-
     for (int atomI = 0; atomI < numberOfAtoms; atomI++) {
 
-        Surreal<double> radii_derivs(0,0);
+        Surreal<double> radii_derivs(0, 0);
         if (born_radii[atomI].real > 0.0) {
             double atomic_radii = params[atomic_radii_idxs[atomI]];
-            double r            = atomic_radii + probe_radius;
-            Surreal<double> ar           = atomic_radii/born_radii[atomI];
-            Surreal<double> ar2          = ar*ar;
-            Surreal<double> ar4          = ar2*ar2;
-            Surreal<double> ratio6          = ar4*ar2;
-            Surreal<double> saTerm       = surface_tension*r*r*ratio6;
-            bornForces[atomI]  -= 6.0*saTerm/born_radii[atomI];
-            Surreal<double> br2 = born_radii[atomI]*born_radii[atomI];
-            Surreal<double> br4 = br2*br2;
-            Surreal<double> br6 = br4*br2;
-            radii_derivs += 2*pow(atomic_radii, 5)*surface_tension*(probe_radius + atomic_radii)*(3*probe_radius + 4*atomic_radii)/br6;
+            double r = atomic_radii + probe_radius;
+            Surreal<double> ar = atomic_radii / born_radii[atomI];
+            Surreal<double> ar2 = ar * ar;
+            Surreal<double> ar4 = ar2 * ar2;
+            Surreal<double> ratio6 = ar4 * ar2;
+            Surreal<double> saTerm = surface_tension * r * r * ratio6;
+            bornForces[atomI] -= 6.0 * saTerm / born_radii[atomI];
+            Surreal<double> br2 = born_radii[atomI] * born_radii[atomI];
+            Surreal<double> br4 = br2 * br2;
+            Surreal<double> br6 = br4 * br2;
+            radii_derivs += 2 * pow(atomic_radii, 5) * surface_tension * (probe_radius + atomic_radii) *
+                            (3 * probe_radius + 4 * atomic_radii) / br6;
         }
         radii_derivs += bornForces[atomI] * obc_chain_ri[atomI];
         out_MvP[atomic_radii_idxs[atomI]] += radii_derivs.imag;
         bornForces[atomI] *= obc_chain[atomI];
     }
-
 }
 
-
 // ported over from OpenMM with minor corrections
-template<int D>
+template <int D>
 void compute_born_radii_jvp(
-    const std::vector<Surreal<double> >& coords,
-    const std::vector<double>& params,
-    const std::vector<int>& atomic_radii_idxs,
-    const std::vector<int>& scale_factor_idxs,
+    const std::vector<Surreal<double>> &coords,
+    const std::vector<double> &params,
+    const std::vector<int> &atomic_radii_idxs,
+    const std::vector<int> &scale_factor_idxs,
     const double dielectric_offset,
     const double alpha_obc,
     const double beta_obc,
     const double gamma_obc,
     const double cutoff,
-    std::vector<Surreal<double> > & born_radii,
-    std::vector<Surreal<double> > & obc_chain,
-    std::vector<Surreal<double> > & obc_chain_ri) {
+    std::vector<Surreal<double>> &born_radii,
+    std::vector<Surreal<double>> &obc_chain,
+    std::vector<Surreal<double>> &obc_chain_ri) {
 
     int numberOfAtoms = atomic_radii_idxs.size();
     int N = numberOfAtoms;
 
-    if(coords.size() / D != numberOfAtoms) {
+    if (coords.size() / D != numberOfAtoms) {
         throw std::runtime_error("compute born radii number of atoms are inconsistent");
     }
 
     for (int i_idx = 0; i_idx < numberOfAtoms; i_idx++) {
 
-       double radiusI         = params[atomic_radii_idxs[i_idx]];
-       double offsetRadiusI   = radiusI - dielectric_offset;
-       double radiusIInverse  = 1.0/offsetRadiusI;
-       Surreal<double> sum(0, 0);
+        double radiusI = params[atomic_radii_idxs[i_idx]];
+        double offsetRadiusI = radiusI - dielectric_offset;
+        double radiusIInverse = 1.0 / offsetRadiusI;
+        Surreal<double> sum(0, 0);
 
-       // HCT code
-       for (int j_idx = 0; j_idx < numberOfAtoms; j_idx++) {
+        // HCT code
+        for (int j_idx = 0; j_idx < numberOfAtoms; j_idx++) {
 
-          if (j_idx != i_idx) {
+            if (j_idx != i_idx) {
 
-             Surreal<double> r(0, 0);
-             for(int d=0; d < D; d++) {
-                Surreal<double> dx = coords[i_idx*D+d] - coords[j_idx*D+d];
-                r += dx*dx;
-             }
-             r = sqrt(r);
-
-             double offsetRadiusJ   = params[atomic_radii_idxs[j_idx]] - dielectric_offset;
-             double scaledRadiusJ   = offsetRadiusJ*params[scale_factor_idxs[j_idx]];
-             Surreal<double> rScaledRadiusJ  = r + scaledRadiusJ;
-             Surreal<double> rSubScaledRadiusJ =  r - scaledRadiusJ;
-             if (offsetRadiusI < rScaledRadiusJ.real) {
-                Surreal<double> rInverse = 1.0/r;
-
-                Surreal<double> l_ij(0, 0);
-                if(offsetRadiusI > abs(rSubScaledRadiusJ).real) {
-                  l_ij.real = offsetRadiusI;
-                  l_ij.imag = 0;
-                } else {
-                  l_ij = abs(rSubScaledRadiusJ);
+                Surreal<double> r(0, 0);
+                for (int d = 0; d < D; d++) {
+                    Surreal<double> dx = coords[i_idx * D + d] - coords[j_idx * D + d];
+                    r += dx * dx;
                 }
+                r = sqrt(r);
 
-                l_ij     = 1.0/l_ij;
+                double offsetRadiusJ = params[atomic_radii_idxs[j_idx]] - dielectric_offset;
+                double scaledRadiusJ = offsetRadiusJ * params[scale_factor_idxs[j_idx]];
+                Surreal<double> rScaledRadiusJ = r + scaledRadiusJ;
+                Surreal<double> rSubScaledRadiusJ = r - scaledRadiusJ;
+                if (offsetRadiusI < rScaledRadiusJ.real) {
+                    Surreal<double> rInverse = 1.0 / r;
 
-                Surreal<double> u_ij     = 1.0/rScaledRadiusJ;
+                    Surreal<double> l_ij(0, 0);
+                    if (offsetRadiusI > abs(rSubScaledRadiusJ).real) {
+                        l_ij.real = offsetRadiusI;
+                        l_ij.imag = 0;
+                    } else {
+                        l_ij = abs(rSubScaledRadiusJ);
+                    }
 
-                Surreal<double> l_ij2    = l_ij*l_ij;
-                Surreal<double> u_ij2    = u_ij*u_ij;
+                    l_ij = 1.0 / l_ij;
 
-                Surreal<double> ratio    = log((u_ij/l_ij));
-                Surreal<double> term     = l_ij - u_ij + 0.25*r*(u_ij2 - l_ij2)  + (0.5*rInverse*ratio) + (0.25*scaledRadiusJ*scaledRadiusJ*rInverse)*(l_ij2 - u_ij2);
+                    Surreal<double> u_ij = 1.0 / rScaledRadiusJ;
 
-                // this case (atom i completely inside atom j) is not considered in the original paper
-                // Jay Ponder and the authors of Tinker recognized this and
-                // worked out the details
-                if (offsetRadiusI < (scaledRadiusJ - r).real) {
-                   term += 2.0*(radiusIInverse - l_ij);
+                    Surreal<double> l_ij2 = l_ij * l_ij;
+                    Surreal<double> u_ij2 = u_ij * u_ij;
+
+                    Surreal<double> ratio = log((u_ij / l_ij));
+                    Surreal<double> term = l_ij - u_ij + 0.25 * r * (u_ij2 - l_ij2) + (0.5 * rInverse * ratio) +
+                                           (0.25 * scaledRadiusJ * scaledRadiusJ * rInverse) * (l_ij2 - u_ij2);
+
+                    // this case (atom i completely inside atom j) is not considered in the original paper
+                    // Jay Ponder and the authors of Tinker recognized this and
+                    // worked out the details
+                    if (offsetRadiusI < (scaledRadiusJ - r).real) {
+                        term += 2.0 * (radiusIInverse - l_ij);
+                    }
+                    sum += term;
                 }
-                sum += term;
-
-               }
             }
-         }
-       sum              *= 0.5*offsetRadiusI;
-       Surreal<double> sum2       = sum*sum;
-       Surreal<double> sum3       = sum*sum2;
-       Surreal<double> tanhSum    = tanh(alpha_obc*sum - beta_obc*sum2 + gamma_obc*sum3);
+        }
+        sum *= 0.5 * offsetRadiusI;
+        Surreal<double> sum2 = sum * sum;
+        Surreal<double> sum3 = sum * sum2;
+        Surreal<double> tanhSum = tanh(alpha_obc * sum - beta_obc * sum2 + gamma_obc * sum3);
 
-       born_radii[i_idx]      = 1.0/(1.0/offsetRadiusI - tanhSum/radiusI);
+        born_radii[i_idx] = 1.0 / (1.0 / offsetRadiusI - tanhSum / radiusI);
 
-       // dRi/dPsi
-       obc_chain[i_idx]       = (alpha_obc - 2.0*beta_obc*sum + 3.0*gamma_obc*sum2); // !@#$ why did you move it here!
-       obc_chain[i_idx]       = (1.0 - tanhSum*tanhSum)*obc_chain[i_idx]/radiusI; // this takes care of the radiusI prefactor
-       obc_chain[i_idx]      *= born_radii[i_idx]*born_radii[i_idx];
+        // dRi/dPsi
+        obc_chain[i_idx] =
+            (alpha_obc - 2.0 * beta_obc * sum + 3.0 * gamma_obc * sum2); // !@#$ why did you move it here!
+        obc_chain[i_idx] =
+            (1.0 - tanhSum * tanhSum) * obc_chain[i_idx] / radiusI; // this takes care of the radiusI prefactor
+        obc_chain[i_idx] *= born_radii[i_idx] * born_radii[i_idx];
 
-       // dRi/dri
-       obc_chain_ri[i_idx]    = 1.0/(offsetRadiusI*offsetRadiusI) - tanhSum/(radiusI*radiusI);
-       obc_chain_ri[i_idx]   *= born_radii[i_idx]*born_radii[i_idx];
-
+        // dRi/dri
+        obc_chain_ri[i_idx] = 1.0 / (offsetRadiusI * offsetRadiusI) - tanhSum / (radiusI * radiusI);
+        obc_chain_ri[i_idx] *= born_radii[i_idx] * born_radii[i_idx];
     }
 }
 
-
-
-template<int D>
+template <int D>
 double compute_born_first_loop_jvp(
-    const std::vector<Surreal<double> >& coords,
-    const std::vector<double>& params,
-    const std::vector<int>& charge_param_idxs,
-    const std::vector<Surreal<double> >& born_radii,
+    const std::vector<Surreal<double>> &coords,
+    const std::vector<double> &params,
+    const std::vector<int> &charge_param_idxs,
+    const std::vector<Surreal<double>> &born_radii,
     const double prefactor,
     const double cutoff,
-    std::vector<Surreal<double> > &bornForces,
+    std::vector<Surreal<double>> &bornForces,
     std::vector<double> &out_forces,
     std::vector<double> &dU_dp) {
 
@@ -176,49 +171,49 @@ double compute_born_first_loop_jvp(
     //     preFactor = 0.0;
     // }
     // printf("preFactor %f\n", preFactor);
-    std::vector<Surreal<double> > charge_derivs(N, Surreal<double>(0, 0));
+    std::vector<Surreal<double>> charge_derivs(N, Surreal<double>(0, 0));
 
     for (int atomI = 0; atomI < numberOfAtoms; atomI++) {
 
         double partialChargeI = params[charge_param_idxs[atomI]];
         for (int atomJ = atomI; atomJ < numberOfAtoms; atomJ++) {
 
-            Surreal<double> r2(0,0);
+            Surreal<double> r2(0, 0);
             Surreal<double> dxs[D] = {Surreal<double>(0, 0)};
-            for(int d=0; d < D; d++) {
-                Surreal<double> dx = coords[atomI*D+d] - coords[atomJ*D+d];
+            for (int d = 0; d < D; d++) {
+                Surreal<double> dx = coords[atomI * D + d] - coords[atomJ * D + d];
                 dxs[d] = dx;
-                r2 += dx*dx;
+                r2 += dx * dx;
             }
             Surreal<double> r = sqrt(r2);
-            Surreal<double> alpha2_ij          = born_radii[atomI]*born_radii[atomJ];
-            Surreal<double> D_ij               = r2/(4.0*alpha2_ij);
+            Surreal<double> alpha2_ij = born_radii[atomI] * born_radii[atomJ];
+            Surreal<double> D_ij = r2 / (4.0 * alpha2_ij);
 
-            Surreal<double> expTerm            = exp(-D_ij);
-            Surreal<double> denominator2       = r2 + alpha2_ij*expTerm;
-            Surreal<double> denominator        = sqrt(denominator2);
+            Surreal<double> expTerm = exp(-D_ij);
+            Surreal<double> denominator2 = r2 + alpha2_ij * expTerm;
+            Surreal<double> denominator = sqrt(denominator2);
 
-            double partialChargeJ     = params[charge_param_idxs[atomJ]];
-            Surreal<double> Gpol               = (prefactor*partialChargeI*partialChargeJ)/denominator;
+            double partialChargeJ = params[charge_param_idxs[atomJ]];
+            Surreal<double> Gpol = (prefactor * partialChargeI * partialChargeJ) / denominator;
 
-            Surreal<double> dGpol_dr           = -Gpol*(1.0 - 0.25*expTerm)/denominator2;
-            Surreal<double> dGpol_dalpha2_ij   = -0.5*Gpol*expTerm*(1.0 + D_ij)/denominator2;
+            Surreal<double> dGpol_dr = -Gpol * (1.0 - 0.25 * expTerm) / denominator2;
+            Surreal<double> dGpol_dalpha2_ij = -0.5 * Gpol * expTerm * (1.0 + D_ij) / denominator2;
 
             // printf("%d %d dGpol_dalpha2_ij %f\n", atomI, atomJ, dGpol_dalpha2_ij);
 
             Surreal<double> energy = Gpol;
 
-            Surreal<double> dE_dqi = prefactor*partialChargeJ/denominator;
-            Surreal<double> dE_dqj = prefactor*partialChargeI/denominator;
+            Surreal<double> dE_dqi = prefactor * partialChargeJ / denominator;
+            Surreal<double> dE_dqj = prefactor * partialChargeI / denominator;
 
             if (atomI != atomJ) {
 
                 // TBD: determine what we should do with cutoff
                 // energy -= partialChargeI*partialCharges[atomJ]/cutoff;
-                bornForces[atomJ]        += dGpol_dalpha2_ij*born_radii[atomI];
-                for(int d=0; d < D; d++) {
-                    out_forces[atomI*D+d] += (dxs[d]*dGpol_dr).imag;
-                    out_forces[atomJ*D+d] -= (dxs[d]*dGpol_dr).imag;
+                bornForces[atomJ] += dGpol_dalpha2_ij * born_radii[atomI];
+                for (int d = 0; d < D; d++) {
+                    out_forces[atomI * D + d] += (dxs[d] * dGpol_dr).imag;
+                    out_forces[atomJ * D + d] -= (dxs[d] * dGpol_dr).imag;
                 }
             } else {
                 dE_dqi *= 0.5;
@@ -226,31 +221,29 @@ double compute_born_first_loop_jvp(
                 energy *= 0.5;
             }
 
-            charge_derivs[atomI]     += dE_dqi;
-            charge_derivs[atomJ]     += dE_dqj;
+            charge_derivs[atomI] += dE_dqi;
+            charge_derivs[atomJ] += dE_dqj;
 
             // obcEnergy         += energy;
-            bornForces[atomI] += dGpol_dalpha2_ij*born_radii[atomJ];
-
+            bornForces[atomI] += dGpol_dalpha2_ij * born_radii[atomJ];
         }
     }
 
-    for(int i=0; i < charge_derivs.size(); i++) {
-      // std::cout << "???" << charge_derivs[i] << std::endl;
+    for (int i = 0; i < charge_derivs.size(); i++) {
+        // std::cout << "???" << charge_derivs[i] << std::endl;
         dU_dp[charge_param_idxs[i]] += charge_derivs[i].imag;
     }
-
 };
 
 template <int D>
 double compute_born_energy_and_forces_jvp(
-    const std::vector<Surreal<double> >& coords,
-    const std::vector<double>& params,
-    const std::vector<int>& atomic_radii_idxs,
-    const std::vector<int>& scale_factor_idxs,
-    const std::vector<Surreal<double> > & born_radii,
-    const std::vector<Surreal<double> > & obc_chain,
-    const std::vector<Surreal<double> > & obc_chain_ri,
+    const std::vector<Surreal<double>> &coords,
+    const std::vector<double> &params,
+    const std::vector<int> &atomic_radii_idxs,
+    const std::vector<int> &scale_factor_idxs,
+    const std::vector<Surreal<double>> &born_radii,
+    const std::vector<Surreal<double>> &obc_chain,
+    const std::vector<Surreal<double>> &obc_chain_ri,
     const double dielectric_offset,
     // const double screening,
     // const double surface_tension, // surface area factor
@@ -258,10 +251,9 @@ double compute_born_energy_and_forces_jvp(
     // const double solvent_dielectric,
     // const double probe_radius,
     const double cutoff,
-    std::vector<Surreal<double> > &bornForces,
+    std::vector<Surreal<double>> &bornForces,
     std::vector<double> &out_HvP,
-    std::vector<double> &out_MvP
-) {
+    std::vector<double> &out_MvP) {
 
     // constants
     const int numberOfAtoms = atomic_radii_idxs.size();
@@ -270,149 +262,219 @@ double compute_born_energy_and_forces_jvp(
     const double dielectricOffset = dielectric_offset;
     const double cutoffDistance = cutoff;
 
-    std::vector<Surreal<double> > dPsi_dx(N*D, Surreal<double>(0, 0));
-    std::vector<Surreal<double> > dPsi_dri(N, Surreal<double>(0, 0));
-    std::vector<Surreal<double> > dPsi_dsi(N, Surreal<double>(0, 0));
+    std::vector<Surreal<double>> dPsi_dx(N * D, Surreal<double>(0, 0));
+    std::vector<Surreal<double>> dPsi_dri(N, Surreal<double>(0, 0));
+    std::vector<Surreal<double>> dPsi_dsi(N, Surreal<double>(0, 0));
 
     for (int atomI = 0; atomI < numberOfAtoms; atomI++) {
 
-       // radius w/ dielectric offset applied
+        // radius w/ dielectric offset applied
 
-       double radiusI        = params[atomic_radii_idxs[atomI]];
-       double offsetRadiusI  = radiusI - dielectricOffset;
-       double offsetRadiusI2 = offsetRadiusI*offsetRadiusI;
-       double offsetRadiusI3 = offsetRadiusI2*offsetRadiusI;
+        double radiusI = params[atomic_radii_idxs[atomI]];
+        double offsetRadiusI = radiusI - dielectricOffset;
+        double offsetRadiusI2 = offsetRadiusI * offsetRadiusI;
+        double offsetRadiusI3 = offsetRadiusI2 * offsetRadiusI;
 
-       for (int atomJ = 0; atomJ < numberOfAtoms; atomJ++) {
+        for (int atomJ = 0; atomJ < numberOfAtoms; atomJ++) {
 
-          if (atomJ != atomI) {
+            if (atomJ != atomI) {
 
-             Surreal<double> r2(0, 0);
-             Surreal<double> dxs[D] = {Surreal<double>(0,0)};
-             for(int d=0; d < D; d++) {
-                Surreal<double> dx = coords[atomI*D+d] - coords[atomJ*D+d];
-                dxs[d] = dx;
-                r2 += dx*dx;
-             }
-             Surreal<double> r = sqrt(r2);
-
-             // radius w/ dielectric offset applied
-
-             double radiusJ            = params[atomic_radii_idxs[atomJ]];
-             double offsetRadiusJ      = radiusJ - dielectricOffset;
-             double offsetRadiusJ2     = offsetRadiusJ*offsetRadiusJ;
-
-             double scaleFactorJ       = params[scale_factor_idxs[atomJ]];
-             double scaleFactorJ2      = scaleFactorJ*scaleFactorJ;
-             double scaleFactorJ3      = scaleFactorJ2*scaleFactorJ;
-             double scaledRadiusJ      = offsetRadiusJ*scaleFactorJ;
-             double scaledRadiusJ2     = scaledRadiusJ*scaledRadiusJ;
-             Surreal<double> rScaledRadiusJ     = r + scaledRadiusJ;
-             Surreal<double> rScaledRadiusJ2    = rScaledRadiusJ*rScaledRadiusJ;
-             Surreal<double> rScaledRadiusJ3    = rScaledRadiusJ2*rScaledRadiusJ;
-
-             // dL/dr & dU/dr are zero (this can be shown analytically)
-             // removed from calculation
-
-             if (offsetRadiusI < rScaledRadiusJ.real) {
-
-                // double l_ij          = offsetRadiusI > abs(rSubScaledRadiusJ) ? offsetRadiusI : abs(rSubScaledRadiusJ);
-                //        l_ij          = 1.0/l_ij;
-                // double u_ij          = 1.0/rScaledRadiusJ;
-                // double l_ij2         = l_ij*l_ij;
-                // double u_ij2         = u_ij*u_ij;
-                // double rInverse      = 1.0/r;
-                // double r2Inverse     = rInverse*rInverse;
-                // double t3            = 0.125*(1.0 + scaledRadiusJ2*r2Inverse)*(l_ij2 - u_ij2) + 0.25*log(u_ij/l_ij)*r2Inverse;
-
-                // printf("%d t3 RHS: %.8f\n", atomI, t3);
-                // double de            = bornForces[atomI]*t3*rInverse;
-
-                // for(int d=0; d < D; d++) {
-                //     dPsi_dx[atomI*D+d] -= dxs[d]*de;
-                //     dPsi_dx[atomJ*D+d] += dxs[d]*de;
-                // }
-
-                // start manual derivative
-                Surreal<double> de(0, 0); // derivative of Psi wrt the distance
-                Surreal<double> dpsi_dri(0, 0);
-                Surreal<double> dpsi_drj(0, 0);
-                Surreal<double> dpsi_dsj(0, 0);
-
-                Surreal<double> rSubScaledRadiusJ = r - scaledRadiusJ;
-                Surreal<double> rSubScaledRadiusJ2 = rSubScaledRadiusJ*rSubScaledRadiusJ;
-                Surreal<double> rSubScaledRadiusJ3 = rSubScaledRadiusJ2*rSubScaledRadiusJ;
-
-                // factor out as much as we can to outside of the conditional for reduce convergence
-                if(offsetRadiusI > abs(rSubScaledRadiusJ).real) {
-                  Surreal<double> term = 0.5*(-offsetRadiusI)*(-0.25*r*(1/rScaledRadiusJ2 - 1/offsetRadiusI2) + 1.0/rScaledRadiusJ + 1.0/(-offsetRadiusI) + 0.25*scaleFactorJ2*offsetRadiusJ2*(1/rScaledRadiusJ2 - 1/offsetRadiusI2)/r - 0.5*log(offsetRadiusI/rScaledRadiusJ)/r);
-                  de = -0.5*r/rScaledRadiusJ3 + (5.0/4.0)/rScaledRadiusJ2 - 0.25/offsetRadiusI2 + 0.5*scaleFactorJ2*offsetRadiusJ2/(r*rScaledRadiusJ3) - 0.5/(r*rScaledRadiusJ) - 0.25*scaleFactorJ2*offsetRadiusJ2*(-1/rScaledRadiusJ2 + 1/offsetRadiusI2)/r2 - 0.5*log(offsetRadiusI/rScaledRadiusJ)/r2;
-                  dpsi_dri = 0.25*r*(1/rScaledRadiusJ2 - 1/offsetRadiusI2) + offsetRadiusI*(0.5*r/offsetRadiusI3 - 1/offsetRadiusI2 - 0.5*scaleFactorJ2*offsetRadiusJ2/(r*offsetRadiusI3) + 0.5/(r*offsetRadiusI)) - 1/rScaledRadiusJ + 1.0/offsetRadiusI + 0.25*scaleFactorJ2*offsetRadiusJ2*(-1/rScaledRadiusJ2 + 1/offsetRadiusI2)/r + 0.5*log(offsetRadiusI/rScaledRadiusJ)/r;
-                  dpsi_drj = offsetRadiusI*(-0.5*r*scaleFactorJ/rScaledRadiusJ3 + scaleFactorJ/rScaledRadiusJ2 + 0.5*scaleFactorJ3*offsetRadiusJ2/(r*rScaledRadiusJ3) + 0.25*scaleFactorJ2*(-2*dielectricOffset + 2*radiusJ)*(-1/rScaledRadiusJ2 + 1/offsetRadiusI2)/r - 0.5*scaleFactorJ/(r*rScaledRadiusJ));
-                  dpsi_dsj = offsetRadiusI*(0.25*r*(2*dielectricOffset - 2*radiusJ)/rScaledRadiusJ3 + offsetRadiusJ/rScaledRadiusJ2 - 0.25*scaleFactorJ2*offsetRadiusJ2*(2*dielectricOffset - 2*radiusJ)/(r*rScaledRadiusJ3) + 0.5*scaleFactorJ*offsetRadiusJ2*(-1/rScaledRadiusJ2 + 1/offsetRadiusI2)/r + 0.5*(-offsetRadiusJ)/(r*rScaledRadiusJ));
-                  if(offsetRadiusI < (scaledRadiusJ - r).real) {
-                   de += 0;
-                   dpsi_dri += 0;
-                   dpsi_drj += 0;
-                   dpsi_dsj += 0;
-                  }
-
-                } else {
-                  Surreal<double> term = -0.5*(-offsetRadiusI)*(-0.25*r*(1/rSubScaledRadiusJ2 - 1/rScaledRadiusJ2) + 1.0/fabs(rSubScaledRadiusJ) - 1/rScaledRadiusJ - 0.25*scaleFactorJ2*offsetRadiusJ2*(-1/rSubScaledRadiusJ2 + 1/rScaledRadiusJ2)/r + 0.5*log(fabs(rSubScaledRadiusJ)/rScaledRadiusJ)/r);
-                  de = 0.25*r*(-2/rScaledRadiusJ3 + 2/rSubScaledRadiusJ3) + (5.0/4.0)/rScaledRadiusJ2 - sign(rSubScaledRadiusJ)/rSubScaledRadiusJ2 - 0.25/rSubScaledRadiusJ2 + 0.25*scaleFactorJ2*offsetRadiusJ2*(2/rScaledRadiusJ3 - 2/rSubScaledRadiusJ3)/r + 0.5*rScaledRadiusJ*(sign(rSubScaledRadiusJ)/rScaledRadiusJ - fabs(rSubScaledRadiusJ)/rScaledRadiusJ2)/(r*fabs(rSubScaledRadiusJ)) - 0.25*scaleFactorJ2*offsetRadiusJ2*(-1/rScaledRadiusJ2 + 1/rSubScaledRadiusJ2)/r2 - 0.5*log(fabs(rSubScaledRadiusJ)/rScaledRadiusJ)/r2;
-                  dpsi_dri = 0.25*r*(1/rScaledRadiusJ2 - 1/rSubScaledRadiusJ2) + 1.0/fabs(rSubScaledRadiusJ) - 1/rScaledRadiusJ + 0.25*scaleFactorJ2*offsetRadiusJ2*(-1/rScaledRadiusJ2 + 1/rSubScaledRadiusJ2)/r + 0.5*log(fabs(rSubScaledRadiusJ)/rScaledRadiusJ)/r;
-                  dpsi_drj = offsetRadiusI*(0.25*r*(-2*scaleFactorJ/rScaledRadiusJ3 - 2*scaleFactorJ/rSubScaledRadiusJ3) + scaleFactorJ/rScaledRadiusJ2 + scaleFactorJ*sign(rSubScaledRadiusJ)/rSubScaledRadiusJ2 + 0.25*scaleFactorJ2*(-2*dielectricOffset + 2*radiusJ)*(-1/rScaledRadiusJ2 + 1/rSubScaledRadiusJ2)/r + 0.25*scaleFactorJ2*offsetRadiusJ2*(2*scaleFactorJ/rScaledRadiusJ3 + 2*scaleFactorJ/rSubScaledRadiusJ3)/r + 0.5*rScaledRadiusJ*(-scaleFactorJ*sign(rSubScaledRadiusJ)/rScaledRadiusJ - scaleFactorJ*fabs(rSubScaledRadiusJ)/rScaledRadiusJ2)/(r*fabs(rSubScaledRadiusJ)));
-                  dpsi_dsj = offsetRadiusI*(0.25*r*(-(-2*dielectricOffset + 2*radiusJ)/rSubScaledRadiusJ3 + (2*dielectricOffset - 2*radiusJ)/rScaledRadiusJ3) + offsetRadiusJ/rScaledRadiusJ2 + offsetRadiusJ*sign(rSubScaledRadiusJ)/rSubScaledRadiusJ2 + 0.25*scaleFactorJ2*offsetRadiusJ2*((-2*dielectricOffset + 2*radiusJ)/rSubScaledRadiusJ3 - (2*dielectricOffset - 2*radiusJ)/rScaledRadiusJ3)/r + 0.5*scaleFactorJ*offsetRadiusJ2*(-1/rScaledRadiusJ2 + 1/rSubScaledRadiusJ2)/r + 0.5*rScaledRadiusJ*((-offsetRadiusJ)*sign(rSubScaledRadiusJ)/rScaledRadiusJ + (-offsetRadiusJ)*fabs(rSubScaledRadiusJ)/rScaledRadiusJ2)/(r*fabs(rSubScaledRadiusJ)));
-                  if (offsetRadiusI < (scaledRadiusJ - r).real) {
-                   de += 2.0*sign(rSubScaledRadiusJ)/rSubScaledRadiusJ2;
-                   dpsi_dri += -2.0/fabs(rSubScaledRadiusJ);
-                   dpsi_drj += -2.0*scaleFactorJ*offsetRadiusI*sign(rSubScaledRadiusJ)/rSubScaledRadiusJ2;
-                   dpsi_dsj += 2.0*offsetRadiusI*(-offsetRadiusJ)*sign(rSubScaledRadiusJ)/rSubScaledRadiusJ2;
-                  }
+                Surreal<double> r2(0, 0);
+                Surreal<double> dxs[D] = {Surreal<double>(0, 0)};
+                for (int d = 0; d < D; d++) {
+                    Surreal<double> dx = coords[atomI * D + d] - coords[atomJ * D + d];
+                    dxs[d] = dx;
+                    r2 += dx * dx;
                 }
+                Surreal<double> r = sqrt(r2);
 
-                // is bornForces
+                // radius w/ dielectric offset applied
 
-                de *= 0.5*bornForces[atomI]*offsetRadiusI;
-                dpsi_dri *= 0.5*bornForces[atomI];
-                dpsi_drj *= 0.5*bornForces[atomI];
-                dpsi_dsj *= 0.5*bornForces[atomI];
+                double radiusJ = params[atomic_radii_idxs[atomJ]];
+                double offsetRadiusJ = radiusJ - dielectricOffset;
+                double offsetRadiusJ2 = offsetRadiusJ * offsetRadiusJ;
 
-                dPsi_dri[atomI] += dpsi_dri;
-                dPsi_dri[atomJ] += dpsi_drj;
-                dPsi_dsi[atomJ] += dpsi_dsj;
+                double scaleFactorJ = params[scale_factor_idxs[atomJ]];
+                double scaleFactorJ2 = scaleFactorJ * scaleFactorJ;
+                double scaleFactorJ3 = scaleFactorJ2 * scaleFactorJ;
+                double scaledRadiusJ = offsetRadiusJ * scaleFactorJ;
+                double scaledRadiusJ2 = scaledRadiusJ * scaledRadiusJ;
+                Surreal<double> rScaledRadiusJ = r + scaledRadiusJ;
+                Surreal<double> rScaledRadiusJ2 = rScaledRadiusJ * rScaledRadiusJ;
+                Surreal<double> rScaledRadiusJ3 = rScaledRadiusJ2 * rScaledRadiusJ;
 
-                for(int d=0; d < D; d++) {
-                    dPsi_dx[atomI*D+d] += (dxs[d]/r)*de;
-                    dPsi_dx[atomJ*D+d] -= (dxs[d]/r)*de;
+                // dL/dr & dU/dr are zero (this can be shown analytically)
+                // removed from calculation
+
+                if (offsetRadiusI < rScaledRadiusJ.real) {
+
+                    // double l_ij          = offsetRadiusI > abs(rSubScaledRadiusJ) ? offsetRadiusI : abs(rSubScaledRadiusJ);
+                    //        l_ij          = 1.0/l_ij;
+                    // double u_ij          = 1.0/rScaledRadiusJ;
+                    // double l_ij2         = l_ij*l_ij;
+                    // double u_ij2         = u_ij*u_ij;
+                    // double rInverse      = 1.0/r;
+                    // double r2Inverse     = rInverse*rInverse;
+                    // double t3            = 0.125*(1.0 + scaledRadiusJ2*r2Inverse)*(l_ij2 - u_ij2) + 0.25*log(u_ij/l_ij)*r2Inverse;
+
+                    // printf("%d t3 RHS: %.8f\n", atomI, t3);
+                    // double de            = bornForces[atomI]*t3*rInverse;
+
+                    // for(int d=0; d < D; d++) {
+                    //     dPsi_dx[atomI*D+d] -= dxs[d]*de;
+                    //     dPsi_dx[atomJ*D+d] += dxs[d]*de;
+                    // }
+
+                    // start manual derivative
+                    Surreal<double> de(0, 0); // derivative of Psi wrt the distance
+                    Surreal<double> dpsi_dri(0, 0);
+                    Surreal<double> dpsi_drj(0, 0);
+                    Surreal<double> dpsi_dsj(0, 0);
+
+                    Surreal<double> rSubScaledRadiusJ = r - scaledRadiusJ;
+                    Surreal<double> rSubScaledRadiusJ2 = rSubScaledRadiusJ * rSubScaledRadiusJ;
+                    Surreal<double> rSubScaledRadiusJ3 = rSubScaledRadiusJ2 * rSubScaledRadiusJ;
+
+                    // factor out as much as we can to outside of the conditional for reduce convergence
+                    if (offsetRadiusI > abs(rSubScaledRadiusJ).real) {
+                        Surreal<double> term =
+                            0.5 * (-offsetRadiusI) *
+                            (-0.25 * r * (1 / rScaledRadiusJ2 - 1 / offsetRadiusI2) + 1.0 / rScaledRadiusJ +
+                             1.0 / (-offsetRadiusI) +
+                             0.25 * scaleFactorJ2 * offsetRadiusJ2 * (1 / rScaledRadiusJ2 - 1 / offsetRadiusI2) / r -
+                             0.5 * log(offsetRadiusI / rScaledRadiusJ) / r);
+                        de = -0.5 * r / rScaledRadiusJ3 + (5.0 / 4.0) / rScaledRadiusJ2 - 0.25 / offsetRadiusI2 +
+                             0.5 * scaleFactorJ2 * offsetRadiusJ2 / (r * rScaledRadiusJ3) - 0.5 / (r * rScaledRadiusJ) -
+                             0.25 * scaleFactorJ2 * offsetRadiusJ2 * (-1 / rScaledRadiusJ2 + 1 / offsetRadiusI2) / r2 -
+                             0.5 * log(offsetRadiusI / rScaledRadiusJ) / r2;
+                        dpsi_dri =
+                            0.25 * r * (1 / rScaledRadiusJ2 - 1 / offsetRadiusI2) +
+                            offsetRadiusI * (0.5 * r / offsetRadiusI3 - 1 / offsetRadiusI2 -
+                                             0.5 * scaleFactorJ2 * offsetRadiusJ2 / (r * offsetRadiusI3) +
+                                             0.5 / (r * offsetRadiusI)) -
+                            1 / rScaledRadiusJ + 1.0 / offsetRadiusI +
+                            0.25 * scaleFactorJ2 * offsetRadiusJ2 * (-1 / rScaledRadiusJ2 + 1 / offsetRadiusI2) / r +
+                            0.5 * log(offsetRadiusI / rScaledRadiusJ) / r;
+                        dpsi_drj = offsetRadiusI *
+                                   (-0.5 * r * scaleFactorJ / rScaledRadiusJ3 + scaleFactorJ / rScaledRadiusJ2 +
+                                    0.5 * scaleFactorJ3 * offsetRadiusJ2 / (r * rScaledRadiusJ3) +
+                                    0.25 * scaleFactorJ2 * (-2 * dielectricOffset + 2 * radiusJ) *
+                                        (-1 / rScaledRadiusJ2 + 1 / offsetRadiusI2) / r -
+                                    0.5 * scaleFactorJ / (r * rScaledRadiusJ));
+                        dpsi_dsj = offsetRadiusI * (0.25 * r * (2 * dielectricOffset - 2 * radiusJ) / rScaledRadiusJ3 +
+                                                    offsetRadiusJ / rScaledRadiusJ2 -
+                                                    0.25 * scaleFactorJ2 * offsetRadiusJ2 *
+                                                        (2 * dielectricOffset - 2 * radiusJ) / (r * rScaledRadiusJ3) +
+                                                    0.5 * scaleFactorJ * offsetRadiusJ2 *
+                                                        (-1 / rScaledRadiusJ2 + 1 / offsetRadiusI2) / r +
+                                                    0.5 * (-offsetRadiusJ) / (r * rScaledRadiusJ));
+                        if (offsetRadiusI < (scaledRadiusJ - r).real) {
+                            de += 0;
+                            dpsi_dri += 0;
+                            dpsi_drj += 0;
+                            dpsi_dsj += 0;
+                        }
+
+                    } else {
+                        Surreal<double> term = -0.5 * (-offsetRadiusI) *
+                                               (-0.25 * r * (1 / rSubScaledRadiusJ2 - 1 / rScaledRadiusJ2) +
+                                                1.0 / fabs(rSubScaledRadiusJ) - 1 / rScaledRadiusJ -
+                                                0.25 * scaleFactorJ2 * offsetRadiusJ2 *
+                                                    (-1 / rSubScaledRadiusJ2 + 1 / rScaledRadiusJ2) / r +
+                                                0.5 * log(fabs(rSubScaledRadiusJ) / rScaledRadiusJ) / r);
+                        de =
+                            0.25 * r * (-2 / rScaledRadiusJ3 + 2 / rSubScaledRadiusJ3) + (5.0 / 4.0) / rScaledRadiusJ2 -
+                            sign(rSubScaledRadiusJ) / rSubScaledRadiusJ2 - 0.25 / rSubScaledRadiusJ2 +
+                            0.25 * scaleFactorJ2 * offsetRadiusJ2 * (2 / rScaledRadiusJ3 - 2 / rSubScaledRadiusJ3) / r +
+                            0.5 * rScaledRadiusJ *
+                                (sign(rSubScaledRadiusJ) / rScaledRadiusJ - fabs(rSubScaledRadiusJ) / rScaledRadiusJ2) /
+                                (r * fabs(rSubScaledRadiusJ)) -
+                            0.25 * scaleFactorJ2 * offsetRadiusJ2 * (-1 / rScaledRadiusJ2 + 1 / rSubScaledRadiusJ2) /
+                                r2 -
+                            0.5 * log(fabs(rSubScaledRadiusJ) / rScaledRadiusJ) / r2;
+                        dpsi_dri = 0.25 * r * (1 / rScaledRadiusJ2 - 1 / rSubScaledRadiusJ2) +
+                                   1.0 / fabs(rSubScaledRadiusJ) - 1 / rScaledRadiusJ +
+                                   0.25 * scaleFactorJ2 * offsetRadiusJ2 *
+                                       (-1 / rScaledRadiusJ2 + 1 / rSubScaledRadiusJ2) / r +
+                                   0.5 * log(fabs(rSubScaledRadiusJ) / rScaledRadiusJ) / r;
+                        dpsi_drj =
+                            offsetRadiusI *
+                            (0.25 * r * (-2 * scaleFactorJ / rScaledRadiusJ3 - 2 * scaleFactorJ / rSubScaledRadiusJ3) +
+                             scaleFactorJ / rScaledRadiusJ2 +
+                             scaleFactorJ * sign(rSubScaledRadiusJ) / rSubScaledRadiusJ2 +
+                             0.25 * scaleFactorJ2 * (-2 * dielectricOffset + 2 * radiusJ) *
+                                 (-1 / rScaledRadiusJ2 + 1 / rSubScaledRadiusJ2) / r +
+                             0.25 * scaleFactorJ2 * offsetRadiusJ2 *
+                                 (2 * scaleFactorJ / rScaledRadiusJ3 + 2 * scaleFactorJ / rSubScaledRadiusJ3) / r +
+                             0.5 * rScaledRadiusJ *
+                                 (-scaleFactorJ * sign(rSubScaledRadiusJ) / rScaledRadiusJ -
+                                  scaleFactorJ * fabs(rSubScaledRadiusJ) / rScaledRadiusJ2) /
+                                 (r * fabs(rSubScaledRadiusJ)));
+                        dpsi_dsj = offsetRadiusI * (0.25 * r *
+                                                        (-(-2 * dielectricOffset + 2 * radiusJ) / rSubScaledRadiusJ3 +
+                                                         (2 * dielectricOffset - 2 * radiusJ) / rScaledRadiusJ3) +
+                                                    offsetRadiusJ / rScaledRadiusJ2 +
+                                                    offsetRadiusJ * sign(rSubScaledRadiusJ) / rSubScaledRadiusJ2 +
+                                                    0.25 * scaleFactorJ2 * offsetRadiusJ2 *
+                                                        ((-2 * dielectricOffset + 2 * radiusJ) / rSubScaledRadiusJ3 -
+                                                         (2 * dielectricOffset - 2 * radiusJ) / rScaledRadiusJ3) /
+                                                        r +
+                                                    0.5 * scaleFactorJ * offsetRadiusJ2 *
+                                                        (-1 / rScaledRadiusJ2 + 1 / rSubScaledRadiusJ2) / r +
+                                                    0.5 * rScaledRadiusJ *
+                                                        ((-offsetRadiusJ) * sign(rSubScaledRadiusJ) / rScaledRadiusJ +
+                                                         (-offsetRadiusJ) * fabs(rSubScaledRadiusJ) / rScaledRadiusJ2) /
+                                                        (r * fabs(rSubScaledRadiusJ)));
+                        if (offsetRadiusI < (scaledRadiusJ - r).real) {
+                            de += 2.0 * sign(rSubScaledRadiusJ) / rSubScaledRadiusJ2;
+                            dpsi_dri += -2.0 / fabs(rSubScaledRadiusJ);
+                            dpsi_drj +=
+                                -2.0 * scaleFactorJ * offsetRadiusI * sign(rSubScaledRadiusJ) / rSubScaledRadiusJ2;
+                            dpsi_dsj +=
+                                2.0 * offsetRadiusI * (-offsetRadiusJ) * sign(rSubScaledRadiusJ) / rSubScaledRadiusJ2;
+                        }
+                    }
+
+                    // is bornForces
+
+                    de *= 0.5 * bornForces[atomI] * offsetRadiusI;
+                    dpsi_dri *= 0.5 * bornForces[atomI];
+                    dpsi_drj *= 0.5 * bornForces[atomI];
+                    dpsi_dsj *= 0.5 * bornForces[atomI];
+
+                    dPsi_dri[atomI] += dpsi_dri;
+                    dPsi_dri[atomJ] += dpsi_drj;
+                    dPsi_dsi[atomJ] += dpsi_dsj;
+
+                    for (int d = 0; d < D; d++) {
+                        dPsi_dx[atomI * D + d] += (dxs[d] / r) * de;
+                        dPsi_dx[atomJ * D + d] -= (dxs[d] / r) * de;
+                    }
                 }
-             }
-          }
-       }
-
+            }
+        }
     }
-
 
     // std::vector<double> &out_HvP,
     // std::vector<double> &out_MvP
     for (int atomI = 0; atomI < numberOfAtoms; atomI++) {
-      for(int d=0; d < D; d++) {
-        out_HvP[atomI*D+d] += dPsi_dx[atomI*D+d].imag;
-      }
+        for (int d = 0; d < D; d++) {
+            out_HvP[atomI * D + d] += dPsi_dx[atomI * D + d].imag;
+        }
     }
 
     // for(int i=0; i < dPsi_dri.size(); i++) {
     //   std::cout << "dPsi_dri: " << dPsi_dri[i]+atomic_radii_derivatives[i] << std::endl;
     // }
 
-    for(int i=0; i < dPsi_dri.size(); i++) {
-      // std::cout << "dPsi_dri parts: " << dPsi_dri[i] << " " << atomic_radii_derivatives[i] << std::endl;
-      // out_MvP[atomic_radii_idxs[i]] += dPsi_dri[i].imag + atomic_radii_derivatives[i].imag;
-      out_MvP[atomic_radii_idxs[i]] += dPsi_dri[i].imag;
+    for (int i = 0; i < dPsi_dri.size(); i++) {
+        // std::cout << "dPsi_dri parts: " << dPsi_dri[i] << " " << atomic_radii_derivatives[i] << std::endl;
+        // out_MvP[atomic_radii_idxs[i]] += dPsi_dri[i].imag + atomic_radii_derivatives[i].imag;
+        out_MvP[atomic_radii_idxs[i]] += dPsi_dri[i].imag;
     }
 
-    for(int i=0; i < dPsi_dsi.size(); i++) {
-      out_MvP[scale_factor_idxs[i]] += dPsi_dsi[i].imag;
+    for (int i = 0; i < dPsi_dsi.size(); i++) {
+        out_MvP[scale_factor_idxs[i]] += dPsi_dsi[i].imag;
     }
 
     // for(int i=0; i < charge_derivs.size(); i++) {
@@ -424,5 +486,4 @@ double compute_born_energy_and_forces_jvp(
     // return obcEnergy;
 }
 
-
-}
+} // namespace timemachine

--- a/timemachine/cpp/src/gpu_utils.cu
+++ b/timemachine/cpp/src/gpu_utils.cu
@@ -1,15 +1,10 @@
 #include "gpu_utils.cuh"
 
-curandStatus_t templateCurandNormal(
-    curandGenerator_t generator,
-    float *outputPtr, size_t n,
-    float mean, float stddev) {
+curandStatus_t templateCurandNormal(curandGenerator_t generator, float *outputPtr, size_t n, float mean, float stddev) {
     return curandGenerateNormal(generator, outputPtr, n, mean, stddev);
 }
 
-curandStatus_t templateCurandNormal(
-    curandGenerator_t generator,
-    double *outputPtr, size_t n,
-    double mean, double stddev) {
+curandStatus_t
+templateCurandNormal(curandGenerator_t generator, double *outputPtr, size_t n, double mean, double stddev) {
     return curandGenerateNormalDouble(generator, outputPtr, n, mean, stddev);
 }

--- a/timemachine/cpp/src/gpu_utils.cuh
+++ b/timemachine/cpp/src/gpu_utils.cuh
@@ -1,69 +1,56 @@
 #pragma once
 
-#include <iostream>
-#include <cstdio>
 #include "curand.h"
+#include <cstdio>
+#include <iostream>
 
-curandStatus_t templateCurandNormal(
-    curandGenerator_t generator,
-    float *outputPtr, size_t n,
-    float mean, float stddev);
+curandStatus_t templateCurandNormal(curandGenerator_t generator, float *outputPtr, size_t n, float mean, float stddev);
 
-curandStatus_t templateCurandNormal(
-    curandGenerator_t generator,
-    double *outputPtr, size_t n,
-    double mean, double stddev);
+curandStatus_t
+templateCurandNormal(curandGenerator_t generator, double *outputPtr, size_t n, double mean, double stddev);
 
-
-
-
-
-#define gpuErrchk(ans) { gpuAssert((ans), __FILE__, __LINE__); }
-inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=true)
-{
-   if (code != cudaSuccess)
-   {
-      fprintf(stderr,"GPUassert: %s %s %d\n", cudaGetErrorString(code), file, line);
-      if (abort) exit(code);
-   }
+#define gpuErrchk(ans)                                                                                                 \
+    { gpuAssert((ans), __FILE__, __LINE__); }
+inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort = true) {
+    if (code != cudaSuccess) {
+        fprintf(stderr, "GPUassert: %s %s %d\n", cudaGetErrorString(code), file, line);
+        if (abort)
+            exit(code);
+    }
 }
 
-#define curandErrchk(ans) { curandAssert((ans), __FILE__, __LINE__); }
-inline void curandAssert(curandStatus_t code, const char *file, int line, bool abort=true)
-{
-   if (code != CURAND_STATUS_SUCCESS)
-   {
-      fprintf(stderr,"curand failure, code: %d %s %d\n", code, file, line);
-      if (abort) exit(code);
-   }
+#define curandErrchk(ans)                                                                                              \
+    { curandAssert((ans), __FILE__, __LINE__); }
+inline void curandAssert(curandStatus_t code, const char *file, int line, bool abort = true) {
+    if (code != CURAND_STATUS_SUCCESS) {
+        fprintf(stderr, "curand failure, code: %d %s %d\n", code, file, line);
+        if (abort)
+            exit(code);
+    }
 }
 
 // safe is for use of gpuErrchk
-template<typename T>
-T* gpuErrchkCudaMallocAndCopy(const T *host_array, int count) {
-    T* device_array;
-    gpuErrchk(cudaMalloc(&device_array, count*sizeof(*host_array)));
-    gpuErrchk(cudaMemcpy(device_array, host_array, count*sizeof(*host_array), cudaMemcpyHostToDevice));
+template <typename T> T *gpuErrchkCudaMallocAndCopy(const T *host_array, int count) {
+    T *device_array;
+    gpuErrchk(cudaMalloc(&device_array, count * sizeof(*host_array)));
+    gpuErrchk(cudaMemcpy(device_array, host_array, count * sizeof(*host_array), cudaMemcpyHostToDevice));
     return device_array;
 }
 
-template<typename T>
-void __global__ k_initialize_array(int count, T *array, T val) {
-    const int idx = blockIdx.x*blockDim.x + threadIdx.x;
-    if(idx >= count) {
+template <typename T> void __global__ k_initialize_array(int count, T *array, T val) {
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= count) {
         return;
     }
 
     array[idx] = val;
 }
 
-template<typename T>
-void initializeArray(int count, T *array, T val) {
+template <typename T> void initializeArray(int count, T *array, T val) {
 
     int tpb = 32;
-    int B = (count+tpb-1)/tpb; // total number of blocks we need to process
+    int B = (count + tpb - 1) / tpb; // total number of blocks we need to process
 
     k_initialize_array<<<B, tpb, 0>>>(count, array, val);
     gpuErrchk(cudaPeekAtLastError());
-
 }

--- a/timemachine/cpp/src/gradient.cu
+++ b/timemachine/cpp/src/gradient.cu
@@ -1,21 +1,21 @@
 
 #include <iostream>
 
-#include "gradient.hpp"
 #include "gpu_utils.cuh"
+#include "gradient.hpp"
 #include "surreal.cuh"
 
 namespace timemachine {
 
 void Potential::execute_host(
     const int N,
-    const double *h_x, // [N,3]
-    const double *h_params, // [P,]
-    const double *h_box, // [3, 3]
-    const double lambda, // [1]
+    const double *h_x,           // [N,3]
+    const double *h_params,      // [P,]
+    const double *h_box,         // [3, 3]
+    const double lambda,         // [1]
     unsigned long long *h_du_dx, // [N,3]
-    double *h_du_dp, // [P]
-    double *h_du_dl, //
+    double *h_du_dp,             // [P]
+    double *h_du_dl,             //
     double *h_u) {
 
     double *d_x;
@@ -23,37 +23,28 @@ void Potential::execute_host(
 
     const int D = 3;
 
-    gpuErrchk(cudaMalloc(&d_x, N*D*sizeof(double)));
-    gpuErrchk(cudaMemcpy(d_x, h_x, N*D*sizeof(double), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_x, N * D * sizeof(double)));
+    gpuErrchk(cudaMemcpy(d_x, h_x, N * D * sizeof(double), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_box, D*D*sizeof(double)));
-    gpuErrchk(cudaMemcpy(d_box, h_box, D*D*sizeof(double), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_box, D * D * sizeof(double)));
+    gpuErrchk(cudaMemcpy(d_box, h_box, D * D * sizeof(double), cudaMemcpyHostToDevice));
 
     unsigned long long *d_du_dx; // du/dx
 
-    double *d_du_dl; // du/dl
+    double *d_du_dl;       // du/dl
     double *d_u = nullptr; // u
 
     // very important that these are initialized to zero since the kernels themselves just accumulate
-    gpuErrchk(cudaMalloc(&d_du_dx, N*D*sizeof(unsigned long long)));
-    gpuErrchk(cudaMemset(d_du_dx, 0, N*D*sizeof(unsigned long long)));
+    gpuErrchk(cudaMalloc(&d_du_dx, N * D * sizeof(unsigned long long)));
+    gpuErrchk(cudaMemset(d_du_dx, 0, N * D * sizeof(unsigned long long)));
     gpuErrchk(cudaMalloc(&d_du_dl, sizeof(double)));
     gpuErrchk(cudaMemset(d_du_dl, 0, sizeof(double)));
     gpuErrchk(cudaMalloc(&d_u, sizeof(double)));
     gpuErrchk(cudaMemset(d_u, 0, sizeof(double)));
 
+    this->execute_device(N, d_x, lambda, d_du_dx, d_du_dl, d_u, static_cast<cudaStream_t>(0));
 
-    this->execute_device(
-        N,
-        d_x,
-        lambda,
-        d_du_dx,
-        d_du_dl,
-        d_u,
-        static_cast<cudaStream_t>(0)
-    );
-
-    gpuErrchk(cudaMemcpy(h_du_dx, d_du_dx, N*D*sizeof(*h_du_dx), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(h_du_dx, d_du_dx, N * D * sizeof(*h_du_dx), cudaMemcpyDeviceToHost));
     gpuErrchk(cudaFree(d_du_dx));
     gpuErrchk(cudaMemcpy(h_du_dl, d_du_dl, sizeof(*h_du_dl), cudaMemcpyDeviceToHost));
     gpuErrchk(cudaFree(d_du_dl));
@@ -61,7 +52,6 @@ void Potential::execute_host(
     gpuErrchk(cudaFree(d_u));
     gpuErrchk(cudaFree(d_coords));
     gpuErrchk(cudaFree(d_box));
-
 };
 
 // void Gradient::execute_lambda_jvp_host(
@@ -116,4 +106,4 @@ void Potential::execute_host(
 
 // };
 
-}
+} // namespace timemachine

--- a/timemachine/cpp/src/harmonic_angle.cu
+++ b/timemachine/cpp/src/harmonic_angle.cu
@@ -1,10 +1,10 @@
+#include "gpu_utils.cuh"
+#include "harmonic_angle.hpp"
+#include "k_harmonic_angle.cuh"
 #include <chrono>
+#include <complex>
 #include <iostream>
 #include <vector>
-#include <complex>
-#include "harmonic_angle.hpp"
-#include "gpu_utils.cuh"
-#include "k_harmonic_angle.cuh"
 
 namespace timemachine {
 
@@ -12,53 +12,52 @@ template <typename RealType>
 HarmonicAngle<RealType>::HarmonicAngle(
     const std::vector<int> &angle_idxs, // [A, 3]
     const std::vector<int> &lambda_mult,
-    const std::vector<int> &lambda_offset
-) : A_(angle_idxs.size()/3) {
+    const std::vector<int> &lambda_offset)
+    : A_(angle_idxs.size() / 3) {
 
-    if(angle_idxs.size() % 3 != 0) {
+    if (angle_idxs.size() % 3 != 0) {
         throw std::runtime_error("angle_idxs.size() must be exactly 3*A");
     }
 
-    if(lambda_mult.size() > 0 && lambda_mult.size() != A_) {
+    if (lambda_mult.size() > 0 && lambda_mult.size() != A_) {
         throw std::runtime_error("bad lambda_mult size()");
     }
 
-    if(lambda_offset.size() > 0 && lambda_offset.size() != A_) {
+    if (lambda_offset.size() > 0 && lambda_offset.size() != A_) {
         throw std::runtime_error("bad lambda_offset size()");
     }
 
-    for(int a=0; a < A_; a++) {
-        auto i = angle_idxs[a*3+0];
-        auto j = angle_idxs[a*3+1];
-        auto k = angle_idxs[a*3+2];
-        if(i == j || j == k || i == k) {
+    for (int a = 0; a < A_; a++) {
+        auto i = angle_idxs[a * 3 + 0];
+        auto j = angle_idxs[a * 3 + 1];
+        auto k = angle_idxs[a * 3 + 2];
+        if (i == j || j == k || i == k) {
             throw std::runtime_error("angle triplets must be unique");
         }
     }
 
-    gpuErrchk(cudaMalloc(&d_angle_idxs_, A_*3*sizeof(*d_angle_idxs_)));
-    gpuErrchk(cudaMemcpy(d_angle_idxs_, &angle_idxs[0], A_*3*sizeof(*d_angle_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_angle_idxs_, A_ * 3 * sizeof(*d_angle_idxs_)));
+    gpuErrchk(cudaMemcpy(d_angle_idxs_, &angle_idxs[0], A_ * 3 * sizeof(*d_angle_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_lambda_mult_, A_*sizeof(*d_lambda_mult_)));
-    gpuErrchk(cudaMalloc(&d_lambda_offset_, A_*sizeof(*d_lambda_offset_)));
+    gpuErrchk(cudaMalloc(&d_lambda_mult_, A_ * sizeof(*d_lambda_mult_)));
+    gpuErrchk(cudaMalloc(&d_lambda_offset_, A_ * sizeof(*d_lambda_offset_)));
 
-    if(lambda_mult.size() > 0) {
-        gpuErrchk(cudaMemcpy(d_lambda_mult_, &lambda_mult[0], A_*sizeof(*d_lambda_mult_), cudaMemcpyHostToDevice));
+    if (lambda_mult.size() > 0) {
+        gpuErrchk(cudaMemcpy(d_lambda_mult_, &lambda_mult[0], A_ * sizeof(*d_lambda_mult_), cudaMemcpyHostToDevice));
     } else {
         initializeArray(A_, d_lambda_mult_, 0);
     }
 
-    if(lambda_offset.size() > 0) {
-        gpuErrchk(cudaMemcpy(d_lambda_offset_, &lambda_offset[0], A_*sizeof(*d_lambda_offset_), cudaMemcpyHostToDevice));
+    if (lambda_offset.size() > 0) {
+        gpuErrchk(
+            cudaMemcpy(d_lambda_offset_, &lambda_offset[0], A_ * sizeof(*d_lambda_offset_), cudaMemcpyHostToDevice));
     } else {
         // can't memset this
         initializeArray(A_, d_lambda_offset_, 1);
     }
-
 };
 
-template <typename RealType>
-HarmonicAngle<RealType>::~HarmonicAngle() {
+template <typename RealType> HarmonicAngle<RealType>::~HarmonicAngle() {
     gpuErrchk(cudaFree(d_angle_idxs_));
     gpuErrchk(cudaFree(d_lambda_mult_));
     gpuErrchk(cudaFree(d_lambda_offset_));
@@ -79,27 +78,14 @@ void HarmonicAngle<RealType>::execute_device(
     cudaStream_t stream) {
 
     int tpb = 32;
-    int blocks = (A_+tpb-1)/tpb;
+    int blocks = (A_ + tpb - 1) / tpb;
 
-    if(A_ > 0) {
+    if (A_ > 0) {
         k_harmonic_angle_inference<RealType, 3><<<blocks, tpb, 0, stream>>>(
-            A_,
-            d_x,
-            d_p,
-            lambda,
-            d_lambda_mult_,
-            d_lambda_offset_,
-            d_angle_idxs_,
-            d_du_dx,
-            d_du_dp,
-            d_du_dl,
-            d_u
-        );
+            A_, d_x, d_p, lambda, d_lambda_mult_, d_lambda_offset_, d_angle_idxs_, d_du_dx, d_du_dp, d_du_dl, d_u);
         gpuErrchk(cudaPeekAtLastError());
     }
-
 }
-
 
 template class HarmonicAngle<double>;
 template class HarmonicAngle<float>;

--- a/timemachine/cpp/src/harmonic_bond.cu
+++ b/timemachine/cpp/src/harmonic_bond.cu
@@ -1,63 +1,60 @@
+#include "gpu_utils.cuh"
+#include "harmonic_bond.hpp"
+#include "k_harmonic_bond.cuh"
 #include <chrono>
+#include <complex>
 #include <iostream>
 #include <vector>
-#include <complex>
-#include "harmonic_bond.hpp"
-#include "gpu_utils.cuh"
-#include "k_harmonic_bond.cuh"
 
 namespace timemachine {
 
 template <typename RealType>
 HarmonicBond<RealType>::HarmonicBond(
-    const std::vector<int> &bond_idxs,
-    const std::vector<int> &lambda_mult,
-    const std::vector<int> &lambda_offset
-) : B_(bond_idxs.size()/2) {
+    const std::vector<int> &bond_idxs, const std::vector<int> &lambda_mult, const std::vector<int> &lambda_offset)
+    : B_(bond_idxs.size() / 2) {
 
-    if(bond_idxs.size() % 2 != 0) {
+    if (bond_idxs.size() % 2 != 0) {
         throw std::runtime_error("bond_idxs.size() must be exactly 2*k!");
     }
 
-    if(lambda_mult.size() > 0 && lambda_mult.size() != B_) {
+    if (lambda_mult.size() > 0 && lambda_mult.size() != B_) {
         throw std::runtime_error("bad lambda_mult size()");
     }
 
-    if(lambda_offset.size() > 0 && lambda_offset.size() != B_) {
+    if (lambda_offset.size() > 0 && lambda_offset.size() != B_) {
         throw std::runtime_error("bad lambda_offset size()");
     }
 
-    for(int b=0; b < B_; b++) {
-        auto src = bond_idxs[b*2+0];
-        auto dst = bond_idxs[b*2+1];
-        if(src == dst) {
+    for (int b = 0; b < B_; b++) {
+        auto src = bond_idxs[b * 2 + 0];
+        auto dst = bond_idxs[b * 2 + 1];
+        if (src == dst) {
             throw std::runtime_error("src == dst");
         }
     }
 
-    gpuErrchk(cudaMalloc(&d_bond_idxs_, B_*2*sizeof(*d_bond_idxs_)));
-    gpuErrchk(cudaMemcpy(d_bond_idxs_, &bond_idxs[0], B_*2*sizeof(*d_bond_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_bond_idxs_, B_ * 2 * sizeof(*d_bond_idxs_)));
+    gpuErrchk(cudaMemcpy(d_bond_idxs_, &bond_idxs[0], B_ * 2 * sizeof(*d_bond_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_lambda_mult_, B_*sizeof(*d_lambda_mult_)));
-    gpuErrchk(cudaMalloc(&d_lambda_offset_, B_*sizeof(*d_lambda_offset_)));
+    gpuErrchk(cudaMalloc(&d_lambda_mult_, B_ * sizeof(*d_lambda_mult_)));
+    gpuErrchk(cudaMalloc(&d_lambda_offset_, B_ * sizeof(*d_lambda_offset_)));
 
-    if(lambda_mult.size() > 0) {
-        gpuErrchk(cudaMemcpy(d_lambda_mult_, &lambda_mult[0], B_*sizeof(*d_lambda_mult_), cudaMemcpyHostToDevice));
+    if (lambda_mult.size() > 0) {
+        gpuErrchk(cudaMemcpy(d_lambda_mult_, &lambda_mult[0], B_ * sizeof(*d_lambda_mult_), cudaMemcpyHostToDevice));
     } else {
         initializeArray(B_, d_lambda_mult_, 0);
     }
 
-    if(lambda_offset.size() > 0) {
-        gpuErrchk(cudaMemcpy(d_lambda_offset_, &lambda_offset[0], B_*sizeof(*d_lambda_offset_), cudaMemcpyHostToDevice));
+    if (lambda_offset.size() > 0) {
+        gpuErrchk(
+            cudaMemcpy(d_lambda_offset_, &lambda_offset[0], B_ * sizeof(*d_lambda_offset_), cudaMemcpyHostToDevice));
     } else {
         // can't memset this
         initializeArray(B_, d_lambda_offset_, 1);
     }
-
 };
 
-template <typename RealType>
-HarmonicBond<RealType>::~HarmonicBond() {
+template <typename RealType> HarmonicBond<RealType>::~HarmonicBond() {
     gpuErrchk(cudaFree(d_bond_idxs_));
     gpuErrchk(cudaFree(d_lambda_mult_));
     gpuErrchk(cudaFree(d_lambda_offset_));
@@ -77,26 +74,14 @@ void HarmonicBond<RealType>::execute_device(
     unsigned long long *d_u,
     cudaStream_t stream) {
 
-    if(B_ > 0) {
+    if (B_ > 0) {
         int tpb = 32;
-        int blocks = (B_+tpb-1)/tpb;
+        int blocks = (B_ + tpb - 1) / tpb;
 
         k_harmonic_bond<RealType><<<blocks, tpb, 0, stream>>>(
-            B_,
-            d_x,
-            d_p,
-            lambda,
-            d_lambda_mult_,
-            d_lambda_offset_,
-            d_bond_idxs_,
-            d_du_dx,
-            d_du_dp,
-            d_du_dl,
-            d_u
-        );
+            B_, d_x, d_p, lambda, d_lambda_mult_, d_lambda_offset_, d_bond_idxs_, d_du_dx, d_du_dp, d_du_dl, d_u);
         gpuErrchk(cudaPeekAtLastError());
     }
-
 };
 
 template class HarmonicBond<double>;

--- a/timemachine/cpp/src/interpolated_potential.cu
+++ b/timemachine/cpp/src/interpolated_potential.cu
@@ -1,6 +1,6 @@
-#include "interpolated_potential.hpp"
 #include "fixed_point.hpp"
 #include "gpu_utils.cuh"
+#include "interpolated_potential.hpp"
 
 #include <cub/cub.cuh>
 
@@ -8,19 +8,15 @@
 
 namespace timemachine {
 
+__global__ void k_final_add(const double *in, double *out) {
 
-__global__ void k_final_add(
-    const double *in,
-    double *out) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
-
-    if(idx >= 1) {
+    if (idx >= 1) {
         return;
     }
 
     atomicAdd(out, in[0]);
-
 }
 
 __global__ void k_reduce_du_dl(
@@ -31,16 +27,14 @@ __global__ void k_reduce_du_dl(
     const double *d_p_dst,
     double *d_du_dl_buf) {
 
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    if(idx >= P_base) {
+    if (idx >= P_base) {
         return;
     }
 
-    d_du_dl_buf[idx] = d_du_dp_buf[idx]*(d_p_dst[idx] - d_p_src[idx]);
-
+    d_du_dl_buf[idx] = d_du_dp_buf[idx] * (d_p_dst[idx] - d_p_src[idx]);
 }
-
 
 __global__ void k_reduce_du_dp(
     const double lambda,
@@ -48,52 +42,46 @@ __global__ void k_reduce_du_dp(
     const double *d_du_dp_buf, // interpolated
     double *d_du_dp) {
 
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    if(idx >= P_base) {
+    if (idx >= P_base) {
         return;
     }
 
     // no atomics needed since they write uniquely. unlike other terms (u, du_dx, du_dl),
     // the parameters are local and not shared between classes.
-    d_du_dp[idx] += d_du_dp_buf[idx]*(1-lambda);
-    d_du_dp[P_base + idx] += d_du_dp_buf[idx]*lambda;
-
+    d_du_dp[idx] += d_du_dp_buf[idx] * (1 - lambda);
+    d_du_dp[P_base + idx] += d_du_dp_buf[idx] * lambda;
 }
-
 
 __global__ void k_interpolate_parameters(
     const double lambda,
     const int P_base,
-    const double * __restrict__ params_src,
-    const double * __restrict__ params_dst,
+    const double *__restrict__ params_src,
+    const double *__restrict__ params_dst,
     double *params_out) {
 
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    if(idx >= P_base) {
+    if (idx >= P_base) {
         return;
     }
 
-    params_out[idx] = (1-lambda)*params_src[idx] + lambda*params_dst[idx];
+    params_out[idx] = (1 - lambda) * params_src[idx] + lambda * params_dst[idx];
 }
 
-InterpolatedPotential::InterpolatedPotential(
-    std::shared_ptr<Potential> u,
-    int N,
-    int P) : u_(u) {
+InterpolatedPotential::InterpolatedPotential(std::shared_ptr<Potential> u, int N, int P) : u_(u) {
 
-    if(P % 2 != 0) {
+    if (P % 2 != 0) {
         throw std::runtime_error("P must be divisible by 2 for interpolation.");
     }
 
-    int P_base = P/2;
+    int P_base = P / 2;
 
-
-    gpuErrchk(cudaMalloc(&d_du_dp_buffer_, P*sizeof(*d_du_dp_buffer_)));
+    gpuErrchk(cudaMalloc(&d_du_dp_buffer_, P * sizeof(*d_du_dp_buffer_)));
     // this has shape P_base because we need to dot over du_dp
-    gpuErrchk(cudaMalloc(&d_du_dl_buffer_, P_base*sizeof(*d_du_dp_buffer_)));
-    gpuErrchk(cudaMalloc(&d_p_interpolated_, P_base*sizeof(*d_p_interpolated_)));
+    gpuErrchk(cudaMalloc(&d_du_dl_buffer_, P_base * sizeof(*d_du_dp_buffer_)));
+    gpuErrchk(cudaMalloc(&d_p_interpolated_, P_base * sizeof(*d_p_interpolated_)));
     gpuErrchk(cudaMalloc(&d_sum_storage_out_, sizeof(*d_sum_storage_out_)));
 
     // (ytz): pseudo-associative reduction, results may differ on different devices.
@@ -101,22 +89,20 @@ InterpolatedPotential::InterpolatedPotential(
     // because we cannot directly write out to d_du_dl since its an assignment and not
     // atomicAdd.
     cub::DeviceReduce::Sum(
-        nullptr, // void *d_temp_storage,
+        nullptr,              // void *d_temp_storage,
         d_sum_storage_bytes_, // size_t &temp_storage_bytes,
-        d_du_dl_buffer_, //InputIteratorT d_in,
-        d_sum_storage_out_, //OutputIteratorT d_out,
-        P_base // int num_items,
+        d_du_dl_buffer_,      //InputIteratorT d_in,
+        d_sum_storage_out_,   //OutputIteratorT d_out,
+        P_base                // int num_items,
     );
 
     gpuErrchk(cudaPeekAtLastError());
     gpuErrchk(cudaMalloc(&d_sum_storage_buffer_, d_sum_storage_bytes_));
-
 }
 
 InterpolatedPotential::~InterpolatedPotential() {
     gpuErrchk(cudaFree(d_du_dp_buffer_));
-    gpuErrchk(cudaFree(d_du_dl_buffer_))
-    gpuErrchk(cudaFree(d_p_interpolated_));
+    gpuErrchk(cudaFree(d_du_dl_buffer_)) gpuErrchk(cudaFree(d_p_interpolated_));
     gpuErrchk(cudaFree(d_sum_storage_buffer_));
     gpuErrchk(cudaFree(d_sum_storage_out_));
 }
@@ -134,22 +120,21 @@ void InterpolatedPotential::execute_device(
     double *d_u,
     cudaStream_t stream) {
 
-
-    if(P % 2 != 0) {
+    if (P % 2 != 0) {
         throw std::runtime_error("P must be divisible by 2 for interpolation.");
     }
 
-    int P_base = P/2;
+    int P_base = P / 2;
     int tpb = 32;
-    int B = (P_base + tpb - 1)/tpb;
+    int B = (P_base + tpb - 1) / tpb;
 
     // clear buffers
-    if(d_du_dl) {
-        gpuErrchk(cudaMemsetAsync(d_du_dl_buffer_, 0, P_base*sizeof(*d_du_dl_buffer_), stream));
+    if (d_du_dl) {
+        gpuErrchk(cudaMemsetAsync(d_du_dl_buffer_, 0, P_base * sizeof(*d_du_dl_buffer_), stream));
     }
 
-    if(d_du_dp || d_du_dl) {
-        gpuErrchk(cudaMemsetAsync(d_du_dp_buffer_, 0, P*sizeof(*d_du_dp_buffer_), stream));
+    if (d_du_dp || d_du_dl) {
+        gpuErrchk(cudaMemsetAsync(d_du_dp_buffer_, 0, P * sizeof(*d_du_dp_buffer_), stream));
     }
 
     k_interpolate_parameters<<<B, tpb, 0, stream>>>(lambda, P_base, d_p, d_p + P_base, d_p_interpolated_);
@@ -157,19 +142,18 @@ void InterpolatedPotential::execute_device(
 
     u_->execute_device(
         N,
-        P/2,
+        P / 2,
         d_x,
         d_p_interpolated_,
         d_box,
         lambda,
-        d_du_dx, // no buffering needed
+        d_du_dx,                                          // no buffering needed
         (d_du_dp || d_du_dl) ? d_du_dp_buffer_ : nullptr, // du_dl requires du_dp
         d_du_dl,
         d_u, // no buffering needed
-        stream
-    );
+        stream);
 
-    if(d_du_dl) {
+    if (d_du_dl) {
 
         // why is this zero for nonbonded terms? clearly charges are different!
         k_reduce_du_dl<<<B, tpb, 0, stream>>>(lambda, P_base, d_du_dp_buffer_, d_p, d_p + P_base, d_du_dl_buffer_);
@@ -177,26 +161,23 @@ void InterpolatedPotential::execute_device(
 
         cub::DeviceReduce::Sum(
             d_sum_storage_buffer_, // void *d_temp_storage,
-            d_sum_storage_bytes_, // size_t &temp_storage_bytes,
-            d_du_dl_buffer_, //InputIteratorT d_in,
-            d_sum_storage_out_, //OutputIteratorT d_out,
-            P_base // int num_items,
+            d_sum_storage_bytes_,  // size_t &temp_storage_bytes,
+            d_du_dl_buffer_,       //InputIteratorT d_in,
+            d_sum_storage_out_,    //OutputIteratorT d_out,
+            P_base                 // int num_items,
         );
         gpuErrchk(cudaPeekAtLastError());
 
         k_final_add<<<1, tpb, 0, stream>>>(d_sum_storage_out_, d_du_dl);
         gpuErrchk(cudaPeekAtLastError());
-
     }
 
-    if(d_du_dp) {
+    if (d_du_dp) {
         // we don't need a pseudo-associate reduction here because we write to unique indices.
         // only one instance of force should ever be present.
         k_reduce_du_dp<<<B, tpb, 0, stream>>>(lambda, P_base, d_du_dp_buffer_, d_du_dp);
         gpuErrchk(cudaPeekAtLastError());
     }
-
-
 }
 
-}
+} // namespace timemachine

--- a/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
@@ -2,80 +2,80 @@
 
 #include "k_fixed_point.cuh"
 
-template<typename RealType>
+template <typename RealType>
 void __global__ k_calc_centroid(
-    const double * __restrict__ d_coords,  // [n, 3]
-    const int * __restrict__ d_group_a_idxs,
-    const int * __restrict__ d_group_b_idxs,
+    const double *__restrict__ d_coords, // [n, 3]
+    const int *__restrict__ d_group_a_idxs,
+    const int *__restrict__ d_group_b_idxs,
     const int N_A,
     const int N_B,
-    unsigned long long * d_centroid_a, // [3]
-    unsigned long long * d_centroid_b // [3]
-    ){
-    int t_idx = blockDim.x*blockIdx.x + threadIdx.x;
+    unsigned long long *d_centroid_a, // [3]
+    unsigned long long *d_centroid_b  // [3]
+) {
+    int t_idx = blockDim.x * blockIdx.x + threadIdx.x;
     if (N_A + N_B <= t_idx) {
         return;
     }
     int group_idx = t_idx < N_A ? t_idx : t_idx - N_A;
-    unsigned long long * centroid = t_idx < N_A ? d_centroid_a : d_centroid_b;
-    const int * cur_array = t_idx < N_A ? d_group_a_idxs : d_group_b_idxs;
+    unsigned long long *centroid = t_idx < N_A ? d_centroid_a : d_centroid_b;
+    const int *cur_array = t_idx < N_A ? d_group_a_idxs : d_group_b_idxs;
 
-    #pragma unroll
-    for(int d=0; d < 3; d++) {
-        atomicAdd(centroid + d, FLOAT_TO_FIXED<RealType>(d_coords[cur_array[group_idx]*3+d]));
+#pragma unroll
+    for (int d = 0; d < 3; d++) {
+        atomicAdd(centroid + d, FLOAT_TO_FIXED<RealType>(d_coords[cur_array[group_idx] * 3 + d]));
     }
- }
+}
 
-template<typename RealType>
+template <typename RealType>
 void __global__ k_centroid_restraint(
     // const int N,     // number of bonds, ignore for now
-    const double * __restrict__ d_coords,  // [n, 3]
-    const int * __restrict__ d_group_a_idxs,
-    const int * __restrict__ d_group_b_idxs,
+    const double *__restrict__ d_coords, // [n, 3]
+    const int *__restrict__ d_group_a_idxs,
+    const int *__restrict__ d_group_b_idxs,
     const int N_A,
     const int N_B,
-    const unsigned long long * __restrict__ d_centroid_a, // [3]
-    const unsigned long long * __restrict__ d_centroid_b, // [3]
+    const unsigned long long *__restrict__ d_centroid_a, // [3]
+    const unsigned long long *__restrict__ d_centroid_b, // [3]
     // const double *d_masses, // ignore d_masses for now
     const double kb,
     const double b0,
     unsigned long long *d_du_dx,
     unsigned long long *d_u) {
 
-    const int t_idx = blockDim.x*blockIdx.x + threadIdx.x;
+    const int t_idx = blockDim.x * blockIdx.x + threadIdx.x;
     if (N_A + N_B <= t_idx) {
         return;
     }
     int group_idx = t_idx < N_A ? t_idx : t_idx - N_A;
     int count = t_idx < N_A ? N_A : N_B;
-    const int * cur_array = t_idx < N_A ? d_group_a_idxs : d_group_b_idxs;
+    const int *cur_array = t_idx < N_A ? d_group_a_idxs : d_group_b_idxs;
     RealType sign = t_idx < N_A ? 1.0 : -1.0;
     RealType dij = 0;
     RealType deltas[3];
-    #pragma unroll
-    for (int d=0; d < 3; d++) {
+#pragma unroll
+    for (int d = 0; d < 3; d++) {
         deltas[d] = FIXED_TO_FLOAT<RealType>(d_centroid_a[d]) / N_A - FIXED_TO_FLOAT<RealType>(d_centroid_b[d]) / N_B;
-        dij += deltas[d]*deltas[d];
+        dij += deltas[d] * deltas[d];
     }
     dij = sqrt(dij);
 
-    if(t_idx == 0 && d_u) {
-        RealType nrg = kb*(dij-b0)*(dij-b0);
+    if (t_idx == 0 && d_u) {
+        RealType nrg = kb * (dij - b0) * (dij - b0);
         d_u[0] = FLOAT_TO_FIXED<RealType>(nrg);
     }
 
     // grads
-    if(d_du_dx) {
-        #pragma unroll
-        for(int d=0; d < 3; d++) {
-            if(b0 != 0) {
-                RealType du_ddij = 2*kb*(dij-b0);
-                RealType ddij_dxi = deltas[d]/dij;
-                RealType delta = sign*du_ddij*ddij_dxi/count;
-                atomicAdd(d_du_dx + cur_array[group_idx]*3 + d, FLOAT_TO_FIXED<RealType>(delta));
+    if (d_du_dx) {
+#pragma unroll
+        for (int d = 0; d < 3; d++) {
+            if (b0 != 0) {
+                RealType du_ddij = 2 * kb * (dij - b0);
+                RealType ddij_dxi = deltas[d] / dij;
+                RealType delta = sign * du_ddij * ddij_dxi / count;
+                atomicAdd(d_du_dx + cur_array[group_idx] * 3 + d, FLOAT_TO_FIXED<RealType>(delta));
             } else {
-                RealType delta = sign*2*kb*deltas[d]/count;
-                atomicAdd(d_du_dx + cur_array[group_idx]*3 + d, FLOAT_TO_FIXED<RealType>(delta));
+                RealType delta = sign * 2 * kb * deltas[d] / count;
+                atomicAdd(d_du_dx + cur_array[group_idx] * 3 + d, FLOAT_TO_FIXED<RealType>(delta));
             }
         }
     }

--- a/timemachine/cpp/src/kernels/k_fixed_point.cuh
+++ b/timemachine/cpp/src/kernels/k_fixed_point.cuh
@@ -5,30 +5,29 @@
 
 // we need to use a different level of precision for parameter derivatives
 #define FIXED_EXPONENT_DU_DCHARGE 0x1000000000
-#define FIXED_EXPONENT_DU_DSIG    0x2000000000
-#define FIXED_EXPONENT_DU_DEPS    0x4000000000 // this is just getting silly
+#define FIXED_EXPONENT_DU_DSIG 0x2000000000
+#define FIXED_EXPONENT_DU_DEPS 0x4000000000 // this is just getting silly
 
-
-template<typename RealType, unsigned long long EXPONENT>
+template <typename RealType, unsigned long long EXPONENT>
 RealType __device__ __forceinline__ FIXED_TO_FLOAT_DU_DP(unsigned long long v) {
-    return static_cast<RealType>(static_cast<long long>(v))/EXPONENT;
+    return static_cast<RealType>(static_cast<long long>(v)) / EXPONENT;
 }
 
 // (ytz): courtesy of @scottlegrand/NVIDIA, even faster conversion
 // This was original a hack to improve perf on Maxwell, that is now needed for Ampere
 long long __device__ __forceinline__ real_to_int64(float x) {
 #if __CUDA_ARCH__ == 860 || __CUDA_ARCH__ == 750
-  float z = x * (float)0x1.00000p-32;
-  int hi = __float2int_rz( z );                         // First convert high bits
-  float delta = x - ((float)0x1.00000p32*((float)hi));  // Check remainder sign
-  int test = (__float_as_uint(delta) > 0xbf000000);
-  int lo = __float2uint_rn(fabsf(delta));               // Convert the (unsigned) remainder
-  lo = (test) ? -lo: lo;
-  hi -= test;                                           // Two's complement correction
-  long long res = __double_as_longlong(__hiloint2double(hi,lo)); // Return 64-bit result
-  return res;
+    float z = x * (float)0x1.00000p-32;
+    int hi = __float2int_rz(z);                            // First convert high bits
+    float delta = x - ((float)0x1.00000p32 * ((float)hi)); // Check remainder sign
+    int test = (__float_as_uint(delta) > 0xbf000000);
+    int lo = __float2uint_rn(fabsf(delta)); // Convert the (unsigned) remainder
+    lo = (test) ? -lo : lo;
+    hi -= test;                                                     // Two's complement correction
+    long long res = __double_as_longlong(__hiloint2double(hi, lo)); // Return 64-bit result
+    return res;
 #else
-  return llrintf(x);
+    return llrintf(x);
 #endif
 }
 
@@ -59,27 +58,22 @@ long long __device__ __forceinline__ real_to_int64(float x) {
 //     return m;
 // }
 
-long long __device__ __forceinline__ real_to_int64(double x) {
-    return llrint(x);
-}
+long long __device__ __forceinline__ real_to_int64(double x) { return llrint(x); }
 
 // generic version
-template<typename RealType>
-unsigned long long __device__ __forceinline__ FLOAT_TO_FIXED(RealType v) {
-    return static_cast<unsigned long long>(real_to_int64(v*FIXED_EXPONENT));
+template <typename RealType> unsigned long long __device__ __forceinline__ FLOAT_TO_FIXED(RealType v) {
+    return static_cast<unsigned long long>(real_to_int64(v * FIXED_EXPONENT));
 }
 
-template<typename RealType, unsigned long long EXPONENT>
+template <typename RealType, unsigned long long EXPONENT>
 unsigned long long __device__ __forceinline__ FLOAT_TO_FIXED_DU_DP(RealType v) {
-    return static_cast<unsigned long long>(real_to_int64(v*EXPONENT));
+    return static_cast<unsigned long long>(real_to_int64(v * EXPONENT));
 }
 
-template<typename RealType>
-unsigned long long __device__ __forceinline__ FLOAT_TO_FIXED_NONBONDED(RealType v) {
-    return static_cast<unsigned long long>(real_to_int64(v*FIXED_EXPONENT));
+template <typename RealType> unsigned long long __device__ __forceinline__ FLOAT_TO_FIXED_NONBONDED(RealType v) {
+    return static_cast<unsigned long long>(real_to_int64(v * FIXED_EXPONENT));
 }
 
-template<typename RealType>
-unsigned long long __device__ __forceinline__ FLOAT_TO_FIXED_BONDED(RealType v) {
-    return static_cast<unsigned long long>(real_to_int64(v*FIXED_EXPONENT));
+template <typename RealType> unsigned long long __device__ __forceinline__ FLOAT_TO_FIXED_BONDED(RealType v) {
+    return static_cast<unsigned long long>(real_to_int64(v * FIXED_EXPONENT));
 }

--- a/timemachine/cpp/src/kernels/k_gbsa.cuh
+++ b/timemachine/cpp/src/kernels/k_gbsa.cuh
@@ -1,8 +1,8 @@
-#include <stdexcept>
-#include <iostream>
 #include "../fixed_point.hpp"
-#include "surreal.cuh"
 #include "kernel_utils.cuh"
+#include "surreal.cuh"
+#include <iostream>
+#include <stdexcept>
 
 #define WARPSIZE 32
 
@@ -13,61 +13,60 @@
 
 // #define RADII_EXP 4, used for switching function shenanigans, disabled for now
 
-
 // nope, still need to parallelize out
-template<typename RealType>
+template <typename RealType>
 __global__ void k_compute_born_radii(
     const int N,
-    const double* coords,
+    const double *coords,
     const double lambda,
-    const int *lambda_plane_idxs, // 0 or 1, which non-interacting plane we're on
+    const int *lambda_plane_idxs,  // 0 or 1, which non-interacting plane we're on
     const int *lambda_offset_idxs, // 0 or 1, how much we offset from the plane by cutoff
     const double *gb_params,
     const double dielectric_offset,
     const double cutoff,
     const double *block_bounds_ctr,
     const double *block_bounds_ext,
-    unsigned long long* born_psi) {
+    unsigned long long *born_psi) {
 
     RealType block_d2ij = 0;
-    for(int d=0; d < 3; d++) {
-        RealType block_row_ctr = block_bounds_ctr[blockIdx.x*3+d];
-        RealType block_col_ctr = block_bounds_ctr[blockIdx.y*3+d];
-        RealType block_row_ext = block_bounds_ext[blockIdx.x*3+d];
-        RealType block_col_ext = block_bounds_ext[blockIdx.y*3+d];
-        RealType dx = max(0.0, fabs(block_row_ctr-block_col_ctr) - (block_row_ext+block_col_ext));
-        block_d2ij += dx*dx;
+    for (int d = 0; d < 3; d++) {
+        RealType block_row_ctr = block_bounds_ctr[blockIdx.x * 3 + d];
+        RealType block_col_ctr = block_bounds_ctr[blockIdx.y * 3 + d];
+        RealType block_row_ext = block_bounds_ext[blockIdx.x * 3 + d];
+        RealType block_col_ext = block_bounds_ext[blockIdx.y * 3 + d];
+        RealType dx = max(0.0, fabs(block_row_ctr - block_col_ctr) - (block_row_ext + block_col_ext));
+        block_d2ij += dx * dx;
     }
 
-    if(block_d2ij > cutoff*cutoff) {
+    if (block_d2ij > cutoff * cutoff) {
         return;
     }
 
-    int atom_i_idx = blockIdx.x*32 + threadIdx.x;
+    int atom_i_idx = blockIdx.x * 32 + threadIdx.x;
     int lambda_plane_i = 0;
     int lambda_offset_i = 0;
 
-    if(atom_i_idx < N) {
+    if (atom_i_idx < N) {
         lambda_plane_i = lambda_plane_idxs[atom_i_idx];
         lambda_offset_i = lambda_offset_idxs[atom_i_idx];
     }
 
     RealType ci[3];
-    for(int d=0; d < 3; d++) {
-        ci[d] = atom_i_idx < N ? coords[atom_i_idx*3+d] : 0;
+    for (int d = 0; d < 3; d++) {
+        ci[d] = atom_i_idx < N ? coords[atom_i_idx * 3 + d] : 0;
     }
     // int radii_param_idx_i = atom_i_idx < N ? atomic_radii_idxs[atom_i_idx] : 0;
-    int radii_param_idx_i = atom_i_idx < N ? atom_i_idx*2 + 0: 0;
+    int radii_param_idx_i = atom_i_idx < N ? atom_i_idx * 2 + 0 : 0;
 
     RealType radiusI = atom_i_idx < N ? gb_params[radii_param_idx_i] : 0;
-    RealType offsetRadiusI   = radiusI - dielectric_offset;
-    RealType radiusIInverse  = 1/offsetRadiusI;
+    RealType offsetRadiusI = radiusI - dielectric_offset;
+    RealType radiusIInverse = 1 / offsetRadiusI;
 
-    int atom_j_idx = blockIdx.y*32 + threadIdx.x;
+    int atom_j_idx = blockIdx.y * 32 + threadIdx.x;
     int lambda_plane_j = 0;
     int lambda_offset_j = 0;
 
-    if(atom_j_idx < N) {
+    if (atom_j_idx < N) {
         lambda_plane_j = lambda_plane_idxs[atom_j_idx];
         lambda_offset_j = lambda_offset_idxs[atom_j_idx];
     }
@@ -76,106 +75,102 @@ __global__ void k_compute_born_radii(
     double sum = 0;
 
     RealType cj[3];
-    for(int d=0; d < 3; d++) {
-        cj[d] = atom_j_idx < N ? coords[atom_j_idx*3+d] : 0;
+    for (int d = 0; d < 3; d++) {
+        cj[d] = atom_j_idx < N ? coords[atom_j_idx * 3 + d] : 0;
     }
 
-    int radii_param_idx_j = atom_j_idx < N ? atom_j_idx*2+0 : 0;
-    int scale_param_idx_j = atom_j_idx < N ? atom_j_idx*2+1 : 0;
+    int radii_param_idx_j = atom_j_idx < N ? atom_j_idx * 2 + 0 : 0;
+    int scale_param_idx_j = atom_j_idx < N ? atom_j_idx * 2 + 1 : 0;
 
     RealType radiusJ = atom_j_idx < N ? gb_params[radii_param_idx_j] : 0;
     RealType scaleFactorJ = atom_j_idx < N ? gb_params[scale_param_idx_j] : 0;
 
     RealType offsetRadiusJ = radiusJ - dielectric_offset;
-    RealType scaledRadiusJ = offsetRadiusJ*scaleFactorJ;
+    RealType scaledRadiusJ = offsetRadiusJ * scaleFactorJ;
 
-    for(int round = 0; round < 32; round++) {
+    for (int round = 0; round < 32; round++) {
 
         RealType dxs[4];
-        for(int d=0; d < 3; d++) {
+        for (int d = 0; d < 3; d++) {
             dxs[d] = ci[d] - cj[d];
         }
         // RealType delta_lambda = lambda_i - lambda_j;
-        RealType delta_lambda = (lambda_plane_i - lambda_plane_j)*cutoff + (lambda_offset_i - lambda_offset_j)*lambda;
+        RealType delta_lambda =
+            (lambda_plane_i - lambda_plane_j) * cutoff + (lambda_offset_i - lambda_offset_j) * lambda;
 
         dxs[3] = delta_lambda;
 
         RealType r = fast_vec_norm<RealType, 4>(dxs);
-        RealType rInverse = 1/r;
-        RealType rScaledRadiusJ  = r + scaledRadiusJ;
-        RealType rSubScaledRadiusJ =  r - scaledRadiusJ;
+        RealType rInverse = 1 / r;
+        RealType rScaledRadiusJ = r + scaledRadiusJ;
+        RealType rSubScaledRadiusJ = r - scaledRadiusJ;
 
-        if(atom_j_idx != atom_i_idx && r < cutoff && atom_j_idx < N && atom_i_idx < N) {
+        if (atom_j_idx != atom_i_idx && r < cutoff && atom_j_idx < N && atom_i_idx < N) {
 
             if (offsetRadiusI < rScaledRadiusJ) {
 
                 RealType l_ij = 0;
-                if(offsetRadiusI > abs(rSubScaledRadiusJ)) {
-                  l_ij = offsetRadiusI;
+                if (offsetRadiusI > abs(rSubScaledRadiusJ)) {
+                    l_ij = offsetRadiusI;
                 } else {
-                  l_ij = abs(rSubScaledRadiusJ);
+                    l_ij = abs(rSubScaledRadiusJ);
                 }
 
-                l_ij = 1/l_ij;
+                l_ij = 1 / l_ij;
 
                 // RealType inv_uij = rScaledRadiusJ;
-                RealType u_ij     = 1/rScaledRadiusJ;
+                RealType u_ij = 1 / rScaledRadiusJ;
 
-                RealType l_ij2    = l_ij*l_ij;
-                RealType u_ij2    = u_ij*u_ij;
+                RealType l_ij2 = l_ij * l_ij;
+                RealType u_ij2 = u_ij * u_ij;
 
-                RealType ratio    = log(u_ij/l_ij);
+                RealType ratio = log(u_ij / l_ij);
                 // RealType term     = l_ij - u_ij + 0.25*r*(u_ij2 - l_ij2)  + (0.5*rInverse*ratio) + (0.25*scaledRadiusJ*scaledRadiusJ*rInverse)*(l_ij2 - u_ij2);
-                RealType term     = l_ij - u_ij + r*(u_ij2 - l_ij2)/4 + scaledRadiusJ*scaledRadiusJ*rInverse*(l_ij2 - u_ij2)/4 + rInverse*ratio/2;
+                RealType term = l_ij - u_ij + r * (u_ij2 - l_ij2) / 4 +
+                                scaledRadiusJ * scaledRadiusJ * rInverse * (l_ij2 - u_ij2) / 4 + rInverse * ratio / 2;
 
                 // this case (atom i completely inside atom j) is not considered in the original paper
                 // Jay Ponder and the authors of Tinker recognized this and
                 // worked out the details
                 if (offsetRadiusI < (scaledRadiusJ - r)) {
-                    term += 2*(radiusIInverse - l_ij);
+                    term += 2 * (radiusIInverse - l_ij);
                 }
-
 
                 // RealType inner = (PI*pow(r,RADII_EXP))/(BOXSIZE);
                 // RealType sw = cos(inner);
                 // sw = sw*sw;
 
                 RealType sw = 1;
-                term = sw*term;
+                term = sw * term;
 
                 sum += term;
             }
         }
 
-
         const int srcLane = (threadIdx.x + 1) % WARPSIZE;
         scaledRadiusJ = __shfl_sync(0xffffffff, scaledRadiusJ, srcLane);
         atom_j_idx = __shfl_sync(0xffffffff, atom_j_idx, srcLane);
-        for(int d=0; d < 3; d++) {
+        for (int d = 0; d < 3; d++) {
             cj[d] = __shfl_sync(0xffffffff, cj[d], srcLane);
         }
         lambda_plane_j = __shfl_sync(0xffffffff, lambda_plane_j, srcLane);
         lambda_offset_j = __shfl_sync(0xffffffff, lambda_offset_j, srcLane);
-
     }
 
-    if(atom_i_idx < N) {
-        atomicAdd(born_psi + atom_i_idx, static_cast<unsigned long long>((long long) (sum*FIXED_BORN_PSI)));
+    if (atom_i_idx < N) {
+        atomicAdd(born_psi + atom_i_idx, static_cast<unsigned long long>((long long)(sum * FIXED_BORN_PSI)));
     }
-
 }
-
-
 
 template <typename RealType>
 void __global__ k_compute_born_first_loop_gpu(
     const int N,
-    const double* coords,
+    const double *coords,
     const double lambda,
-    const int *lambda_plane_idxs, // 0 or 1, which non-interacting plane we're on
+    const int *lambda_plane_idxs,  // 0 or 1, which non-interacting plane we're on
     const int *lambda_offset_idxs, // 0 or 1, how much we offset from the plane by cutoff
-    const double* charge_params,
-    const double* born_radii,
+    const double *charge_params,
+    const double *born_radii,
     const double prefactor,
     const double cutoff,
     const double *block_bounds_ctr,
@@ -185,38 +180,38 @@ void __global__ k_compute_born_first_loop_gpu(
     double *du_dl,
     double *out_energy) {
 
-    if(blockIdx.y > blockIdx.x) {
+    if (blockIdx.y > blockIdx.x) {
         return;
     }
 
     RealType block_d2ij = 0;
-    for(int d=0; d < 3; d++) {
-        RealType block_row_ctr = block_bounds_ctr[blockIdx.x*3+d];
-        RealType block_col_ctr = block_bounds_ctr[blockIdx.y*3+d];
-        RealType block_row_ext = block_bounds_ext[blockIdx.x*3+d];
-        RealType block_col_ext = block_bounds_ext[blockIdx.y*3+d];
-        RealType dx = max(0.0, fabs(block_row_ctr-block_col_ctr) - (block_row_ext+block_col_ext));
-        block_d2ij += dx*dx;
+    for (int d = 0; d < 3; d++) {
+        RealType block_row_ctr = block_bounds_ctr[blockIdx.x * 3 + d];
+        RealType block_col_ctr = block_bounds_ctr[blockIdx.y * 3 + d];
+        RealType block_row_ext = block_bounds_ext[blockIdx.x * 3 + d];
+        RealType block_col_ext = block_bounds_ext[blockIdx.y * 3 + d];
+        RealType dx = max(0.0, fabs(block_row_ctr - block_col_ctr) - (block_row_ext + block_col_ext));
+        block_d2ij += dx * dx;
     }
 
-    if(block_d2ij > cutoff*cutoff) {
+    if (block_d2ij > cutoff * cutoff) {
         return;
     }
 
-    int atom_i_idx =  blockIdx.x*32 + threadIdx.x;
+    int atom_i_idx = blockIdx.x * 32 + threadIdx.x;
     RealType du_dl_i = 0;
     int lambda_plane_i = 0;
     int lambda_offset_i = 0;
 
-    if(atom_i_idx < N) {
+    if (atom_i_idx < N) {
         lambda_plane_i = lambda_plane_idxs[atom_i_idx];
         lambda_offset_i = lambda_offset_idxs[atom_i_idx];
     }
 
     RealType ci[3];
     RealType gi[3] = {0};
-    for(int d=0; d < 3; d++) {
-        ci[d] = atom_i_idx < N ? coords[atom_i_idx*3+d] : 0;
+    for (int d = 0; d < 3; d++) {
+        ci[d] = atom_i_idx < N ? coords[atom_i_idx * 3 + d] : 0;
     }
     int charge_param_idx_i = atom_i_idx < N ? atom_i_idx : 0;
     RealType qi = atom_i_idx < N ? charge_params[charge_param_idx_i] : 0;
@@ -225,20 +220,20 @@ void __global__ k_compute_born_first_loop_gpu(
     // RealType dE_dqi_accum = 0;
     RealType born_force_i_accum = 0;
 
-    int atom_j_idx = blockIdx.y*32 + threadIdx.x;
+    int atom_j_idx = blockIdx.y * 32 + threadIdx.x;
     RealType du_dl_j = 0;
     int lambda_plane_j = 0;
     int lambda_offset_j = 0;
 
-    if(atom_j_idx < N) {
+    if (atom_j_idx < N) {
         lambda_plane_j = lambda_plane_idxs[atom_j_idx];
         lambda_offset_j = lambda_offset_idxs[atom_j_idx];
     }
 
     RealType cj[3];
     RealType gj[3] = {0};
-    for(int d=0; d < 3; d++) {
-        cj[d] = atom_j_idx < N ? coords[atom_j_idx*3+d] : 0;
+    for (int d = 0; d < 3; d++) {
+        cj[d] = atom_j_idx < N ? coords[atom_j_idx * 3 + d] : 0;
     }
     int charge_param_idx_j = atom_j_idx < N ? atom_j_idx : 0;
     RealType qj = atom_j_idx < N ? charge_params[charge_param_idx_j] : 0;
@@ -249,30 +244,31 @@ void __global__ k_compute_born_first_loop_gpu(
     RealType obc_energy = 0;
 
     // In inference mode, we don't care about gradients with respect to parameters.
-    for(int round = 0; round < 32; round++) {
+    for (int round = 0; round < 32; round++) {
 
         RealType dxs[4];
-        for(int d=0; d < 3; d++) {
+        for (int d = 0; d < 3; d++) {
             dxs[d] = ci[d] - cj[d];
         }
-        RealType delta_lambda = (lambda_plane_i - lambda_plane_j)*cutoff + (lambda_offset_i - lambda_offset_j)*lambda;
+        RealType delta_lambda =
+            (lambda_plane_i - lambda_plane_j) * cutoff + (lambda_offset_i - lambda_offset_j) * lambda;
 
         dxs[3] = delta_lambda;
         RealType r = fast_vec_norm<RealType, 4>(dxs);
-        RealType r2 = r*r;
+        RealType r2 = r * r;
         // RealType rInverse = 1/r;
         // RealType rInverse = fast_vec_rnorm<RealType, D>(dxs);
 
-        if(atom_j_idx <= atom_i_idx && r < cutoff && atom_j_idx < N && atom_i_idx < N) {
+        if (atom_j_idx <= atom_i_idx && r < cutoff && atom_j_idx < N && atom_i_idx < N) {
 
-            RealType alpha2_ij          = born_radii_i*born_radii_j;
-            RealType D_ij               = r2/(4*alpha2_ij);
-            RealType expTerm            = exp(-D_ij);
-            RealType denominator2       = r2 + alpha2_ij*expTerm;
-            RealType denominator        = sqrt(denominator2);
-            RealType Gpol               = (prefactor*qi*qj)/denominator;
-            RealType dGpol_dr           = -Gpol*(1 - expTerm/4)/denominator2;
-            RealType dGpol_dalpha2_ij   = -(Gpol/2)*expTerm*(1 + D_ij)/denominator2;
+            RealType alpha2_ij = born_radii_i * born_radii_j;
+            RealType D_ij = r2 / (4 * alpha2_ij);
+            RealType expTerm = exp(-D_ij);
+            RealType denominator2 = r2 + alpha2_ij * expTerm;
+            RealType denominator = sqrt(denominator2);
+            RealType Gpol = (prefactor * qi * qj) / denominator;
+            RealType dGpol_dr = -Gpol * (1 - expTerm / 4) / denominator2;
+            RealType dGpol_dalpha2_ij = -(Gpol / 2) * expTerm * (1 + D_ij) / denominator2;
 
             RealType energy = Gpol;
 
@@ -284,39 +280,37 @@ void __global__ k_compute_born_first_loop_gpu(
             RealType sw = 1;
             RealType dsw_dr = 0;
 
-            RealType dsw_dr_dot_E = dsw_dr*energy;
-
+            RealType dsw_dr_dot_E = dsw_dr * energy;
 
             if (atom_i_idx != atom_j_idx) {
 
-                energy = sw*energy;
+                energy = sw * energy;
 
-                born_force_j_accum += sw*dGpol_dalpha2_ij*born_radii_i;
+                born_force_j_accum += sw * dGpol_dalpha2_ij * born_radii_i;
 
-                for(int d=0; d < 3; d++) {
+                for (int d = 0; d < 3; d++) {
 
                     // gi[d] += dxs[d]*dGpol_dr;
                     // gj[d] -= dxs[d]*dGpol_dr;
-                    gi[d] += dxs[d]*sw*dGpol_dr + dsw_dr_dot_E*dxs[d]/r;
-                    gj[d] -= dxs[d]*sw*dGpol_dr + dsw_dr_dot_E*dxs[d]/r;
+                    gi[d] += dxs[d] * sw * dGpol_dr + dsw_dr_dot_E * dxs[d] / r;
+                    gj[d] -= dxs[d] * sw * dGpol_dr + dsw_dr_dot_E * dxs[d] / r;
                 }
 
                 int dw_i = lambda_offset_i;
                 int dw_j = lambda_offset_j;
 
-
                 // du_dl_i += dxs[3]*dGpol_dr*dw_i;
                 // du_dl_j -= dxs[3]*dGpol_dr*dw_j;
 
-                du_dl_i += (dxs[3]*sw*dGpol_dr + dsw_dr_dot_E*dxs[3]/r)*dw_i;
-                du_dl_j -= (dxs[3]*sw*dGpol_dr + dsw_dr_dot_E*dxs[3]/r)*dw_j;
+                du_dl_i += (dxs[3] * sw * dGpol_dr + dsw_dr_dot_E * dxs[3] / r) * dw_i;
+                du_dl_j -= (dxs[3] * sw * dGpol_dr + dsw_dr_dot_E * dxs[3] / r) * dw_j;
 
             } else {
                 energy *= 0.5;
             }
 
             obc_energy += energy;
-            born_force_i_accum += sw*dGpol_dalpha2_ij*born_radii_j;
+            born_force_i_accum += sw * dGpol_dalpha2_ij * born_radii_j;
         }
 
         const int srcLane = (threadIdx.x + 1) % WARPSIZE;
@@ -324,7 +318,7 @@ void __global__ k_compute_born_first_loop_gpu(
         qj = __shfl_sync(0xffffffff, qj, srcLane);
         born_radii_j = __shfl_sync(0xffffffff, born_radii_j, srcLane);
         born_force_j_accum = __shfl_sync(0xffffffff, born_force_j_accum, srcLane);
-        for(size_t d=0; d < 3; d++) {
+        for (size_t d = 0; d < 3; d++) {
             cj[d] = __shfl_sync(0xffffffff, cj[d], srcLane);
             gj[d] = __shfl_sync(0xffffffff, gj[d], srcLane);
         }
@@ -333,28 +327,32 @@ void __global__ k_compute_born_first_loop_gpu(
         du_dl_j = __shfl_sync(0xffffffff, du_dl_j, srcLane);
     }
 
-    for(int d=0; d < 3; d++) {
-        if(atom_i_idx < N) {
-            atomicAdd(out_forces + atom_i_idx*3 + d, static_cast<unsigned long long>((long long) (gi[d]*FIXED_EXPONENT)));
+    for (int d = 0; d < 3; d++) {
+        if (atom_i_idx < N) {
+            atomicAdd(
+                out_forces + atom_i_idx * 3 + d, static_cast<unsigned long long>((long long)(gi[d] * FIXED_EXPONENT)));
         }
-        if(atom_j_idx < N) {
-            atomicAdd(out_forces + atom_j_idx*3 + d, static_cast<unsigned long long>((long long) (gj[d]*FIXED_EXPONENT)));
+        if (atom_j_idx < N) {
+            atomicAdd(
+                out_forces + atom_j_idx * 3 + d, static_cast<unsigned long long>((long long)(gj[d] * FIXED_EXPONENT)));
         }
     }
 
-    if(atom_i_idx < N) {
-        atomicAdd(bornForces + atom_i_idx, static_cast<unsigned long long>((long long) (born_force_i_accum*FIXED_EXPONENT_BORN_FORCES)));
+    if (atom_i_idx < N) {
+        atomicAdd(
+            bornForces + atom_i_idx,
+            static_cast<unsigned long long>((long long)(born_force_i_accum * FIXED_EXPONENT_BORN_FORCES)));
     }
 
-    if(atom_j_idx < N) {
-        atomicAdd(bornForces + atom_j_idx, static_cast<unsigned long long>((long long) (born_force_j_accum*FIXED_EXPONENT_BORN_FORCES)));
+    if (atom_j_idx < N) {
+        atomicAdd(
+            bornForces + atom_j_idx,
+            static_cast<unsigned long long>((long long)(born_force_j_accum * FIXED_EXPONENT_BORN_FORCES)));
     }
 
     atomicAdd(du_dl, du_dl_i + du_dl_j);
     atomicAdd(out_energy, obc_energy);
-
 }
-
 
 __global__ void k_reduce_born_radii(
     const int N,
@@ -365,83 +363,77 @@ __global__ void k_reduce_born_radii(
     const double gamma_obc,
     const unsigned long long *born_psi,
     double *born_radii,
-    double *obc_chain
-) {
+    double *obc_chain) {
 
-    int atom_i_idx =  blockIdx.x*32 + threadIdx.x;
-    if(atom_i_idx >= N) {
+    int atom_i_idx = blockIdx.x * 32 + threadIdx.x;
+    if (atom_i_idx >= N) {
         return;
     }
 
-    int radii_param_idx_i = atom_i_idx < N ? atom_i_idx*2+0 : 0;
+    int radii_param_idx_i = atom_i_idx < N ? atom_i_idx * 2 + 0 : 0;
     double radiusI = atom_i_idx < N ? gb_params[radii_param_idx_i] : 0;
-    double offsetRadiusI   = radiusI - dielectric_offset;
+    double offsetRadiusI = radiusI - dielectric_offset;
 
-    double sum = static_cast<double>(static_cast<long long>(born_psi[atom_i_idx]))/FIXED_BORN_PSI;
-    sum *= offsetRadiusI/2;
+    double sum = static_cast<double>(static_cast<long long>(born_psi[atom_i_idx])) / FIXED_BORN_PSI;
+    sum *= offsetRadiusI / 2;
 
-    double sum2       = sum*sum;
-    double sum3       = sum*sum2;
-    double inner      = alpha_obc*sum - beta_obc*sum2 + gamma_obc*sum3;
-    double tanhSum    = tanh(inner);
+    double sum2 = sum * sum;
+    double sum3 = sum * sum2;
+    double inner = alpha_obc * sum - beta_obc * sum2 + gamma_obc * sum3;
+    double tanhSum = tanh(inner);
 
-    if(atom_i_idx < N) {
-        double br = offsetRadiusI*radiusI/(radiusI - offsetRadiusI*tanhSum);
+    if (atom_i_idx < N) {
+        double br = offsetRadiusI * radiusI / (radiusI - offsetRadiusI * tanhSum);
         born_radii[atom_i_idx] = br;
-        obc_chain[atom_i_idx] = br*br*(1 - tanhSum*tanhSum)*(alpha_obc - 2*beta_obc*sum + 3*gamma_obc*sum2)/radiusI;
+        obc_chain[atom_i_idx] =
+            br * br * (1 - tanhSum * tanhSum) * (alpha_obc - 2 * beta_obc * sum + 3 * gamma_obc * sum2) / radiusI;
     }
 }
-
 
 // this is entirely done in double precision
 __global__ void k_reduce_born_forces(
     const int N,
-    const double* gb_params,
-    const double* born_radii,
-    const double* obc_chain,
+    const double *gb_params,
+    const double *born_radii,
+    const double *obc_chain,
     const double surface_tension, // surface area factor
     const double probe_radius,
-    unsigned long long* bornForces, // dU/Ri
-    double *energy
-) {
+    unsigned long long *bornForces, // dU/Ri
+    double *energy) {
 
     // surface area term
 
-    int atomI =  blockIdx.x*32 + threadIdx.x;
-    if(atomI >= N) {
+    int atomI = blockIdx.x * 32 + threadIdx.x;
+    if (atomI >= N) {
         return;
     }
 
     // double radii_derivs = 0;
-    double born_force_i = static_cast<double>(static_cast<long long>(bornForces[atomI]))/FIXED_EXPONENT_BORN_FORCES;
+    double born_force_i = static_cast<double>(static_cast<long long>(bornForces[atomI])) / FIXED_EXPONENT_BORN_FORCES;
     double br = born_radii[atomI];
-
 
     // ACE term
     if (br > 0.0) {
-        int atomic_radii_idx_i = atomI*2 + 0;
+        int atomic_radii_idx_i = atomI * 2 + 0;
         // double atomic_radii = params[atomic_radii_idxs[atomI]];
         double atomic_radii = gb_params[atomic_radii_idx_i];
-        double r            = atomic_radii + probe_radius;
-        double ratio6       = pow(atomic_radii/born_radii[atomI], 6.0);
-        double saTerm       = surface_tension*r*r*ratio6;
+        double r = atomic_radii + probe_radius;
+        double ratio6 = pow(atomic_radii / born_radii[atomI], 6.0);
+        double saTerm = surface_tension * r * r * ratio6;
         atomicAdd(energy, saTerm);
-        born_force_i  -= 6.0*saTerm/born_radii[atomI];
+        born_force_i -= 6.0 * saTerm / born_radii[atomI];
     }
 
     born_force_i *= obc_chain[atomI];
-    bornForces[atomI] = static_cast<unsigned long long>((long long) (born_force_i*FIXED_EXPONENT_BORN_FORCES));
-
+    bornForces[atomI] = static_cast<unsigned long long>((long long)(born_force_i * FIXED_EXPONENT_BORN_FORCES));
 }
-
-
 
 template <typename RealType>
 __global__ void k_compute_born_energy_and_forces(
     const int N,
-    const double* coords,
+    const double *coords,
     const double lambda,
-    const int *lambda_plane_idxs, // 0 or 1, which non-interacting plane we're on
+    const int *lambda_plane_idxs,  // 0 or 1, which non-interacting plane we're on
     const int *lambda_offset_idxs, // 0 or 1, how much we offset from the plane by cutoff
     const double *gb_params,
     const double *born_radii,
@@ -450,96 +442,99 @@ __global__ void k_compute_born_energy_and_forces(
     const double cutoff,
     const double *block_bounds_ctr,
     const double *block_bounds_ext,
-    const unsigned long long* bornForces,
-    unsigned long long* out_forces,
+    const unsigned long long *bornForces,
+    unsigned long long *out_forces,
     double *du_dl) {
 
     RealType block_d2ij = 0;
-    for(int d=0; d < 3; d++) {
-        RealType block_row_ctr = block_bounds_ctr[blockIdx.x*3+d];
-        RealType block_col_ctr = block_bounds_ctr[blockIdx.y*3+d];
-        RealType block_row_ext = block_bounds_ext[blockIdx.x*3+d];
-        RealType block_col_ext = block_bounds_ext[blockIdx.y*3+d];
-        RealType dx = max(0.0, fabs(block_row_ctr-block_col_ctr) - (block_row_ext+block_col_ext));
-        block_d2ij += dx*dx;
+    for (int d = 0; d < 3; d++) {
+        RealType block_row_ctr = block_bounds_ctr[blockIdx.x * 3 + d];
+        RealType block_col_ctr = block_bounds_ctr[blockIdx.y * 3 + d];
+        RealType block_row_ext = block_bounds_ext[blockIdx.x * 3 + d];
+        RealType block_col_ext = block_bounds_ext[blockIdx.y * 3 + d];
+        RealType dx = max(0.0, fabs(block_row_ctr - block_col_ctr) - (block_row_ext + block_col_ext));
+        block_d2ij += dx * dx;
     }
 
-    if(block_d2ij > cutoff*cutoff) {
+    if (block_d2ij > cutoff * cutoff) {
         return;
     }
 
-    int atom_i_idx =  blockIdx.x*32 + threadIdx.x;
+    int atom_i_idx = blockIdx.x * 32 + threadIdx.x;
     RealType du_dl_i = 0;
     int lambda_plane_i = 0;
     int lambda_offset_i = 0;
 
-    if(atom_i_idx < N) {
+    if (atom_i_idx < N) {
         lambda_plane_i = lambda_plane_idxs[atom_i_idx];
         lambda_offset_i = lambda_offset_idxs[atom_i_idx];
     }
 
     RealType ci[3];
     RealType dPsi_dx_i[3] = {0};
-    for(int d=0; d < 3; d++) {
-        ci[d] = atom_i_idx < N ? coords[atom_i_idx*3+d] : 0;
+    for (int d = 0; d < 3; d++) {
+        ci[d] = atom_i_idx < N ? coords[atom_i_idx * 3 + d] : 0;
     }
 
-    int atomic_radii_idx_i = atom_i_idx < N ? atom_i_idx*2+0 : 0;
+    int atomic_radii_idx_i = atom_i_idx < N ? atom_i_idx * 2 + 0 : 0;
     RealType radiusI = atom_i_idx < N ? gb_params[atomic_radii_idx_i] : 0;
-    RealType born_force_i = atom_i_idx < N ? static_cast<RealType>(static_cast<long long>(bornForces[atom_i_idx]))/FIXED_EXPONENT_BORN_FORCES : 0;
+    RealType born_force_i = atom_i_idx < N ? static_cast<RealType>(static_cast<long long>(bornForces[atom_i_idx])) /
+                                                 FIXED_EXPONENT_BORN_FORCES
+                                           : 0;
     // RealType born_radii_i = atom_i_idx < N ? born_radii[atom_i_idx] : 0;
     // RealType dPsi_dri = 0;
 
-    int atom_j_idx = blockIdx.y*32 + threadIdx.x;
+    int atom_j_idx = blockIdx.y * 32 + threadIdx.x;
     RealType du_dl_j = 0;
     int lambda_plane_j = 0;
     int lambda_offset_j = 0;
 
-    if(atom_j_idx < N) {
+    if (atom_j_idx < N) {
         lambda_plane_j = lambda_plane_idxs[atom_j_idx];
         lambda_offset_j = lambda_offset_idxs[atom_j_idx];
     }
 
     RealType cj[3];
     RealType dPsi_dx_j[3] = {0};
-    for(int d=0; d < 3; d++) {
-        cj[d] = atom_j_idx < N ? coords[atom_j_idx*3+d] : 0;
+    for (int d = 0; d < 3; d++) {
+        cj[d] = atom_j_idx < N ? coords[atom_j_idx * 3 + d] : 0;
     }
 
-    int atomic_radii_idx_j = atom_j_idx < N ? atom_j_idx*2+0 : 0;
+    int atomic_radii_idx_j = atom_j_idx < N ? atom_j_idx * 2 + 0 : 0;
     RealType radiusJ = atom_j_idx < N ? gb_params[atomic_radii_idx_j] : 0;
 
-    int scale_factor_idx_j = atom_j_idx < N ? atom_j_idx*2+1 : 0;
+    int scale_factor_idx_j = atom_j_idx < N ? atom_j_idx * 2 + 1 : 0;
     RealType scaleFactorJ = atom_j_idx < N ? gb_params[scale_factor_idx_j] : 0;
     RealType born_radii_j = atom_j_idx < N ? born_radii[atom_j_idx] : 0;
 
     const RealType dielectricOffset = dielectric_offset;
 
-    RealType offsetRadiusI  = radiusI - dielectricOffset;
+    RealType offsetRadiusI = radiusI - dielectricOffset;
 
     // int atomI = atom_i_idx;
     // int atomJ = atom_j_idx;
 
-    for(int round = 0; round < 32; round++) {
+    for (int round = 0; round < 32; round++) {
 
         RealType dxs[4];
-        for(int d=0; d < 3; d++) {
+        for (int d = 0; d < 3; d++) {
             dxs[d] = ci[d] - cj[d];
         }
         // RealType delta_lambda = lambda_i - lambda_j;
-        RealType delta_lambda = (lambda_plane_i - lambda_plane_j)*cutoff + (lambda_offset_i - lambda_offset_j)*lambda;
+        RealType delta_lambda =
+            (lambda_plane_i - lambda_plane_j) * cutoff + (lambda_offset_i - lambda_offset_j) * lambda;
 
         dxs[3] = delta_lambda;
         RealType r = fast_vec_norm<RealType, 4>(dxs);
 
         if (atom_j_idx != atom_i_idx && r < cutoff && atom_j_idx < N && atom_i_idx < N) {
-            RealType rInverse = 1/r;
+            RealType rInverse = 1 / r;
             // RealType rInverse = fast_vec_rnorm<RealType, D>(dxs);
             // radius w/ dielectric offset applied
-            RealType offsetRadiusJ      = radiusJ - dielectricOffset;
-            RealType scaledRadiusJ      = offsetRadiusJ*scaleFactorJ;
-            RealType scaledRadiusJ2     = scaledRadiusJ*scaledRadiusJ;
-            RealType rScaledRadiusJ     = r + scaledRadiusJ;
+            RealType offsetRadiusJ = radiusJ - dielectricOffset;
+            RealType scaledRadiusJ = offsetRadiusJ * scaleFactorJ;
+            RealType scaledRadiusJ2 = scaledRadiusJ * scaledRadiusJ;
+            RealType rScaledRadiusJ = r + scaledRadiusJ;
 
             if (offsetRadiusI < rScaledRadiusJ) {
 
@@ -553,49 +548,50 @@ __global__ void k_compute_born_energy_and_forces(
                 // RealType t3            = 0.125*(1.0 + scaledRadiusJ2*r2Inverse)*(l_ij2 - u_ij2) + 0.25*log(u_ij/l_ij)*r2Inverse;
 
                 RealType rSubScaledRadiusJ = r - scaledRadiusJ;
-                RealType rSubScaledRadiusJ2 = rSubScaledRadiusJ*rSubScaledRadiusJ;
+                RealType rSubScaledRadiusJ2 = rSubScaledRadiusJ * rSubScaledRadiusJ;
 
                 RealType arss = abs(rSubScaledRadiusJ);
 
                 RealType l_ij = offsetRadiusI > arss ? offsetRadiusI : arss;
-                l_ij = 1/l_ij;
-                RealType l_ij2 = l_ij*l_ij;
+                l_ij = 1 / l_ij;
+                RealType l_ij2 = l_ij * l_ij;
 
-                RealType u_ij = 1/rScaledRadiusJ;
-                RealType u_ij2 = u_ij*u_ij;
+                RealType u_ij = 1 / rScaledRadiusJ;
+                RealType u_ij2 = u_ij * u_ij;
 
                 // original expression
                 // RealType term = l_ij - u_ij + 0.25*(u_ij2 - l_ij2)*t1 + (0.5*rInverse*ratio);
 
-                RealType dl_dr = offsetRadiusI > arss ? 0 : -l_ij2*sign(rSubScaledRadiusJ);
-                RealType du_dr = -u_ij2*sign(rScaledRadiusJ);
+                RealType dl_dr = offsetRadiusI > arss ? 0 : -l_ij2 * sign(rSubScaledRadiusJ);
+                RealType du_dr = -u_ij2 * sign(rScaledRadiusJ);
 
-                RealType t1 = r - scaledRadiusJ2*rInverse;
-                RealType dt1_dr = (1 + scaledRadiusJ2*rInverse*rInverse);
-                RealType ratio = log(u_ij/l_ij);
+                RealType t1 = r - scaledRadiusJ2 * rInverse;
+                RealType dt1_dr = (1 + scaledRadiusJ2 * rInverse * rInverse);
+                RealType ratio = log(u_ij / l_ij);
 
                 RealType de1 = dl_dr - du_dr;
                 // we may need three separate accumulators for precision
-                RealType de2 = (u_ij*du_dr - l_ij*dl_dr)*t1;
-                RealType de3 = (u_ij2 - l_ij2)*dt1_dr/2;
-                RealType de4 = rInverse*(rInverse*ratio - (du_dr/u_ij - dl_dr/l_ij));
-                RealType de = de1 + (de2 + de3 - de4)/2; // this is the derivative with respect to r
+                RealType de2 = (u_ij * du_dr - l_ij * dl_dr) * t1;
+                RealType de3 = (u_ij2 - l_ij2) * dt1_dr / 2;
+                RealType de4 = rInverse * (rInverse * ratio - (du_dr / u_ij - dl_dr / l_ij));
+                RealType de = de1 + (de2 + de3 - de4) / 2; // this is the derivative with respect to r
 
-                if(offsetRadiusI > arss) {
+                if (offsetRadiusI > arss) {
                     // if(offsetRadiusI < (scaledRadiusJ - r)) {
-                        // de += 0;
+                    // de += 0;
                     // }
                 } else {
-                    if(offsetRadiusI >= rSubScaledRadiusJ) {
-                        de += 2*sign(rSubScaledRadiusJ)/rSubScaledRadiusJ2;
+                    if (offsetRadiusI >= rSubScaledRadiusJ) {
+                        de += 2 * sign(rSubScaledRadiusJ) / rSubScaledRadiusJ2;
                     }
                 }
 
                 // needed for switch rescale
-                RealType term = l_ij - u_ij + r*(u_ij2 - l_ij2)/4 + scaledRadiusJ*scaledRadiusJ*rInverse*(l_ij2 - u_ij2)/4 + rInverse*ratio/2;
+                RealType term = l_ij - u_ij + r * (u_ij2 - l_ij2) / 4 +
+                                scaledRadiusJ * scaledRadiusJ * rInverse * (l_ij2 - u_ij2) / 4 + rInverse * ratio / 2;
                 if (offsetRadiusI < (scaledRadiusJ - r)) {
-                    RealType radiusIInverse  = 1/offsetRadiusI;
-                    term += 2*(radiusIInverse - l_ij);
+                    RealType radiusIInverse = 1 / offsetRadiusI;
+                    term += 2 * (radiusIInverse - l_ij);
                 }
 
                 // RealType inner = (PI*pow(r, RADII_EXP))/(BOXSIZE);
@@ -606,12 +602,12 @@ __global__ void k_compute_born_energy_and_forces(
                 RealType sw = 1;
                 RealType dsw_dr = 0;
 
-                de = dsw_dr*term + de*sw;
+                de = dsw_dr * term + de * sw;
 
-                de *= born_force_i*offsetRadiusI/2;
+                de *= born_force_i * offsetRadiusI / 2;
 
-                for(int d=0; d < 3; d++) {
-                    RealType deriv = dxs[d]*de*rInverse;
+                for (int d = 0; d < 3; d++) {
+                    RealType deriv = dxs[d] * de * rInverse;
                     dPsi_dx_i[d] += deriv;
                     dPsi_dx_j[d] -= deriv;
                 }
@@ -619,9 +615,8 @@ __global__ void k_compute_born_energy_and_forces(
                 int dw_i = lambda_offset_i;
                 int dw_j = lambda_offset_j;
 
-                du_dl_i += dxs[3]*de*dw_i*rInverse;
-                du_dl_j -= dxs[3]*de*dw_j*rInverse;
-
+                du_dl_i += dxs[3] * de * dw_i * rInverse;
+                du_dl_j -= dxs[3] * de * dw_j * rInverse;
             }
         }
 
@@ -634,7 +629,7 @@ __global__ void k_compute_born_energy_and_forces(
         atomic_radii_idx_i = __shfl_sync(0xffffffff, atomic_radii_idx_i, srcLane);
         scale_factor_idx_j = __shfl_sync(0xffffffff, scale_factor_idx_j, srcLane);
 
-        for(int d=0; d < 3; d++) {
+        for (int d = 0; d < 3; d++) {
             cj[d] = __shfl_sync(0xffffffff, cj[d], srcLane);
             dPsi_dx_j[d] = __shfl_sync(0xffffffff, dPsi_dx_j[d], srcLane);
         }
@@ -642,18 +637,20 @@ __global__ void k_compute_born_energy_and_forces(
         lambda_plane_j = __shfl_sync(0xffffffff, lambda_plane_j, srcLane);
         lambda_offset_j = __shfl_sync(0xffffffff, lambda_offset_j, srcLane);
         du_dl_j = __shfl_sync(0xffffffff, du_dl_j, srcLane);
-
     }
 
-    for(int d=0; d < 3; d++) {
-        if(atom_i_idx < N) {
-            atomicAdd(out_forces + atom_i_idx*3+d,  static_cast<unsigned long long>((long long) (dPsi_dx_i[d]*FIXED_EXPONENT)));
+    for (int d = 0; d < 3; d++) {
+        if (atom_i_idx < N) {
+            atomicAdd(
+                out_forces + atom_i_idx * 3 + d,
+                static_cast<unsigned long long>((long long)(dPsi_dx_i[d] * FIXED_EXPONENT)));
         }
-        if(atom_j_idx < N) {
-            atomicAdd(out_forces + atom_j_idx*3+d,  static_cast<unsigned long long>((long long) (dPsi_dx_j[d]*FIXED_EXPONENT)));
+        if (atom_j_idx < N) {
+            atomicAdd(
+                out_forces + atom_j_idx * 3 + d,
+                static_cast<unsigned long long>((long long)(dPsi_dx_j[d] * FIXED_EXPONENT)));
         }
     }
 
     atomicAdd(du_dl, du_dl_i + du_dl_j);
-
 }

--- a/timemachine/cpp/src/kernels/k_harmonic_angle.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_angle.cuh
@@ -1,29 +1,29 @@
 #include "../fixed_point.hpp"
 #include "k_fixed_point.cuh"
 
-template<typename RealType, int D>
+template <typename RealType, int D>
 void __global__ k_harmonic_angle_inference(
-    const int A,     // number of bonds
-    const double * __restrict__ coords,  // [N, 3]
-    const double * __restrict__ params,  // [P, 2]
+    const int A,                       // number of bonds
+    const double *__restrict__ coords, // [N, 3]
+    const double *__restrict__ params, // [P, 2]
     const double lambda,
-    const int * __restrict__ lambda_mult,
-    const int * __restrict__ lambda_offset,
-    const int * __restrict__ angle_idxs,    // [A, 3]
+    const int *__restrict__ lambda_mult,
+    const int *__restrict__ lambda_offset,
+    const int *__restrict__ angle_idxs, // [A, 3]
     unsigned long long *__restrict__ du_dx,
-    double * __restrict__ du_dp,
-    unsigned long long * __restrict__ du_dl,
-    unsigned long long * __restrict__ u) {
+    double *__restrict__ du_dp,
+    unsigned long long *__restrict__ du_dl,
+    unsigned long long *__restrict__ u) {
 
-    const auto a_idx = blockDim.x*blockIdx.x + threadIdx.x;
+    const auto a_idx = blockDim.x * blockIdx.x + threadIdx.x;
 
-    if(a_idx >= A) {
+    if (a_idx >= A) {
         return;
     }
 
-    int i_idx = angle_idxs[a_idx*3+0];
-    int j_idx = angle_idxs[a_idx*3+1];
-    int k_idx = angle_idxs[a_idx*3+2];
+    int i_idx = angle_idxs[a_idx * 3 + 0];
+    int j_idx = angle_idxs[a_idx * 3 + 1];
+    int k_idx = angle_idxs[a_idx * 3 + 2];
 
     RealType rij[3];
     RealType rjk[3];
@@ -31,61 +31,62 @@ void __global__ k_harmonic_angle_inference(
     RealType njk = 0; // initialize your summed variables!
     RealType top = 0;
     // this is a little confusing
-    for(int d=0; d < 3; d++) {
-        RealType vij = coords[j_idx*D+d] - coords[i_idx*D+d];
-        RealType vjk = coords[j_idx*D+d] - coords[k_idx*D+d];
+    for (int d = 0; d < 3; d++) {
+        RealType vij = coords[j_idx * D + d] - coords[i_idx * D + d];
+        RealType vjk = coords[j_idx * D + d] - coords[k_idx * D + d];
 
         rij[d] = vij;
         rjk[d] = vjk;
-        nij += vij*vij;
-        njk += vjk*vjk;
+        nij += vij * vij;
+        njk += vjk * vjk;
 
-        top += vij*vjk;
+        top += vij * vjk;
     }
 
     nij = sqrt(nij);
     njk = sqrt(njk);
 
-    RealType nijk = nij*njk;
-    RealType n3ij = nij*nij*nij;
-    RealType n3jk = njk*njk*njk;
+    RealType nijk = nij * njk;
+    RealType n3ij = nij * nij * nij;
+    RealType n3jk = njk * njk * njk;
 
-    int ka_idx = a_idx*2+0;
-    int a0_idx = a_idx*2+1;
+    int ka_idx = a_idx * 2 + 0;
+    int a0_idx = a_idx * 2 + 1;
 
     RealType ka = params[ka_idx];
     RealType a0 = params[a0_idx];
 
-    RealType delta = top/nijk - cos(a0);
+    RealType delta = top / nijk - cos(a0);
 
-    RealType prefactor = lambda_offset[a_idx] + lambda_mult[a_idx]*lambda;
+    RealType prefactor = lambda_offset[a_idx] + lambda_mult[a_idx] * lambda;
 
-    if(du_dx) {
-        for(int d=0; d < 3; d++) {
-            RealType grad_i = ka*delta*(rij[d]*top/(n3ij*njk) + (-rjk[d])/nijk);
-            atomicAdd(du_dx + i_idx*D + d, FLOAT_TO_FIXED_BONDED<RealType>(grad_i*prefactor));
+    if (du_dx) {
+        for (int d = 0; d < 3; d++) {
+            RealType grad_i = ka * delta * (rij[d] * top / (n3ij * njk) + (-rjk[d]) / nijk);
+            atomicAdd(du_dx + i_idx * D + d, FLOAT_TO_FIXED_BONDED<RealType>(grad_i * prefactor));
 
-            RealType grad_j = ka*delta*((-rij[d]*top/(n3ij*njk) + (-rjk[d])*top/(nij*n3jk) + (rij[d] + rjk[d])/nijk));
-            atomicAdd(du_dx + j_idx*D + d, FLOAT_TO_FIXED_BONDED<RealType>(grad_j*prefactor));
+            RealType grad_j =
+                ka * delta *
+                ((-rij[d] * top / (n3ij * njk) + (-rjk[d]) * top / (nij * n3jk) + (rij[d] + rjk[d]) / nijk));
+            atomicAdd(du_dx + j_idx * D + d, FLOAT_TO_FIXED_BONDED<RealType>(grad_j * prefactor));
 
-            RealType grad_k = ka*delta*(-rij[d]/nijk + rjk[d]*top/(nij*n3jk));
-            atomicAdd(du_dx + k_idx*D + d, FLOAT_TO_FIXED_BONDED<RealType>(grad_k*prefactor));
+            RealType grad_k = ka * delta * (-rij[d] / nijk + rjk[d] * top / (nij * n3jk));
+            atomicAdd(du_dx + k_idx * D + d, FLOAT_TO_FIXED_BONDED<RealType>(grad_k * prefactor));
         }
     }
 
-    if(du_dp) {
-        RealType dka_grad = delta*delta/2;
-        atomicAdd(du_dp + ka_idx, dka_grad*prefactor);
-        RealType da0_grad = delta*ka*sin(a0);
-        atomicAdd(du_dp + a0_idx, da0_grad*prefactor);
+    if (du_dp) {
+        RealType dka_grad = delta * delta / 2;
+        atomicAdd(du_dp + ka_idx, dka_grad * prefactor);
+        RealType da0_grad = delta * ka * sin(a0);
+        atomicAdd(du_dp + a0_idx, da0_grad * prefactor);
     }
 
-    if(u) {
-        atomicAdd(u + i_idx, FLOAT_TO_FIXED_BONDED(ka/2*delta*delta*prefactor));
+    if (u) {
+        atomicAdd(u + i_idx, FLOAT_TO_FIXED_BONDED(ka / 2 * delta * delta * prefactor));
     }
 
-    if(du_dl) {
-        atomicAdd(du_dl + i_idx, FLOAT_TO_FIXED_BONDED(lambda_mult[a_idx]*ka/2*delta*delta));
+    if (du_dl) {
+        atomicAdd(du_dl + i_idx, FLOAT_TO_FIXED_BONDED(lambda_mult[a_idx] * ka / 2 * delta * delta));
     }
-
 }

--- a/timemachine/cpp/src/kernels/k_harmonic_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_bond.cuh
@@ -1,39 +1,39 @@
 #include "../fixed_point.hpp"
 #include "k_fixed_point.cuh"
 
-template<typename RealType>
+template <typename RealType>
 void __global__ k_harmonic_bond(
-    const int B,           // number of bonds
-    const double * __restrict__ coords,
-    const double * __restrict__ params,  // [p, 2]
+    const int B, // number of bonds
+    const double *__restrict__ coords,
+    const double *__restrict__ params, // [p, 2]
     const double lambda,
-    const int * __restrict__ lambda_mult,
-    const int * __restrict__ lambda_offset,
-    const int * __restrict__ bond_idxs,  // [b, 2]
-    unsigned long long * __restrict__ du_dx,
-    double * __restrict__ du_dp,
-    unsigned long long * __restrict__ du_dl,
-    unsigned long long * __restrict__ u) {
+    const int *__restrict__ lambda_mult,
+    const int *__restrict__ lambda_offset,
+    const int *__restrict__ bond_idxs, // [b, 2]
+    unsigned long long *__restrict__ du_dx,
+    double *__restrict__ du_dp,
+    unsigned long long *__restrict__ du_dl,
+    unsigned long long *__restrict__ u) {
 
-    const auto b_idx = blockDim.x*blockIdx.x + threadIdx.x;
+    const auto b_idx = blockDim.x * blockIdx.x + threadIdx.x;
 
-    if(b_idx >= B) {
+    if (b_idx >= B) {
         return;
     }
 
-    int src_idx = bond_idxs[b_idx*2+0];
-    int dst_idx = bond_idxs[b_idx*2+1];
+    int src_idx = bond_idxs[b_idx * 2 + 0];
+    int dst_idx = bond_idxs[b_idx * 2 + 1];
 
     RealType dx[3];
     RealType d2ij = 0;
-    for(int d=0; d < 3; d++) {
-        RealType delta = coords[src_idx*3+d] - coords[dst_idx*3+d];
+    for (int d = 0; d < 3; d++) {
+        RealType delta = coords[src_idx * 3 + d] - coords[dst_idx * 3 + d];
         dx[d] = delta;
-        d2ij += delta*delta;
+        d2ij += delta * delta;
     }
 
-    int kb_idx = b_idx*2+0;
-    int b0_idx = b_idx*2+1;
+    int kb_idx = b_idx * 2 + 0;
+    int b0_idx = b_idx * 2 + 1;
 
     RealType kb = params[kb_idx];
     RealType b0 = params[b0_idx];
@@ -41,32 +41,31 @@ void __global__ k_harmonic_bond(
     RealType dij = sqrt(d2ij);
     RealType db = dij - b0;
 
-    RealType prefactor = lambda_offset[b_idx] + lambda_mult[b_idx]*lambda;
+    RealType prefactor = lambda_offset[b_idx] + lambda_mult[b_idx] * lambda;
 
-    if(du_dx) {
-        for(int d=0; d < 3; d++) {
+    if (du_dx) {
+        for (int d = 0; d < 3; d++) {
             RealType grad_delta;
-            if(b0 != 0) {
-                grad_delta = kb*db*dx[d]/dij;
-            } else{
-                grad_delta = kb*dx[d];
+            if (b0 != 0) {
+                grad_delta = kb * db * dx[d] / dij;
+            } else {
+                grad_delta = kb * dx[d];
             }
-            atomicAdd(du_dx + src_idx*3 + d, FLOAT_TO_FIXED_BONDED<RealType>(grad_delta*prefactor));
-            atomicAdd(du_dx + dst_idx*3 + d, FLOAT_TO_FIXED_BONDED<RealType>(-grad_delta*prefactor));
+            atomicAdd(du_dx + src_idx * 3 + d, FLOAT_TO_FIXED_BONDED<RealType>(grad_delta * prefactor));
+            atomicAdd(du_dx + dst_idx * 3 + d, FLOAT_TO_FIXED_BONDED<RealType>(-grad_delta * prefactor));
         }
     }
 
-    if(du_dp) {
-        atomicAdd(du_dp + kb_idx, 0.5*db*db*prefactor);
-        atomicAdd(du_dp + b0_idx, -kb*db*prefactor);
+    if (du_dp) {
+        atomicAdd(du_dp + kb_idx, 0.5 * db * db * prefactor);
+        atomicAdd(du_dp + b0_idx, -kb * db * prefactor);
     }
 
-    if(u) {
-        atomicAdd(u + src_idx, FLOAT_TO_FIXED_BONDED<RealType>(kb/2*db*db*prefactor));
+    if (u) {
+        atomicAdd(u + src_idx, FLOAT_TO_FIXED_BONDED<RealType>(kb / 2 * db * db * prefactor));
     }
 
-    if(du_dl) {
-        atomicAdd(du_dl + src_idx, FLOAT_TO_FIXED_BONDED<RealType>(lambda_mult[b_idx]*kb/2*db*db));
+    if (du_dl) {
+        atomicAdd(du_dl + src_idx, FLOAT_TO_FIXED_BONDED<RealType>(lambda_mult[b_idx] * kb / 2 * db * db));
     }
-
 }

--- a/timemachine/cpp/src/kernels/k_lambda_transformer_jit.cuh
+++ b/timemachine/cpp/src/kernels/k_lambda_transformer_jit.cuh
@@ -1,27 +1,24 @@
 jit_program
 
-#include "KERNEL_DIR/surreal.cuh"
 #include "KERNEL_DIR/k_fixed_point.cuh"
+#include "KERNEL_DIR/surreal.cuh"
 
 #define PI 3.141592653589793115997963468544185161
 
-template <typename NumericType>
-NumericType __device__ __forceinline__ transform_lambda_charge(NumericType lambda) {
+    template <typename NumericType>
+    NumericType __device__ __forceinline__ transform_lambda_charge(NumericType lambda) {
     return CUSTOM_EXPRESSION_CHARGE;
 }
 
-template <typename NumericType>
-NumericType __device__ __forceinline__ transform_lambda_sigma(NumericType lambda) {
+template <typename NumericType> NumericType __device__ __forceinline__ transform_lambda_sigma(NumericType lambda) {
     return CUSTOM_EXPRESSION_SIGMA;
 }
 
-template <typename NumericType>
-NumericType __device__ __forceinline__ transform_lambda_epsilon(NumericType lambda) {
+template <typename NumericType> NumericType __device__ __forceinline__ transform_lambda_epsilon(NumericType lambda) {
     return CUSTOM_EXPRESSION_EPSILON;
 }
 
-template <typename NumericType>
-NumericType __device__ __forceinline__ transform_lambda_w(NumericType lambda) {
+template <typename NumericType> NumericType __device__ __forceinline__ transform_lambda_w(NumericType lambda) {
     return CUSTOM_EXPRESSION_W;
 }
 
@@ -29,14 +26,14 @@ void __global__ k_compute_w_coords(
     const int N,
     const double lambda,
     const double cutoff,
-    const int * __restrict__ lambda_plane_idxs, // 0 or 1, shift
-    const int * __restrict__ lambda_offset_idxs,
-    double * __restrict__ coords_w,
-    double * __restrict__ dw_dl) {
+    const int *__restrict__ lambda_plane_idxs, // 0 or 1, shift
+    const int *__restrict__ lambda_offset_idxs,
+    double *__restrict__ coords_w,
+    double *__restrict__ dw_dl) {
 
-    int atom_i_idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int atom_i_idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    if(atom_i_idx >= N) {
+    if (atom_i_idx >= N) {
         return;
     }
 
@@ -47,10 +44,10 @@ void __global__ k_compute_w_coords(
 
     double step = 1e-7;
     Surreal<double> lambda_surreal(lambda, step);
-    double f_lambda_grad = (transform_lambda_w(lambda_surreal).imag)/step;
+    double f_lambda_grad = (transform_lambda_w(lambda_surreal).imag) / step;
 
-    double coords_w_i = (lambda_plane_i + lambda_offset_i*f_lambda)*cutoff;
-    double dw_dl_i = lambda_offset_i*f_lambda_grad*cutoff;
+    double coords_w_i = (lambda_plane_i + lambda_offset_i * f_lambda) * cutoff;
+    double dw_dl_i = lambda_offset_i * f_lambda_grad * cutoff;
 
     coords_w[atom_i_idx] = coords_w_i;
     dw_dl[atom_i_idx] = dw_dl_i;
@@ -60,23 +57,23 @@ void __global__ k_compute_w_coords(
 void __global__ k_permute_interpolated(
     const double lambda,
     const int N,
-    const unsigned int * __restrict__ perm,
-    const double * __restrict__ d_p,
-    double * __restrict__ d_sorted_p,
-    double * __restrict__ d_sorted_dp_dl) {
+    const unsigned int *__restrict__ perm,
+    const double *__restrict__ d_p,
+    double *__restrict__ d_sorted_p,
+    double *__restrict__ d_sorted_dp_dl) {
 
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int stride = gridDim.y;
     int stride_idx = blockIdx.y;
 
-    if(idx >= N) {
+    if (idx >= N) {
         return;
     }
 
-    int size = N*stride;
+    int size = N * stride;
 
-    int source_idx = idx*stride+stride_idx;
-    int target_idx = perm[idx]*stride+stride_idx;
+    int source_idx = idx * stride + stride_idx;
+    int target_idx = perm[idx] * stride + stride_idx;
 
     double step = 1e-7;
     Surreal<double> lambda_surreal(lambda, step);
@@ -84,54 +81,58 @@ void __global__ k_permute_interpolated(
     double f_lambda;
     double f_lambda_grad;
 
-    if(stride_idx == 0) {
+    if (stride_idx == 0) {
         f_lambda = transform_lambda_charge(lambda);
-        f_lambda_grad = (transform_lambda_charge(lambda_surreal).imag)/step;
+        f_lambda_grad = (transform_lambda_charge(lambda_surreal).imag) / step;
     }
-    if(stride_idx == 1) {
+    if (stride_idx == 1) {
         f_lambda = transform_lambda_sigma(lambda);
-        f_lambda_grad = (transform_lambda_sigma(lambda_surreal).imag)/step;
+        f_lambda_grad = (transform_lambda_sigma(lambda_surreal).imag) / step;
     }
-    if(stride_idx == 2) {
+    if (stride_idx == 2) {
         f_lambda = transform_lambda_epsilon(lambda);
-        f_lambda_grad = (transform_lambda_epsilon(lambda_surreal).imag)/step;
+        f_lambda_grad = (transform_lambda_epsilon(lambda_surreal).imag) / step;
     }
 
-    d_sorted_p[source_idx] = (1-f_lambda)*d_p[target_idx] + f_lambda*d_p[size+target_idx];
-    d_sorted_dp_dl[source_idx] = f_lambda_grad*(d_p[size+target_idx] - d_p[target_idx]);
-
+    d_sorted_p[source_idx] = (1 - f_lambda) * d_p[target_idx] + f_lambda * d_p[size + target_idx];
+    d_sorted_dp_dl[source_idx] = f_lambda_grad * (d_p[size + target_idx] - d_p[target_idx]);
 }
 
 void __global__ k_add_ull_to_real_interpolated(
     const double lambda,
     const int N,
-    const unsigned long long * __restrict__ ull_array,
-    double * __restrict__ real_array) {
+    const unsigned long long *__restrict__ ull_array,
+    double *__restrict__ real_array) {
 
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int stride = gridDim.y;
     int stride_idx = blockIdx.y;
 
-    if(idx >= N) {
+    if (idx >= N) {
         return;
     }
 
-    int size = N*stride;
-    int target_idx = idx*stride+stride_idx;
+    int size = N * stride;
+    int target_idx = idx * stride + stride_idx;
 
     // handle charges, sigmas, epsilons with different exponents
-    if(stride_idx == 0) {
+    if (stride_idx == 0) {
         double f_lambda = transform_lambda_charge(lambda);
-        real_array[target_idx] += (1-f_lambda)*FIXED_TO_FLOAT_DU_DP<double, FIXED_EXPONENT_DU_DCHARGE>(ull_array[target_idx]);
-        real_array[size+target_idx] += f_lambda*FIXED_TO_FLOAT_DU_DP<double, FIXED_EXPONENT_DU_DCHARGE>(ull_array[target_idx]);
-    } else if(stride_idx == 1) {
+        real_array[target_idx] +=
+            (1 - f_lambda) * FIXED_TO_FLOAT_DU_DP<double, FIXED_EXPONENT_DU_DCHARGE>(ull_array[target_idx]);
+        real_array[size + target_idx] +=
+            f_lambda * FIXED_TO_FLOAT_DU_DP<double, FIXED_EXPONENT_DU_DCHARGE>(ull_array[target_idx]);
+    } else if (stride_idx == 1) {
         double f_lambda = transform_lambda_sigma(lambda);
-        real_array[target_idx] += (1-f_lambda)*FIXED_TO_FLOAT_DU_DP<double, FIXED_EXPONENT_DU_DSIG>(ull_array[target_idx]);
-        real_array[size+target_idx] += f_lambda*FIXED_TO_FLOAT_DU_DP<double, FIXED_EXPONENT_DU_DSIG>(ull_array[target_idx]);
-    } else if(stride_idx == 2) {
+        real_array[target_idx] +=
+            (1 - f_lambda) * FIXED_TO_FLOAT_DU_DP<double, FIXED_EXPONENT_DU_DSIG>(ull_array[target_idx]);
+        real_array[size + target_idx] +=
+            f_lambda * FIXED_TO_FLOAT_DU_DP<double, FIXED_EXPONENT_DU_DSIG>(ull_array[target_idx]);
+    } else if (stride_idx == 2) {
         double f_lambda = transform_lambda_epsilon(lambda);
-        real_array[target_idx] += (1-f_lambda)*FIXED_TO_FLOAT_DU_DP<double, FIXED_EXPONENT_DU_DEPS>(ull_array[target_idx]);
-        real_array[size+target_idx] += f_lambda*FIXED_TO_FLOAT_DU_DP<double, FIXED_EXPONENT_DU_DEPS>(ull_array[target_idx]);
+        real_array[target_idx] +=
+            (1 - f_lambda) * FIXED_TO_FLOAT_DU_DP<double, FIXED_EXPONENT_DU_DEPS>(ull_array[target_idx]);
+        real_array[size + target_idx] +=
+            f_lambda * FIXED_TO_FLOAT_DU_DP<double, FIXED_EXPONENT_DU_DEPS>(ull_array[target_idx]);
     }
-
 }

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -4,38 +4,38 @@
 #define TILESIZE 32
 #define WARPSIZE 32
 
-template<typename RealType>
+template <typename RealType>
 void __global__ k_find_block_bounds(
-    const int N, // Number of atoms
-    const int D, // Box dimensions, typically 3
-    const int T, // Number of tiles
-    const double * __restrict__ coords, // [N*3]
-    const double * __restrict__ box, // [D*3]
-    double *block_bounds_ctr, // [T*3]
-    double *block_bounds_ext // [T*3]
+    const int N,                       // Number of atoms
+    const int D,                       // Box dimensions, typically 3
+    const int T,                       // Number of tiles
+    const double *__restrict__ coords, // [N*3]
+    const double *__restrict__ box,    // [D*3]
+    double *block_bounds_ctr,          // [T*3]
+    double *block_bounds_ext           // [T*3]
 ) {
 
     // Algorithm taken from https://github.com/openmm/openmm/blob/master/platforms/cuda/src/kernels/findInteractingBlocks.cu#L7
     // Computes smaller bounding boxes than simpler form by accounting for periodic box conditions
 
     // each thread processes one tile
-    const int index = blockIdx.x*blockDim.x+threadIdx.x;
-    if(index >= T) {
+    const int index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (index >= T) {
         return;
     }
 
-    const RealType bx = box[0*3+0];
-    const RealType by = box[1*3+1];
-    const RealType bz = box[2*3+2];
+    const RealType bx = box[0 * 3 + 0];
+    const RealType by = box[1 * 3 + 1];
+    const RealType bz = box[2 * 3 + 2];
 
-    const RealType inv_bx = 1/bx;
-    const RealType inv_by = 1/by;
-    const RealType inv_bz = 1/bz;
-    const int base = index*TILESIZE;
+    const RealType inv_bx = 1 / bx;
+    const RealType inv_by = 1 / by;
+    const RealType inv_bz = 1 / bz;
+    const int base = index * TILESIZE;
 
-    RealType pos_x = coords[base*3+0];
-    RealType pos_y = coords[base*3+1];
-    RealType pos_z = coords[base*3+2];
+    RealType pos_x = coords[base * 3 + 0];
+    RealType pos_y = coords[base * 3 + 1];
+    RealType pos_z = coords[base * 3 + 2];
 
     RealType minPos_x = pos_x;
     RealType minPos_y = pos_y;
@@ -45,98 +45,97 @@ void __global__ k_find_block_bounds(
     RealType maxPos_y = pos_y;
     RealType maxPos_z = pos_z;
 
-    const int last = min(base+TILESIZE, N);
-    for (int i = base+1; i < last; i++) {
-        pos_x = coords[i*3+0];
-        pos_y = coords[i*3+1];
-        pos_z = coords[i*3+2];
+    const int last = min(base + TILESIZE, N);
+    for (int i = base + 1; i < last; i++) {
+        pos_x = coords[i * 3 + 0];
+        pos_y = coords[i * 3 + 1];
+        pos_z = coords[i * 3 + 2];
         // Build up center over time, and recenter before computing
         // min and max, to reduce overall size of box thanks to accounting
         // for periodic boundary conditions
-        RealType center_x = static_cast<RealType>(0.5)*(maxPos_x+minPos_x);
-        RealType center_y = static_cast<RealType>(0.5)*(maxPos_y+minPos_y);
-        RealType center_z = static_cast<RealType>(0.5)*(maxPos_z+minPos_z);
-        pos_x -= bx*nearbyint((pos_x-center_x)*inv_bx);
-        pos_y -= by*nearbyint((pos_y-center_y)*inv_by);
-        pos_z -= bz*nearbyint((pos_z-center_z)*inv_bz);
-        minPos_x = min(minPos_x,pos_x);
-        minPos_y = min(minPos_y,pos_y);
-        minPos_z = min(minPos_z,pos_z);
+        RealType center_x = static_cast<RealType>(0.5) * (maxPos_x + minPos_x);
+        RealType center_y = static_cast<RealType>(0.5) * (maxPos_y + minPos_y);
+        RealType center_z = static_cast<RealType>(0.5) * (maxPos_z + minPos_z);
+        pos_x -= bx * nearbyint((pos_x - center_x) * inv_bx);
+        pos_y -= by * nearbyint((pos_y - center_y) * inv_by);
+        pos_z -= bz * nearbyint((pos_z - center_z) * inv_bz);
+        minPos_x = min(minPos_x, pos_x);
+        minPos_y = min(minPos_y, pos_y);
+        minPos_z = min(minPos_z, pos_z);
 
-        maxPos_x = max(maxPos_x,pos_x);
-        maxPos_y = max(maxPos_y,pos_y);
-        maxPos_z = max(maxPos_z,pos_z);
+        maxPos_x = max(maxPos_x, pos_x);
+        maxPos_y = max(maxPos_y, pos_y);
+        maxPos_z = max(maxPos_z, pos_z);
     }
 
-    block_bounds_ctr[index*3+0]  = static_cast<RealType>(0.5)*(maxPos_x+minPos_x);
-    block_bounds_ctr[index*3+1]  = static_cast<RealType>(0.5)*(maxPos_y+minPos_y);
-    block_bounds_ctr[index*3+2]  = static_cast<RealType>(0.5)*(maxPos_z+minPos_z);
+    block_bounds_ctr[index * 3 + 0] = static_cast<RealType>(0.5) * (maxPos_x + minPos_x);
+    block_bounds_ctr[index * 3 + 1] = static_cast<RealType>(0.5) * (maxPos_y + minPos_y);
+    block_bounds_ctr[index * 3 + 2] = static_cast<RealType>(0.5) * (maxPos_z + minPos_z);
 
-    block_bounds_ext[index*3+0] = static_cast<RealType>(0.5)*(maxPos_x-minPos_x);
-    block_bounds_ext[index*3+1] = static_cast<RealType>(0.5)*(maxPos_y-minPos_y);
-    block_bounds_ext[index*3+2] = static_cast<RealType>(0.5)*(maxPos_z-minPos_z);
+    block_bounds_ext[index * 3 + 0] = static_cast<RealType>(0.5) * (maxPos_x - minPos_x);
+    block_bounds_ext[index * 3 + 1] = static_cast<RealType>(0.5) * (maxPos_y - minPos_y);
+    block_bounds_ext[index * 3 + 2] = static_cast<RealType>(0.5) * (maxPos_z - minPos_z);
 }
 
 void __global__ k_compact_trim_atoms(
     const int N,
     const int Y,
-    unsigned int* __restrict__ trim_atoms,
-    unsigned int* __restrict__ interactionCount,
-    int* __restrict__ interactingTiles,
-    unsigned int* __restrict__ interactingAtoms) {
+    unsigned int *__restrict__ trim_atoms,
+    unsigned int *__restrict__ interactionCount,
+    int *__restrict__ interactingTiles,
+    unsigned int *__restrict__ interactingAtoms) {
 
-    __shared__ int ixn_j_buffer[64]; // we can probably get away with using only 32 if we do some fancier remainder tricks, but this isn't a huge save
+    __shared__ int ixn_j_buffer
+        [64]; // we can probably get away with using only 32 if we do some fancier remainder tricks, but this isn't a huge save
     ixn_j_buffer[threadIdx.x] = N;
-    ixn_j_buffer[WARPSIZE+threadIdx.x] = N;
+    ixn_j_buffer[WARPSIZE + threadIdx.x] = N;
 
-    const int indexInWarp = threadIdx.x%WARPSIZE;
-    const int warpMask = (1<<indexInWarp)-1;
+    const int indexInWarp = threadIdx.x % WARPSIZE;
+    const int warpMask = (1 << indexInWarp) - 1;
     const int row_block_idx = blockIdx.x;
 
     __shared__ volatile int sync_start[1];
     int neighborsInBuffer = 0;
 
-    for(int trim_block_idx=0; trim_block_idx < Y; trim_block_idx++) {
+    for (int trim_block_idx = 0; trim_block_idx < Y; trim_block_idx++) {
 
-        int atom_j_idx = trim_atoms[row_block_idx*Y*WARPSIZE + trim_block_idx*WARPSIZE + threadIdx.x];
+        int atom_j_idx = trim_atoms[row_block_idx * Y * WARPSIZE + trim_block_idx * WARPSIZE + threadIdx.x];
         bool interacts = atom_j_idx < N;
 
         int includeAtomFlags = __ballot_sync(FULL_MASK, interacts);
 
         if (interacts) {
             // only interacting atoms partake in this
-            int index = neighborsInBuffer+__popc(includeAtomFlags & warpMask); // where to store this in shared memory
+            int index = neighborsInBuffer + __popc(includeAtomFlags & warpMask); // where to store this in shared memory
             ixn_j_buffer[index] = atom_j_idx;
         }
         neighborsInBuffer += __popc(includeAtomFlags);
 
-        if(neighborsInBuffer > WARPSIZE) {
+        if (neighborsInBuffer > WARPSIZE) {
             int tilesToStore = 1;
-            if(indexInWarp == 0) {
+            if (indexInWarp == 0) {
                 sync_start[0] = atomicAdd(interactionCount, tilesToStore);
             }
             __syncwarp();
             interactingTiles[sync_start[0]] = row_block_idx; // IS THIS CORRECT? CONTESTED
-            interactingAtoms[sync_start[0]*WARPSIZE + threadIdx.x] = ixn_j_buffer[threadIdx.x];
+            interactingAtoms[sync_start[0] * WARPSIZE + threadIdx.x] = ixn_j_buffer[threadIdx.x];
 
-            ixn_j_buffer[threadIdx.x] = ixn_j_buffer[WARPSIZE+threadIdx.x];
-            ixn_j_buffer[WARPSIZE+threadIdx.x] = N; // reset old values
+            ixn_j_buffer[threadIdx.x] = ixn_j_buffer[WARPSIZE + threadIdx.x];
+            ixn_j_buffer[WARPSIZE + threadIdx.x] = N; // reset old values
             neighborsInBuffer -= WARPSIZE;
         }
     }
 
-    if(neighborsInBuffer > 0) {
+    if (neighborsInBuffer > 0) {
         int tilesToStore = 1;
-        if(indexInWarp == 0) {
+        if (indexInWarp == 0) {
             sync_start[0] = atomicAdd(interactionCount, tilesToStore);
         }
         __syncwarp();
         interactingTiles[sync_start[0]] = row_block_idx;
-        interactingAtoms[sync_start[0]*WARPSIZE + threadIdx.x] = ixn_j_buffer[threadIdx.x];
+        interactingAtoms[sync_start[0] * WARPSIZE + threadIdx.x] = ixn_j_buffer[threadIdx.x];
     }
-
 }
-
 
 /*
 
@@ -155,58 +154,59 @@ Each block proceeds as follows:
 
 */
 
-template<typename RealType>
+template <typename RealType>
 void __global__ k_find_blocks_with_ixns(
     const int N,
-    const double * __restrict__ bb_ctr, // [N * 3]
-    const double * __restrict__ bb_ext, // [N * 3]
-    const double* __restrict__ coords, //TBD make float32 version
-    const double* __restrict__ box,
-    unsigned int* __restrict__ interactionCount, // number of tiles that have interactions
-    int* __restrict__ interactingTiles, // the row block idx of the tile that is interacting
-    unsigned int* __restrict__ interactingAtoms, // the col block of the atoms that are interacting
-    unsigned int* __restrict__ trim_atoms, // the left-over trims that will later be compacted
+    const double *__restrict__ bb_ctr, // [N * 3]
+    const double *__restrict__ bb_ext, // [N * 3]
+    const double *__restrict__ coords, //TBD make float32 version
+    const double *__restrict__ box,
+    unsigned int *__restrict__ interactionCount, // number of tiles that have interactions
+    int *__restrict__ interactingTiles,          // the row block idx of the tile that is interacting
+    unsigned int *__restrict__ interactingAtoms, // the col block of the atoms that are interacting
+    unsigned int *__restrict__ trim_atoms,       // the left-over trims that will later be compacted
     const double cutoff) {
 
-    const int indexInWarp = threadIdx.x%WARPSIZE;
-    const int warpMask = (1<<indexInWarp)-1;
+    const int indexInWarp = threadIdx.x % WARPSIZE;
+    const int warpMask = (1 << indexInWarp) - 1;
 
-    __shared__ int ixn_j_buffer[64]; // we can probably get away with using only 32 if we do some fancier remainder tricks, but this isn't a huge save
+    __shared__ int ixn_j_buffer
+        [64]; // we can probably get away with using only 32 if we do some fancier remainder tricks, but this isn't a huge save
 
     // initialize
     ixn_j_buffer[threadIdx.x] = N;
-    ixn_j_buffer[WARPSIZE+threadIdx.x] = N;
+    ixn_j_buffer[WARPSIZE + threadIdx.x] = N;
 
     __shared__ volatile int sync_start[1];
 
     const int row_block_idx = blockIdx.x;
 
     // Retrieve the center coords of row's box and outer limits of row box.
-    RealType row_bb_ctr_x = bb_ctr[row_block_idx*3+0];
-    RealType row_bb_ctr_y = bb_ctr[row_block_idx*3+1];
-    RealType row_bb_ctr_z = bb_ctr[row_block_idx*3+2];
+    RealType row_bb_ctr_x = bb_ctr[row_block_idx * 3 + 0];
+    RealType row_bb_ctr_y = bb_ctr[row_block_idx * 3 + 1];
+    RealType row_bb_ctr_z = bb_ctr[row_block_idx * 3 + 2];
 
-    RealType row_bb_ext_x = bb_ext[row_block_idx*3+0];
-    RealType row_bb_ext_y = bb_ext[row_block_idx*3+1];
-    RealType row_bb_ext_z = bb_ext[row_block_idx*3+2];
+    RealType row_bb_ext_x = bb_ext[row_block_idx * 3 + 0];
+    RealType row_bb_ext_y = bb_ext[row_block_idx * 3 + 1];
+    RealType row_bb_ext_z = bb_ext[row_block_idx * 3 + 2];
 
     int neighborsInBuffer = 0;
 
-    const unsigned int atom_i_idx = blockIdx.x*blockDim.x + threadIdx.x;
+    const unsigned int atom_i_idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    RealType pos_i_x = atom_i_idx < N ? coords[atom_i_idx*3 + 0] : 0;
-    RealType pos_i_y = atom_i_idx < N ? coords[atom_i_idx*3 + 1] : 0;
-    RealType pos_i_z = atom_i_idx < N ? coords[atom_i_idx*3 + 2] : 0;
+    RealType pos_i_x = atom_i_idx < N ? coords[atom_i_idx * 3 + 0] : 0;
+    RealType pos_i_y = atom_i_idx < N ? coords[atom_i_idx * 3 + 1] : 0;
+    RealType pos_i_z = atom_i_idx < N ? coords[atom_i_idx * 3 + 2] : 0;
 
-    const int NUM_BLOCKS = (N+TILESIZE-1)/TILESIZE;
+    const int NUM_BLOCKS = (N + TILESIZE - 1) / TILESIZE;
 
-    RealType bx = box[0*3+0];
-    RealType by = box[1*3+1];
-    RealType bz = box[2*3+2];
+    RealType bx = box[0 * 3 + 0];
+    RealType by = box[1 * 3 + 1];
+    RealType bz = box[2 * 3 + 2];
 
-    RealType inv_bx = 1/bx;
-    RealType inv_by = 1/by;
-    RealType inv_bz = 1/bz;
+    RealType inv_bx = 1 / bx;
+    RealType inv_by = 1 / by;
+    RealType inv_bz = 1 / bz;
 
     RealType non_periodic_dist_i = 0;
     RealType non_periodic_dist_j = 0;
@@ -214,34 +214,34 @@ void __global__ k_find_blocks_with_ixns(
     // Determine if the row block can be translated into a periodic box
     // to optimize distance calculations
     // https://github.com/proteneer/timemachine/issues/320
-    const bool single_periodic_box = (0.5f*bx-row_bb_ext_x >= cutoff &&
-                                      0.5f*by-row_bb_ext_y >= cutoff &&
-                                      0.5f*bz-row_bb_ext_z >= cutoff);
+    const bool single_periodic_box =
+        (0.5f * bx - row_bb_ext_x >= cutoff && 0.5f * by - row_bb_ext_y >= cutoff &&
+         0.5f * bz - row_bb_ext_z >= cutoff);
     if (single_periodic_box) {
-        pos_i_x -= bx*nearbyint((pos_i_x-row_bb_ctr_x)*inv_bx);
-        pos_i_y -= by*nearbyint((pos_i_y-row_bb_ctr_y)*inv_by);
-        pos_i_z -= bz*nearbyint((pos_i_z-row_bb_ctr_z)*inv_bz);
+        pos_i_x -= bx * nearbyint((pos_i_x - row_bb_ctr_x) * inv_bx);
+        pos_i_y -= by * nearbyint((pos_i_y - row_bb_ctr_y) * inv_by);
+        pos_i_z -= bz * nearbyint((pos_i_z - row_bb_ctr_z) * inv_bz);
 
-        non_periodic_dist_i = static_cast<RealType>(0.5) * (pos_i_x*pos_i_x + pos_i_y*pos_i_y + pos_i_z*pos_i_z);
+        non_periodic_dist_i = static_cast<RealType>(0.5) * (pos_i_x * pos_i_x + pos_i_y * pos_i_y + pos_i_z * pos_i_z);
     }
 
-    const RealType cutoff_squared = static_cast<RealType>(cutoff)*static_cast<RealType>(cutoff);
+    const RealType cutoff_squared = static_cast<RealType>(cutoff) * static_cast<RealType>(cutoff);
 
-    int col_block_base = blockIdx.y*TILESIZE;
+    int col_block_base = blockIdx.y * TILESIZE;
 
-    int col_block_idx = col_block_base+indexInWarp;
+    int col_block_idx = col_block_base + indexInWarp;
     bool include_col_block = (col_block_idx < NUM_BLOCKS) && (col_block_idx >= row_block_idx);
 
     if (include_col_block) {
 
         // Compute center of column box and extent coords.
-        RealType col_bb_ctr_x = bb_ctr[col_block_idx*3+0];
-        RealType col_bb_ctr_y = bb_ctr[col_block_idx*3+1];
-        RealType col_bb_ctr_z = bb_ctr[col_block_idx*3+2];
+        RealType col_bb_ctr_x = bb_ctr[col_block_idx * 3 + 0];
+        RealType col_bb_ctr_y = bb_ctr[col_block_idx * 3 + 1];
+        RealType col_bb_ctr_z = bb_ctr[col_block_idx * 3 + 2];
 
-        RealType col_bb_ext_x = bb_ext[col_block_idx*3+0];
-        RealType col_bb_ext_y = bb_ext[col_block_idx*3+1];
-        RealType col_bb_ext_z = bb_ext[col_block_idx*3+2];
+        RealType col_bb_ext_x = bb_ext[col_block_idx * 3 + 0];
+        RealType col_bb_ext_y = bb_ext[col_block_idx * 3 + 1];
+        RealType col_bb_ext_z = bb_ext[col_block_idx * 3 + 2];
 
         // Find delta between boxes
         RealType box_box_dx = row_bb_ctr_x - col_bb_ctr_x;
@@ -249,9 +249,9 @@ void __global__ k_find_blocks_with_ixns(
         RealType box_box_dz = row_bb_ctr_z - col_bb_ctr_z;
 
         // Recenter delta box
-        box_box_dx -= bx*nearbyint(box_box_dx*inv_bx);
-        box_box_dy -= by*nearbyint(box_box_dy*inv_by);
-        box_box_dz -= bz*nearbyint(box_box_dz*inv_bz);
+        box_box_dx -= bx * nearbyint(box_box_dx * inv_bx);
+        box_box_dy -= by * nearbyint(box_box_dy * inv_by);
+        box_box_dz -= bz * nearbyint(box_box_dz * inv_bz);
 
         // If boxes overlap, treat distance as 0
         box_box_dx = max(static_cast<RealType>(0.0), fabs(box_box_dx) - row_bb_ext_x - col_bb_ext_x);
@@ -259,8 +259,8 @@ void __global__ k_find_blocks_with_ixns(
         box_box_dz = max(static_cast<RealType>(0.0), fabs(box_box_dz) - row_bb_ext_z - col_bb_ext_z);
 
         // Check if the deltas between boxes are within cutoff
-        include_col_block &= (box_box_dx*box_box_dx + box_box_dy*box_box_dy + box_box_dz*box_box_dz) < (cutoff_squared);
-
+        include_col_block &=
+            (box_box_dx * box_box_dx + box_box_dy * box_box_dy + box_box_dz * box_box_dz) < (cutoff_squared);
     }
 
     // __ballot returns bit flags to indicate which thread in the warp identified a column block within the cutoff.
@@ -277,27 +277,27 @@ void __global__ k_find_blocks_with_ixns(
         // ffs(2^3=8) == 4
         // ffs(2^31) == 32
 
-        int offset = __ffs(includeBlockFlags)-1;
+        int offset = __ffs(includeBlockFlags) - 1;
 
-        includeBlockFlags &= includeBlockFlags-1;
+        includeBlockFlags &= includeBlockFlags - 1;
         int col_block = col_block_base + offset;
         // Compute overlap between column bounding box and row atom
-        RealType col_bb_ctr_x = bb_ctr[col_block*3+0];
-        RealType col_bb_ctr_y = bb_ctr[col_block*3+1];
-        RealType col_bb_ctr_z = bb_ctr[col_block*3+2];
+        RealType col_bb_ctr_x = bb_ctr[col_block * 3 + 0];
+        RealType col_bb_ctr_y = bb_ctr[col_block * 3 + 1];
+        RealType col_bb_ctr_z = bb_ctr[col_block * 3 + 2];
 
-        RealType col_bb_ext_x = bb_ext[col_block*3+0];
-        RealType col_bb_ext_y = bb_ext[col_block*3+1];
-        RealType col_bb_ext_z = bb_ext[col_block*3+2];
+        RealType col_bb_ext_x = bb_ext[col_block * 3 + 0];
+        RealType col_bb_ext_y = bb_ext[col_block * 3 + 1];
+        RealType col_bb_ext_z = bb_ext[col_block * 3 + 2];
 
         // Don't use pos_i_* here, as might have been shifted to center
-        RealType atom_box_dx = (atom_i_idx < N ? coords[atom_i_idx*3 + 0] : 0) - col_bb_ctr_x;
-        RealType atom_box_dy = (atom_i_idx < N ? coords[atom_i_idx*3 + 1] : 0) - col_bb_ctr_y;
-        RealType atom_box_dz = (atom_i_idx < N ? coords[atom_i_idx*3 + 2] : 0) - col_bb_ctr_z;
+        RealType atom_box_dx = (atom_i_idx < N ? coords[atom_i_idx * 3 + 0] : 0) - col_bb_ctr_x;
+        RealType atom_box_dy = (atom_i_idx < N ? coords[atom_i_idx * 3 + 1] : 0) - col_bb_ctr_y;
+        RealType atom_box_dz = (atom_i_idx < N ? coords[atom_i_idx * 3 + 2] : 0) - col_bb_ctr_z;
 
-        atom_box_dx -= bx*nearbyint(atom_box_dx*inv_bx);
-        atom_box_dy -= by*nearbyint(atom_box_dy*inv_by);
-        atom_box_dz -= bz*nearbyint(atom_box_dz*inv_bz);
+        atom_box_dx -= bx * nearbyint(atom_box_dx * inv_bx);
+        atom_box_dy -= by * nearbyint(atom_box_dy * inv_by);
+        atom_box_dz -= bz * nearbyint(atom_box_dz * inv_bz);
 
         atom_box_dx = max(static_cast<RealType>(0.0), fabs(atom_box_dx) - col_bb_ext_x);
         atom_box_dy = max(static_cast<RealType>(0.0), fabs(atom_box_dy) - col_bb_ext_y);
@@ -305,8 +305,10 @@ void __global__ k_find_blocks_with_ixns(
 
         // Find rows where the row atom and column boxes are within cutoff
         bool interacts = false;
-        unsigned atomFlags = __ballot_sync(FULL_MASK, atom_box_dx*atom_box_dx + atom_box_dy*atom_box_dy + atom_box_dz*atom_box_dz < cutoff_squared);
-        int atom_j_idx = col_block*WARPSIZE+threadIdx.x; // each thread loads a different atom
+        unsigned atomFlags = __ballot_sync(
+            FULL_MASK,
+            atom_box_dx * atom_box_dx + atom_box_dy * atom_box_dy + atom_box_dz * atom_box_dz < cutoff_squared);
+        int atom_j_idx = col_block * WARPSIZE + threadIdx.x; // each thread loads a different atom
 
         //       threadIdx
         //      0 1 2 3 4 5
@@ -322,24 +324,24 @@ void __global__ k_find_blocks_with_ixns(
         // s 0  0 0 0 0 0 0
         //   0  0 0 0 0 0 0
 
-        RealType pos_j_x = atom_j_idx < N ? coords[atom_j_idx*3 + 0] : 0;
-        RealType pos_j_y = atom_j_idx < N ? coords[atom_j_idx*3 + 1] : 0;
-        RealType pos_j_z = atom_j_idx < N ? coords[atom_j_idx*3 + 2] : 0;
+        RealType pos_j_x = atom_j_idx < N ? coords[atom_j_idx * 3 + 0] : 0;
+        RealType pos_j_y = atom_j_idx < N ? coords[atom_j_idx * 3 + 1] : 0;
+        RealType pos_j_z = atom_j_idx < N ? coords[atom_j_idx * 3 + 2] : 0;
 
         if (single_periodic_box) {
             // Recenter using **row** box center
-            pos_j_x -= bx*nearbyint((pos_j_x-row_bb_ctr_x)*inv_bx);
-            pos_j_y -= by*nearbyint((pos_j_y-row_bb_ctr_y)*inv_by);
-            pos_j_z -= bz*nearbyint((pos_j_z-row_bb_ctr_z)*inv_bz);
+            pos_j_x -= bx * nearbyint((pos_j_x - row_bb_ctr_x) * inv_bx);
+            pos_j_y -= by * nearbyint((pos_j_y - row_bb_ctr_y) * inv_by);
+            pos_j_z -= bz * nearbyint((pos_j_z - row_bb_ctr_z) * inv_bz);
 
-            non_periodic_dist_j = static_cast<RealType>(0.5) * (pos_j_x*pos_j_x + pos_j_y*pos_j_y + pos_j_z*pos_j_z);
+            non_periodic_dist_j =
+                static_cast<RealType>(0.5) * (pos_j_x * pos_j_x + pos_j_y * pos_j_y + pos_j_z * pos_j_z);
         }
 
-
         unsigned includeAtomFlags = 0;
-        while(atomFlags) {
-            const int row_atom = __ffs(atomFlags)-1;
-            atomFlags &= atomFlags-1;
+        while (atomFlags) {
+            const int row_atom = __ffs(atomFlags) - 1;
+            atomFlags &= atomFlags - 1;
             RealType row_i_x = __shfl_sync(FULL_MASK, pos_i_x, row_atom);
             RealType row_i_y = __shfl_sync(FULL_MASK, pos_i_y, row_atom);
             RealType row_i_z = __shfl_sync(FULL_MASK, pos_i_z, row_atom);
@@ -348,17 +350,19 @@ void __global__ k_find_blocks_with_ixns(
                 RealType atom_atom_dy = row_i_y - pos_j_y;
                 RealType atom_atom_dz = row_i_z - pos_j_z;
 
-                atom_atom_dx -= bx*nearbyint(atom_atom_dx*inv_bx);
-                atom_atom_dy -= by*nearbyint(atom_atom_dy*inv_by);
-                atom_atom_dz -= bz*nearbyint(atom_atom_dz*inv_bz);
+                atom_atom_dx -= bx * nearbyint(atom_atom_dx * inv_bx);
+                atom_atom_dy -= by * nearbyint(atom_atom_dy * inv_by);
+                atom_atom_dz -= bz * nearbyint(atom_atom_dz * inv_bz);
 
-                interacts |= (atom_atom_dx*atom_atom_dx + atom_atom_dy*atom_atom_dy + atom_atom_dz*atom_atom_dz) < cutoff_squared;
+                interacts |= (atom_atom_dx * atom_atom_dx + atom_atom_dy * atom_atom_dy + atom_atom_dz * atom_atom_dz) <
+                             cutoff_squared;
             } else {
                 // All threads in warp need single_periodic_box to be true for this not to hang
                 RealType corrected_i = __shfl_sync(FULL_MASK, non_periodic_dist_i, row_atom);
 
                 // Below is half the magnitude of the distance equation, expanded.
-                RealType half_dist = corrected_i + non_periodic_dist_j - row_i_x*pos_j_x - row_i_y*pos_j_y - row_i_z*pos_j_z;
+                RealType half_dist =
+                    corrected_i + non_periodic_dist_j - row_i_x * pos_j_x - row_i_y * pos_j_y - row_i_z * pos_j_z;
                 interacts |= half_dist < (static_cast<RealType>(0.5) * cutoff_squared);
             }
             includeAtomFlags = __ballot_sync(FULL_MASK, interacts);
@@ -370,28 +374,28 @@ void __global__ k_find_blocks_with_ixns(
 
         // Add any interacting atoms to the buffer.
         if (interacts) {
-            int index = neighborsInBuffer+__popc(includeAtomFlags & warpMask); // where to store this in shared memory
+            int index = neighborsInBuffer + __popc(includeAtomFlags & warpMask); // where to store this in shared memory
             // Indices can be at most 64
             ixn_j_buffer[index] = atom_j_idx;
         }
         neighborsInBuffer += __popc(includeAtomFlags);
 
-        if(neighborsInBuffer > WARPSIZE) {
+        if (neighborsInBuffer > WARPSIZE) {
             int tilesToStore = 1;
-            if(indexInWarp == 0) {
+            if (indexInWarp == 0) {
                 sync_start[0] = atomicAdd(interactionCount, tilesToStore);
             }
             __syncwarp();
             interactingTiles[sync_start[0]] = row_block_idx;
-            interactingAtoms[sync_start[0]*WARPSIZE + threadIdx.x] = ixn_j_buffer[threadIdx.x];
+            interactingAtoms[sync_start[0] * WARPSIZE + threadIdx.x] = ixn_j_buffer[threadIdx.x];
 
-            ixn_j_buffer[threadIdx.x] = ixn_j_buffer[WARPSIZE+threadIdx.x];
-            ixn_j_buffer[WARPSIZE+threadIdx.x] = N; // reset old values
+            ixn_j_buffer[threadIdx.x] = ixn_j_buffer[WARPSIZE + threadIdx.x];
+            ixn_j_buffer[WARPSIZE + threadIdx.x] = N; // reset old values
             neighborsInBuffer -= WARPSIZE;
         }
     }
 
     // store trim
     const int Y = gridDim.y;
-    trim_atoms[blockIdx.x*Y*WARPSIZE+blockIdx.y*WARPSIZE+threadIdx.x] = ixn_j_buffer[threadIdx.x];
+    trim_atoms[blockIdx.x * Y * WARPSIZE + blockIdx.y * WARPSIZE + threadIdx.x] = ixn_j_buffer[threadIdx.x];
 }

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -1,14 +1,13 @@
 #pragma once
 
-#include "surreal.cuh"
 #include "../fixed_point.hpp"
 #include "k_fixed_point.cuh"
 #include "kernel_utils.cuh"
+#include "surreal.cuh"
 #define WARPSIZE 32
 
 #define PI 3.141592653589793115997963468544185161
 #define TWO_OVER_SQRT_PI 1.128379167095512595889238330988549829708
-
 
 // generate kv values from coordinates to be radix sorted
 void __global__ k_coords_to_kv(
@@ -19,304 +18,277 @@ void __global__ k_coords_to_kv(
     unsigned int *keys,
     unsigned int *vals) {
 
-    const int atom_idx = blockIdx.x*blockDim.x + threadIdx.x;
+    const int atom_idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    if(atom_idx >= N) {
+    if (atom_idx >= N) {
         return;
     }
 
     // these coords have to be centered
-    double bx = box[0*3+0];
-    double by = box[1*3+1];
-    double bz = box[2*3+2];
+    double bx = box[0 * 3 + 0];
+    double by = box[1 * 3 + 1];
+    double bz = box[2 * 3 + 2];
 
-    double binWidth = max(max(bx, by), bz)/255.0;
+    double binWidth = max(max(bx, by), bz) / 255.0;
 
-    double x = coords[atom_idx*3+0];
-    double y = coords[atom_idx*3+1];
-    double z = coords[atom_idx*3+2];
+    double x = coords[atom_idx * 3 + 0];
+    double y = coords[atom_idx * 3 + 1];
+    double z = coords[atom_idx * 3 + 2];
 
-    x -= bx*floor(x/bx);
-    y -= by*floor(y/by);
-    z -= bz*floor(z/bz);
+    x -= bx * floor(x / bx);
+    y -= by * floor(y / by);
+    z -= bz * floor(z / bz);
 
-    unsigned int bin_x = x/binWidth;
-    unsigned int bin_y = y/binWidth;
-    unsigned int bin_z = z/binWidth;
+    unsigned int bin_x = x / binWidth;
+    unsigned int bin_y = y / binWidth;
+    unsigned int bin_z = z / binWidth;
 
-    keys[atom_idx] = bin_to_idx[bin_x*256*256+bin_y*256+bin_z];
+    keys[atom_idx] = bin_to_idx[bin_x * 256 * 256 + bin_y * 256 + bin_z];
     // uncomment below if you want to preserve the atom ordering
     // keys[atom_idx] = atom_idx;
     vals[atom_idx] = atom_idx;
-
 }
 
 template <typename RealType>
-void __global__ k_check_rebuild_box(
-    const int N,
-    const double *new_box,
-    const double *old_box,
-    int *rebuild) {
+void __global__ k_check_rebuild_box(const int N, const double *new_box, const double *old_box, int *rebuild) {
 
-    const int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    if(idx >= 9) {
+    if (idx >= 9) {
         return;
     }
 
     // (ytz): box vectors have exactly 9 components
     // we can probably derive a looser bound later on.
-    if(old_box[idx] != new_box[idx]) {
+    if (old_box[idx] != new_box[idx]) {
         rebuild[0] = 1;
     }
-
 }
 
 template <typename RealType>
 void __global__ k_check_rebuild_coords_and_box(
     const int N,
-    const double * __restrict__ new_coords,
-    const double * __restrict__ old_coords,
-    const double * __restrict__ new_box,
-    const double * __restrict__ old_box,
+    const double *__restrict__ new_coords,
+    const double *__restrict__ old_coords,
+    const double *__restrict__ new_box,
+    const double *__restrict__ old_box,
     const double padding,
     int *rebuild) {
 
-    const int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    if(idx < 9) {
+    if (idx < 9) {
         // (ytz): box vectors have exactly 9 components
         // we can probably derive a looser bound later on.
-        if(old_box[idx] != new_box[idx]) {
+        if (old_box[idx] != new_box[idx]) {
             rebuild[0] = 1;
         }
     }
 
-    if(idx >= N) {
+    if (idx >= N) {
         return;
     }
 
-    RealType xi = old_coords[idx*3+0];
-    RealType yi = old_coords[idx*3+1];
-    RealType zi = old_coords[idx*3+2];
+    RealType xi = old_coords[idx * 3 + 0];
+    RealType yi = old_coords[idx * 3 + 1];
+    RealType zi = old_coords[idx * 3 + 2];
 
-    RealType xj = new_coords[idx*3+0];
-    RealType yj = new_coords[idx*3+1];
-    RealType zj = new_coords[idx*3+2];
+    RealType xj = new_coords[idx * 3 + 0];
+    RealType yj = new_coords[idx * 3 + 1];
+    RealType zj = new_coords[idx * 3 + 2];
 
     RealType dx = xi - xj;
     RealType dy = yi - yj;
     RealType dz = zi - zj;
 
-    RealType d2ij = dx*dx + dy*dy + dz*dz;
-    if(d2ij > static_cast<RealType>(0.25)*padding*padding) {
+    RealType d2ij = dx * dx + dy * dy + dz * dz;
+    if (d2ij > static_cast<RealType>(0.25) * padding * padding) {
         // (ytz): this is *safe* but technically is a race condition
         rebuild[0] = 1;
     }
-
 }
 
-template<typename RealType>
+template <typename RealType>
 void __global__ k_copy_nblist_coords_and_box(
     const int N,
-    const int * __restrict__ rebuild,
-    const double * __restrict__ new_coords,
-    const double * __restrict__ new_box,
-    double * __restrict__ nblist_coords,
-    double * __restrict__ nblist_box
-) {
+    const int *__restrict__ rebuild,
+    const double *__restrict__ new_coords,
+    const double *__restrict__ new_box,
+    double *__restrict__ nblist_coords,
+    double *__restrict__ nblist_box) {
     if (rebuild[0] <= 0) {
         return;
     }
-    const int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    if(idx >= N) {
+    if (idx >= N) {
         return;
     }
-    if(idx < 9) {
+    if (idx < 9) {
         nblist_box[idx] = new_box[idx];
     }
-    #pragma unroll 3
-    for(int i = 0; i < 3; i++) {
-        nblist_coords[idx*3+i] = new_coords[idx*3+i];
+#pragma unroll 3
+    for (int i = 0; i < 3; i++) {
+        nblist_coords[idx * 3 + i] = new_coords[idx * 3 + i];
     }
 }
 
 template <typename RealType>
 void __global__ k_permute(
     const int N,
-    const unsigned int * __restrict__ perm,
-    const RealType * __restrict__ array,
-    RealType * __restrict__ sorted_array) {
+    const unsigned int *__restrict__ perm,
+    const RealType *__restrict__ array,
+    RealType *__restrict__ sorted_array) {
 
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int stride = gridDim.y;
     int stride_idx = blockIdx.y;
 
-    if(idx >= N) {
+    if (idx >= N) {
         return;
     }
 
-    sorted_array[idx*stride+stride_idx] = array[perm[idx]*stride+stride_idx];
-
+    sorted_array[idx * stride + stride_idx] = array[perm[idx] * stride + stride_idx];
 }
 
 template <typename RealType>
 void __global__ k_permute_2x(
     const int N,
-    const unsigned int * __restrict__ perm,
-    const RealType * __restrict__ array_1,
-    const RealType * __restrict__ array_2,
-    RealType * __restrict__ sorted_array_1,
-    RealType * __restrict__ sorted_array_2) {
+    const unsigned int *__restrict__ perm,
+    const RealType *__restrict__ array_1,
+    const RealType *__restrict__ array_2,
+    RealType *__restrict__ sorted_array_1,
+    RealType *__restrict__ sorted_array_2) {
 
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int stride = gridDim.y;
     int stride_idx = blockIdx.y;
 
-    if(idx >= N) {
+    if (idx >= N) {
         return;
     }
 
-    sorted_array_1[idx*stride+stride_idx] = array_1[perm[idx]*stride+stride_idx];
-    sorted_array_2[idx*stride+stride_idx] = array_2[perm[idx]*stride+stride_idx];
-
+    sorted_array_1[idx * stride + stride_idx] = array_1[perm[idx] * stride + stride_idx];
+    sorted_array_2[idx * stride + stride_idx] = array_2[perm[idx] * stride + stride_idx];
 }
-
 
 template <typename RealType>
 void __global__ k_inv_permute_accum(
     const int N,
-    const unsigned int * __restrict__ perm,
-    const RealType * __restrict__ sorted_array,
-    RealType * __restrict__ array) {
+    const unsigned int *__restrict__ perm,
+    const RealType *__restrict__ sorted_array,
+    RealType *__restrict__ array) {
 
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int stride = gridDim.y;
     int stride_idx = blockIdx.y;
 
-    if(idx >= N) {
+    if (idx >= N) {
         return;
     }
 
-    array[perm[idx]*stride+stride_idx] += sorted_array[idx*stride+stride_idx];
-
+    array[perm[idx] * stride + stride_idx] += sorted_array[idx * stride + stride_idx];
 }
 
 template <typename RealType>
 void __global__ k_inv_permute_assign(
     const int N,
-    const unsigned int * __restrict__ perm,
-    const RealType * __restrict__ sorted_array,
-    RealType * __restrict__ array) {
+    const unsigned int *__restrict__ perm,
+    const RealType *__restrict__ sorted_array,
+    RealType *__restrict__ array) {
 
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int stride = gridDim.y;
     int stride_idx = blockIdx.y;
 
-    if(idx >= N) {
+    if (idx >= N) {
         return;
     }
 
-    array[perm[idx]*stride+stride_idx] = sorted_array[idx*stride+stride_idx];
-
+    array[perm[idx] * stride + stride_idx] = sorted_array[idx * stride + stride_idx];
 }
-
 
 template <typename RealType>
 void __global__ k_inv_permute_assign_2x(
     const int N,
-    const unsigned int * __restrict__ perm,
-    const RealType * __restrict__ sorted_array_1,
-    const RealType * __restrict__ sorted_array_2,
-    RealType * __restrict__ array_1,
-    RealType * __restrict__ array_2) {
+    const unsigned int *__restrict__ perm,
+    const RealType *__restrict__ sorted_array_1,
+    const RealType *__restrict__ sorted_array_2,
+    RealType *__restrict__ array_1,
+    RealType *__restrict__ array_2) {
 
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int stride = gridDim.y;
     int stride_idx = blockIdx.y;
 
-    if(idx >= N) {
+    if (idx >= N) {
         return;
     }
 
-    array_1[perm[idx]*stride+stride_idx] = sorted_array_1[idx*stride+stride_idx];
-    array_2[perm[idx]*stride+stride_idx] = sorted_array_2[idx*stride+stride_idx];
-
+    array_1[perm[idx] * stride + stride_idx] = sorted_array_1[idx * stride + stride_idx];
+    array_2[perm[idx] * stride + stride_idx] = sorted_array_2[idx * stride + stride_idx];
 }
 
-
 template <typename RealType>
-void __global__ k_add_ull_to_real(
-    const int N,
-    const unsigned long long * __restrict__ ull_array,
-    RealType * __restrict__ real_array) {
+void __global__
+k_add_ull_to_real(const int N, const unsigned long long *__restrict__ ull_array, RealType *__restrict__ real_array) {
 
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int stride = gridDim.y;
     int stride_idx = blockIdx.y;
 
-    if(idx >= N) {
+    if (idx >= N) {
         return;
     }
 
     // handle charges, sigmas, epsilons with different exponents
-    if(stride_idx == 0) {
-        real_array[idx*stride+stride_idx] += FIXED_TO_FLOAT_DU_DP<RealType, FIXED_EXPONENT_DU_DCHARGE>(ull_array[idx*stride+stride_idx]);
-    } else if(stride_idx == 1) {
-        real_array[idx*stride+stride_idx] += FIXED_TO_FLOAT_DU_DP<RealType, FIXED_EXPONENT_DU_DSIG>(ull_array[idx*stride+stride_idx]);
-    } else if(stride_idx == 2) {
-        real_array[idx*stride+stride_idx] += FIXED_TO_FLOAT_DU_DP<RealType, FIXED_EXPONENT_DU_DEPS>(ull_array[idx*stride+stride_idx]);
+    if (stride_idx == 0) {
+        real_array[idx * stride + stride_idx] +=
+            FIXED_TO_FLOAT_DU_DP<RealType, FIXED_EXPONENT_DU_DCHARGE>(ull_array[idx * stride + stride_idx]);
+    } else if (stride_idx == 1) {
+        real_array[idx * stride + stride_idx] +=
+            FIXED_TO_FLOAT_DU_DP<RealType, FIXED_EXPONENT_DU_DSIG>(ull_array[idx * stride + stride_idx]);
+    } else if (stride_idx == 2) {
+        real_array[idx * stride + stride_idx] +=
+            FIXED_TO_FLOAT_DU_DP<RealType, FIXED_EXPONENT_DU_DEPS>(ull_array[idx * stride + stride_idx]);
     }
-
 }
 
+template <typename RealType> void __global__ k_reduce_buffer(int N, RealType *d_buffer, RealType *d_sum) {
 
-template<typename RealType>
-void __global__ k_reduce_buffer(
-    int N,
-    RealType *d_buffer,
-    RealType *d_sum) {
-
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
     RealType elem = idx < N ? d_buffer[idx] : 0;
 
     atomicAdd(d_sum, elem);
-
 };
 
-template<typename RealType>
-void __global__ k_reduce_ull_buffer(
-    int N,
-    unsigned long long *d_buffer,
-    RealType *d_sum) {
+template <typename RealType> void __global__ k_reduce_ull_buffer(int N, unsigned long long *d_buffer, RealType *d_sum) {
 
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
     RealType elem = idx < N ? FIXED_TO_FLOAT<RealType>(d_buffer[idx]) : 0;
 
     atomicAdd(d_sum, elem);
-
 };
 
 double __device__ __forceinline__ real_es_factor(double real_beta, double dij, double inv_d2ij, double &erfc_beta_dij) {
-    double beta_dij = real_beta*dij;
-    double exp_beta_dij_2 = exp(-beta_dij*beta_dij);
+    double beta_dij = real_beta * dij;
+    double exp_beta_dij_2 = exp(-beta_dij * beta_dij);
     erfc_beta_dij = erfc(beta_dij);
-    return -inv_d2ij*(static_cast<double>(TWO_OVER_SQRT_PI)*beta_dij*exp_beta_dij_2 + erfc_beta_dij);
+    return -inv_d2ij * (static_cast<double>(TWO_OVER_SQRT_PI) * beta_dij * exp_beta_dij_2 + erfc_beta_dij);
 }
 
 float __device__ __forceinline__ real_es_factor(float real_beta, float dij, float inv_d2ij, float &erfc_beta_dij) {
-    float beta_dij = real_beta*dij;
+    float beta_dij = real_beta * dij;
     // max ulp error is: 2 + floor(abs(1.16 * x))
-    float exp_beta_dij_2 = __expf(-beta_dij*beta_dij);
+    float exp_beta_dij_2 = __expf(-beta_dij * beta_dij);
     // 5th order gaussian polynomial approximation, we need the exp(-x^2) anyways for the chain rule
     // so we use last variant in https://en.wikipedia.org/wiki/Error_function#Approximation_with_elementary_functions
-    float t = 1.0f/(1.0f+0.3275911f*beta_dij);
-    erfc_beta_dij = (0.254829592f+(-0.284496736f+(1.421413741f+(-1.453152027f+1.061405429f*t)*t)*t)*t)*t*exp_beta_dij_2;
-    return -inv_d2ij*(static_cast<float>(TWO_OVER_SQRT_PI)*beta_dij*exp_beta_dij_2 + erfc_beta_dij);
+    float t = 1.0f / (1.0f + 0.3275911f * beta_dij);
+    erfc_beta_dij = (0.254829592f + (-0.284496736f + (1.421413741f + (-1.453152027f + 1.061405429f * t) * t) * t) * t) *
+                    t * exp_beta_dij_2;
+    return -inv_d2ij * (static_cast<float>(TWO_OVER_SQRT_PI) * beta_dij * exp_beta_dij_2 + erfc_beta_dij);
 }
-
 
 // These are two lines of code are to deal with the formation of a non-commutative fma.
 // For more information, see: https://github.com/proteneer/timemachine/issues/386
@@ -354,15 +326,11 @@ double __device__ __forceinline__ fix_nvidia_fmad(double a, double b, double c, 
 
 // } // 0 or 1, how much we offset from the plane by )
 
-
 // Compute the terms associated with electrostatics.
 // This is pulled out into a function to ensure that the same bit values
 // are computed to ensure that that the fixed point values are exactly the same regardless
 // of where the values are computed.
-template <
-    typename RealType,
-    bool COMPUTE_U
->
+template <typename RealType, bool COMPUTE_U>
 void __device__ __forceinline__ compute_electrostatics(
     const RealType charge_scale,
     const RealType qi,
@@ -374,18 +342,17 @@ void __device__ __forceinline__ compute_electrostatics(
     RealType &inv_d2ij,
     RealType &ebd,
     RealType &es_prefactor,
-    RealType &u
-) {
+    RealType &u) {
     inv_dij = rsqrt(d2ij);
 
-    dij = d2ij*inv_dij;
-    inv_d2ij = inv_dij*inv_dij;
+    dij = d2ij * inv_dij;
+    inv_d2ij = inv_dij * inv_dij;
 
-    RealType qij = qi*qj;
-    es_prefactor = charge_scale*qij*inv_dij*real_es_factor(beta, dij, inv_d2ij, ebd);
+    RealType qij = qi * qj;
+    es_prefactor = charge_scale * qij * inv_dij * real_es_factor(beta, dij, inv_d2ij, ebd);
 
     if (COMPUTE_U) {
-        u = charge_scale*qij*inv_dij*ebd;
+        u = charge_scale * qij * inv_dij * ebd;
     }
 }
 
@@ -393,10 +360,7 @@ void __device__ __forceinline__ compute_electrostatics(
 // This is pulled out into a function to ensure that the same bit values
 // are computed to ensure that that the fixed point values are exactly the same regardless
 // of where the values are computed.
-template <
-    typename RealType,
-    bool COMPUTE_U
->
+template <typename RealType, bool COMPUTE_U>
 void __device__ __forceinline__ compute_lj(
     RealType lj_scale,
     RealType eps_i,
@@ -408,28 +372,26 @@ void __device__ __forceinline__ compute_lj(
     RealType &u,
     RealType &delta_prefactor,
     RealType &sig_grad,
-    RealType &eps_grad
-) {
+    RealType &eps_grad) {
     RealType eps_ij = eps_i * eps_j;
     RealType sig_ij = sig_i + sig_j;
 
-    RealType sig_inv_dij = sig_ij*inv_dij;
-    RealType sig2_inv_d2ij = sig_inv_dij*sig_inv_dij;
-    RealType sig4_inv_d4ij = sig2_inv_d2ij*sig2_inv_d2ij;
-    RealType sig6_inv_d6ij = sig4_inv_d4ij*sig2_inv_d2ij;
-    RealType sig6_inv_d8ij = sig6_inv_d6ij*inv_d2ij;
-    RealType sig5_inv_d6ij = sig_ij*sig4_inv_d4ij*inv_d2ij;
+    RealType sig_inv_dij = sig_ij * inv_dij;
+    RealType sig2_inv_d2ij = sig_inv_dij * sig_inv_dij;
+    RealType sig4_inv_d4ij = sig2_inv_d2ij * sig2_inv_d2ij;
+    RealType sig6_inv_d6ij = sig4_inv_d4ij * sig2_inv_d2ij;
+    RealType sig6_inv_d8ij = sig6_inv_d6ij * inv_d2ij;
+    RealType sig5_inv_d6ij = sig_ij * sig4_inv_d4ij * inv_d2ij;
 
-    RealType lj_prefactor = lj_scale*eps_ij*sig6_inv_d8ij*(sig6_inv_d6ij*48 - 24);
-    if(COMPUTE_U) {
-        u += lj_scale*4*eps_ij*(sig6_inv_d6ij-1)*sig6_inv_d6ij;
+    RealType lj_prefactor = lj_scale * eps_ij * sig6_inv_d8ij * (sig6_inv_d6ij * 48 - 24);
+    if (COMPUTE_U) {
+        u += lj_scale * 4 * eps_ij * (sig6_inv_d6ij - 1) * sig6_inv_d6ij;
     }
 
     delta_prefactor -= lj_prefactor;
 
-    sig_grad = lj_scale*24*eps_ij*sig5_inv_d6ij*(2*sig6_inv_d6ij-1);
-    eps_grad = lj_scale*4*(sig6_inv_d6ij-1)*sig6_inv_d6ij;
-
+    sig_grad = lj_scale * 24 * eps_ij * sig5_inv_d6ij * (2 * sig6_inv_d6ij - 1);
+    eps_grad = lj_scale * 4 * (sig6_inv_d6ij - 1) * sig6_inv_d6ij;
 }
 
 // ALCHEMICAL == false guarantees that the tile's atoms are such that
@@ -443,53 +405,52 @@ template <
     bool COMPUTE_U,
     bool COMPUTE_DU_DX,
     bool COMPUTE_DU_DL,
-    bool COMPUTE_DU_DP
->
+    bool COMPUTE_DU_DP>
 // void __device__ __forceinline__ v_nonbonded_unified(
 void __device__ v_nonbonded_unified(
     const int N,
-    const double * __restrict__ coords,
-    const double * __restrict__ params, // [N]
-    const double * __restrict__ box,
-    const double * __restrict__ dp_dl,
-    const double * __restrict__ coords_w, // 4D coords
-    const double * __restrict__ dw_dl, // 4D derivatives
+    const double *__restrict__ coords,
+    const double *__restrict__ params, // [N]
+    const double *__restrict__ box,
+    const double *__restrict__ dp_dl,
+    const double *__restrict__ coords_w, // 4D coords
+    const double *__restrict__ dw_dl,    // 4D derivatives
     const double lambda,
     // const int * __restrict__ lambda_plane_idxs, // 0 or 1, shift
     // const int * __restrict__ lambda_offset_idxs, // 0 or 1, how much we offset from the plane by cutoff
     const double beta,
     const double cutoff,
-    const int * __restrict__ ixn_tiles,
-    const unsigned int * __restrict__ ixn_atoms,
-    unsigned long long * __restrict__ du_dx,
-    unsigned long long * __restrict__ du_dp,
-    unsigned long long * __restrict__ du_dl_buffer,
-    unsigned long long * __restrict__ u_buffer) {
+    const int *__restrict__ ixn_tiles,
+    const unsigned int *__restrict__ ixn_atoms,
+    unsigned long long *__restrict__ du_dx,
+    unsigned long long *__restrict__ du_dp,
+    unsigned long long *__restrict__ du_dl_buffer,
+    unsigned long long *__restrict__ u_buffer) {
 
     int tile_idx = blockIdx.x;
 
-    RealType box_x = box[0*3+0];
-    RealType box_y = box[1*3+1];
-    RealType box_z = box[2*3+2];
+    RealType box_x = box[0 * 3 + 0];
+    RealType box_y = box[1 * 3 + 1];
+    RealType box_z = box[2 * 3 + 2];
 
-    RealType inv_box_x = 1/box_x;
-    RealType inv_box_y = 1/box_y;
-    RealType inv_box_z = 1/box_z;
+    RealType inv_box_x = 1 / box_x;
+    RealType inv_box_y = 1 / box_y;
+    RealType inv_box_z = 1 / box_z;
 
     int row_block_idx = ixn_tiles[tile_idx];
 
-    int atom_i_idx = row_block_idx*32 + threadIdx.x;
+    int atom_i_idx = row_block_idx * 32 + threadIdx.x;
     // int lambda_offset_i = atom_i_idx < N ? lambda_offset_idxs[atom_i_idx] : 0;
     // int lambda_plane_i = atom_i_idx < N ? lambda_plane_idxs[atom_i_idx] : 0;
 
-    RealType ci_x = atom_i_idx < N ? coords[atom_i_idx*3+0] : 0;
-    RealType ci_y = atom_i_idx < N ? coords[atom_i_idx*3+1] : 0;
-    RealType ci_z = atom_i_idx < N ? coords[atom_i_idx*3+2] : 0;
+    RealType ci_x = atom_i_idx < N ? coords[atom_i_idx * 3 + 0] : 0;
+    RealType ci_y = atom_i_idx < N ? coords[atom_i_idx * 3 + 1] : 0;
+    RealType ci_z = atom_i_idx < N ? coords[atom_i_idx * 3 + 2] : 0;
     RealType ci_w = atom_i_idx < N ? coords_w[atom_i_idx] : 0;
 
-    RealType dq_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+0] : 0;
-    RealType dsig_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+1] : 0;
-    RealType deps_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+2] : 0;
+    RealType dq_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx * 3 + 0] : 0;
+    RealType dsig_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx * 3 + 1] : 0;
+    RealType deps_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx * 3 + 2] : 0;
     RealType dw_dl_i = atom_i_idx < N ? dw_dl[atom_i_idx] : 0;
 
     unsigned long long gi_x = 0;
@@ -497,9 +458,9 @@ void __device__ v_nonbonded_unified(
     unsigned long long gi_z = 0;
     unsigned long long du_dl = 0;
 
-    int charge_param_idx_i = atom_i_idx*3 + 0;
-    int lj_param_idx_sig_i = atom_i_idx*3 + 1;
-    int lj_param_idx_eps_i = atom_i_idx*3 + 2;
+    int charge_param_idx_i = atom_i_idx * 3 + 0;
+    int lj_param_idx_sig_i = atom_i_idx * 3 + 1;
+    int lj_param_idx_eps_i = atom_i_idx * 3 + 2;
 
     RealType qi = atom_i_idx < N ? params[charge_param_idx_i] : 0;
     RealType sig_i = atom_i_idx < N ? params[lj_param_idx_sig_i] : 0;
@@ -510,27 +471,27 @@ void __device__ v_nonbonded_unified(
     unsigned long long g_epsi = 0;
 
     // i idx is contiguous but j is not, so we should swap them to avoid having to shuffle atom_j_idx
-    int atom_j_idx = ixn_atoms[tile_idx*32 + threadIdx.x];
+    int atom_j_idx = ixn_atoms[tile_idx * 32 + threadIdx.x];
     // int lambda_offset_j = atom_j_idx < N ? lambda_offset_idxs[atom_j_idx] : 0;
     // int lambda_plane_j = atom_j_idx < N ? lambda_plane_idxs[atom_j_idx] : 0;
 
-    RealType cj_x = atom_j_idx < N ? coords[atom_j_idx*3+0] : 0;
-    RealType cj_y = atom_j_idx < N ? coords[atom_j_idx*3+1] : 0;
-    RealType cj_z = atom_j_idx < N ? coords[atom_j_idx*3+2] : 0;
+    RealType cj_x = atom_j_idx < N ? coords[atom_j_idx * 3 + 0] : 0;
+    RealType cj_y = atom_j_idx < N ? coords[atom_j_idx * 3 + 1] : 0;
+    RealType cj_z = atom_j_idx < N ? coords[atom_j_idx * 3 + 2] : 0;
     RealType cj_w = atom_j_idx < N ? coords_w[atom_j_idx] : 0;
 
-    RealType dq_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+0] : 0;
-    RealType dsig_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+1] : 0;
-    RealType deps_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+2] : 0;
+    RealType dq_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx * 3 + 0] : 0;
+    RealType dsig_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx * 3 + 1] : 0;
+    RealType deps_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx * 3 + 2] : 0;
     RealType dw_dl_j = atom_j_idx < N ? dw_dl[atom_j_idx] : 0;
 
     unsigned long long gj_x = 0;
     unsigned long long gj_y = 0;
     unsigned long long gj_z = 0;
 
-    int charge_param_idx_j = atom_j_idx*3 + 0;
-    int lj_param_idx_sig_j = atom_j_idx*3 + 1;
-    int lj_param_idx_eps_j = atom_j_idx*3 + 2;
+    int charge_param_idx_j = atom_j_idx * 3 + 0;
+    int lj_param_idx_sig_j = atom_j_idx * 3 + 1;
+    int lj_param_idx_eps_j = atom_j_idx * 3 + 2;
 
     RealType qj = atom_j_idx < N ? params[charge_param_idx_j] : 0;
     RealType sig_j = atom_j_idx < N ? params[lj_param_idx_sig_j] : 0;
@@ -541,7 +502,7 @@ void __device__ v_nonbonded_unified(
     unsigned long long g_epsj = 0;
 
     RealType real_cutoff = static_cast<RealType>(cutoff);
-    RealType cutoff_squared = real_cutoff*real_cutoff;
+    RealType cutoff_squared = real_cutoff * real_cutoff;
 
     unsigned long long energy = 0;
 
@@ -550,20 +511,20 @@ void __device__ v_nonbonded_unified(
 
     const int srcLane = (threadIdx.x + 1) % WARPSIZE; // fixed
     // #pragma unroll
-    for(int round = 0; round < 32; round++) {
+    for (int round = 0; round < 32; round++) {
 
         RealType delta_x = ci_x - cj_x;
         RealType delta_y = ci_y - cj_y;
         RealType delta_z = ci_z - cj_z;
 
-        delta_x -= box_x*nearbyint(delta_x*inv_box_x);
-        delta_y -= box_y*nearbyint(delta_y*inv_box_y);
-        delta_z -= box_z*nearbyint(delta_z*inv_box_z);
+        delta_x -= box_x * nearbyint(delta_x * inv_box_x);
+        delta_y -= box_y * nearbyint(delta_y * inv_box_y);
+        delta_z -= box_z * nearbyint(delta_z * inv_box_z);
 
-        RealType d2ij = delta_x*delta_x + delta_y*delta_y + delta_z*delta_z;
+        RealType d2ij = delta_x * delta_x + delta_y * delta_y + delta_z * delta_z;
         RealType delta_w;
 
-        if(ALCHEMICAL) {
+        if (ALCHEMICAL) {
             // (ytz): we are guaranteed that delta_w is zero if ALCHEMICAL == false
             // delta_w = (lambda_plane_i - lambda_plane_j)*real_cutoff + (lambda_offset_i - lambda_offset_j)*real_lambda*real_cutoff;
             delta_w = ci_w - cj_w;
@@ -573,7 +534,7 @@ void __device__ v_nonbonded_unified(
         // (ytz): note that d2ij must be *strictly* less than cutoff_squared. This is because we set the
         // non-interacting atoms to exactly real_cutoff*real_cutoff. This ensures that atoms who's 4th dimension
         // is set to cutoff are non-interacting.
-        if(d2ij < cutoff_squared && atom_j_idx > atom_i_idx && atom_j_idx < N && atom_i_idx < N) {
+        if (d2ij < cutoff_squared && atom_j_idx > atom_i_idx && atom_j_idx < N && atom_i_idx < N) {
 
             // electrostatics
             RealType u;
@@ -583,70 +544,59 @@ void __device__ v_nonbonded_unified(
             RealType inv_dij;
             RealType inv_d2ij;
             compute_electrostatics<RealType, COMPUTE_U>(
-                1.0,
-                qi,
-                qj,
-                d2ij,
-                beta,
-                dij,
-                inv_dij,
-                inv_d2ij,
-                ebd,
-                es_prefactor,
-                u
-            );
+                1.0, qi, qj, d2ij, beta, dij, inv_dij, inv_d2ij, ebd, es_prefactor, u);
 
             RealType delta_prefactor = es_prefactor;
 
             RealType real_du_dl = 0;
 
             // lennard jones force
-            if(eps_i != 0 && eps_j != 0) {
+            if (eps_i != 0 && eps_j != 0) {
                 RealType sig_grad;
                 RealType eps_grad;
-                compute_lj<RealType, COMPUTE_U>(1.0, eps_i, eps_j, sig_i, sig_j, inv_dij, inv_d2ij, u, delta_prefactor, sig_grad, eps_grad);
+                compute_lj<RealType, COMPUTE_U>(
+                    1.0, eps_i, eps_j, sig_i, sig_j, inv_dij, inv_d2ij, u, delta_prefactor, sig_grad, eps_grad);
 
                 // do chain rule inside loop
-                if(COMPUTE_DU_DP) {
+                if (COMPUTE_DU_DP) {
                     g_sigi += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DSIG>(sig_grad);
                     g_sigj += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DSIG>(sig_grad);
-                    g_epsi += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DEPS>(eps_grad*eps_j);
-                    g_epsj += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DEPS>(eps_grad*eps_i);
+                    g_epsi += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DEPS>(eps_grad * eps_j);
+                    g_epsj += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DEPS>(eps_grad * eps_i);
                 }
 
-                if(COMPUTE_DU_DL && ALCHEMICAL) {
-                    real_du_dl += sig_grad*(dsig_dl_i + dsig_dl_j);
-                    RealType term = eps_grad*fix_nvidia_fmad(eps_j, deps_dl_i, eps_i, deps_dl_j);
+                if (COMPUTE_DU_DL && ALCHEMICAL) {
+                    real_du_dl += sig_grad * (dsig_dl_i + dsig_dl_j);
+                    RealType term = eps_grad * fix_nvidia_fmad(eps_j, deps_dl_i, eps_i, deps_dl_j);
                     real_du_dl += term;
                 }
             }
 
-            if(COMPUTE_DU_DX) {
-                gi_x += FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_x);
-                gi_y += FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_y);
-                gi_z += FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_z);
+            if (COMPUTE_DU_DX) {
+                gi_x += FLOAT_TO_FIXED_NONBONDED(delta_prefactor * delta_x);
+                gi_y += FLOAT_TO_FIXED_NONBONDED(delta_prefactor * delta_y);
+                gi_z += FLOAT_TO_FIXED_NONBONDED(delta_prefactor * delta_z);
 
-                gj_x += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_x);
-                gj_y += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_y);
-                gj_z += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_z);
+                gj_x += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor * delta_x);
+                gj_y += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor * delta_y);
+                gj_z += FLOAT_TO_FIXED_NONBONDED(-delta_prefactor * delta_z);
             }
 
-            if(COMPUTE_DU_DP) {
-                g_qi += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DCHARGE>(qj*inv_dij*ebd);
-                g_qj += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DCHARGE>(qi*inv_dij*ebd);
+            if (COMPUTE_DU_DP) {
+                g_qi += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DCHARGE>(qj * inv_dij * ebd);
+                g_qj += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DCHARGE>(qi * inv_dij * ebd);
             }
 
-            if(COMPUTE_DU_DL && ALCHEMICAL) {
+            if (COMPUTE_DU_DL && ALCHEMICAL) {
                 // needed for cancellation of nans (if one term blows up)
-                real_du_dl += delta_w*delta_prefactor*(dw_dl_i - dw_dl_j);
-                real_du_dl += inv_dij*ebd*fix_nvidia_fmad(qj, dq_dl_i, qi, dq_dl_j);
+                real_du_dl += delta_w * delta_prefactor * (dw_dl_i - dw_dl_j);
+                real_du_dl += inv_dij * ebd * fix_nvidia_fmad(qj, dq_dl_i, qi, dq_dl_j);
                 du_dl += FLOAT_TO_FIXED_NONBONDED(real_du_dl);
             }
 
-            if(COMPUTE_U) {
+            if (COMPUTE_U) {
                 energy += FLOAT_TO_FIXED_NONBONDED(u);
             }
-
         }
 
         atom_j_idx = __shfl_sync(0xffffffff, atom_j_idx, srcLane); // we can pre-compute this probably
@@ -658,52 +608,51 @@ void __device__ v_nonbonded_unified(
         cj_y = __shfl_sync(0xffffffff, cj_y, srcLane);
         cj_z = __shfl_sync(0xffffffff, cj_z, srcLane);
 
-        if(ALCHEMICAL) {
+        if (ALCHEMICAL) {
             cj_w = __shfl_sync(0xffffffff, cj_w, srcLane); // this also can be optimized away
             dw_dl_j = __shfl_sync(0xffffffff, dw_dl_j, srcLane);
         }
 
-        if(COMPUTE_DU_DX) {
+        if (COMPUTE_DU_DX) {
             gj_x = __shfl_sync(0xffffffff, gj_x, srcLane);
             gj_y = __shfl_sync(0xffffffff, gj_y, srcLane);
             gj_z = __shfl_sync(0xffffffff, gj_z, srcLane);
         }
 
-        if(COMPUTE_DU_DP) {
+        if (COMPUTE_DU_DP) {
             g_qj = __shfl_sync(0xffffffff, g_qj, srcLane);
             g_sigj = __shfl_sync(0xffffffff, g_sigj, srcLane);
             g_epsj = __shfl_sync(0xffffffff, g_epsj, srcLane);
         }
 
-        if(COMPUTE_DU_DL && ALCHEMICAL) {
+        if (COMPUTE_DU_DL && ALCHEMICAL) {
             dsig_dl_j = __shfl_sync(0xffffffff, dsig_dl_j, srcLane);
             deps_dl_j = __shfl_sync(0xffffffff, deps_dl_j, srcLane);
             dq_dl_j = __shfl_sync(0xffffffff, dq_dl_j, srcLane);
         }
-
     }
 
-    if(COMPUTE_DU_DX) {
-        if(atom_i_idx < N) {
-            atomicAdd(du_dx + atom_i_idx*3 + 0, gi_x);
-            atomicAdd(du_dx + atom_i_idx*3 + 1, gi_y);
-            atomicAdd(du_dx + atom_i_idx*3 + 2, gi_z);
+    if (COMPUTE_DU_DX) {
+        if (atom_i_idx < N) {
+            atomicAdd(du_dx + atom_i_idx * 3 + 0, gi_x);
+            atomicAdd(du_dx + atom_i_idx * 3 + 1, gi_y);
+            atomicAdd(du_dx + atom_i_idx * 3 + 2, gi_z);
         }
-        if(atom_j_idx < N) {
-            atomicAdd(du_dx + atom_j_idx*3 + 0, gj_x);
-            atomicAdd(du_dx + atom_j_idx*3 + 1, gj_y);
-            atomicAdd(du_dx + atom_j_idx*3 + 2, gj_z);
+        if (atom_j_idx < N) {
+            atomicAdd(du_dx + atom_j_idx * 3 + 0, gj_x);
+            atomicAdd(du_dx + atom_j_idx * 3 + 1, gj_y);
+            atomicAdd(du_dx + atom_j_idx * 3 + 2, gj_z);
         }
     }
 
-    if(COMPUTE_DU_DP) {
-        if(atom_i_idx < N) {
+    if (COMPUTE_DU_DP) {
+        if (atom_i_idx < N) {
             atomicAdd(du_dp + charge_param_idx_i, g_qi);
             atomicAdd(du_dp + lj_param_idx_sig_i, g_sigi);
             atomicAdd(du_dp + lj_param_idx_eps_i, g_epsi);
         }
 
-        if(atom_j_idx < N) {
+        if (atom_j_idx < N) {
             atomicAdd(du_dp + charge_param_idx_j, g_qj);
             atomicAdd(du_dp + lj_param_idx_sig_j, g_sigj);
             atomicAdd(du_dp + lj_param_idx_eps_j, g_epsj);
@@ -711,76 +660,61 @@ void __device__ v_nonbonded_unified(
     }
 
     // these are buffered and then reduced to avoid massive conflicts
-    if(COMPUTE_DU_DL && ALCHEMICAL) {
-        if(atom_i_idx < N) {
+    if (COMPUTE_DU_DL && ALCHEMICAL) {
+        if (atom_i_idx < N) {
             atomicAdd(du_dl_buffer + atom_i_idx, du_dl);
         }
     }
 
-    if(COMPUTE_U) {
-        if(atom_i_idx < N) {
+    if (COMPUTE_U) {
+        if (atom_i_idx < N) {
             atomicAdd(u_buffer + atom_i_idx, energy);
         }
     }
-
 }
 
-
-template <
-    typename RealType,
-    bool COMPUTE_U,
-    bool COMPUTE_DU_DX,
-    bool COMPUTE_DU_DL,
-    bool COMPUTE_DU_DP
->
+template <typename RealType, bool COMPUTE_U, bool COMPUTE_DU_DX, bool COMPUTE_DU_DL, bool COMPUTE_DU_DP>
 void __global__ k_nonbonded_unified(
     const int N,
-    const double * __restrict__ coords,
-    const double * __restrict__ params, // [N]
-    const double * __restrict__ box,
-    const double * __restrict__ dp_dl,
-    const double * __restrict__ coords_w, // 4D coords
-    const double * __restrict__ dw_dl, // 4D derivatives
+    const double *__restrict__ coords,
+    const double *__restrict__ params, // [N]
+    const double *__restrict__ box,
+    const double *__restrict__ dp_dl,
+    const double *__restrict__ coords_w, // 4D coords
+    const double *__restrict__ dw_dl,    // 4D derivatives
     const double lambda,
     const double beta,
     const double cutoff,
-    const int * __restrict__ ixn_tiles,
-    const unsigned int * __restrict__ ixn_atoms,
-    unsigned long long * __restrict__ du_dx,
-    unsigned long long * __restrict__ du_dp,
-    unsigned long long * __restrict__ du_dl_buffer,
-    unsigned long long * __restrict__ u_buffer) {
+    const int *__restrict__ ixn_tiles,
+    const unsigned int *__restrict__ ixn_atoms,
+    unsigned long long *__restrict__ du_dx,
+    unsigned long long *__restrict__ du_dp,
+    unsigned long long *__restrict__ du_dl_buffer,
+    unsigned long long *__restrict__ u_buffer) {
 
     int tile_idx = blockIdx.x;
     int row_block_idx = ixn_tiles[tile_idx];
-    int atom_i_idx = row_block_idx*32 + threadIdx.x;
+    int atom_i_idx = row_block_idx * 32 + threadIdx.x;
 
-    RealType dq_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+0] : 0;
-    RealType dsig_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+1] : 0;
-    RealType deps_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx*3+2] : 0;
+    RealType dq_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx * 3 + 0] : 0;
+    RealType dsig_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx * 3 + 1] : 0;
+    RealType deps_dl_i = atom_i_idx < N ? dp_dl[atom_i_idx * 3 + 2] : 0;
     RealType cw_i = atom_i_idx < N ? coords_w[atom_i_idx] : 0;
 
-    int atom_j_idx = ixn_atoms[tile_idx*32 + threadIdx.x];
+    int atom_j_idx = ixn_atoms[tile_idx * 32 + threadIdx.x];
 
-    RealType dq_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+0] : 0;
-    RealType dsig_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+1] : 0;
-    RealType deps_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx*3+2] : 0;
+    RealType dq_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx * 3 + 0] : 0;
+    RealType dsig_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx * 3 + 1] : 0;
+    RealType deps_dl_j = atom_j_idx < N ? dp_dl[atom_j_idx * 3 + 2] : 0;
     RealType cw_j = atom_j_idx < N ? coords_w[atom_j_idx] : 0;
 
-    int is_vanilla = (
-        cw_i == 0 &&
-        dq_dl_i == 0 &&
-        dsig_dl_i == 0 &&
-        deps_dl_i == 0 &&
-        cw_j == 0 &&
-        dq_dl_j == 0 &&
-        dsig_dl_j == 0 &&
-        deps_dl_j == 0
-    );
+    int is_vanilla =
+        (cw_i == 0 && dq_dl_i == 0 && dsig_dl_i == 0 && deps_dl_i == 0 && cw_j == 0 && dq_dl_j == 0 && dsig_dl_j == 0 &&
+         deps_dl_j == 0);
 
     bool tile_is_vanilla = __all_sync(0xffffffff, is_vanilla);
 
-    if(tile_is_vanilla) {
+    if (tile_is_vanilla) {
         v_nonbonded_unified<RealType, 0, COMPUTE_U, COMPUTE_DU_DX, COMPUTE_DU_DL, COMPUTE_DU_DP>(
             N,
             coords,
@@ -797,8 +731,7 @@ void __global__ k_nonbonded_unified(
             du_dx,
             du_dp,
             du_dl_buffer,
-            u_buffer
-        );
+            u_buffer);
     } else {
         v_nonbonded_unified<RealType, 1, COMPUTE_U, COMPUTE_DU_DX, COMPUTE_DU_DL, COMPUTE_DU_DP>(
             N,
@@ -816,32 +749,29 @@ void __global__ k_nonbonded_unified(
             du_dx,
             du_dp,
             du_dl_buffer,
-            u_buffer
-        );
+            u_buffer);
     };
-
-
 }
 
 // tbd add restrict
-template<typename RealType>
+template <typename RealType>
 void __global__ k_nonbonded_exclusions(
     const int E, // number of exclusions
-    const double * __restrict__ coords,
-    const double * __restrict__ params,
-    const double * __restrict__ box,
-    const double * __restrict__ dp_dl,
-    const double * __restrict__ coords_w, // 4D coords
-    const double * __restrict__ dw_dl, // 4D derivatives
+    const double *__restrict__ coords,
+    const double *__restrict__ params,
+    const double *__restrict__ box,
+    const double *__restrict__ dp_dl,
+    const double *__restrict__ coords_w, // 4D coords
+    const double *__restrict__ dw_dl,    // 4D derivatives
     const double lambda,
-    const int * __restrict__ exclusion_idxs, // [E, 2] pair-list of atoms to be excluded
-    const double * __restrict__ scales, // [E]
+    const int *__restrict__ exclusion_idxs, // [E, 2] pair-list of atoms to be excluded
+    const double *__restrict__ scales,      // [E]
     const double beta,
     const double cutoff,
-    unsigned long long * __restrict__ du_dx,
-    unsigned long long * __restrict__ du_dp,
-    unsigned long long * __restrict__ du_dl_buffer,
-    unsigned long long * __restrict__ u_buffer) {
+    unsigned long long *__restrict__ du_dx,
+    unsigned long long *__restrict__ du_dp,
+    unsigned long long *__restrict__ du_dl_buffer,
+    unsigned long long *__restrict__ u_buffer) {
 
     // (ytz): oddly enough the order of atom_i and atom_j
     // seem to not matter. I think this is because distance calculations
@@ -850,30 +780,30 @@ void __global__ k_nonbonded_exclusions(
     // that of the nonbonded kernel itself. Remember that floating points
     // commute but are not associative.
 
-    const int e_idx = blockIdx.x*blockDim.x + threadIdx.x;
-    if(e_idx >= E) {
+    const int e_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (e_idx >= E) {
         return;
     }
 
-    int atom_i_idx = exclusion_idxs[e_idx*2 + 0];
+    int atom_i_idx = exclusion_idxs[e_idx * 2 + 0];
 
-    RealType ci_x = coords[atom_i_idx*3+0];
-    RealType ci_y = coords[atom_i_idx*3+1];
-    RealType ci_z = coords[atom_i_idx*3+2];
+    RealType ci_x = coords[atom_i_idx * 3 + 0];
+    RealType ci_y = coords[atom_i_idx * 3 + 1];
+    RealType ci_z = coords[atom_i_idx * 3 + 2];
     RealType ci_w = coords_w[atom_i_idx];
 
-    RealType dq_dl_i = dp_dl[atom_i_idx*3+0];
-    RealType dsig_dl_i = dp_dl[atom_i_idx*3+1];
-    RealType deps_dl_i = dp_dl[atom_i_idx*3+2];
+    RealType dq_dl_i = dp_dl[atom_i_idx * 3 + 0];
+    RealType dsig_dl_i = dp_dl[atom_i_idx * 3 + 1];
+    RealType deps_dl_i = dp_dl[atom_i_idx * 3 + 2];
     RealType dw_dl_i = dw_dl[atom_i_idx];
 
     unsigned long long gi_x = 0;
     unsigned long long gi_y = 0;
     unsigned long long gi_z = 0;
 
-    int charge_param_idx_i = atom_i_idx*3 + 0;
-    int lj_param_idx_sig_i = atom_i_idx*3 + 1;
-    int lj_param_idx_eps_i = atom_i_idx*3 + 2;
+    int charge_param_idx_i = atom_i_idx * 3 + 0;
+    int lj_param_idx_sig_i = atom_i_idx * 3 + 1;
+    int lj_param_idx_eps_i = atom_i_idx * 3 + 2;
 
     RealType qi = params[charge_param_idx_i];
     RealType sig_i = params[lj_param_idx_sig_i];
@@ -883,25 +813,25 @@ void __global__ k_nonbonded_exclusions(
     unsigned long long g_sigi = 0;
     unsigned long long g_epsi = 0;
 
-    int atom_j_idx = exclusion_idxs[e_idx*2 + 1];
+    int atom_j_idx = exclusion_idxs[e_idx * 2 + 1];
 
-    RealType cj_x = coords[atom_j_idx*3+0];
-    RealType cj_y = coords[atom_j_idx*3+1];
-    RealType cj_z = coords[atom_j_idx*3+2];
+    RealType cj_x = coords[atom_j_idx * 3 + 0];
+    RealType cj_y = coords[atom_j_idx * 3 + 1];
+    RealType cj_z = coords[atom_j_idx * 3 + 2];
     RealType cj_w = coords_w[atom_j_idx];
 
-    RealType dq_dl_j = dp_dl[atom_j_idx*3+0];
-    RealType dsig_dl_j = dp_dl[atom_j_idx*3+1];
-    RealType deps_dl_j = dp_dl[atom_j_idx*3+2];
+    RealType dq_dl_j = dp_dl[atom_j_idx * 3 + 0];
+    RealType dsig_dl_j = dp_dl[atom_j_idx * 3 + 1];
+    RealType deps_dl_j = dp_dl[atom_j_idx * 3 + 2];
     RealType dw_dl_j = dw_dl[atom_j_idx];
 
     unsigned long long gj_x = 0;
     unsigned long long gj_y = 0;
     unsigned long long gj_z = 0;
 
-    int charge_param_idx_j = atom_j_idx*3+0;
-    int lj_param_idx_sig_j = atom_j_idx*3 + 1;
-    int lj_param_idx_eps_j = atom_j_idx*3 + 2;
+    int charge_param_idx_j = atom_j_idx * 3 + 0;
+    int lj_param_idx_sig_j = atom_j_idx * 3 + 1;
+    int lj_param_idx_eps_j = atom_j_idx * 3 + 2;
 
     RealType qj = params[charge_param_idx_j];
     RealType sig_j = params[lj_param_idx_sig_j];
@@ -915,45 +845,38 @@ void __global__ k_nonbonded_exclusions(
     RealType real_beta = static_cast<RealType>(beta);
 
     RealType real_cutoff = static_cast<RealType>(cutoff);
-    RealType cutoff_squared = real_cutoff*real_cutoff;
+    RealType cutoff_squared = real_cutoff * real_cutoff;
 
-    RealType charge_scale = scales[e_idx*2 + 0];
-    RealType lj_scale = scales[e_idx*2 + 1];
+    RealType charge_scale = scales[e_idx * 2 + 0];
+    RealType lj_scale = scales[e_idx * 2 + 1];
 
-    RealType box_x = box[0*3+0];
-    RealType box_y = box[1*3+1];
-    RealType box_z = box[2*3+2];
+    RealType box_x = box[0 * 3 + 0];
+    RealType box_y = box[1 * 3 + 1];
+    RealType box_z = box[2 * 3 + 2];
 
-    RealType inv_box_x = 1/box_x;
-    RealType inv_box_y = 1/box_y;
-    RealType inv_box_z = 1/box_z;
+    RealType inv_box_x = 1 / box_x;
+    RealType inv_box_y = 1 / box_y;
+    RealType inv_box_z = 1 / box_z;
 
     RealType delta_x = ci_x - cj_x;
     RealType delta_y = ci_y - cj_y;
     RealType delta_z = ci_z - cj_z;
 
-    delta_x -= box_x*nearbyint(delta_x*inv_box_x);
-    delta_y -= box_y*nearbyint(delta_y*inv_box_y);
-    delta_z -= box_z*nearbyint(delta_z*inv_box_z);
+    delta_x -= box_x * nearbyint(delta_x * inv_box_x);
+    delta_y -= box_y * nearbyint(delta_y * inv_box_y);
+    delta_z -= box_z * nearbyint(delta_z * inv_box_z);
 
     RealType delta_w = ci_w - cj_w;
-    RealType d2ij = delta_x*delta_x + delta_y*delta_y + delta_z*delta_z + delta_w*delta_w;
+    RealType d2ij = delta_x * delta_x + delta_y * delta_y + delta_z * delta_z + delta_w * delta_w;
 
     unsigned long long energy = 0;
 
-    int is_vanilla = (
-        ci_w == 0 &&
-        dq_dl_i == 0 &&
-        dsig_dl_i == 0 &&
-        deps_dl_i == 0 &&
-        cj_w == 0 &&
-        dq_dl_j == 0 &&
-        dsig_dl_j == 0 &&
-        deps_dl_j == 0
-    );
+    int is_vanilla =
+        (ci_w == 0 && dq_dl_i == 0 && dsig_dl_i == 0 && deps_dl_i == 0 && cj_w == 0 && dq_dl_j == 0 && dsig_dl_j == 0 &&
+         deps_dl_j == 0);
 
     // see note: this must be strictly less than
-    if(d2ij < cutoff_squared) {
+    if (d2ij < cutoff_squared) {
 
         RealType u;
         RealType ebd;
@@ -962,65 +885,55 @@ void __global__ k_nonbonded_exclusions(
         RealType inv_dij;
         RealType inv_d2ij;
         compute_electrostatics<RealType, true>(
-            charge_scale,
-            qi,
-            qj,
-            d2ij,
-            beta,
-            dij,
-            inv_dij,
-            inv_d2ij,
-            ebd,
-            es_prefactor,
-            u
-        );
+            charge_scale, qi, qj, d2ij, beta, dij, inv_dij, inv_d2ij, ebd, es_prefactor, u);
 
         RealType delta_prefactor = es_prefactor;
         RealType real_du_dl = 0;
         // lennard jones force
-        if(eps_i != 0 && eps_j != 0) {
+        if (eps_i != 0 && eps_j != 0) {
             RealType sig_grad;
             RealType eps_grad;
-            compute_lj<RealType, true>(lj_scale, eps_i, eps_j, sig_i, sig_j, inv_dij, inv_d2ij, u, delta_prefactor, sig_grad, eps_grad);
+            compute_lj<RealType, true>(
+                lj_scale, eps_i, eps_j, sig_i, sig_j, inv_dij, inv_d2ij, u, delta_prefactor, sig_grad, eps_grad);
 
             g_sigi += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DSIG>(-sig_grad);
             g_sigj += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DSIG>(-sig_grad);
-            g_epsi += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DEPS>(-eps_grad*eps_j);
-            g_epsj += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DEPS>(-eps_grad*eps_i);
+            g_epsi += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DEPS>(-eps_grad * eps_j);
+            g_epsj += FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DEPS>(-eps_grad * eps_i);
 
-            real_du_dl -= sig_grad*(dsig_dl_i + dsig_dl_j);
-            RealType term = eps_grad*fix_nvidia_fmad(eps_j, deps_dl_i, eps_i, deps_dl_j);
+            real_du_dl -= sig_grad * (dsig_dl_i + dsig_dl_j);
+            RealType term = eps_grad * fix_nvidia_fmad(eps_j, deps_dl_i, eps_i, deps_dl_j);
             real_du_dl -= term;
         }
 
-        gi_x -= FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_x);
-        gi_y -= FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_y);
-        gi_z -= FLOAT_TO_FIXED_NONBONDED(delta_prefactor*delta_z);
+        gi_x -= FLOAT_TO_FIXED_NONBONDED(delta_prefactor * delta_x);
+        gi_y -= FLOAT_TO_FIXED_NONBONDED(delta_prefactor * delta_y);
+        gi_z -= FLOAT_TO_FIXED_NONBONDED(delta_prefactor * delta_z);
 
-        gj_x -= FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_x);
-        gj_y -= FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_y);
-        gj_z -= FLOAT_TO_FIXED_NONBONDED(-delta_prefactor*delta_z);
+        gj_x -= FLOAT_TO_FIXED_NONBONDED(-delta_prefactor * delta_x);
+        gj_y -= FLOAT_TO_FIXED_NONBONDED(-delta_prefactor * delta_y);
+        gj_z -= FLOAT_TO_FIXED_NONBONDED(-delta_prefactor * delta_z);
 
         // energy is size extensive so this may not be a good idea
         energy -= FLOAT_TO_FIXED_NONBONDED(u);
 
-        g_qi -= FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DCHARGE>(charge_scale*qj*inv_dij*ebd);
-        g_qj -= FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DCHARGE>(charge_scale*qi*inv_dij*ebd);
+        g_qi -= FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DCHARGE>(charge_scale * qj * inv_dij * ebd);
+        g_qj -= FLOAT_TO_FIXED_DU_DP<RealType, FIXED_EXPONENT_DU_DCHARGE>(charge_scale * qi * inv_dij * ebd);
 
-        real_du_dl -= delta_w*delta_prefactor*(dw_dl_i - dw_dl_j);
-        real_du_dl -= charge_scale*inv_dij*ebd*fix_nvidia_fmad(qj, dq_dl_i, qi, dq_dl_j);
+        real_du_dl -= delta_w * delta_prefactor * (dw_dl_i - dw_dl_j);
+        real_du_dl -= charge_scale * inv_dij * ebd * fix_nvidia_fmad(qj, dq_dl_i, qi, dq_dl_j);
 
-        if(du_dx) {
-            atomicAdd(du_dx + atom_i_idx*3 + 0, gi_x);
-            atomicAdd(du_dx + atom_i_idx*3 + 1, gi_y);
-            atomicAdd(du_dx + atom_i_idx*3 + 2, gi_z);
+        if (du_dx) {
+            atomicAdd(du_dx + atom_i_idx * 3 + 0, gi_x);
+            atomicAdd(du_dx + atom_i_idx * 3 + 1, gi_y);
+            atomicAdd(du_dx + atom_i_idx * 3 + 2, gi_z);
 
-            atomicAdd(du_dx + atom_j_idx*3 + 0, gj_x);
-            atomicAdd(du_dx + atom_j_idx*3 + 1, gj_y);
-            atomicAdd(du_dx + atom_j_idx*3 + 2, gj_z);
+            atomicAdd(du_dx + atom_j_idx * 3 + 0, gj_x);
+            atomicAdd(du_dx + atom_j_idx * 3 + 1, gj_y);
+            atomicAdd(du_dx + atom_j_idx * 3 + 2, gj_z);
         }
 
-        if(du_dp) {
+        if (du_dp) {
             atomicAdd(du_dp + charge_param_idx_i, g_qi);
             atomicAdd(du_dp + charge_param_idx_j, g_qj);
 
@@ -1031,14 +944,12 @@ void __global__ k_nonbonded_exclusions(
             atomicAdd(du_dp + lj_param_idx_eps_j, g_epsj);
         }
 
-        if(du_dl_buffer && !is_vanilla) {
+        if (du_dl_buffer && !is_vanilla) {
             atomicAdd(du_dl_buffer + atom_i_idx, FLOAT_TO_FIXED_NONBONDED(real_du_dl));
         }
 
-        if(u_buffer) {
+        if (u_buffer) {
             atomicAdd(u_buffer + atom_i_idx, energy);
         }
-
     }
-
 }

--- a/timemachine/cpp/src/kernels/k_periodic_torsion.cuh
+++ b/timemachine/cpp/src/kernels/k_periodic_torsion.cuh
@@ -1,52 +1,43 @@
 #include "../fixed_point.hpp"
 #include "k_fixed_point.cuh"
 
-template<typename RealType>
-inline __device__ RealType dot_product(
-    const RealType a[3],
-    const RealType b[3]) {
+template <typename RealType> inline __device__ RealType dot_product(const RealType a[3], const RealType b[3]) {
 
-    return a[0]*b[0]+a[1]*b[1]+a[2]*b[2];
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 }
 
-
-template<typename RealType>
-inline __device__ void cross_product(
-    const RealType a[3],
-    const RealType b[3],
-    RealType c[3]) {
+template <typename RealType>
+inline __device__ void cross_product(const RealType a[3], const RealType b[3], RealType c[3]) {
     // fix this one indexed garbage later
-    c[1-1] = a[2-1]*b[3-1] - a[3-1]*b[2-1];
-    c[2-1] = a[3-1]*b[1-1] - a[1-1]*b[3-1];
-    c[3-1] = a[1-1]*b[2-1] - a[2-1]*b[1-1];
-
+    c[1 - 1] = a[2 - 1] * b[3 - 1] - a[3 - 1] * b[2 - 1];
+    c[2 - 1] = a[3 - 1] * b[1 - 1] - a[1 - 1] * b[3 - 1];
+    c[3 - 1] = a[1 - 1] * b[2 - 1] - a[2 - 1] * b[1 - 1];
 }
 
-
-template<typename RealType, int D>
+template <typename RealType, int D>
 void __global__ k_periodic_torsion(
-    const int T,     // number of bonds
-    const double * __restrict__ coords,  // [n, 3]
-    const double * __restrict__ params,  // [p, 3]
+    const int T,                       // number of bonds
+    const double *__restrict__ coords, // [n, 3]
+    const double *__restrict__ params, // [p, 3]
     const double lambda,
-    const int * __restrict__ lambda_mult,
-    const int * __restrict__ lambda_offset,
-    const int * __restrict__ torsion_idxs,    // [b, 4]
-    unsigned long long * __restrict__ du_dx,
-    double * __restrict__ du_dp,
-    unsigned long long * __restrict__ du_dl,
-    unsigned long long * __restrict__ u) {
+    const int *__restrict__ lambda_mult,
+    const int *__restrict__ lambda_offset,
+    const int *__restrict__ torsion_idxs, // [b, 4]
+    unsigned long long *__restrict__ du_dx,
+    double *__restrict__ du_dp,
+    unsigned long long *__restrict__ du_dl,
+    unsigned long long *__restrict__ u) {
 
-    const auto t_idx = blockDim.x*blockIdx.x + threadIdx.x;
+    const auto t_idx = blockDim.x * blockIdx.x + threadIdx.x;
 
-    if(t_idx >= T) {
+    if (t_idx >= T) {
         return;
     }
 
-    int i_idx = torsion_idxs[t_idx*4+0];
-    int j_idx = torsion_idxs[t_idx*4+1];
-    int k_idx = torsion_idxs[t_idx*4+2];
-    int l_idx = torsion_idxs[t_idx*4+3];
+    int i_idx = torsion_idxs[t_idx * 4 + 0];
+    int j_idx = torsion_idxs[t_idx * 4 + 1];
+    int k_idx = torsion_idxs[t_idx * 4 + 2];
+    int l_idx = torsion_idxs[t_idx * 4 + 3];
 
     RealType rij[3];
     RealType rkj[3];
@@ -55,14 +46,14 @@ void __global__ k_periodic_torsion(
     RealType rkj_norm_square = 0;
 
     // (todo) cap to three dims, while keeping stride at 4
-    for(int d=0; d < 3; d++) {
-        RealType vij = coords[j_idx*D+d] - coords[i_idx*D+d];
-        RealType vkj = coords[j_idx*D+d] - coords[k_idx*D+d];
-        RealType vkl = coords[l_idx*D+d] - coords[k_idx*D+d];
+    for (int d = 0; d < 3; d++) {
+        RealType vij = coords[j_idx * D + d] - coords[i_idx * D + d];
+        RealType vkj = coords[j_idx * D + d] - coords[k_idx * D + d];
+        RealType vkl = coords[l_idx * D + d] - coords[k_idx * D + d];
         rij[d] = vij;
         rkj[d] = vkj;
         rkl[d] = vkl;
-        rkj_norm_square += vkj*vkj;
+        rkj_norm_square += vkj * vkj;
     }
 
     RealType rkj_norm = sqrt(rkj_norm_square);
@@ -87,16 +78,18 @@ void __global__ k_periodic_torsion(
     RealType rij_dot_rkj = dot_product(rij, rkj);
     RealType rkl_dot_rkj = dot_product(rkl, rkj);
 
-    for(int d=0; d < 3; d++) {
-        d_angle_dR0[d] = rkj_norm/n1_norm_square * n1[d];
-        d_angle_dR3[d] = -rkj_norm/n2_norm_square * n2[d];
-        d_angle_dR1[d] = (rij_dot_rkj/rkj_norm_square - 1)*d_angle_dR0[d] - d_angle_dR3[d]*rkl_dot_rkj/rkj_norm_square;
-        d_angle_dR2[d] = (rkl_dot_rkj/rkj_norm_square - 1)*d_angle_dR3[d] - d_angle_dR0[d]*rij_dot_rkj/rkj_norm_square;
+    for (int d = 0; d < 3; d++) {
+        d_angle_dR0[d] = rkj_norm / n1_norm_square * n1[d];
+        d_angle_dR3[d] = -rkj_norm / n2_norm_square * n2[d];
+        d_angle_dR1[d] =
+            (rij_dot_rkj / rkj_norm_square - 1) * d_angle_dR0[d] - d_angle_dR3[d] * rkl_dot_rkj / rkj_norm_square;
+        d_angle_dR2[d] =
+            (rkl_dot_rkj / rkj_norm_square - 1) * d_angle_dR3[d] - d_angle_dR0[d] * rij_dot_rkj / rkj_norm_square;
     }
 
     RealType rkj_n = sqrt(dot_product(rkj, rkj));
 
-    for(int d=0; d < 3; d++) {
+    for (int d = 0; d < 3; d++) {
         rkj[d] /= rkj_n;
     }
 
@@ -104,43 +97,46 @@ void __global__ k_periodic_torsion(
     RealType x = dot_product(n1, n2);
     RealType angle = atan2(y, x);
 
-    int kt_idx = t_idx*3+0;
-    int phase_idx = t_idx*3+1;
-    int period_idx = t_idx*3+2;
+    int kt_idx = t_idx * 3 + 0;
+    int phase_idx = t_idx * 3 + 1;
+    int period_idx = t_idx * 3 + 2;
 
     RealType kt = params[kt_idx];
     RealType phase = params[phase_idx];
     RealType period = params[period_idx];
 
-    RealType prefactor = kt*sin(period*angle - phase)*period;
-    RealType lambda_prefactor = lambda_offset[t_idx] + lambda_mult[t_idx]*lambda;
+    RealType prefactor = kt * sin(period * angle - phase) * period;
+    RealType lambda_prefactor = lambda_offset[t_idx] + lambda_mult[t_idx] * lambda;
 
-    if(du_dx) {
-        for(int d=0; d < 3; d++) {
-            atomicAdd(du_dx + i_idx*D + d, FLOAT_TO_FIXED_BONDED<RealType>(d_angle_dR0[d] * prefactor * lambda_prefactor));
-            atomicAdd(du_dx + j_idx*D + d, FLOAT_TO_FIXED_BONDED<RealType>(d_angle_dR1[d] * prefactor * lambda_prefactor));
-            atomicAdd(du_dx + k_idx*D + d, FLOAT_TO_FIXED_BONDED<RealType>(d_angle_dR2[d] * prefactor * lambda_prefactor));
-            atomicAdd(du_dx + l_idx*D + d, FLOAT_TO_FIXED_BONDED<RealType>(d_angle_dR3[d] * prefactor * lambda_prefactor));
+    if (du_dx) {
+        for (int d = 0; d < 3; d++) {
+            atomicAdd(
+                du_dx + i_idx * D + d, FLOAT_TO_FIXED_BONDED<RealType>(d_angle_dR0[d] * prefactor * lambda_prefactor));
+            atomicAdd(
+                du_dx + j_idx * D + d, FLOAT_TO_FIXED_BONDED<RealType>(d_angle_dR1[d] * prefactor * lambda_prefactor));
+            atomicAdd(
+                du_dx + k_idx * D + d, FLOAT_TO_FIXED_BONDED<RealType>(d_angle_dR2[d] * prefactor * lambda_prefactor));
+            atomicAdd(
+                du_dx + l_idx * D + d, FLOAT_TO_FIXED_BONDED<RealType>(d_angle_dR3[d] * prefactor * lambda_prefactor));
         }
     }
 
-    if(du_dp) {
-        RealType du_dkt = 1 + cos(period*angle - phase);
-        RealType du_dphase = kt*sin(period*angle - phase);
-        RealType du_dperiod = -kt*sin(period*angle - phase)*angle;
+    if (du_dp) {
+        RealType du_dkt = 1 + cos(period * angle - phase);
+        RealType du_dphase = kt * sin(period * angle - phase);
+        RealType du_dperiod = -kt * sin(period * angle - phase) * angle;
 
-        atomicAdd(du_dp + kt_idx, du_dkt*lambda_prefactor);
-        atomicAdd(du_dp + phase_idx, du_dphase*lambda_prefactor);
-        atomicAdd(du_dp + period_idx, du_dperiod*lambda_prefactor);
+        atomicAdd(du_dp + kt_idx, du_dkt * lambda_prefactor);
+        atomicAdd(du_dp + phase_idx, du_dphase * lambda_prefactor);
+        atomicAdd(du_dp + period_idx, du_dperiod * lambda_prefactor);
     }
 
-    if(u) {
+    if (u) {
         // printf("%f\n", lambda_prefactor*kt*(1+cos(period*angle - phase)));
-        atomicAdd(u + i_idx, FLOAT_TO_FIXED_BONDED(lambda_prefactor*kt*(1+cos(period*angle - phase))));
+        atomicAdd(u + i_idx, FLOAT_TO_FIXED_BONDED(lambda_prefactor * kt * (1 + cos(period * angle - phase))));
     }
 
-    if(du_dl) {
-        atomicAdd(du_dl + i_idx, FLOAT_TO_FIXED_BONDED(lambda_mult[t_idx]*kt*(1+cos(period*angle - phase))));
+    if (du_dl) {
+        atomicAdd(du_dl + i_idx, FLOAT_TO_FIXED_BONDED(lambda_mult[t_idx] * kt * (1 + cos(period * angle - phase))));
     }
-
 }

--- a/timemachine/cpp/src/kernels/k_periodic_utils.cuh
+++ b/timemachine/cpp/src/kernels/k_periodic_utils.cuh
@@ -4,7 +4,6 @@
 
 // #define BOXSIZE 100*cutoff
 
-
 // template<typename T>
 // __device__ T apply_delta(T delta, double box) {
 //     return delta;

--- a/timemachine/cpp/src/kernels/k_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_restraint.cuh
@@ -1,51 +1,50 @@
 
-#include "surreal.cuh"
 #include "../fixed_point.hpp"
-
+#include "surreal.cuh"
 
 __device__ const double PI = 3.14159265358979323846;
 
-template<typename RealType>
+template <typename RealType>
 void __global__ k_restraint_inference(
-    const int B,     // number of bonds
-    const double *coords,  // [n, 3]
-    const double *params,  // [p,]
+    const int B,          // number of bonds
+    const double *coords, // [n, 3]
+    const double *params, // [p,]
     const double lambda,
-    const int *bond_idxs,    // [b, 2]
+    const int *bond_idxs, // [b, 2]
     // const int *param_idxs,   // [b, 3]
     const int *lambda_flags,
     unsigned long long *grad_coords,
     double *du_dl,
     double *energy) {
 
-    const auto b_idx = blockDim.x*blockIdx.x + threadIdx.x;
+    const auto b_idx = blockDim.x * blockIdx.x + threadIdx.x;
 
-    if(b_idx >= B) {
+    if (b_idx >= B) {
         return;
     }
 
-    double f_lambda = lambda*lambda_flags[b_idx];
+    double f_lambda = lambda * lambda_flags[b_idx];
     double df = lambda_flags[b_idx];
 
-    int src_idx = bond_idxs[b_idx*2+0];
-    int dst_idx = bond_idxs[b_idx*2+1];
+    int src_idx = bond_idxs[b_idx * 2 + 0];
+    int dst_idx = bond_idxs[b_idx * 2 + 1];
 
     RealType dx[4];
     RealType d2ij = 0; // initialize your summed variables!
-    for(int d=0; d < 3; d++) {
-        RealType delta = coords[src_idx*3+d] - coords[dst_idx*3+d];
+    for (int d = 0; d < 3; d++) {
+        RealType delta = coords[src_idx * 3 + d] - coords[dst_idx * 3 + d];
         dx[d] = delta;
-        d2ij += delta*delta;
+        d2ij += delta * delta;
     }
 
     RealType w = f_lambda;
 
     dx[3] = w; // unused
-    d2ij += w*w;
+    d2ij += w * w;
 
-    int kb_idx = b_idx*3+0;
-    int b0_idx = b_idx*3+1;
-    int a0_idx = b_idx*3+2;
+    int kb_idx = b_idx * 3 + 0;
+    int b0_idx = b_idx * 3 + 1;
+    int a0_idx = b_idx * 3 + 2;
 
     RealType kb = params[kb_idx];
     RealType b0 = params[b0_idx];
@@ -54,69 +53,69 @@ void __global__ k_restraint_inference(
     RealType dij = sqrt(d2ij);
     RealType db = dij - b0;
 
-    RealType prefactor = 2*a0*exp(-a0*(-b0+dij))*(1-exp(-a0*(-b0+dij)))*kb;
+    RealType prefactor = 2 * a0 * exp(-a0 * (-b0 + dij)) * (1 - exp(-a0 * (-b0 + dij))) * kb;
 
-    for(int d=0; d < 3; d++) {
-        RealType grad_delta = prefactor*dx[d]/dij;
-        atomicAdd(grad_coords + src_idx*3 + d, static_cast<unsigned long long>((long long) (grad_delta*FIXED_EXPONENT)));
-        atomicAdd(grad_coords + dst_idx*3 + d, static_cast<unsigned long long>((long long) (-grad_delta*FIXED_EXPONENT)));
+    for (int d = 0; d < 3; d++) {
+        RealType grad_delta = prefactor * dx[d] / dij;
+        atomicAdd(
+            grad_coords + src_idx * 3 + d, static_cast<unsigned long long>((long long)(grad_delta * FIXED_EXPONENT)));
+        atomicAdd(
+            grad_coords + dst_idx * 3 + d, static_cast<unsigned long long>((long long)(-grad_delta * FIXED_EXPONENT)));
     }
 
-    double term = (1-exp(-a0*db));
-    double u = kb*term*term;
+    double term = (1 - exp(-a0 * db));
+    double u = kb * term * term;
 
-    atomicAdd(du_dl, df*prefactor*(w/dij));
+    atomicAdd(du_dl, df * prefactor * (w / dij));
     atomicAdd(energy, u);
-
 }
 
-
-template<typename RealType>
+template <typename RealType>
 void __global__ k_restraint_jvp(
-    const int B,     // number of bonds
+    const int B, // number of bonds
     const double *coords,
     const double *coords_tangent,
-    const double *params,  // [p,]
+    const double *params, // [p,]
     const double lambda_primal,
     const double lambda_tangent,
-    const int *bond_idxs,    // [b, 2]
+    const int *bond_idxs, // [b, 2]
     const int *lambda_flags,
     double *grad_coords_primals,
     double *grad_coords_tangents,
     double *grad_params_primals,
     double *grad_params_tangents) {
 
-    const auto b_idx = blockDim.x*blockIdx.x + threadIdx.x;
+    const auto b_idx = blockDim.x * blockIdx.x + threadIdx.x;
 
-    if(b_idx >= B) {
+    if (b_idx >= B) {
         return;
     }
 
     Surreal<RealType> lambda(lambda_primal, lambda_tangent);
-    Surreal<RealType> f_lambda = lambda*lambda_flags[b_idx];
+    Surreal<RealType> f_lambda = lambda * lambda_flags[b_idx];
     Surreal<RealType> df(lambda_flags[b_idx], 0);
 
-    int src_idx = bond_idxs[b_idx*2+0];
-    int dst_idx = bond_idxs[b_idx*2+1];
+    int src_idx = bond_idxs[b_idx * 2 + 0];
+    int dst_idx = bond_idxs[b_idx * 2 + 1];
 
     Surreal<RealType> dx[4];
     Surreal<RealType> d2ij(0.0, 0.0); // initialize your summed variables!
-    for(int d=0; d < 3; d++) {
+    for (int d = 0; d < 3; d++) {
         Surreal<RealType> delta;
-        delta.real = coords[src_idx*3+d] - coords[dst_idx*3+d];
-        delta.imag = coords_tangent[src_idx*3+d] - coords_tangent[dst_idx*3+d];
+        delta.real = coords[src_idx * 3 + d] - coords[dst_idx * 3 + d];
+        delta.imag = coords_tangent[src_idx * 3 + d] - coords_tangent[dst_idx * 3 + d];
         dx[d] = delta;
-        d2ij += delta*delta;
+        d2ij += delta * delta;
     }
 
     Surreal<RealType> w = f_lambda;
 
     dx[3] = w; // unused
-    d2ij += w*w;
+    d2ij += w * w;
 
-    int kb_idx = b_idx*3+0;
-    int b0_idx = b_idx*3+1;
-    int a0_idx = b_idx*3+2;
+    int kb_idx = b_idx * 3 + 0;
+    int b0_idx = b_idx * 3 + 1;
+    int a0_idx = b_idx * 3 + 2;
 
     RealType kb = params[kb_idx];
     RealType b0 = params[b0_idx];
@@ -125,23 +124,22 @@ void __global__ k_restraint_jvp(
     Surreal<RealType> dij = sqrt(d2ij);
     Surreal<RealType> db = dij - b0;
 
-    Surreal<RealType> prefactor = 2*a0*exp(-a0*(-b0+dij))*(1-exp(-a0*(-b0+dij)))*kb;
+    Surreal<RealType> prefactor = 2 * a0 * exp(-a0 * (-b0 + dij)) * (1 - exp(-a0 * (-b0 + dij))) * kb;
 
-    for(int d=0; d < 3; d++) {
-        Surreal<RealType> grad_delta = prefactor*dx[d]/dij;
-        atomicAdd(grad_coords_primals + src_idx*3 + d, grad_delta.real);
-        atomicAdd(grad_coords_primals + dst_idx*3 + d, -grad_delta.real);
+    for (int d = 0; d < 3; d++) {
+        Surreal<RealType> grad_delta = prefactor * dx[d] / dij;
+        atomicAdd(grad_coords_primals + src_idx * 3 + d, grad_delta.real);
+        atomicAdd(grad_coords_primals + dst_idx * 3 + d, -grad_delta.real);
 
-        atomicAdd(grad_coords_tangents + src_idx*3 + d, grad_delta.imag);
-        atomicAdd(grad_coords_tangents + dst_idx*3 + d, -grad_delta.imag);
+        atomicAdd(grad_coords_tangents + src_idx * 3 + d, grad_delta.imag);
+        atomicAdd(grad_coords_tangents + dst_idx * 3 + d, -grad_delta.imag);
     }
 
+    Surreal<RealType> term = 1 - exp(-a0 * db);
+    Surreal<RealType> du_dk = term * term;
 
-    Surreal<RealType> term = 1-exp(-a0*db);
-    Surreal<RealType> du_dk = term*term;
-
-    Surreal<RealType> du_db = -2*a0*kb*exp(-a0*db)*(1 - exp(-a0*db));
-    Surreal<RealType> du_da = 2*kb*db*exp(-a0*db)*(1 - exp(-a0*db));
+    Surreal<RealType> du_db = -2 * a0 * kb * exp(-a0 * db) * (1 - exp(-a0 * db));
+    Surreal<RealType> du_da = 2 * kb * db * exp(-a0 * db) * (1 - exp(-a0 * db));
 
     atomicAdd(grad_params_primals + kb_idx, du_dk.real);
     atomicAdd(grad_params_tangents + kb_idx, du_dk.imag);
@@ -151,5 +149,4 @@ void __global__ k_restraint_jvp(
 
     atomicAdd(grad_params_primals + a0_idx, du_da.real);
     atomicAdd(grad_params_tangents + a0_idx, du_da.imag);
-
 }

--- a/timemachine/cpp/src/kernels/kernel_utils.cuh
+++ b/timemachine/cpp/src/kernels/kernel_utils.cuh
@@ -3,11 +3,11 @@
 #include <cstdio>
 #define WARP_SIZE 32
 
-#define HESS_3N3N(i,j,N,di,dj) (di*N*3*N + i*3*N + dj*N + j)
-#define HESS_N3N3(i,j,N,di,dj) (i*3*N*3 + di*N*3 + j*3 + dj)
+#define HESS_3N3N(i, j, N, di, dj) (di * N * 3 * N + i * 3 * N + dj * N + j)
+#define HESS_N3N3(i, j, N, di, dj) (i * 3 * N * 3 + di * N * 3 + j * 3 + dj)
 #define HESS_IDX HESS_N3N3
 
-#define HESS_NDND(i,j,N,di,dj,D) (i*D*N*D + di*N*D + j*D + dj)
+#define HESS_NDND(i, j, N, di, dj, D) (i * D * N * D + di * N * D + j * D + dj)
 // dimensions first
 
 // these are dimension major, atom minor, x0x1..xn, y0y1...yn, z0z1...zn, etc
@@ -26,15 +26,13 @@
 //     return ii*DN + jj;
 // }
 
-#define MP_IDX_ND(p,i,N,d,D) (p*N*D + i*D + d)
+#define MP_IDX_ND(p, i, N, d, D) (p * N * D + i * D + d)
 
 // #define MP_IDX_ND(p,i,N,d,D) (p*D*N + d*N + i)
 
 #define ONE_4PI_EPS0 138.935456
 
-inline __device__ int linearize(int i, int j, int d) {
-    return d*(d-1)/2 - (d-i) * (d-i-1)/2 +j;
-}
+inline __device__ int linearize(int i, int j, int d) { return d * (d - 1) / 2 - (d - i) * (d - i - 1) / 2 + j; }
 
 // inline __device__ float gpuSqrt(float arg) {
 //   return sqrtf(arg);
@@ -52,64 +50,38 @@ __device__ __forceinline__ double real_rnorm4d(const double a, const double b, c
     return rnorm4d(a, b, c, d);
 }
 
-__device__ __forceinline__ float real_sqrt(const float x) {
-    return sqrtf(x);
-}
+__device__ __forceinline__ float real_sqrt(const float x) { return sqrtf(x); }
 
-__device__ __forceinline__ double real_sqrt(const double x) {
-    return sqrt(x);
-}
+__device__ __forceinline__ double real_sqrt(const double x) { return sqrt(x); }
 
-__device__ __forceinline__ float real_exp(const float x) {
-    return expf(x);
-}
+__device__ __forceinline__ float real_exp(const float x) { return expf(x); }
 
-__device__ __forceinline__ double real_exp(const double x) {
-    return exp(x);
-}
+__device__ __forceinline__ double real_exp(const double x) { return exp(x); }
 
-template<typename RealType, int D>
-inline __device__ RealType fast_vec_rnorm(const RealType v[D]);
+template <typename RealType, int D> inline __device__ RealType fast_vec_rnorm(const RealType v[D]);
 
-template<>
-inline __device__ float fast_vec_rnorm<float, 3>(const float v[3]) {
-    return rnorm3df(v[0], v[1], v[2]);
-};
+template <> inline __device__ float fast_vec_rnorm<float, 3>(const float v[3]) { return rnorm3df(v[0], v[1], v[2]); };
 
-template<>
-inline __device__ double fast_vec_rnorm<double, 3>(const double v[3]) {
-    return rnorm3d(v[0], v[1], v[2]);
-};
+template <> inline __device__ double fast_vec_rnorm<double, 3>(const double v[3]) { return rnorm3d(v[0], v[1], v[2]); };
 
-template<>
-inline __device__ float fast_vec_rnorm<float, 4>(const float v[4]) {
+template <> inline __device__ float fast_vec_rnorm<float, 4>(const float v[4]) {
     return rnorm4df(v[0], v[1], v[2], v[3]);
 };
 
-template<>
-inline __device__ double fast_vec_rnorm<double, 4>(const double v[4]) {
+template <> inline __device__ double fast_vec_rnorm<double, 4>(const double v[4]) {
     return rnorm4d(v[0], v[1], v[2], v[3]);
 };
 
-template<typename RealType, int D>
-inline __device__ RealType fast_vec_norm(const RealType v[D]);
+template <typename RealType, int D> inline __device__ RealType fast_vec_norm(const RealType v[D]);
 
-template<>
-inline __device__ float fast_vec_norm<float, 3>(const float v[3]) {
-    return norm3df(v[0], v[1], v[2]);
-};
+template <> inline __device__ float fast_vec_norm<float, 3>(const float v[3]) { return norm3df(v[0], v[1], v[2]); };
 
-template<>
-inline __device__ double fast_vec_norm<double, 3>(const double v[3]) {
-    return norm3d(v[0], v[1], v[2]);
-};
+template <> inline __device__ double fast_vec_norm<double, 3>(const double v[3]) { return norm3d(v[0], v[1], v[2]); };
 
-template<>
-inline __device__ float fast_vec_norm<float, 4>(const float v[4]) {
+template <> inline __device__ float fast_vec_norm<float, 4>(const float v[4]) {
     return norm4df(v[0], v[1], v[2], v[3]);
 };
 
-template<>
-inline __device__ double fast_vec_norm<double, 4>(const double v[4]) {
+template <> inline __device__ double fast_vec_norm<double, 4>(const double v[4]) {
     return norm4d(v[0], v[1], v[2], v[3]);
 };

--- a/timemachine/cpp/src/kernels/surreal.cuh
+++ b/timemachine/cpp/src/kernels/surreal.cuh
@@ -2,355 +2,265 @@
 
 #define ERR (1.e-24)
 #ifdef __NVCC__
-    #define DECL __host__ __device__
+#define DECL __host__ __device__
 #else
-    #define DECL
+#define DECL
 #endif
 
-template<typename RealType>
-struct Surreal {
+template <typename RealType> struct Surreal {
 
     typedef RealType value_type;
     RealType real, imag;
 
-    DECL Surreal<RealType>() {}; // uninitialized for efficiency
-    DECL Surreal<RealType>(const RealType& v, const RealType& d) : real(v), imag(d) {}
-    DECL Surreal<RealType>(const RealType& v) : real(v), imag(0) {}
+    DECL Surreal<RealType>(){}; // uninitialized for efficiency
+    DECL Surreal<RealType>(const RealType &v, const RealType &d) : real(v), imag(d) {}
+    DECL Surreal<RealType>(const RealType &v) : real(v), imag(0) {}
 
     // copy constructor
     DECL Surreal<RealType>(const Surreal<RealType> &z) : real(z.real), imag(z.imag) {}
 
-    DECL Surreal& operator=(const Surreal & s) {real = s.real ; imag = s.imag; return *this;};
+    DECL Surreal &operator=(const Surreal &s) {
+        real = s.real;
+        imag = s.imag;
+        return *this;
+    };
 
-    DECL Surreal& operator+=(const Surreal&);
-    DECL Surreal& operator+=(const RealType&);
+    DECL Surreal &operator+=(const Surreal &);
+    DECL Surreal &operator+=(const RealType &);
 
     DECL Surreal operator-() const;
 
-    DECL Surreal& operator-=(const Surreal&);
-    DECL Surreal& operator-=(const RealType&);
+    DECL Surreal &operator-=(const Surreal &);
+    DECL Surreal &operator-=(const RealType &);
 
-    DECL Surreal& operator*=(const Surreal&);
-    DECL Surreal& operator*=(const RealType&);
+    DECL Surreal &operator*=(const Surreal &);
+    DECL Surreal &operator*=(const RealType &);
 
-    DECL Surreal& operator/=(const Surreal&);
-    DECL Surreal& operator/=(const RealType&);
-    template<typename OtherType>
-    DECL Surreal& operator/=(const OtherType&);
+    DECL Surreal &operator/=(const Surreal &);
+    DECL Surreal &operator/=(const RealType &);
+    template <typename OtherType> DECL Surreal &operator/=(const OtherType &);
 
-    DECL Surreal sin(const Surreal&);
-    DECL Surreal cos(const Surreal&);
+    DECL Surreal sin(const Surreal &);
+    DECL Surreal cos(const Surreal &);
 
-    DECL Surreal acos(const Surreal&);
-    DECL Surreal atan2(const Surreal&, const Surreal&);
+    DECL Surreal acos(const Surreal &);
+    DECL Surreal atan2(const Surreal &, const Surreal &);
 
-    DECL Surreal sqrt(const Surreal&);
-    DECL Surreal exp(const Surreal&);
-
+    DECL Surreal sqrt(const Surreal &);
+    DECL Surreal exp(const Surreal &);
 };
 
-template <typename RealType>
-DECL Surreal<RealType> abs(const Surreal<RealType>& v) {
-    return v.real < 0.0 ? -v: v;
-}
+template <typename RealType> DECL Surreal<RealType> abs(const Surreal<RealType> &v) { return v.real < 0.0 ? -v : v; }
 
-template <typename RealType>
-DECL Surreal<RealType> fabs(const Surreal<RealType>& v) {
-    return v.real < 0.0 ? -v: v;
-}
+template <typename RealType> DECL Surreal<RealType> fabs(const Surreal<RealType> &v) { return v.real < 0.0 ? -v : v; }
 
-template <typename RealType>
-DECL Surreal<RealType> max(const double &a, const Surreal<RealType>& v) {
-    return v.real > a ? v: Surreal<RealType>(a);
+template <typename RealType> DECL Surreal<RealType> max(const double &a, const Surreal<RealType> &v) {
+    return v.real > a ? v : Surreal<RealType>(a);
 }
 
 #ifdef __NVCC__
 template <typename RealType>
-DECL Surreal<RealType> __shfl_sync(unsigned mask, Surreal<RealType> &var, int srcLane, int width=warpSize) {
+DECL Surreal<RealType> __shfl_sync(unsigned mask, Surreal<RealType> &var, int srcLane, int width = warpSize) {
     var.real = __shfl_sync(mask, var.real, srcLane, width);
     var.imag = __shfl_sync(mask, var.imag, srcLane, width);
     return var;
 }
 
-
 template <typename RealType>
-__device__ inline void atomicAddOffset(Surreal<RealType> *base_ptr, const unsigned offset, const Surreal<RealType> &val) {
-    RealType* real_ptr = reinterpret_cast<RealType*>(base_ptr) + offset*2;
-    RealType* imag_ptr = real_ptr + 1;
+__device__ inline void
+atomicAddOffset(Surreal<RealType> *base_ptr, const unsigned offset, const Surreal<RealType> &val) {
+    RealType *real_ptr = reinterpret_cast<RealType *>(base_ptr) + offset * 2;
+    RealType *imag_ptr = real_ptr + 1;
     atomicAdd(real_ptr, val.real);
     atomicAdd(imag_ptr, val.imag);
 }
 
 template <typename PtrType, typename SecondType>
-__device__ inline void atomicAddOffsetSplit(Surreal<PtrType> *base_ptr, const unsigned offset, const Surreal<SecondType> &val) {
-    PtrType* real_ptr = reinterpret_cast<PtrType*>(base_ptr) + offset*2;
-    PtrType* imag_ptr = real_ptr + 1;
+__device__ inline void
+atomicAddOffsetSplit(Surreal<PtrType> *base_ptr, const unsigned offset, const Surreal<SecondType> &val) {
+    PtrType *real_ptr = reinterpret_cast<PtrType *>(base_ptr) + offset * 2;
+    PtrType *imag_ptr = real_ptr + 1;
     atomicAdd(real_ptr, val.real);
     atomicAdd(imag_ptr, val.imag);
 }
 
 #endif
 
-
-template <typename RealType>
-DECL bool operator>(const Surreal<RealType> &l, const Surreal<RealType> &r) {
+template <typename RealType> DECL bool operator>(const Surreal<RealType> &l, const Surreal<RealType> &r) {
     return l.real > r.real;
 }
 
-template <typename RealType>
-DECL bool operator<(const Surreal<RealType> &l, const Surreal<RealType> &r) {
+template <typename RealType> DECL bool operator<(const Surreal<RealType> &l, const Surreal<RealType> &r) {
     return l.real < r.real;
 }
 
-template <typename RealType>
-DECL bool operator>(const Surreal<RealType> &l, const double &r) {
-    return l.real > r;
-}
+template <typename RealType> DECL bool operator>(const Surreal<RealType> &l, const double &r) { return l.real > r; }
 
-template <typename RealType>
-DECL bool operator<(const Surreal<RealType> &l, const double &r) {
-    return l.real < r;
-}
+template <typename RealType> DECL bool operator<(const Surreal<RealType> &l, const double &r) { return l.real < r; }
 
-template <typename RealType>
-DECL Surreal<RealType>& Surreal<RealType>::operator+=(const Surreal<RealType>& z) {
+template <typename RealType> DECL Surreal<RealType> &Surreal<RealType>::operator+=(const Surreal<RealType> &z) {
     real += z.real;
     imag += z.imag;
     return *this;
 }
 
-template <typename RealType>
-DECL Surreal<RealType>& Surreal<RealType>::operator+=(const RealType& r) {
+template <typename RealType> DECL Surreal<RealType> &Surreal<RealType>::operator+=(const RealType &r) {
     real += r;
     return *this;
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator+(const Surreal<RealType>& a, const Surreal<RealType>& b) {
-    return Surreal<RealType>(a.real+b.real, a.imag+b.imag);
+template <typename RealType> DECL Surreal<RealType> operator+(const Surreal<RealType> &a, const Surreal<RealType> &b) {
+    return Surreal<RealType>(a.real + b.real, a.imag + b.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator+(const int& i, const Surreal<RealType>& z) {
-    return Surreal<RealType>(i+z.real,z.imag);
+template <typename RealType> DECL Surreal<RealType> operator+(const int &i, const Surreal<RealType> &z) {
+    return Surreal<RealType>(i + z.real, z.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator+(const float& i, const Surreal<RealType>& z) {
-    return Surreal<RealType>(i+z.real,z.imag);
+template <typename RealType> DECL Surreal<RealType> operator+(const float &i, const Surreal<RealType> &z) {
+    return Surreal<RealType>(i + z.real, z.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator+(const double& i, const Surreal<RealType>& z) {
-    return Surreal<RealType>(i+z.real,z.imag);
+template <typename RealType> DECL Surreal<RealType> operator+(const double &i, const Surreal<RealType> &z) {
+    return Surreal<RealType>(i + z.real, z.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator+(const Surreal<RealType>& z, const int& i) {
-    return Surreal<RealType>(i+z.real,z.imag);
+template <typename RealType> DECL Surreal<RealType> operator+(const Surreal<RealType> &z, const int &i) {
+    return Surreal<RealType>(i + z.real, z.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator+(const Surreal<RealType>& z, const float& i) {
-    return Surreal<RealType>(i+z.real,z.imag);
+template <typename RealType> DECL Surreal<RealType> operator+(const Surreal<RealType> &z, const float &i) {
+    return Surreal<RealType>(i + z.real, z.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator+(const Surreal<RealType>& z, const double& i) {
-    return Surreal<RealType>(i+z.real,z.imag);
+template <typename RealType> DECL Surreal<RealType> operator+(const Surreal<RealType> &z, const double &i) {
+    return Surreal<RealType>(i + z.real, z.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> Surreal<RealType>::operator-() const {
-    return Surreal<RealType>(-real,-imag);
+template <typename RealType> DECL Surreal<RealType> Surreal<RealType>::operator-() const {
+    return Surreal<RealType>(-real, -imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator-(const Surreal<RealType>& a, const Surreal<RealType>& b) {
+template <typename RealType> DECL Surreal<RealType> operator-(const Surreal<RealType> &a, const Surreal<RealType> &b) {
     return Surreal<RealType>(a.real - b.real, a.imag - b.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator-(const Surreal<RealType>& a, const float& b) {
+template <typename RealType> DECL Surreal<RealType> operator-(const Surreal<RealType> &a, const float &b) {
     return Surreal<RealType>(a.real - b, a.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator-(const Surreal<RealType>& a, const double& b) {
+template <typename RealType> DECL Surreal<RealType> operator-(const Surreal<RealType> &a, const double &b) {
     return Surreal<RealType>(a.real - b, a.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator-(const Surreal<RealType>& a, const int& b) {
+template <typename RealType> DECL Surreal<RealType> operator-(const Surreal<RealType> &a, const int &b) {
     return Surreal<RealType>(a.real - b, a.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator-(const float& b, const Surreal<RealType>& a) {
+template <typename RealType> DECL Surreal<RealType> operator-(const float &b, const Surreal<RealType> &a) {
     return Surreal<RealType>(b - a.real, -a.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator-(const double& b, const Surreal<RealType>& a) {
+template <typename RealType> DECL Surreal<RealType> operator-(const double &b, const Surreal<RealType> &a) {
     return Surreal<RealType>(b - a.real, -a.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator-(const int& b, const Surreal<RealType>& a) {
+template <typename RealType> DECL Surreal<RealType> operator-(const int &b, const Surreal<RealType> &a) {
     return Surreal<RealType>(b - a.real, -a.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType>& Surreal<RealType>::operator-=(const Surreal<RealType>& z) {
+template <typename RealType> DECL Surreal<RealType> &Surreal<RealType>::operator-=(const Surreal<RealType> &z) {
     real -= z.real;
     imag -= z.imag;
     return *this;
 }
 
-template <typename RealType>
-DECL Surreal<RealType>& Surreal<RealType>::operator-=(const RealType& r) {
+template <typename RealType> DECL Surreal<RealType> &Surreal<RealType>::operator-=(const RealType &r) {
     real -= r;
     return *this;
 }
 
-template <typename RealType>
-DECL Surreal<RealType>& Surreal<RealType>::operator*=(const Surreal<RealType>& z) {
-    imag = real*z.imag+z.real*imag;
+template <typename RealType> DECL Surreal<RealType> &Surreal<RealType>::operator*=(const Surreal<RealType> &z) {
+    imag = real * z.imag + z.real * imag;
     real *= z.real;
     return *this;
 }
 
-template <typename RealType>
-DECL Surreal<RealType>& Surreal<RealType>::operator*=(const RealType& r) {
+template <typename RealType> DECL Surreal<RealType> &Surreal<RealType>::operator*=(const RealType &r) {
     real *= r;
     imag *= r;
     return *this;
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator*(
-    const Surreal<RealType>& a,
-    const Surreal<RealType>& b) {
+template <typename RealType> DECL Surreal<RealType> operator*(const Surreal<RealType> &a, const Surreal<RealType> &b) {
     return Surreal<RealType>(
-        b.real*a.real, // we don't do b.imag*b.imag cuz autodiff
-        b.real*a.imag + a.real*b.imag
-    );
+        b.real * a.real, // we don't do b.imag*b.imag cuz autodiff
+        b.real * a.imag + a.real * b.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator*(const float& i, const Surreal<RealType>& z) {
-    return Surreal<RealType>(
-        i*z.real,
-        i*z.imag
-    );
+template <typename RealType> DECL Surreal<RealType> operator*(const float &i, const Surreal<RealType> &z) {
+    return Surreal<RealType>(i * z.real, i * z.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator*(const double& i, const Surreal<RealType>& z) {
-    return Surreal<RealType>(
-        i*z.real,
-        i*z.imag
-    );
+template <typename RealType> DECL Surreal<RealType> operator*(const double &i, const Surreal<RealType> &z) {
+    return Surreal<RealType>(i * z.real, i * z.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator*(const int& i, const Surreal<RealType>& z) {
-    return Surreal<RealType>(
-        i*z.real,
-        i*z.imag
-    );
+template <typename RealType> DECL Surreal<RealType> operator*(const int &i, const Surreal<RealType> &z) {
+    return Surreal<RealType>(i * z.real, i * z.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator*(const Surreal<RealType>& z, const float& i) {
-    return Surreal<RealType>(
-        i*z.real,
-        i*z.imag
-    );
+template <typename RealType> DECL Surreal<RealType> operator*(const Surreal<RealType> &z, const float &i) {
+    return Surreal<RealType>(i * z.real, i * z.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator*(const Surreal<RealType>& z, const double& i) {
-    return Surreal<RealType>(
-        i*z.real,
-        i*z.imag
-    );
+template <typename RealType> DECL Surreal<RealType> operator*(const Surreal<RealType> &z, const double &i) {
+    return Surreal<RealType>(i * z.real, i * z.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator*(const Surreal<RealType>& z, const int& i) {
-    return Surreal<RealType>(
-        i*z.real,
-        i*z.imag
-    );
+template <typename RealType> DECL Surreal<RealType> operator*(const Surreal<RealType> &z, const int &i) {
+    return Surreal<RealType>(i * z.real, i * z.imag);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator/(
-    const Surreal<RealType>& a,
-    const Surreal<RealType>& b) {
-    return Surreal<RealType>(
-        a.real/b.real,
-        (b.real*a.imag - a.real*b.imag)/(b.real*b.real)
-    );
+template <typename RealType> DECL Surreal<RealType> operator/(const Surreal<RealType> &a, const Surreal<RealType> &b) {
+    return Surreal<RealType>(a.real / b.real, (b.real * a.imag - a.real * b.imag) / (b.real * b.real));
 }
 
 //
 
-template <typename RealType>
-DECL Surreal<RealType> operator/(
-    const Surreal<RealType> & z,
-    const int& r) {
-    return Surreal<RealType>(z.real/r, z.imag/r);
+template <typename RealType> DECL Surreal<RealType> operator/(const Surreal<RealType> &z, const int &r) {
+    return Surreal<RealType>(z.real / r, z.imag / r);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator/(
-    const Surreal<RealType> & z,
-    const float& r) {
-    return Surreal<RealType>(z.real/r, z.imag/r);
+template <typename RealType> DECL Surreal<RealType> operator/(const Surreal<RealType> &z, const float &r) {
+    return Surreal<RealType>(z.real / r, z.imag / r);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator/(
-    const Surreal<RealType> & z,
-    const double& r) {
-    return Surreal<RealType>(z.real/r, z.imag/r);
+template <typename RealType> DECL Surreal<RealType> operator/(const Surreal<RealType> &z, const double &r) {
+    return Surreal<RealType>(z.real / r, z.imag / r);
 }
 
 // dividing a real by a complex is different from divding a complex by a real
 
-template <typename RealType>
-DECL Surreal<RealType> operator/(
-    const int& r,
-    const Surreal<RealType> & z) {
-    return Surreal<RealType>(r/z.real, -r*z.imag/(z.real*z.real));
+template <typename RealType> DECL Surreal<RealType> operator/(const int &r, const Surreal<RealType> &z) {
+    return Surreal<RealType>(r / z.real, -r * z.imag / (z.real * z.real));
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator/(
-    const float& r,
-    const Surreal<RealType> & z) {
-    return Surreal<RealType>(r/z.real, -r*z.imag/(z.real*z.real));
+template <typename RealType> DECL Surreal<RealType> operator/(const float &r, const Surreal<RealType> &z) {
+    return Surreal<RealType>(r / z.real, -r * z.imag / (z.real * z.real));
 }
 
-template <typename RealType>
-DECL Surreal<RealType> operator/(
-    const double& r,
-    const Surreal<RealType> & z) {
-    return Surreal<RealType>(r/z.real, -r*z.imag/(z.real*z.real));
+template <typename RealType> DECL Surreal<RealType> operator/(const double &r, const Surreal<RealType> &z) {
+    return Surreal<RealType>(r / z.real, -r * z.imag / (z.real * z.real));
 }
 
-
-template <typename RealType>
-DECL Surreal<RealType>& Surreal<RealType>::operator/=(const Surreal<RealType>& z) {
-    imag = (z.real*imag-real*z.imag)/(z.real*z.real);
+template <typename RealType> DECL Surreal<RealType> &Surreal<RealType>::operator/=(const Surreal<RealType> &z) {
+    imag = (z.real * imag - real * z.imag) / (z.real * z.real);
     real /= z.real;
     return *this;
 }
 
-template <typename RealType>
-DECL Surreal<RealType>& Surreal<RealType>::operator/=(const RealType& r) {
+template <typename RealType> DECL Surreal<RealType> &Surreal<RealType>::operator/=(const RealType &r) {
     real /= r;
     imag /= r;
     return *this;
@@ -358,100 +268,61 @@ DECL Surreal<RealType>& Surreal<RealType>::operator/=(const RealType& r) {
 
 template <typename RealType>
 template <typename OtherType>
-DECL Surreal<RealType>& Surreal<RealType>::operator/=(const OtherType& i) {
+DECL Surreal<RealType> &Surreal<RealType>::operator/=(const OtherType &i) {
     real /= RealType(i);
     imag /= RealType(i); // wtf?
     return *this;
 }
 
-template <typename RealType>
-DECL Surreal<RealType> sin(const Surreal<RealType>& z) {
-    return Surreal<RealType>(
-        sin(z.real),
-        z.imag*cos(z.real)
-    );
+template <typename RealType> DECL Surreal<RealType> sin(const Surreal<RealType> &z) {
+    return Surreal<RealType>(sin(z.real), z.imag * cos(z.real));
 }
 
-template <typename RealType>
-DECL Surreal<RealType> cos(const Surreal<RealType>& z) {
-    return Surreal<RealType>(
-        cos(z.real),
-        -z.imag*sin(z.real)
-    );
+template <typename RealType> DECL Surreal<RealType> cos(const Surreal<RealType> &z) {
+    return Surreal<RealType>(cos(z.real), -z.imag * sin(z.real));
 }
 
-template <typename RealType>
-DECL Surreal<RealType> acos(const Surreal<RealType>& z) {
-    return Surreal<RealType>(
-        acos(z.real),
-        -z.imag/sqrt(1.0-z.real*z.real+ERR)
-    );
+template <typename RealType> DECL Surreal<RealType> acos(const Surreal<RealType> &z) {
+    return Surreal<RealType>(acos(z.real), -z.imag / sqrt(1.0 - z.real * z.real + ERR));
 }
 
-template <typename RealType>
-DECL Surreal<RealType> tanh(const Surreal<RealType>& z) {
+template <typename RealType> DECL Surreal<RealType> tanh(const Surreal<RealType> &z) {
     double coshv = cosh(z.real);
-    return Surreal<RealType>(
-        tanh(z.real),
-        z.imag/(coshv*coshv)
-    );
+    return Surreal<RealType>(tanh(z.real), z.imag / (coshv * coshv));
 }
 
-template <typename RealType>
-DECL Surreal<RealType> cosh(const Surreal<RealType>& z) {
+template <typename RealType> DECL Surreal<RealType> cosh(const Surreal<RealType> &z) {
     double coshv = cosh(z.real);
     double sinhv = sinh(z.real);
+    return Surreal<RealType>(coshv, z.imag * sinhv);
+}
+
+template <typename RealType> DECL Surreal<RealType> atan2(const Surreal<RealType> &z1, const Surreal<RealType> &z2) {
     return Surreal<RealType>(
-        coshv,
-        z.imag*sinhv
-    );
+        atan2(z1.real, z2.real), (z2.real * z1.imag - z1.real * z2.imag) / (z1.real * z1.real + z2.real * z2.real));
 }
 
-template <typename RealType>
-DECL Surreal<RealType> atan2(const Surreal<RealType>& z1, const Surreal<RealType>& z2) {
-    return Surreal<RealType>(
-        atan2(z1.real,z2.real),
-        (z2.real*z1.imag-z1.real*z2.imag)/(z1.real*z1.real+z2.real*z2.real)
-    );
+template <typename RealType> DECL Surreal<RealType> log(const Surreal<RealType> &z) {
+    return Surreal<RealType>(log(z.real), z.imag / z.real);
 }
 
-
-template <typename RealType>
-DECL Surreal<RealType> log(const Surreal<RealType>& z) {
-    return Surreal<RealType>(log(z.real), z.imag/z.real);
-}
-
-
-template <typename RealType>
-DECL Surreal<RealType> sqrt(const Surreal<RealType>& z) {
+template <typename RealType> DECL Surreal<RealType> sqrt(const Surreal<RealType> &z) {
     RealType sqrtv = sqrt(z.real);
 
-    return Surreal<RealType>(
-        sqrtv,
-        0.5*z.imag/sqrtv
-    );
+    return Surreal<RealType>(sqrtv, 0.5 * z.imag / sqrtv);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> rsqrt(const Surreal<RealType>& z) {
-    RealType rsqrta = 1/sqrt(z.real);
+template <typename RealType> DECL Surreal<RealType> rsqrt(const Surreal<RealType> &z) {
+    RealType rsqrta = 1 / sqrt(z.real);
 
-    return Surreal<RealType>(
-        rsqrta,
-        -(z.imag*rsqrta)/(2*z.real)
-    );
+    return Surreal<RealType>(rsqrta, -(z.imag * rsqrta) / (2 * z.real));
 }
 
-template <typename RealType>
-DECL Surreal<RealType> exp(const Surreal<RealType>& z) {
+template <typename RealType> DECL Surreal<RealType> exp(const Surreal<RealType> &z) {
     RealType expv = exp(z.real);
-    return Surreal<RealType>(
-        expv,
-        z.imag*expv
-    );
+    return Surreal<RealType>(expv, z.imag * expv);
 }
 
-template <typename RealType>
-DECL Surreal<RealType> floor(const Surreal<RealType>& z) {
-    return Surreal<RealType>(floor(z.real),0.);
+template <typename RealType> DECL Surreal<RealType> floor(const Surreal<RealType> &z) {
+    return Surreal<RealType>(floor(z.real), 0.);
 }

--- a/timemachine/cpp/src/lambda_potential.cu
+++ b/timemachine/cpp/src/lambda_potential.cu
@@ -1,19 +1,16 @@
 
-#include "lambda_potential.hpp"
 #include "fixed_point.hpp"
 #include "gpu_utils.cuh"
+#include "lambda_potential.hpp"
 
 namespace timemachine {
 
-__global__ void k_reduce_add_force_buffer(
-    int count,
-    unsigned long long *out,
-    unsigned long long *buffer,
-    double lambda) {
+__global__ void
+k_reduce_add_force_buffer(int count, unsigned long long *out, unsigned long long *buffer, double lambda) {
 
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    if(idx >= count) {
+    if (idx >= count) {
         return;
     }
 
@@ -21,59 +18,39 @@ __global__ void k_reduce_add_force_buffer(
     double val = FIXED_TO_FLOAT<double>(buffer[idx]);
     val *= lambda;
 
-    unsigned long long fixed_val = static_cast<unsigned long long>((long long) (val*FIXED_EXPONENT));
+    unsigned long long fixed_val = static_cast<unsigned long long>((long long)(val * FIXED_EXPONENT));
 
     atomicAdd(out + idx, fixed_val);
-
 }
 
+template <typename RealType>
+__global__ void k_reduce_add_buffer(int count, RealType *out, RealType *buffer, double lambda) {
 
-template<typename RealType>
-__global__ void k_reduce_add_buffer(
-    int count,
-    RealType *out,
-    RealType *buffer,
-    double lambda) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
-
-    if(idx >= count) {
+    if (idx >= count) {
         return;
     }
 
     // does this work if one of them is an unsigned long long?
-    atomicAdd(out + idx, lambda*buffer[idx]);
-
+    atomicAdd(out + idx, lambda * buffer[idx]);
 }
 
-__global__ void k_reduce_add_du_dl(
-    double *du_dl,
-    double *u_buf,
-    double *du_dl_buf,
-    double multiplier,
-    double offset,
-    double lambda) {
+__global__ void
+k_reduce_add_du_dl(double *du_dl, double *u_buf, double *du_dl_buf, double multiplier, double offset, double lambda) {
 
-    if(threadIdx.x == 0) {
-        atomicAdd(du_dl, (multiplier*u_buf[0] + (multiplier*lambda + offset)*du_dl_buf[0]));
+    if (threadIdx.x == 0) {
+        atomicAdd(du_dl, (multiplier * u_buf[0] + (multiplier * lambda + offset) * du_dl_buf[0]));
     }
-
 }
 
+LambdaPotential::LambdaPotential(std::shared_ptr<Potential> u, int N, int P, double multiplier, double offset)
+    : u_(u), multiplier_(multiplier), offset_(offset) {
 
-LambdaPotential::LambdaPotential(
-    std::shared_ptr<Potential> u,
-    int N,
-    int P,
-    double multiplier,
-    double offset) :
-        u_(u), multiplier_(multiplier), offset_(offset) {
-
-    gpuErrchk(cudaMalloc(&d_du_dx_buffer_, N*3*sizeof(*d_du_dx_buffer_)));
-    gpuErrchk(cudaMalloc(&d_du_dp_buffer_, P*sizeof(*d_du_dp_buffer_)));
-    gpuErrchk(cudaMalloc(&d_du_dl_buffer_, 1*sizeof(*d_du_dl_buffer_)));
-    gpuErrchk(cudaMalloc(&d_u_buffer_, 1*sizeof(*d_u_buffer_)));
-
+    gpuErrchk(cudaMalloc(&d_du_dx_buffer_, N * 3 * sizeof(*d_du_dx_buffer_)));
+    gpuErrchk(cudaMalloc(&d_du_dp_buffer_, P * sizeof(*d_du_dp_buffer_)));
+    gpuErrchk(cudaMalloc(&d_du_dl_buffer_, 1 * sizeof(*d_du_dl_buffer_)));
+    gpuErrchk(cudaMalloc(&d_u_buffer_, 1 * sizeof(*d_u_buffer_)));
 }
 
 LambdaPotential::~LambdaPotential() {
@@ -98,21 +75,21 @@ void LambdaPotential::execute_device(
 
     // initialize buffer streams
 
-    if(d_du_dx) {
-       gpuErrchk(cudaMemsetAsync(d_du_dx_buffer_, 0, N*3*sizeof(*d_du_dx_buffer_), stream))
+    if (d_du_dx) {
+        gpuErrchk(cudaMemsetAsync(d_du_dx_buffer_, 0, N * 3 * sizeof(*d_du_dx_buffer_), stream))
     }
 
-    if(d_du_dp) {
-       gpuErrchk(cudaMemsetAsync(d_du_dp_buffer_, 0, P*sizeof(*d_du_dp_buffer_), stream))
+    if (d_du_dp) {
+        gpuErrchk(cudaMemsetAsync(d_du_dp_buffer_, 0, P * sizeof(*d_du_dp_buffer_), stream))
     }
 
-    if(d_du_dl) {
-        gpuErrchk(cudaMemsetAsync(d_du_dl_buffer_, 0, 1*sizeof(*d_du_dl_buffer_)));
+    if (d_du_dl) {
+        gpuErrchk(cudaMemsetAsync(d_du_dl_buffer_, 0, 1 * sizeof(*d_du_dl_buffer_)));
     }
 
     // extra check is due to the chain rule
-    if(d_u || d_du_dl) {
-        gpuErrchk(cudaMemsetAsync(d_u_buffer_, 0, 1*sizeof(*d_u_buffer_)));
+    if (d_u || d_du_dl) {
+        gpuErrchk(cudaMemsetAsync(d_u_buffer_, 0, 1 * sizeof(*d_u_buffer_)));
     }
 
     // let the alchemical potential a(l) be:
@@ -129,34 +106,33 @@ void LambdaPotential::execute_device(
         d_du_dp ? d_du_dp_buffer_ : nullptr,
         d_du_dl ? d_du_dl_buffer_ : nullptr,
         (d_du_dl || d_u) ? d_u_buffer_ : nullptr,
-        stream
-    );
+        stream);
 
     int tpb = 32;
 
-    if(d_du_dx) {
-        int count = N*3;
-        int blocks = (count + tpb - 1)/tpb;
-        k_reduce_add_force_buffer<<<blocks, tpb, 0, stream>>>(count, d_du_dx, d_du_dx_buffer_, multiplier_*lambda + offset_);
+    if (d_du_dx) {
+        int count = N * 3;
+        int blocks = (count + tpb - 1) / tpb;
+        k_reduce_add_force_buffer<<<blocks, tpb, 0, stream>>>(
+            count, d_du_dx, d_du_dx_buffer_, multiplier_ * lambda + offset_);
         gpuErrchk(cudaPeekAtLastError());
     }
 
-    if(d_du_dp) {
-        int blocks = (P + tpb - 1)/tpb;
-        k_reduce_add_buffer<<<blocks, tpb, 0, stream>>>(P, d_du_dp, d_du_dp_buffer_, multiplier_*lambda + offset_);
+    if (d_du_dp) {
+        int blocks = (P + tpb - 1) / tpb;
+        k_reduce_add_buffer<<<blocks, tpb, 0, stream>>>(P, d_du_dp, d_du_dp_buffer_, multiplier_ * lambda + offset_);
         gpuErrchk(cudaPeekAtLastError());
     }
 
-    if(d_du_dl) {
+    if (d_du_dl) {
         k_reduce_add_du_dl<<<1, tpb, 0, stream>>>(d_du_dl, d_u_buffer_, d_du_dl_buffer_, multiplier_, offset_, lambda);
         gpuErrchk(cudaPeekAtLastError());
     }
 
-    if(d_u) {
-        k_reduce_add_buffer<<<1, tpb, 0, stream>>>(1, d_u, d_u_buffer_, multiplier_*lambda + offset_);
+    if (d_u) {
+        k_reduce_add_buffer<<<1, tpb, 0, stream>>>(1, d_u, d_u_buffer_, multiplier_ * lambda + offset_);
         gpuErrchk(cudaPeekAtLastError());
     }
-
 }
 
-}
+} // namespace timemachine

--- a/timemachine/cpp/src/langevin.cu
+++ b/timemachine/cpp/src/langevin.cu
@@ -11,8 +11,6 @@
 // #include "langevin.hpp"
 // #include "gpu_utils.cuh"
 
-
-
 // template <typename RealType>
 // __global__ void update_positions(
 //     const RealType *noise,
@@ -28,14 +26,12 @@
 //     RealType *x_t,
 //     RealType *v_t) {
 
-
 //     int atom_idx = blockIdx.x*blockDim.x + threadIdx.x;
 //     if(atom_idx >= N) {
 //         return;
 //     }
 
 //     int d_idx = blockIdx.y;
-
 
 //     int local_idx = atom_idx*D + d_idx;
 //     // only integrate first three dimensions
@@ -46,14 +42,12 @@
 //         return;
 //     }
 
-
 //     // truncated noise
 //     auto n = noise[local_idx];
 //     v_t[local_idx] = coeff_a*v_t[local_idx] - coeff_bs[atom_idx]*dE_dx[local_idx] + coeff_cs[atom_idx]*n;
 //     x_t[local_idx] = (1 - coeff_d*coeff_bs[atom_idx]*dt)*x_t[local_idx] + v_t[local_idx]*dt;
 
 // }
-
 
 // template<typename RealType>
 // __global__ void update_derivatives(
@@ -87,9 +81,7 @@
 
 // }
 
-
 // namespace timemachine {
-
 
 // template<typename RealType>
 // LangevinOptimizer<RealType>::LangevinOptimizer(
@@ -124,7 +116,6 @@
 //     curandErrchk(curandSetPseudoRandomGeneratorSeed(cr_rng_, seed));
 
 // }
-
 
 // template<typename RealType>
 // LangevinOptimizer<RealType>::~LangevinOptimizer() {
@@ -298,11 +289,9 @@
 //         // cusparseErrchk(cusparseDense2csr(handle, ND, ND, descr_A, d_A, ND, d_A_nnz_per_row,
 //             // d_sparse_A, d_sparse_A_rowptr, d_sparse_A_colptr));
 
-
 //         auto start4 = std::chrono::high_resolution_clock::now();
 //         cusparseErrchk(cusparseDense2csr(handle, N_offset, N_offset, descr_A, d_A, ND, d_A_nnz_per_row,
 //             d_sparse_A, d_sparse_A_rowptr, d_sparse_A_colptr));
-
 
 //         cudaDeviceSynchronize();
 //         auto stop4 = std::chrono::high_resolution_clock::now();

--- a/timemachine/cpp/src/lennard_jones.cu
+++ b/timemachine/cpp/src/lennard_jones.cu
@@ -1,62 +1,59 @@
-#include <chrono>
-#include <iostream>
-#include <vector>
-#include <complex>
-#include <numeric>
 #include <algorithm>
+#include <chrono>
+#include <complex>
+#include <iostream>
+#include <numeric>
+#include <vector>
 
-#include "lennard_jones.hpp"
 #include "gpu_utils.cuh"
+#include "lennard_jones.hpp"
 
 #include "k_lennard_jones.cuh"
 #include "k_lennard_jones_jvp.cuh"
-
 
 namespace timemachine {
 
 template <typename RealType>
 LennardJones<RealType>::LennardJones(
     // const std::vector<double> &lj_params, // [N,2]
-    const std::vector<int> &exclusion_idxs, // [E,2]
-    const std::vector<double> &lj_scales, // [E]
-    const std::vector<int> &lambda_plane_idxs, // [N]
+    const std::vector<int> &exclusion_idxs,     // [E,2]
+    const std::vector<double> &lj_scales,       // [E]
+    const std::vector<int> &lambda_plane_idxs,  // [N]
     const std::vector<int> &lambda_offset_idxs, // [N]
     // const std::vector<int> &lambda_group_idxs, // [N]
-    double cutoff
-) :  N_(lambda_plane_idxs.size()),
-    cutoff_(cutoff),
-    E_(exclusion_idxs.size()/2),
-    nblist_(lambda_plane_idxs.size()),
-    d_perm_(nullptr) {
+    double cutoff)
+    : N_(lambda_plane_idxs.size()), cutoff_(cutoff), E_(exclusion_idxs.size() / 2), nblist_(lambda_plane_idxs.size()),
+      d_perm_(nullptr) {
 
-    if(lambda_plane_idxs.size() != N_) {
+    if (lambda_plane_idxs.size() != N_) {
         throw std::runtime_error("lambda plane idxs need to have size N");
     }
 
-    if(lambda_offset_idxs.size() != N_) {
+    if (lambda_offset_idxs.size() != N_) {
         throw std::runtime_error("lambda offset idxs need to have size N");
     }
 
-    if(lj_scales.size()*2 != exclusion_idxs.size()) {
+    if (lj_scales.size() * 2 != exclusion_idxs.size()) {
         throw std::runtime_error("charge scale idxs size not half of exclusion size!");
     }
 
-    gpuErrchk(cudaMalloc(&d_lambda_plane_idxs_, N_*sizeof(*d_lambda_plane_idxs_)));
-    gpuErrchk(cudaMemcpy(d_lambda_plane_idxs_, &lambda_plane_idxs[0], N_*sizeof(*d_lambda_plane_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_lambda_plane_idxs_, N_ * sizeof(*d_lambda_plane_idxs_)));
+    gpuErrchk(cudaMemcpy(
+        d_lambda_plane_idxs_, &lambda_plane_idxs[0], N_ * sizeof(*d_lambda_plane_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_lambda_offset_idxs_, N_*sizeof(*d_lambda_offset_idxs_)));
-    gpuErrchk(cudaMemcpy(d_lambda_offset_idxs_, &lambda_offset_idxs[0], N_*sizeof(*d_lambda_offset_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_lambda_offset_idxs_, N_ * sizeof(*d_lambda_offset_idxs_)));
+    gpuErrchk(cudaMemcpy(
+        d_lambda_offset_idxs_, &lambda_offset_idxs[0], N_ * sizeof(*d_lambda_offset_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_exclusion_idxs_, E_*2*sizeof(*d_exclusion_idxs_)));
-    gpuErrchk(cudaMemcpy(d_exclusion_idxs_, &exclusion_idxs[0], E_*2*sizeof(*d_exclusion_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_exclusion_idxs_, E_ * 2 * sizeof(*d_exclusion_idxs_)));
+    gpuErrchk(
+        cudaMemcpy(d_exclusion_idxs_, &exclusion_idxs[0], E_ * 2 * sizeof(*d_exclusion_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_lj_scales_, E_*sizeof(*d_lj_scales_)));
-    gpuErrchk(cudaMemcpy(d_lj_scales_, &lj_scales[0], E_*sizeof(*d_lj_scales_), cudaMemcpyHostToDevice));
-
+    gpuErrchk(cudaMalloc(&d_lj_scales_, E_ * sizeof(*d_lj_scales_)));
+    gpuErrchk(cudaMemcpy(d_lj_scales_, &lj_scales[0], E_ * sizeof(*d_lj_scales_), cudaMemcpyHostToDevice));
 };
 
-template <typename RealType>
-LennardJones<RealType>::~LennardJones() {
+template <typename RealType> LennardJones<RealType>::~LennardJones() {
     gpuErrchk(cudaFree(d_exclusion_idxs_));
     gpuErrchk(cudaFree(d_lj_scales_));
     gpuErrchk(cudaFree(d_lambda_plane_idxs_));
@@ -64,18 +61,14 @@ LennardJones<RealType>::~LennardJones() {
     gpuErrchk(cudaFree(d_perm_));
 };
 
-
 // stackoverflow is your best friend
 // https://stackoverflow.com/questions/1577475/c-sorting-and-keeping-track-of-indexes
-template <typename T>
-std::vector<int> argsort(const std::vector<T> &v) {
-  std::vector<int> idx(v.size());
-  iota(idx.begin(), idx.end(), 0);
-  stable_sort(idx.begin(), idx.end(),
-       [&v](int i1, int i2) {return v[i1] < v[i2];});
-  return idx;
+template <typename T> std::vector<int> argsort(const std::vector<T> &v) {
+    std::vector<int> idx(v.size());
+    iota(idx.begin(), idx.end(), 0);
+    stable_sort(idx.begin(), idx.end(), [&v](int i1, int i2) { return v[i1] < v[i2]; });
+    return idx;
 }
-
 
 template <typename RealType>
 void LennardJones<RealType>::execute_device(
@@ -91,30 +84,30 @@ void LennardJones<RealType>::execute_device(
     double *d_u,
     cudaStream_t stream) {
 
-    if(N != N_) {
+    if (N != N_) {
         std::ostringstream err_msg;
         err_msg << "N != N_ " << N << " " << N_;
         throw std::runtime_error(err_msg.str());
     }
 
     const int tpb = 32;
-    const int B = (N_+tpb-1)/tpb;
+    const int B = (N_ + tpb - 1) / tpb;
     const int D = 3;
 
     // sort the particles once based on epsilons
-    if(d_perm_ == nullptr) {
+    if (d_perm_ == nullptr) {
 
-        gpuErrchk(cudaMalloc(&d_perm_, N_*sizeof(*d_perm_)));
+        gpuErrchk(cudaMalloc(&d_perm_, N_ * sizeof(*d_perm_)));
 
-        std::vector<double> lj_params(N*2);
-        gpuErrchk(cudaMemcpy(&lj_params[0], d_p, N*2*sizeof(*d_p), cudaMemcpyDeviceToHost));
+        std::vector<double> lj_params(N * 2);
+        gpuErrchk(cudaMemcpy(&lj_params[0], d_p, N * 2 * sizeof(*d_p), cudaMemcpyDeviceToHost));
         std::vector<double> eps_params(N);
-        for(int i=0; i < N; i++) {
-            eps_params[i] = lj_params[2*i+1];
+        for (int i = 0; i < N; i++) {
+            eps_params[i] = lj_params[2 * i + 1];
         }
 
         std::vector<int> perm = argsort(eps_params);
-        gpuErrchk(cudaMemcpy(d_perm_, &perm[0], N*sizeof(*d_perm_), cudaMemcpyHostToDevice));
+        gpuErrchk(cudaMemcpy(d_perm_, &perm[0], N * sizeof(*d_perm_), cudaMemcpyHostToDevice));
     }
 
     // is this correct?
@@ -130,7 +123,7 @@ void LennardJones<RealType>::execute_device(
     gpuErrchk(cudaPeekAtLastError());
 
     dim3 dimGrid(B, B, 1); // x, y, z dims
-    dim3 dimGridExclusions((E_+tpb-1)/tpb, 1, 1);
+    dim3 dimGridExclusions((E_ + tpb - 1) / tpb, 1, 1);
 
     auto start = std::chrono::high_resolution_clock::now();
 
@@ -167,7 +160,7 @@ void LennardJones<RealType>::execute_device(
     // cudaDeviceSynchronize();
     gpuErrchk(cudaPeekAtLastError());
 
-    if(E_ > 0) {
+    if (E_ > 0) {
         k_lennard_jones_exclusion_inference<RealType><<<dimGridExclusions, tpb, 0, stream>>>(
             E_,
             d_x,
@@ -182,8 +175,7 @@ void LennardJones<RealType>::execute_device(
             d_du_dx,
             d_du_dp,
             d_du_dl,
-            d_u
-        );
+            d_u);
         // cudaDeviceSynchronize();
         gpuErrchk(cudaPeekAtLastError());
     }

--- a/timemachine/cpp/src/math_utils.cuh
+++ b/timemachine/cpp/src/math_utils.cuh
@@ -1,17 +1,9 @@
 #pragma once
 
-__device__ __host__ double sign(double a) {
-  return (a > 0) - (a < 0);
-}
+__device__ __host__ double sign(double a) { return (a > 0) - (a < 0); }
 
-__device__ __host__ float sign(float a) {
-  return (a > 0) - (a < 0);
-}
+__device__ __host__ float sign(float a) { return (a > 0) - (a < 0); }
 
-__device__ __host__ double sign(Surreal<double> a) {
-  return (a.real > 0) - (a.real < 0);
-}
+__device__ __host__ double sign(Surreal<double> a) { return (a.real > 0) - (a.real < 0); }
 
-__device__ __host__ float sign(Surreal<float> a) {
-  return (a.real > 0) - (a.real < 0);
-}
+__device__ __host__ float sign(Surreal<float> a) { return (a.real > 0) - (a.real < 0); }

--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -1,38 +1,33 @@
 #include <cassert>
-#include <vector>
 #include <iostream>
+#include <vector>
 
-#include "neighborlist.hpp"
-#include "k_neighborlist.cuh"
 #include "gpu_utils.cuh"
+#include "k_neighborlist.cuh"
+#include "neighborlist.hpp"
 
 namespace timemachine {
 
-template<typename RealType>
-Neighborlist<RealType>::Neighborlist(
-    int N) : N_(N) {
+template <typename RealType> Neighborlist<RealType>::Neighborlist(int N) : N_(N) {
 
     const int B = this->B(); //(N+32-1)/32;
     const int Y = this->Y(); //(B+32-1)/32;
 
-    unsigned long long MAX_TILE_BUFFER = B*B;
-    unsigned long long MAX_ATOM_BUFFER = B*B*32;
+    unsigned long long MAX_TILE_BUFFER = B * B;
+    unsigned long long MAX_ATOM_BUFFER = B * B * 32;
 
     // interaction buffers
-    gpuErrchk(cudaMalloc(&d_ixn_count_, 1*sizeof(*d_ixn_count_)));
-    gpuErrchk(cudaMalloc(&d_ixn_tiles_, MAX_TILE_BUFFER*sizeof(*d_ixn_tiles_)));
-    gpuErrchk(cudaMalloc(&d_ixn_atoms_, MAX_ATOM_BUFFER*sizeof(*d_ixn_atoms_)));
-    gpuErrchk(cudaMalloc(&d_trim_atoms_, B*Y*32*sizeof(*d_trim_atoms_)));
-
+    gpuErrchk(cudaMalloc(&d_ixn_count_, 1 * sizeof(*d_ixn_count_)));
+    gpuErrchk(cudaMalloc(&d_ixn_tiles_, MAX_TILE_BUFFER * sizeof(*d_ixn_tiles_)));
+    gpuErrchk(cudaMalloc(&d_ixn_atoms_, MAX_ATOM_BUFFER * sizeof(*d_ixn_atoms_)));
+    gpuErrchk(cudaMalloc(&d_trim_atoms_, B * Y * 32 * sizeof(*d_trim_atoms_)));
 
     // bounding box buffers
-    gpuErrchk(cudaMalloc(&d_block_bounds_ctr_, B*3*sizeof(*d_block_bounds_ctr_)));
-    gpuErrchk(cudaMalloc(&d_block_bounds_ext_, B*3*sizeof(*d_block_bounds_ext_)));
-
+    gpuErrchk(cudaMalloc(&d_block_bounds_ctr_, B * 3 * sizeof(*d_block_bounds_ctr_)));
+    gpuErrchk(cudaMalloc(&d_block_bounds_ext_, B * 3 * sizeof(*d_block_bounds_ext_)));
 }
 
-template<typename RealType>
-Neighborlist<RealType>::~Neighborlist() {
+template <typename RealType> Neighborlist<RealType>::~Neighborlist() {
 
     gpuErrchk(cudaFree(d_ixn_count_));
     gpuErrchk(cudaFree(d_ixn_tiles_));
@@ -41,30 +36,31 @@ Neighborlist<RealType>::~Neighborlist() {
 
     gpuErrchk(cudaFree(d_block_bounds_ctr_));
     gpuErrchk(cudaFree(d_block_bounds_ext_));
-
 }
 
-
-bool is_pow_2(int x) {
-    return (x & (x - 1)) == 0;
-}
+bool is_pow_2(int x) { return (x & (x - 1)) == 0; }
 
 int log2_int(int v) {
     int bits = 0;
-    while (v >>= 1) ++bits;
+    while (v >>= 1)
+        ++bits;
     return bits;
 }
 
 int pow_int(int x, int p) {
-  if (p == 0) return 1;
-  if (p == 1) return x;
+    if (p == 0)
+        return 1;
+    if (p == 1)
+        return x;
 
-  int tmp = pow_int(x, p/2);
-  if (p%2 == 0) return tmp * tmp;
-  else return x * tmp * tmp;
+    int tmp = pow_int(x, p / 2);
+    if (p % 2 == 0)
+        return tmp * tmp;
+    else
+        return x * tmp * tmp;
 }
 
-template<typename RealType>
+template <typename RealType>
 void Neighborlist<RealType>::compute_block_bounds_host(
     const int N,
     const int D,
@@ -77,66 +73,53 @@ void Neighborlist<RealType>::compute_block_bounds_host(
     assert(N == N_);
     assert(D == 3);
 
-    double *d_coords = gpuErrchkCudaMallocAndCopy(h_coords, N*3*sizeof(double));
-    double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3*3*sizeof(double));
+    double *d_coords = gpuErrchkCudaMallocAndCopy(h_coords, N * 3 * sizeof(double));
+    double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3 * 3 * sizeof(double));
 
-    this->compute_block_bounds_device(
-        N,
-        D,
-        d_coords,
-        d_box,
-        static_cast<cudaStream_t>(0)
-    );
+    this->compute_block_bounds_device(N, D, d_coords, d_box, static_cast<cudaStream_t>(0));
     gpuErrchk(cudaDeviceSynchronize());
 
-    gpuErrchk(cudaMemcpy(h_bb_ctrs, d_block_bounds_ctr_, this->B()*3*sizeof(*d_block_bounds_ctr_), cudaMemcpyDeviceToHost));
-    gpuErrchk(cudaMemcpy(h_bb_exts, d_block_bounds_ext_, this->B()*3*sizeof(*d_block_bounds_ext_), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(
+        h_bb_ctrs, d_block_bounds_ctr_, this->B() * 3 * sizeof(*d_block_bounds_ctr_), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(
+        h_bb_exts, d_block_bounds_ext_, this->B() * 3 * sizeof(*d_block_bounds_ext_), cudaMemcpyDeviceToHost));
 
     gpuErrchk(cudaFree(d_coords));
     gpuErrchk(cudaFree(d_box));
-
 }
 
-template<typename RealType>
-std::vector<std::vector<int> > Neighborlist<RealType>::get_nblist_host(
-    int N,
-    const double *h_coords,
-    const double *h_box,
-    const double cutoff) {
+template <typename RealType>
+std::vector<std::vector<int>>
+Neighborlist<RealType>::get_nblist_host(int N, const double *h_coords, const double *h_box, const double cutoff) {
 
     // assert(N==N_);
 
-    double *d_coords = gpuErrchkCudaMallocAndCopy(h_coords, N*3*sizeof(double));
-    double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3*3*sizeof(double));
+    double *d_coords = gpuErrchkCudaMallocAndCopy(h_coords, N * 3 * sizeof(double));
+    double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3 * 3 * sizeof(double));
 
-    this->build_nblist_device(
-        N,
-        d_coords,
-        d_box,
-        cutoff,
-        static_cast<cudaStream_t>(0)
-    );
+    this->build_nblist_device(N, d_coords, d_box, cutoff, static_cast<cudaStream_t>(0));
 
     cudaDeviceSynchronize();
     const int B = this->B(); //(N+32-1)/32;
 
-    unsigned long long MAX_TILE_BUFFER = B*B;
-    unsigned long long MAX_ATOM_BUFFER = B*B*32;
+    unsigned long long MAX_TILE_BUFFER = B * B;
+    unsigned long long MAX_ATOM_BUFFER = B * B * 32;
 
     unsigned int h_ixn_count;
-    gpuErrchk(cudaMemcpy(&h_ixn_count, d_ixn_count_, 1*sizeof(*d_ixn_count_), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(&h_ixn_count, d_ixn_count_, 1 * sizeof(*d_ixn_count_), cudaMemcpyDeviceToHost));
     std::vector<int> h_ixn_tiles(MAX_TILE_BUFFER);
     std::vector<unsigned int> h_ixn_atoms(MAX_ATOM_BUFFER);
-    gpuErrchk(cudaMemcpy(&h_ixn_tiles[0], d_ixn_tiles_, MAX_TILE_BUFFER*sizeof(int), cudaMemcpyDeviceToHost));
-    gpuErrchk(cudaMemcpy(&h_ixn_atoms[0], d_ixn_atoms_, MAX_ATOM_BUFFER*sizeof(unsigned int), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(&h_ixn_tiles[0], d_ixn_tiles_, MAX_TILE_BUFFER * sizeof(int), cudaMemcpyDeviceToHost));
+    gpuErrchk(
+        cudaMemcpy(&h_ixn_atoms[0], d_ixn_atoms_, MAX_ATOM_BUFFER * sizeof(unsigned int), cudaMemcpyDeviceToHost));
 
-    std::vector<std::vector<int> > ixn_list(B, std::vector<int>());
+    std::vector<std::vector<int>> ixn_list(B, std::vector<int>());
 
-    for(int i=0; i < h_ixn_count; i++) {
+    for (int i = 0; i < h_ixn_count; i++) {
         int tile_idx = h_ixn_tiles[i];
-        for(int j=0; j < 32; j++) {
-            int atom_j_idx = h_ixn_atoms[i*32+j];
-            if(atom_j_idx < N) {
+        for (int j = 0; j < 32; j++) {
+            int atom_j_idx = h_ixn_atoms[i * 32 + j];
+            if (atom_j_idx < N) {
                 ixn_list[tile_idx].push_back(atom_j_idx);
             }
         }
@@ -146,30 +129,19 @@ std::vector<std::vector<int> > Neighborlist<RealType>::get_nblist_host(
     gpuErrchk(cudaFree(d_box));
 
     return ixn_list;
-
 }
 
-template<typename RealType>
+template <typename RealType>
 void Neighborlist<RealType>::build_nblist_device(
-    const int N,
-    const double *d_coords,
-    const double *d_box,
-    const double cutoff,
-    cudaStream_t stream) {
+    const int N, const double *d_coords, const double *d_box, const double cutoff, cudaStream_t stream) {
 
     // assert(N == N_);
 
     // reset the interaction count
-    gpuErrchk(cudaMemsetAsync(d_ixn_count_, 0, 1*sizeof(*d_ixn_count_), stream));
+    gpuErrchk(cudaMemsetAsync(d_ixn_count_, 0, 1 * sizeof(*d_ixn_count_), stream));
 
     const int D = 3;
-    this->compute_block_bounds_device(
-        N,
-        D,
-        d_coords,
-        d_box,
-        stream
-    );
+    this->compute_block_bounds_device(N, D, d_coords, d_box, stream);
 
     int tpb = 32;
     const int B = this->B(); // (N+32-1)/32;
@@ -188,55 +160,36 @@ void Neighborlist<RealType>::build_nblist_device(
         d_ixn_tiles_,
         d_ixn_atoms_,
         d_trim_atoms_,
-        cutoff
-    );
+        cutoff);
 
     gpuErrchk(cudaPeekAtLastError());
 
-    k_compact_trim_atoms<<<B, tpb, 0, stream>>>(
-        N,
-        Y,
-        d_trim_atoms_,
-        d_ixn_count_,
-        d_ixn_tiles_,
-        d_ixn_atoms_
-    );
+    k_compact_trim_atoms<<<B, tpb, 0, stream>>>(N, Y, d_trim_atoms_, d_ixn_count_, d_ixn_tiles_, d_ixn_atoms_);
 
     gpuErrchk(cudaPeekAtLastError());
-
 }
 
 template <typename RealType>
 void Neighborlist<RealType>::compute_block_bounds_device(
-    const int N, // Number of atoms
-    const int D, // Box dimensions
+    const int N,            // Number of atoms
+    const int D,            // Box dimensions
     const double *d_coords, // [N*3]
-    const double *d_box, // [D*3]
+    const double *d_box,    // [D*3]
     cudaStream_t stream) {
 
     assert(N == N_);
     assert(D == 3);
 
     const int tpb = 32;
-    const int B = (N+tpb-1)/tpb; // total number of blocks we need to process
+    const int B = (N + tpb - 1) / tpb; // total number of blocks we need to process
 
-    k_find_block_bounds<RealType><<<B, tpb, 0, stream>>>(
-        N,
-        D,
-        B,
-        d_coords,
-        d_box,
-        d_block_bounds_ctr_,
-        d_block_bounds_ext_
-    );
+    k_find_block_bounds<RealType>
+        <<<B, tpb, 0, stream>>>(N, D, B, d_coords, d_box, d_block_bounds_ctr_, d_block_bounds_ext_);
 
     gpuErrchk(cudaPeekAtLastError());
-
 };
-
 
 template class Neighborlist<double>;
 template class Neighborlist<float>;
 
-
-}
+} // namespace timemachine

--- a/timemachine/cpp/src/nonbonded.cu
+++ b/timemachine/cpp/src/nonbonded.cu
@@ -1,30 +1,30 @@
+#include "vendored/jitify.hpp"
+#include <algorithm>
 #include <cassert>
 #include <chrono>
-#include <iostream>
-#include <vector>
-#include <algorithm>
 #include <complex>
 #include <cstdlib>
 #include <cub/cub.cuh>
-#include "vendored/jitify.hpp"
+#include <iostream>
+#include <vector>
 
+#include "gpu_utils.cuh"
 #include "nonbonded.hpp"
 #include "vendored/hilbert.h"
-#include "gpu_utils.cuh"
 
 #include "k_nonbonded.cuh"
 
-#include <string>
 #include <fstream>
 #include <streambuf>
+#include <string>
 
 namespace timemachine {
 
 template <typename RealType, bool Interpolated>
 Nonbonded<RealType, Interpolated>::Nonbonded(
-    const std::vector<int> &exclusion_idxs, // [E,2]
-    const std::vector<double> &scales, // [E, 2]
-    const std::vector<int> &lambda_plane_idxs, // [N]
+    const std::vector<int> &exclusion_idxs,     // [E,2]
+    const std::vector<double> &scales,          // [E, 2]
+    const std::vector<int> &lambda_plane_idxs,  // [N]
     const std::vector<int> &lambda_offset_idxs, // [N]
     const double beta,
     const double cutoff,
@@ -33,102 +33,99 @@ Nonbonded<RealType, Interpolated>::Nonbonded(
     // const std::string &transform_lambda_sigma,
     // const std::string &transform_lambda_epsilon,
     // const std::string &transform_lambda_w
-) :  N_(lambda_offset_idxs.size()),
-    cutoff_(cutoff),
-    E_(exclusion_idxs.size()/2),
-    nblist_(lambda_offset_idxs.size()),
-    beta_(beta),
-    d_sort_storage_(nullptr),
-    d_sort_storage_bytes_(0),
-    nblist_padding_(0.1),
-    disable_hilbert_(false),
-    kernel_ptrs_({
-        // enumerate over every possible kernel combination
-        // U: Compute U
-        // X: Compute DU_DL
-        // L: Compute DU_DX
-        // P: Compute DU_DP
-        //                             U  X  L  P
-        &k_nonbonded_unified<RealType, 0, 0, 0, 0>,
-        &k_nonbonded_unified<RealType, 0, 0, 0, 1>,
-        &k_nonbonded_unified<RealType, 0, 0, 1, 0>,
-        &k_nonbonded_unified<RealType, 0, 0, 1, 1>,
-        &k_nonbonded_unified<RealType, 0, 1, 0, 0>,
-        &k_nonbonded_unified<RealType, 0, 1, 0, 1>,
-        &k_nonbonded_unified<RealType, 0, 1, 1, 0>,
-        &k_nonbonded_unified<RealType, 0, 1, 1, 1>,
-        &k_nonbonded_unified<RealType, 1, 0, 0, 0>,
-        &k_nonbonded_unified<RealType, 1, 0, 0, 1>,
-        &k_nonbonded_unified<RealType, 1, 0, 1, 0>,
-        &k_nonbonded_unified<RealType, 1, 0, 1, 1>,
-        &k_nonbonded_unified<RealType, 1, 1, 0, 0>,
-        &k_nonbonded_unified<RealType, 1, 1, 0, 1>,
-        &k_nonbonded_unified<RealType, 1, 1, 1, 0>,
-        &k_nonbonded_unified<RealType, 1, 1, 1, 1>
-    }),
-    compute_w_coords_instance_(kernel_cache_.program(kernel_src.c_str()).kernel("k_compute_w_coords").instantiate()),
-    compute_permute_interpolated_(kernel_cache_.program(kernel_src.c_str()).kernel("k_permute_interpolated").instantiate()),
-    compute_add_ull_to_real_interpolated_(kernel_cache_.program(kernel_src.c_str()).kernel("k_add_ull_to_real_interpolated").instantiate()) {
+    )
+    : N_(lambda_offset_idxs.size()), cutoff_(cutoff), E_(exclusion_idxs.size() / 2), nblist_(lambda_offset_idxs.size()),
+      beta_(beta), d_sort_storage_(nullptr), d_sort_storage_bytes_(0), nblist_padding_(0.1), disable_hilbert_(false),
+      kernel_ptrs_({// enumerate over every possible kernel combination
+                    // U: Compute U
+                    // X: Compute DU_DL
+                    // L: Compute DU_DX
+                    // P: Compute DU_DP
+                    //                             U  X  L  P
+                    &k_nonbonded_unified<RealType, 0, 0, 0, 0>,
+                    &k_nonbonded_unified<RealType, 0, 0, 0, 1>,
+                    &k_nonbonded_unified<RealType, 0, 0, 1, 0>,
+                    &k_nonbonded_unified<RealType, 0, 0, 1, 1>,
+                    &k_nonbonded_unified<RealType, 0, 1, 0, 0>,
+                    &k_nonbonded_unified<RealType, 0, 1, 0, 1>,
+                    &k_nonbonded_unified<RealType, 0, 1, 1, 0>,
+                    &k_nonbonded_unified<RealType, 0, 1, 1, 1>,
+                    &k_nonbonded_unified<RealType, 1, 0, 0, 0>,
+                    &k_nonbonded_unified<RealType, 1, 0, 0, 1>,
+                    &k_nonbonded_unified<RealType, 1, 0, 1, 0>,
+                    &k_nonbonded_unified<RealType, 1, 0, 1, 1>,
+                    &k_nonbonded_unified<RealType, 1, 1, 0, 0>,
+                    &k_nonbonded_unified<RealType, 1, 1, 0, 1>,
+                    &k_nonbonded_unified<RealType, 1, 1, 1, 0>,
+                    &k_nonbonded_unified<RealType, 1, 1, 1, 1>}),
+      compute_w_coords_instance_(kernel_cache_.program(kernel_src.c_str()).kernel("k_compute_w_coords").instantiate()),
+      compute_permute_interpolated_(
+          kernel_cache_.program(kernel_src.c_str()).kernel("k_permute_interpolated").instantiate()),
+      compute_add_ull_to_real_interpolated_(
+          kernel_cache_.program(kernel_src.c_str()).kernel("k_add_ull_to_real_interpolated").instantiate()) {
 
-    if(lambda_offset_idxs.size() != N_) {
+    if (lambda_offset_idxs.size() != N_) {
         throw std::runtime_error("lambda offset idxs need to have size N");
     }
 
-    if(lambda_offset_idxs.size() != lambda_plane_idxs.size()) {
+    if (lambda_offset_idxs.size() != lambda_plane_idxs.size()) {
         throw std::runtime_error("lambda offset idxs and plane idxs need to be equivalent");
     }
 
-    if(scales.size()/2 != E_) {
+    if (scales.size() / 2 != E_) {
         throw std::runtime_error("bad scales size!");
     }
 
-    gpuErrchk(cudaMalloc(&d_lambda_plane_idxs_, N_*sizeof(*d_lambda_plane_idxs_)));
-    gpuErrchk(cudaMemcpy(d_lambda_plane_idxs_, &lambda_plane_idxs[0], N_*sizeof(*d_lambda_plane_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_lambda_plane_idxs_, N_ * sizeof(*d_lambda_plane_idxs_)));
+    gpuErrchk(cudaMemcpy(
+        d_lambda_plane_idxs_, &lambda_plane_idxs[0], N_ * sizeof(*d_lambda_plane_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_lambda_offset_idxs_, N_*sizeof(*d_lambda_offset_idxs_)));
-    gpuErrchk(cudaMemcpy(d_lambda_offset_idxs_, &lambda_offset_idxs[0], N_*sizeof(*d_lambda_offset_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_lambda_offset_idxs_, N_ * sizeof(*d_lambda_offset_idxs_)));
+    gpuErrchk(cudaMemcpy(
+        d_lambda_offset_idxs_, &lambda_offset_idxs[0], N_ * sizeof(*d_lambda_offset_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_perm_, N_*sizeof(*d_perm_)));
+    gpuErrchk(cudaMalloc(&d_perm_, N_ * sizeof(*d_perm_)));
 
-    gpuErrchk(cudaMalloc(&d_sorted_x_, N_*3*sizeof(*d_sorted_x_)));
+    gpuErrchk(cudaMalloc(&d_sorted_x_, N_ * 3 * sizeof(*d_sorted_x_)));
 
-    gpuErrchk(cudaMalloc(&d_w_, N_*sizeof(*d_w_)));
-    gpuErrchk(cudaMalloc(&d_dw_dl_, N_*sizeof(*d_dw_dl_)));
-    gpuErrchk(cudaMalloc(&d_sorted_w_, N_*sizeof(*d_sorted_w_)));
-    gpuErrchk(cudaMalloc(&d_sorted_dw_dl_, N_*sizeof(*d_sorted_dw_dl_)));
+    gpuErrchk(cudaMalloc(&d_w_, N_ * sizeof(*d_w_)));
+    gpuErrchk(cudaMalloc(&d_dw_dl_, N_ * sizeof(*d_dw_dl_)));
+    gpuErrchk(cudaMalloc(&d_sorted_w_, N_ * sizeof(*d_sorted_w_)));
+    gpuErrchk(cudaMalloc(&d_sorted_dw_dl_, N_ * sizeof(*d_sorted_dw_dl_)));
 
-    gpuErrchk(cudaMalloc(&d_unsorted_p_, N_*3*sizeof(*d_unsorted_p_))); // interpolated
-    gpuErrchk(cudaMalloc(&d_sorted_p_, N_*3*sizeof(*d_sorted_p_))); // interpolated
-    gpuErrchk(cudaMalloc(&d_unsorted_dp_dl_, N_*3*sizeof(*d_unsorted_dp_dl_))); // interpolated
-    gpuErrchk(cudaMalloc(&d_sorted_dp_dl_, N_*3*sizeof(*d_sorted_dp_dl_))); // interpolated
-    gpuErrchk(cudaMalloc(&d_sorted_du_dx_, N_*3*sizeof(*d_sorted_du_dx_)));
-    gpuErrchk(cudaMalloc(&d_sorted_du_dp_, N_*3*sizeof(*d_sorted_du_dp_)));
-    gpuErrchk(cudaMalloc(&d_du_dp_buffer_, N_*3*sizeof(*d_du_dp_buffer_)));
+    gpuErrchk(cudaMalloc(&d_unsorted_p_, N_ * 3 * sizeof(*d_unsorted_p_)));         // interpolated
+    gpuErrchk(cudaMalloc(&d_sorted_p_, N_ * 3 * sizeof(*d_sorted_p_)));             // interpolated
+    gpuErrchk(cudaMalloc(&d_unsorted_dp_dl_, N_ * 3 * sizeof(*d_unsorted_dp_dl_))); // interpolated
+    gpuErrchk(cudaMalloc(&d_sorted_dp_dl_, N_ * 3 * sizeof(*d_sorted_dp_dl_)));     // interpolated
+    gpuErrchk(cudaMalloc(&d_sorted_du_dx_, N_ * 3 * sizeof(*d_sorted_du_dx_)));
+    gpuErrchk(cudaMalloc(&d_sorted_du_dp_, N_ * 3 * sizeof(*d_sorted_du_dp_)));
+    gpuErrchk(cudaMalloc(&d_du_dp_buffer_, N_ * 3 * sizeof(*d_du_dp_buffer_)));
 
-    gpuErrchk(cudaMalloc(&d_exclusion_idxs_, E_*2*sizeof(*d_exclusion_idxs_)));
-    gpuErrchk(cudaMemcpy(d_exclusion_idxs_, &exclusion_idxs[0], E_*2*sizeof(*d_exclusion_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_exclusion_idxs_, E_ * 2 * sizeof(*d_exclusion_idxs_)));
+    gpuErrchk(
+        cudaMemcpy(d_exclusion_idxs_, &exclusion_idxs[0], E_ * 2 * sizeof(*d_exclusion_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_scales_, E_*2*sizeof(*d_scales_)));
-    gpuErrchk(cudaMemcpy(d_scales_, &scales[0], E_*2*sizeof(*d_scales_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_scales_, E_ * 2 * sizeof(*d_scales_)));
+    gpuErrchk(cudaMemcpy(d_scales_, &scales[0], E_ * 2 * sizeof(*d_scales_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMallocHost(&p_ixn_count_, 1*sizeof(*p_ixn_count_)));
+    gpuErrchk(cudaMallocHost(&p_ixn_count_, 1 * sizeof(*p_ixn_count_)));
 
-    gpuErrchk(cudaMalloc(&d_nblist_x_, N_*3*sizeof(*d_nblist_x_)));
-    gpuErrchk(cudaMemset(d_nblist_x_, 0, N_*3*sizeof(*d_nblist_x_))); // set non-sensical positions
-    gpuErrchk(cudaMalloc(&d_nblist_box_, 3*3*sizeof(*d_nblist_x_)));
-    gpuErrchk(cudaMemset(d_nblist_box_, 0, 3*3*sizeof(*d_nblist_x_)));
-    gpuErrchk(cudaMalloc(&d_rebuild_nblist_, 1*sizeof(*d_rebuild_nblist_)));
-    gpuErrchk(cudaMallocHost(&p_rebuild_nblist_, 1*sizeof(*p_rebuild_nblist_)));
+    gpuErrchk(cudaMalloc(&d_nblist_x_, N_ * 3 * sizeof(*d_nblist_x_)));
+    gpuErrchk(cudaMemset(d_nblist_x_, 0, N_ * 3 * sizeof(*d_nblist_x_))); // set non-sensical positions
+    gpuErrchk(cudaMalloc(&d_nblist_box_, 3 * 3 * sizeof(*d_nblist_x_)));
+    gpuErrchk(cudaMemset(d_nblist_box_, 0, 3 * 3 * sizeof(*d_nblist_x_)));
+    gpuErrchk(cudaMalloc(&d_rebuild_nblist_, 1 * sizeof(*d_rebuild_nblist_)));
+    gpuErrchk(cudaMallocHost(&p_rebuild_nblist_, 1 * sizeof(*p_rebuild_nblist_)));
 
-    gpuErrchk(cudaMalloc(&d_sort_keys_in_, N_*sizeof(d_sort_keys_in_)));
-    gpuErrchk(cudaMalloc(&d_sort_keys_out_, N_*sizeof(d_sort_keys_out_)));
-    gpuErrchk(cudaMalloc(&d_sort_vals_in_, N_*sizeof(d_sort_vals_in_)));
+    gpuErrchk(cudaMalloc(&d_sort_keys_in_, N_ * sizeof(d_sort_keys_in_)));
+    gpuErrchk(cudaMalloc(&d_sort_keys_out_, N_ * sizeof(d_sort_keys_out_)));
+    gpuErrchk(cudaMalloc(&d_sort_vals_in_, N_ * sizeof(d_sort_vals_in_)));
 
     // initialize hilbert curve
-    std::vector<unsigned int> bin_to_idx(256*256*256);
-    for(int i=0; i < 256; i++) {
-        for(int j=0; j < 256; j++) {
-            for(int k=0; k < 256; k++) {
+    std::vector<unsigned int> bin_to_idx(256 * 256 * 256);
+    for (int i = 0; i < 256; i++) {
+        for (int j = 0; j < 256; j++) {
+            for (int k = 0; k < 256; k++) {
 
                 bitmask_t hilbert_coords[3];
                 hilbert_coords[0] = i;
@@ -136,33 +133,24 @@ Nonbonded<RealType, Interpolated>::Nonbonded(
                 hilbert_coords[2] = k;
 
                 unsigned int bin = static_cast<unsigned int>(hilbert_c2i(3, 8, hilbert_coords));
-                bin_to_idx[i*256*256 + j*256 + k] = bin;
-
+                bin_to_idx[i * 256 * 256 + j * 256 + k] = bin;
             }
         }
     }
 
-    gpuErrchk(cudaMalloc(&d_bin_to_idx_, 256*256*256*sizeof(*d_bin_to_idx_)));
-    gpuErrchk(cudaMemcpy(d_bin_to_idx_, &bin_to_idx[0], 256*256*256*sizeof(*d_bin_to_idx_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_bin_to_idx_, 256 * 256 * 256 * sizeof(*d_bin_to_idx_)));
+    gpuErrchk(
+        cudaMemcpy(d_bin_to_idx_, &bin_to_idx[0], 256 * 256 * 256 * sizeof(*d_bin_to_idx_), cudaMemcpyHostToDevice));
 
     // estimate size needed to do radix sorting, this can use uninitialized data.
     cub::DeviceRadixSort::SortPairs(
-        d_sort_storage_,
-        d_sort_storage_bytes_,
-        d_sort_keys_in_,
-        d_sort_keys_out_,
-        d_sort_vals_in_,
-        d_perm_,
-        N_
-    );
+        d_sort_storage_, d_sort_storage_bytes_, d_sort_keys_in_, d_sort_keys_out_, d_sort_vals_in_, d_perm_, N_);
 
     gpuErrchk(cudaPeekAtLastError());
     gpuErrchk(cudaMalloc(&d_sort_storage_, d_sort_storage_bytes_));
-
 };
 
-template <typename RealType, bool Interpolated>
-Nonbonded<RealType, Interpolated>::~Nonbonded() {
+template <typename RealType, bool Interpolated> Nonbonded<RealType, Interpolated>::~Nonbonded() {
 
     gpuErrchk(cudaFree(d_exclusion_idxs_));
     gpuErrchk(cudaFree(d_scales_));
@@ -198,26 +186,19 @@ Nonbonded<RealType, Interpolated>::~Nonbonded() {
     gpuErrchk(cudaFreeHost(p_rebuild_nblist_));
 };
 
-
-template<typename RealType, bool Interpolated>
-void Nonbonded<RealType, Interpolated>::set_nblist_padding(double val) {
+template <typename RealType, bool Interpolated> void Nonbonded<RealType, Interpolated>::set_nblist_padding(double val) {
     nblist_padding_ = val;
 }
 
-
-template<typename RealType, bool Interpolated>
-void Nonbonded<RealType, Interpolated>::disable_hilbert_sort() {
+template <typename RealType, bool Interpolated> void Nonbonded<RealType, Interpolated>::disable_hilbert_sort() {
     disable_hilbert_ = true;
 }
 
 template <typename RealType, bool Interpolated>
-void Nonbonded<RealType, Interpolated>::hilbert_sort(
-    const double *d_coords,
-    const double *d_box,
-    cudaStream_t stream) {
+void Nonbonded<RealType, Interpolated>::hilbert_sort(const double *d_coords, const double *d_box, cudaStream_t stream) {
 
     const int tpb = 32;
-    const int B = (N_+tpb-1)/tpb;
+    const int B = (N_ + tpb - 1) / tpb;
 
     k_coords_to_kv<<<B, tpb, 0, stream>>>(N_, d_coords, d_box, d_bin_to_idx_, d_sort_keys_in_, d_sort_vals_in_);
 
@@ -231,18 +212,17 @@ void Nonbonded<RealType, Interpolated>::hilbert_sort(
         d_sort_vals_in_,
         d_perm_,
         N_,
-        0, // begin bit
-        sizeof(*d_sort_keys_in_)*8, // end bit
-        stream // cudaStream
+        0,                            // begin bit
+        sizeof(*d_sort_keys_in_) * 8, // end bit
+        stream                        // cudaStream
     );
 
     gpuErrchk(cudaPeekAtLastError());
-
 }
 
 void __global__ k_arange(int N, unsigned int *arr) {
-    const int atom_idx = blockIdx.x*blockDim.x + threadIdx.x;
-    if(atom_idx >= N) {
+    const int atom_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (atom_idx >= N) {
         return;
     }
     arr[atom_idx] = atom_idx;
@@ -250,17 +230,17 @@ void __global__ k_arange(int N, unsigned int *arr) {
 
 template <typename RealType, bool Interpolated>
 void Nonbonded<RealType, Interpolated>::execute_device(
-        const int N,
-        const int P,
-        const double *d_x,
-        const double *d_p, // 2 * N * 3
-        const double *d_box, // 3 * 3
-        const double lambda,
-        unsigned long long *d_du_dx,
-        double *d_du_dp,
-        unsigned long long *d_du_dl,
-        unsigned long long *d_u,
-        cudaStream_t stream) {
+    const int N,
+    const int P,
+    const double *d_x,
+    const double *d_p,   // 2 * N * 3
+    const double *d_box, // 3 * 3
+    const double lambda,
+    unsigned long long *d_du_dx,
+    double *d_du_dp,
+    unsigned long long *d_du_dl,
+    unsigned long long *d_u,
+    cudaStream_t stream) {
 
     // (ytz) the nonbonded algorithm proceeds as follows:
 
@@ -278,14 +258,14 @@ void Nonbonded<RealType, Interpolated>::execute_device(
     // f. u and du/dl is buffered into a per-particle array, and then reduced.
     // g. note that du/dl is not an exact per-particle du/dl - it is only used for reduction purposes.
 
-    if(N != N_) {
+    if (N != N_) {
         std::cout << N << " " << N_ << std::endl;
         throw std::runtime_error("Nonbonded::execute_device() N != N_");
     }
 
     const int M = Interpolated ? 2 : 1;
 
-    if(P != M*N_*3) {
+    if (P != M * N_ * 3) {
         std::cout << P << " " << N_ << std::endl;
         throw std::runtime_error("Nonbonded::execute_device() P != M*N_*3");
     }
@@ -293,33 +273,27 @@ void Nonbonded<RealType, Interpolated>::execute_device(
     // identify which tiles contain interpolated parameters
 
     const int tpb = 32;
-    const int B = (N+tpb-1)/tpb;
+    const int B = (N + tpb - 1) / tpb;
 
     dim3 dimGrid(B, 3, 1);
 
     // (ytz) see if we need to rebuild the neighborlist.
     // (ytz + jfass): note that this logic needs to change if we use NPT later on since a resize in the box
     // can introduce new interactions.
-    k_check_rebuild_coords_and_box<RealType><<<B, tpb, 0, stream>>>(
-        N,
-        d_x,
-        d_nblist_x_,
-        d_box,
-        d_nblist_box_,
-        nblist_padding_,
-        d_rebuild_nblist_
-    );
+    k_check_rebuild_coords_and_box<RealType>
+        <<<B, tpb, 0, stream>>>(N, d_x, d_nblist_x_, d_box, d_nblist_box_, nblist_padding_, d_rebuild_nblist_);
     gpuErrchk(cudaPeekAtLastError());
 
     // we can optimize this away by doing the check on the GPU directly.
-    gpuErrchk(cudaMemcpyAsync(p_rebuild_nblist_, d_rebuild_nblist_, 1*sizeof(*p_rebuild_nblist_), cudaMemcpyDeviceToHost, stream));
+    gpuErrchk(cudaMemcpyAsync(
+        p_rebuild_nblist_, d_rebuild_nblist_, 1 * sizeof(*p_rebuild_nblist_), cudaMemcpyDeviceToHost, stream));
     gpuErrchk(cudaStreamSynchronize(stream)); // slow!
 
-    if(p_rebuild_nblist_[0] > 0) {
+    if (p_rebuild_nblist_[0] > 0) {
 
         // (ytz): update the permutation index before building neighborlist, as the neighborlist is tied
         // to a particular sort order
-        if(!disable_hilbert_) {
+        if (!disable_hilbert_) {
             this->hilbert_sort(d_x, d_box, stream);
         } else {
             k_arange<<<B, tpb, 0, stream>>>(N, d_perm_);
@@ -329,26 +303,22 @@ void Nonbonded<RealType, Interpolated>::execute_device(
         // compute new coordinates, new lambda_idxs, new_plane_idxs
         k_permute<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_x, d_sorted_x_);
         gpuErrchk(cudaPeekAtLastError());
-        nblist_.build_nblist_device(
-            N,
-            d_sorted_x_,
-            d_box,
-            cutoff_+nblist_padding_,
-            stream
-        );
-        gpuErrchk(cudaMemcpyAsync(p_ixn_count_, nblist_.get_ixn_count(), 1*sizeof(*p_ixn_count_), cudaMemcpyDeviceToHost, stream));
+        nblist_.build_nblist_device(N, d_sorted_x_, d_box, cutoff_ + nblist_padding_, stream);
+        gpuErrchk(cudaMemcpyAsync(
+            p_ixn_count_, nblist_.get_ixn_count(), 1 * sizeof(*p_ixn_count_), cudaMemcpyDeviceToHost, stream));
 
         std::vector<double> h_box(9);
-        gpuErrchk(cudaMemcpyAsync(&h_box[0], d_box, 3*3*sizeof(*d_box), cudaMemcpyDeviceToHost, stream));
+        gpuErrchk(cudaMemcpyAsync(&h_box[0], d_box, 3 * 3 * sizeof(*d_box), cudaMemcpyDeviceToHost, stream));
         // Verify that the cutoff and box size are valid together. If cutoff is greater than half the box
         // then a particle can interact with multiple periodic copies.
-        const double db_cutoff = (cutoff_+nblist_padding_) * 2;
+        const double db_cutoff = (cutoff_ + nblist_padding_) * 2;
         cudaStreamSynchronize(stream);
         // Verify that box is orthogonal and the width of the box in all dimensions is greater than twice the cutoff
         for (int i = 0; i < 9; i++) {
             if (i == 0 || i == 4 || i == 8) {
                 if (h_box[i] < db_cutoff) {
-                    throw std::runtime_error("Cutoff with padding is more than half of the box width, neighborlist is no longer reliable");
+                    throw std::runtime_error(
+                        "Cutoff with padding is more than half of the box width, neighborlist is no longer reliable");
                 }
             } else if (h_box[i] != 0.0) {
                 throw std::runtime_error("Provided non-ortholinear box, unable to compute nonbonded energy");
@@ -356,55 +326,40 @@ void Nonbonded<RealType, Interpolated>::execute_device(
         }
 
         gpuErrchk(cudaMemsetAsync(d_rebuild_nblist_, 0, sizeof(*d_rebuild_nblist_), stream));
-        gpuErrchk(cudaMemcpyAsync(d_nblist_x_, d_x, N*3*sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
-        gpuErrchk(cudaMemcpyAsync(d_nblist_box_, d_box, 3*3*sizeof(*d_box), cudaMemcpyDeviceToDevice, stream));
+        gpuErrchk(cudaMemcpyAsync(d_nblist_x_, d_x, N * 3 * sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
+        gpuErrchk(cudaMemcpyAsync(d_nblist_box_, d_box, 3 * 3 * sizeof(*d_box), cudaMemcpyDeviceToDevice, stream));
     } else {
         k_permute<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_x, d_sorted_x_);
         gpuErrchk(cudaPeekAtLastError());
     }
 
     // do parameter interpolation here
-    if(Interpolated) {
+    if (Interpolated) {
         CUresult result = compute_permute_interpolated_.configure(dimGrid, tpb, 0, stream)
-        .launch(
-            lambda,
-            N,
-            d_perm_,
-            d_p,
-            d_sorted_p_,
-            d_sorted_dp_dl_
-        );
-        if(result != 0) {
+                              .launch(lambda, N, d_perm_, d_p, d_sorted_p_, d_sorted_dp_dl_);
+        if (result != 0) {
             throw std::runtime_error("Driver call to k_permute_interpolated failed");
         }
     } else {
         k_permute<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_p, d_sorted_p_);
         gpuErrchk(cudaPeekAtLastError());
-        gpuErrchk(cudaMemsetAsync(d_sorted_dp_dl_, 0, N*3*sizeof(*d_sorted_dp_dl_), stream))
+        gpuErrchk(cudaMemsetAsync(d_sorted_dp_dl_, 0, N * 3 * sizeof(*d_sorted_dp_dl_), stream))
     }
 
     // this stream needs to be synchronized so we can be sure that p_ixn_count_ is properly set.
     // reset buffers and sorted accumulators
-    if(d_du_dx) {
-	    gpuErrchk(cudaMemsetAsync(d_sorted_du_dx_, 0, N*3*sizeof(*d_sorted_du_dx_), stream))
+    if (d_du_dx) {
+        gpuErrchk(cudaMemsetAsync(d_sorted_du_dx_, 0, N * 3 * sizeof(*d_sorted_du_dx_), stream))
     }
-    if(d_du_dp) {
-	    gpuErrchk(cudaMemsetAsync(d_sorted_du_dp_, 0, N*3*sizeof(*d_sorted_du_dp_), stream))
+    if (d_du_dp) {
+        gpuErrchk(cudaMemsetAsync(d_sorted_du_dp_, 0, N * 3 * sizeof(*d_sorted_du_dp_), stream))
     }
 
     // update new w coordinates
     // (tbd): cache lambda value for equilibrium calculations
     CUresult result = compute_w_coords_instance_.configure(B, tpb, 0, stream)
-    .launch(
-        N,
-        lambda,
-        cutoff_,
-        d_lambda_plane_idxs_,
-        d_lambda_offset_idxs_,
-        d_w_,
-        d_dw_dl_
-    );
-    if(result != 0) {
+                          .launch(N, lambda, cutoff_, d_lambda_plane_idxs_, d_lambda_offset_idxs_, d_w_, d_dw_dl_);
+    if (result != 0) {
         throw std::runtime_error("Driver call to k_compute_w_coords");
     }
 
@@ -435,38 +390,32 @@ void Nonbonded<RealType, Interpolated>::execute_device(
         d_sorted_du_dx_,
         d_sorted_du_dp_,
         d_du_dl, // switch to nullptr if we don't request du_dl
-        d_u // switch to nullptr if we don't request energies
+        d_u      // switch to nullptr if we don't request energies
     );
 
     gpuErrchk(cudaPeekAtLastError());
 
     // coords are N,3
-    if(d_du_dx) {
+    if (d_du_dx) {
         k_inv_permute_accum<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_sorted_du_dx_, d_du_dx);
         gpuErrchk(cudaPeekAtLastError());
     }
 
     // params are N,3
     // this needs to be an accumulated permute
-    if(d_du_dp) {
+    if (d_du_dp) {
         k_inv_permute_assign<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_sorted_du_dp_, d_du_dp_buffer_);
         gpuErrchk(cudaPeekAtLastError());
     }
 
     // exclusions use the non-sorted version
-    if(E_ > 0) {
+    if (E_ > 0) {
 
-        dim3 dimGridExclusions((E_+tpb-1)/tpb, 1, 1);
+        dim3 dimGridExclusions((E_ + tpb - 1) / tpb, 1, 1);
 
-        if(Interpolated) {
+        if (Interpolated) {
             k_inv_permute_assign_2x<<<dimGrid, tpb, 0, stream>>>(
-                N,
-                d_perm_,
-                d_sorted_p_,
-                d_sorted_dp_dl_,
-                d_unsorted_p_,
-                d_unsorted_dp_dl_
-            );
+                N, d_perm_, d_sorted_p_, d_sorted_dp_dl_, d_unsorted_p_, d_unsorted_dp_dl_);
             gpuErrchk(cudaPeekAtLastError());
         }
 
@@ -486,39 +435,27 @@ void Nonbonded<RealType, Interpolated>::execute_device(
             d_du_dx,
             d_du_dp_buffer_,
             d_du_dl,
-            d_u
-        );
+            d_u);
         gpuErrchk(cudaPeekAtLastError());
     }
 
-    if(d_du_dp) {
-        if(Interpolated) {
+    if (d_du_dp) {
+        if (Interpolated) {
             CUresult result = compute_add_ull_to_real_interpolated_.configure(dimGrid, tpb, 0, stream)
-            .launch(
-                lambda,
-                N,
-                d_du_dp_buffer_,
-                d_du_dp
-            );
-            if(result != 0) {
+                                  .launch(lambda, N, d_du_dp_buffer_, d_du_dp);
+            if (result != 0) {
                 throw std::runtime_error("Driver call to k_add_ull_to_real_interpolated failed");
             }
         } else {
-            k_add_ull_to_real<<<dimGrid, tpb, 0, stream>>>(
-                N,
-                d_du_dp_buffer_,
-                d_du_dp
-            );
+            k_add_ull_to_real<<<dimGrid, tpb, 0, stream>>>(N, d_du_dp_buffer_, d_du_dp);
         }
         gpuErrchk(cudaPeekAtLastError());
     }
-
 }
 
 template class Nonbonded<double, true>;
 template class Nonbonded<float, true>;
 template class Nonbonded<double, false>;
 template class Nonbonded<float, false>;
-
 
 } // namespace timemachine

--- a/timemachine/cpp/src/optimizer.cu
+++ b/timemachine/cpp/src/optimizer.cu
@@ -1,69 +1,56 @@
-#include "optimizer.hpp"
 #include "kernel_utils.cuh"
+#include "optimizer.hpp"
 
 namespace timemachine {
 
-template<typename RealType>
+template <typename RealType>
 void Optimizer<RealType>::step_host(
-        const int N,
-        const int D,
-        const int P,
-        const RealType *h_dE_dx,
-        const RealType *h_d2E_dx2,
-        const RealType *h_d2E_dxdp, // this is modified in place
-        RealType *h_x_t, // mutable
-        RealType *h_v_t, // mutable
-        RealType *h_dx_dp_t, // mutable
-        RealType *h_dv_dp_t, // mutable
-        const RealType *h_noise_buffer
-    ) const {
+    const int N,
+    const int D,
+    const int P,
+    const RealType *h_dE_dx,
+    const RealType *h_d2E_dx2,
+    const RealType *h_d2E_dxdp, // this is modified in place
+    RealType *h_x_t,            // mutable
+    RealType *h_v_t,            // mutable
+    RealType *h_dx_dp_t,        // mutable
+    RealType *h_dv_dp_t,        // mutable
+    const RealType *h_noise_buffer) const {
 
     RealType *d_dE_dx;
-    gpuErrchk(cudaMalloc((void**)&d_dE_dx, N*D*sizeof(*d_dE_dx)));
+    gpuErrchk(cudaMalloc((void **)&d_dE_dx, N * D * sizeof(*d_dE_dx)));
     RealType *d_d2E_dx2;
-    gpuErrchk(cudaMalloc((void**)&d_d2E_dx2, N*N*D*D*sizeof(*d_d2E_dx2)));
+    gpuErrchk(cudaMalloc((void **)&d_d2E_dx2, N * N * D * D * sizeof(*d_d2E_dx2)));
     RealType *d_d2E_dxdp;
-    gpuErrchk(cudaMalloc((void**)&d_d2E_dxdp, P*N*D*sizeof(*d_d2E_dxdp)));
+    gpuErrchk(cudaMalloc((void **)&d_d2E_dxdp, P * N * D * sizeof(*d_d2E_dxdp)));
     RealType *d_x_t;
-    gpuErrchk(cudaMalloc((void**)&d_x_t, N*D*sizeof(*d_x_t)));
+    gpuErrchk(cudaMalloc((void **)&d_x_t, N * D * sizeof(*d_x_t)));
     RealType *d_v_t;
-    gpuErrchk(cudaMalloc((void**)&d_v_t, N*D*sizeof(*d_v_t)));
+    gpuErrchk(cudaMalloc((void **)&d_v_t, N * D * sizeof(*d_v_t)));
     RealType *d_dx_dp_t;
-    gpuErrchk(cudaMalloc((void**)&d_dx_dp_t, P*N*D*sizeof(*d_dx_dp_t)));
+    gpuErrchk(cudaMalloc((void **)&d_dx_dp_t, P * N * D * sizeof(*d_dx_dp_t)));
     RealType *d_dv_dp_t;
-    gpuErrchk(cudaMalloc((void**)&d_dv_dp_t, P*N*D*sizeof(*d_dv_dp_t)));
+    gpuErrchk(cudaMalloc((void **)&d_dv_dp_t, P * N * D * sizeof(*d_dv_dp_t)));
     RealType *d_noise_buffer;
-    gpuErrchk(cudaMalloc((void**)&d_noise_buffer, N*D*sizeof(*d_noise_buffer)));
+    gpuErrchk(cudaMalloc((void **)&d_noise_buffer, N * D * sizeof(*d_noise_buffer)));
 
-    gpuErrchk(cudaMemcpy(d_x_t, h_x_t, N*D*sizeof(*d_x_t), cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(d_v_t, h_v_t, N*D*sizeof(*d_v_t), cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(d_dx_dp_t, h_dx_dp_t, P*N*D*sizeof(*d_dx_dp_t), cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(d_dv_dp_t, h_dv_dp_t, P*N*D*sizeof(*d_dv_dp_t), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_x_t, h_x_t, N * D * sizeof(*d_x_t), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_v_t, h_v_t, N * D * sizeof(*d_v_t), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_dx_dp_t, h_dx_dp_t, P * N * D * sizeof(*d_dx_dp_t), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_dv_dp_t, h_dv_dp_t, P * N * D * sizeof(*d_dv_dp_t), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMemcpy(d_dE_dx, h_dE_dx, N*D*sizeof(*h_dE_dx), cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(d_d2E_dx2, h_d2E_dx2, N*N*D*D*sizeof(*d_d2E_dx2), cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(d_d2E_dxdp, h_d2E_dxdp, P*N*D*sizeof(*d_d2E_dxdp), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_dE_dx, h_dE_dx, N * D * sizeof(*h_dE_dx), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_d2E_dx2, h_d2E_dx2, N * N * D * D * sizeof(*d_d2E_dx2), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_d2E_dxdp, h_d2E_dxdp, P * N * D * sizeof(*d_d2E_dxdp), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMemcpy(d_noise_buffer, h_noise_buffer, N*D*sizeof(*d_noise_buffer), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_noise_buffer, h_noise_buffer, N * D * sizeof(*d_noise_buffer), cudaMemcpyHostToDevice));
 
-    this->step(
-        N,
-        D,
-        P,
-        d_dE_dx,
-        d_d2E_dx2,
-        d_d2E_dxdp,
-        d_x_t,
-        d_v_t,
-        d_dx_dp_t,
-        d_dv_dp_t,
-        d_noise_buffer
-    );
+    this->step(N, D, P, d_dE_dx, d_d2E_dx2, d_d2E_dxdp, d_x_t, d_v_t, d_dx_dp_t, d_dv_dp_t, d_noise_buffer);
 
-    gpuErrchk(cudaMemcpy(h_x_t, d_x_t, N*D*sizeof(*d_x_t), cudaMemcpyDeviceToHost));
-    gpuErrchk(cudaMemcpy(h_v_t, d_v_t, N*D*sizeof(*d_v_t), cudaMemcpyDeviceToHost));
-    gpuErrchk(cudaMemcpy(h_dx_dp_t, d_dx_dp_t, P*N*D*sizeof(*d_dx_dp_t), cudaMemcpyDeviceToHost));
-    gpuErrchk(cudaMemcpy(h_dv_dp_t, d_dv_dp_t, P*N*D*sizeof(*d_dv_dp_t), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(h_x_t, d_x_t, N * D * sizeof(*d_x_t), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(h_v_t, d_v_t, N * D * sizeof(*d_v_t), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(h_dx_dp_t, d_dx_dp_t, P * N * D * sizeof(*d_dx_dp_t), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(h_dv_dp_t, d_dv_dp_t, P * N * D * sizeof(*d_dv_dp_t), cudaMemcpyDeviceToHost));
 
     gpuErrchk(cudaFree(d_dE_dx));
     gpuErrchk(cudaFree(d_d2E_dx2));
@@ -73,10 +60,9 @@ void Optimizer<RealType>::step_host(
     gpuErrchk(cudaFree(d_dx_dp_t));
     gpuErrchk(cudaFree(d_dv_dp_t));
     gpuErrchk(cudaFree(d_noise_buffer));
-
 }
 
 template class Optimizer<float>;
 template class Optimizer<double>;
 
-}
+} // namespace timemachine

--- a/timemachine/cpp/src/periodic_torsion.cu
+++ b/timemachine/cpp/src/periodic_torsion.cu
@@ -1,10 +1,10 @@
-#include <chrono>
-#include <iostream>
-#include <vector>
-#include <complex>
-#include "periodic_torsion.hpp"
 #include "gpu_utils.cuh"
 #include "k_periodic_torsion.cuh"
+#include "periodic_torsion.hpp"
+#include <chrono>
+#include <complex>
+#include <iostream>
+#include <vector>
 
 namespace timemachine {
 
@@ -12,55 +12,53 @@ template <typename RealType>
 PeriodicTorsion<RealType>::PeriodicTorsion(
     const std::vector<int> &torsion_idxs, // [A, 4]
     const std::vector<int> &lambda_mult,
-    const std::vector<int> &lambda_offset
-) : T_(torsion_idxs.size()/4) {
+    const std::vector<int> &lambda_offset)
+    : T_(torsion_idxs.size() / 4) {
 
-    if(torsion_idxs.size() % 4 != 0) {
+    if (torsion_idxs.size() % 4 != 0) {
         throw std::runtime_error("torsion_idxs.size() must be exactly 4*k");
     }
 
-
-    if(lambda_mult.size() > 0 && lambda_mult.size() != T_) {
+    if (lambda_mult.size() > 0 && lambda_mult.size() != T_) {
         throw std::runtime_error("bad lambda_mult size()");
     }
 
-    if(lambda_offset.size() > 0 && lambda_offset.size() != T_) {
+    if (lambda_offset.size() > 0 && lambda_offset.size() != T_) {
         throw std::runtime_error("bad lambda_offset size()");
     }
 
-    for(int a=0; a < T_; a++) {
-        auto i = torsion_idxs[a*4+0];
-        auto j = torsion_idxs[a*4+1];
-        auto k = torsion_idxs[a*4+2];
-        auto l = torsion_idxs[a*4+3];
-        if(i == j || i == k || i == l || j == k || j == l || k == l) {
+    for (int a = 0; a < T_; a++) {
+        auto i = torsion_idxs[a * 4 + 0];
+        auto j = torsion_idxs[a * 4 + 1];
+        auto k = torsion_idxs[a * 4 + 2];
+        auto l = torsion_idxs[a * 4 + 3];
+        if (i == j || i == k || i == l || j == k || j == l || k == l) {
             throw std::runtime_error("torsion quads must be unique");
         }
     }
 
-    gpuErrchk(cudaMalloc(&d_torsion_idxs_, T_*4*sizeof(*d_torsion_idxs_)));
-    gpuErrchk(cudaMemcpy(d_torsion_idxs_, &torsion_idxs[0], T_*4*sizeof(*d_torsion_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_torsion_idxs_, T_ * 4 * sizeof(*d_torsion_idxs_)));
+    gpuErrchk(cudaMemcpy(d_torsion_idxs_, &torsion_idxs[0], T_ * 4 * sizeof(*d_torsion_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_lambda_mult_, T_*sizeof(*d_lambda_mult_)));
-    gpuErrchk(cudaMalloc(&d_lambda_offset_, T_*sizeof(*d_lambda_offset_)));
+    gpuErrchk(cudaMalloc(&d_lambda_mult_, T_ * sizeof(*d_lambda_mult_)));
+    gpuErrchk(cudaMalloc(&d_lambda_offset_, T_ * sizeof(*d_lambda_offset_)));
 
-    if(lambda_mult.size() > 0) {
-        gpuErrchk(cudaMemcpy(d_lambda_mult_, &lambda_mult[0], T_*sizeof(*d_lambda_mult_), cudaMemcpyHostToDevice));
+    if (lambda_mult.size() > 0) {
+        gpuErrchk(cudaMemcpy(d_lambda_mult_, &lambda_mult[0], T_ * sizeof(*d_lambda_mult_), cudaMemcpyHostToDevice));
     } else {
         initializeArray(T_, d_lambda_mult_, 0);
     }
 
-    if(lambda_offset.size() > 0) {
-        gpuErrchk(cudaMemcpy(d_lambda_offset_, &lambda_offset[0], T_*sizeof(*d_lambda_offset_), cudaMemcpyHostToDevice));
+    if (lambda_offset.size() > 0) {
+        gpuErrchk(
+            cudaMemcpy(d_lambda_offset_, &lambda_offset[0], T_ * sizeof(*d_lambda_offset_), cudaMemcpyHostToDevice));
     } else {
         // can't memset this
         initializeArray(T_, d_lambda_offset_, 1);
     }
-
 };
 
-template <typename RealType>
-PeriodicTorsion<RealType>::~PeriodicTorsion() {
+template <typename RealType> PeriodicTorsion<RealType>::~PeriodicTorsion() {
     gpuErrchk(cudaFree(d_torsion_idxs_));
     gpuErrchk(cudaFree(d_lambda_mult_));
     gpuErrchk(cudaFree(d_lambda_offset_));
@@ -81,27 +79,15 @@ void PeriodicTorsion<RealType>::execute_device(
     cudaStream_t stream) {
 
     int tpb = 32;
-    int blocks = (T_+tpb-1)/tpb;
+    int blocks = (T_ + tpb - 1) / tpb;
 
     const int D = 3;
 
-    if(blocks > 0) {
+    if (blocks > 0) {
         k_periodic_torsion<RealType, D><<<blocks, tpb, 0, stream>>>(
-            T_,
-            d_x,
-            d_p,
-            lambda,
-            d_lambda_mult_,
-            d_lambda_offset_,
-            d_torsion_idxs_,
-            d_du_dx,
-            d_du_dp,
-            d_du_dl,
-            d_u
-        );
+            T_, d_x, d_p, lambda, d_lambda_mult_, d_lambda_offset_, d_torsion_idxs_, d_du_dx, d_du_dp, d_du_dl, d_u);
         gpuErrchk(cudaPeekAtLastError());
     }
-
 };
 
 template class PeriodicTorsion<double>;

--- a/timemachine/cpp/src/restraint.cu
+++ b/timemachine/cpp/src/restraint.cu
@@ -1,10 +1,10 @@
-#include <chrono>
-#include <iostream>
-#include <vector>
-#include <complex>
-#include "restraint.hpp"
 #include "gpu_utils.cuh"
 #include "k_restraint.cuh"
+#include "restraint.hpp"
+#include <chrono>
+#include <complex>
+#include <iostream>
+#include <vector>
 
 namespace timemachine {
 
@@ -12,53 +12,49 @@ template <typename RealType>
 Restraint<RealType>::Restraint(
     const std::vector<int> &bond_idxs, // [N]
     const std::vector<double> &params,
-    const std::vector<int> &lambda_flags
-) : B_(bond_idxs.size()/2) {
+    const std::vector<int> &lambda_flags)
+    : B_(bond_idxs.size() / 2) {
 
-
-    if(bond_idxs.size() % 2 != 0) {
+    if (bond_idxs.size() % 2 != 0) {
         throw std::runtime_error("bond_idxs.size() must be exactly 2*B");
     }
 
-    if(params.size() % 3 != 0) {
+    if (params.size() % 3 != 0) {
         throw std::runtime_error("params.size() must be exactly 3*B");
     }
 
-    if(params.size()/3 != B_) {
+    if (params.size() / 3 != B_) {
         throw std::runtime_error("params.size() must be equal to B*3");
     }
 
-    for(int b=0; b < B_; b++) {
-        auto src = bond_idxs[b*2+0];
-        auto dst = bond_idxs[b*2+1];
-        if(src == dst) {
+    for (int b = 0; b < B_; b++) {
+        auto src = bond_idxs[b * 2 + 0];
+        auto dst = bond_idxs[b * 2 + 1];
+        if (src == dst) {
             throw std::runtime_error("src == dst");
         }
     }
 
-    gpuErrchk(cudaMalloc(&d_lambda_flags_, B_*sizeof(*d_lambda_flags_)));
-    gpuErrchk(cudaMemcpy(d_lambda_flags_, &lambda_flags[0], B_*sizeof(*d_lambda_flags_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_lambda_flags_, B_ * sizeof(*d_lambda_flags_)));
+    gpuErrchk(cudaMemcpy(d_lambda_flags_, &lambda_flags[0], B_ * sizeof(*d_lambda_flags_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_bond_idxs_, B_*2*sizeof(*d_bond_idxs_)));
-    gpuErrchk(cudaMemcpy(d_bond_idxs_, &bond_idxs[0], B_*2*sizeof(*d_bond_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_bond_idxs_, B_ * 2 * sizeof(*d_bond_idxs_)));
+    gpuErrchk(cudaMemcpy(d_bond_idxs_, &bond_idxs[0], B_ * 2 * sizeof(*d_bond_idxs_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_bond_idxs_, B_*2*sizeof(*d_bond_idxs_)));
-    gpuErrchk(cudaMemcpy(d_bond_idxs_, &bond_idxs[0], B_*2*sizeof(*d_bond_idxs_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_bond_idxs_, B_ * 2 * sizeof(*d_bond_idxs_)));
+    gpuErrchk(cudaMemcpy(d_bond_idxs_, &bond_idxs[0], B_ * 2 * sizeof(*d_bond_idxs_), cudaMemcpyHostToDevice));
 
+    gpuErrchk(cudaMalloc(&d_params_, B_ * 3 * sizeof(*d_params_)));
+    gpuErrchk(cudaMemcpy(d_params_, &params[0], B_ * 3 * sizeof(*d_params_), cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_params_, B_*3*sizeof(*d_params_)));
-    gpuErrchk(cudaMemcpy(d_params_, &params[0], B_*3*sizeof(*d_params_), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMalloc(&d_du_dp_primals_, B_ * 3 * sizeof(*d_du_dp_primals_)));
+    gpuErrchk(cudaMemset(d_du_dp_primals_, 0, B_ * 3 * sizeof(*d_du_dp_primals_)));
 
-    gpuErrchk(cudaMalloc(&d_du_dp_primals_, B_*3*sizeof(*d_du_dp_primals_)));
-    gpuErrchk(cudaMemset(d_du_dp_primals_, 0, B_*3*sizeof(*d_du_dp_primals_)));
-
-    gpuErrchk(cudaMalloc(&d_du_dp_tangents_, B_*3*sizeof(*d_du_dp_tangents_)));
-    gpuErrchk(cudaMemset(d_du_dp_tangents_, 0, B_*3*sizeof(*d_du_dp_tangents_)));
-
+    gpuErrchk(cudaMalloc(&d_du_dp_tangents_, B_ * 3 * sizeof(*d_du_dp_tangents_)));
+    gpuErrchk(cudaMemset(d_du_dp_tangents_, 0, B_ * 3 * sizeof(*d_du_dp_tangents_)));
 };
 
-template <typename RealType>
-Restraint<RealType>::~Restraint() {
+template <typename RealType> Restraint<RealType>::~Restraint() {
     gpuErrchk(cudaFree(d_bond_idxs_));
     gpuErrchk(cudaFree(d_lambda_flags_));
 
@@ -67,18 +63,13 @@ Restraint<RealType>::~Restraint() {
     gpuErrchk(cudaFree(d_du_dp_tangents_));
 };
 
-
-
-template <typename RealType>
-void Restraint<RealType>::get_du_dp_primals(double *buf) {
-    gpuErrchk(cudaMemcpy(buf, d_du_dp_primals_, B_*3*sizeof(*d_params_), cudaMemcpyDeviceToHost));
+template <typename RealType> void Restraint<RealType>::get_du_dp_primals(double *buf) {
+    gpuErrchk(cudaMemcpy(buf, d_du_dp_primals_, B_ * 3 * sizeof(*d_params_), cudaMemcpyDeviceToHost));
 }
 
-template <typename RealType>
-void Restraint<RealType>::get_du_dp_tangents(double *buf) {
-    gpuErrchk(cudaMemcpy(buf, d_du_dp_tangents_, B_*3*sizeof(*d_params_), cudaMemcpyDeviceToHost));
+template <typename RealType> void Restraint<RealType>::get_du_dp_tangents(double *buf) {
+    gpuErrchk(cudaMemcpy(buf, d_du_dp_tangents_, B_ * 3 * sizeof(*d_params_), cudaMemcpyDeviceToHost));
 }
-
 
 template <typename RealType>
 void Restraint<RealType>::execute_lambda_inference_device(
@@ -88,12 +79,12 @@ void Restraint<RealType>::execute_lambda_inference_device(
     // const double *d_params_primals,
     const double lambda_primal,
     unsigned long long *d_out_coords_primals, // du/dx
-    double *d_out_lambda_primals, // du/dl
-    double *d_out_energy_primal, // U
+    double *d_out_lambda_primals,             // du/dl
+    double *d_out_energy_primal,              // U
     cudaStream_t stream) {
 
     int tpb = 32;
-    int blocks = (B_+tpb-1)/tpb;
+    int blocks = (B_ + tpb - 1) / tpb;
     k_restraint_inference<RealType><<<blocks, tpb, 0, stream>>>(
         B_,
         d_coords_primals,
@@ -103,14 +94,12 @@ void Restraint<RealType>::execute_lambda_inference_device(
         d_lambda_flags_,
         d_out_coords_primals,
         d_out_lambda_primals,
-        d_out_energy_primal
-    );
+        d_out_energy_primal);
     gpuErrchk(cudaPeekAtLastError());
 
     // auto finish = std::chrono::high_resolution_clock::now();
     // std::chrono::duration<double> elapsed = finish - start;
     // std::cout << "Restraint Elapsed time: " << elapsed.count() << " s\n";
-
 };
 
 template <typename RealType>
@@ -120,7 +109,7 @@ void Restraint<RealType>::execute_lambda_jvp_device(
     const double *d_coords_primals,
     const double *d_coords_tangents,
     // const double *d_params_primals,
-    const double lambda_primal, // unused
+    const double lambda_primal,  // unused
     const double lambda_tangent, // unused
     double *d_out_coords_primals,
     double *d_out_coords_tangents,
@@ -129,7 +118,7 @@ void Restraint<RealType>::execute_lambda_jvp_device(
     cudaStream_t stream) {
 
     int tpb = 32;
-    int blocks = (B_+tpb-1)/tpb;
+    int blocks = (B_ + tpb - 1) / tpb;
 
     k_restraint_jvp<RealType><<<blocks, tpb, 0, stream>>>(
         B_,
@@ -143,8 +132,7 @@ void Restraint<RealType>::execute_lambda_jvp_device(
         d_out_coords_primals,
         d_out_coords_tangents,
         d_du_dp_primals_,
-        d_du_dp_tangents_
-    );
+        d_du_dp_tangents_);
 
     // cudaDeviceSynchronize();
     gpuErrchk(cudaPeekAtLastError());
@@ -152,7 +140,6 @@ void Restraint<RealType>::execute_lambda_jvp_device(
     // auto finish = std::chrono::high_resolution_clock::now();
     // std::chrono::duration<double> elapsed = finish - start;
     // std::cout << "Restraint Elapsed time: " << elapsed.count() << " s\n";
-
 }
 
 template class Restraint<double>;

--- a/timemachine/cpp/src/stepper.cu
+++ b/timemachine/cpp/src/stepper.cu
@@ -1,83 +1,68 @@
-#include "stepper.hpp"
 #include "fixed_point.hpp"
 #include "gpu_utils.cuh"
+#include "stepper.hpp"
 
-#define PI  3.1415926535897932384626433
+#define PI 3.1415926535897932384626433
 
 #include <iostream>
 namespace timemachine {
 
 Stepper::Stepper(int F) : streams_(F) {
-    for(int i=0; i < F; i++) {
+    for (int i = 0; i < F; i++) {
         gpuErrchk(cudaStreamCreate(&streams_[i]));
     }
-
 }
 
 Stepper::~Stepper() {
-    for(int i=0; i <streams_.size(); i++) {
+    for (int i = 0; i < streams_.size(); i++) {
         gpuErrchk(cudaStreamDestroy(streams_[i]));
     }
 }
 
-cudaStream_t Stepper::get_stream(int idx) {
-    return streams_[idx];
-}
+cudaStream_t Stepper::get_stream(int idx) { return streams_[idx]; }
 
 void Stepper::sync_all_streams() {
-    for(int i=0; i < streams_.size(); i++) {
+    for (int i = 0; i < streams_.size(); i++) {
         gpuErrchk(cudaStreamSynchronize(streams_[i]));
     }
 }
-
 
 AlchemicalStepper::~AlchemicalStepper() {
     gpuErrchk(cudaFree(d_du_dl_));
     gpuErrchk(cudaFree(d_energies_));
 }
 
-AlchemicalStepper::AlchemicalStepper(
-    std::vector<Gradient*> forces,
-    const std::vector<double> &lambda_schedule
-) : forces_(forces),
-    lambda_schedule_(lambda_schedule),
-    count_(0),
-    Stepper(forces.size()) {
+AlchemicalStepper::AlchemicalStepper(std::vector<Gradient *> forces, const std::vector<double> &lambda_schedule)
+    : forces_(forces), lambda_schedule_(lambda_schedule), count_(0), Stepper(forces.size()) {
 
     const int F = forces.size();
     const int T = lambda_schedule_.size();
 
-    gpuErrchk(cudaMalloc(&d_du_dl_, F*T*sizeof(*d_du_dl_)));
-    gpuErrchk(cudaMemset(d_du_dl_, 0, F*T*sizeof(*d_du_dl_)));
+    gpuErrchk(cudaMalloc(&d_du_dl_, F * T * sizeof(*d_du_dl_)));
+    gpuErrchk(cudaMemset(d_du_dl_, 0, F * T * sizeof(*d_du_dl_)));
 
-    gpuErrchk(cudaMalloc(&d_energies_, T*sizeof(*d_energies_)));
-    gpuErrchk(cudaMemset(d_energies_, 0, T*sizeof(*d_energies_)));
-
+    gpuErrchk(cudaMalloc(&d_energies_, T * sizeof(*d_energies_)));
+    gpuErrchk(cudaMemset(d_energies_, 0, T * sizeof(*d_energies_)));
 }
 
-void AlchemicalStepper::forward_step(
-    const int N,
-    const double *coords,
-    unsigned long long *dx) {
+void AlchemicalStepper::forward_step(const int N, const double *coords, unsigned long long *dx) {
 
     const int T = lambda_schedule_.size();
 
     gpuErrchk(cudaDeviceSynchronize());
-    for(int f=0; f < forces_.size(); f++) {
+    for (int f = 0; f < forces_.size(); f++) {
         forces_[f]->execute_lambda_inference_device(
             N,
             coords,
             lambda_schedule_[count_],
-            dx, // forces
-            d_du_dl_ + f*T + count_, // du_dl
-            d_energies_ + count_, // energies
-            this->get_stream(f)
-        );
+            dx,                        // forces
+            d_du_dl_ + f * T + count_, // du_dl
+            d_energies_ + count_,      // energies
+            this->get_stream(f));
     }
 
     gpuErrchk(cudaDeviceSynchronize());
     count_ += 1;
-
 };
 
 void AlchemicalStepper::backward_step(
@@ -90,49 +75,43 @@ void AlchemicalStepper::backward_step(
     count_ -= 1;
 
     gpuErrchk(cudaDeviceSynchronize());
-    if(count_ >= du_dl_adjoint_.size()) {
+    if (count_ >= du_dl_adjoint_.size()) {
         throw std::runtime_error("You probably forgot to set du_dl adjoints!\n");
     }
 
-
     const int T = lambda_schedule_.size();
 
-    for(int f=0; f < forces_.size(); f++) {
+    for (int f = 0; f < forces_.size(); f++) {
         forces_[f]->execute_lambda_jvp_device(
             N,
             coords,
             dx_tangent,
             lambda_schedule_[count_],
-            du_dl_adjoint_[f*T + count_], // FIX
+            du_dl_adjoint_[f * T + count_], // FIX
             coords_jvp_primals,
             coords_jvp_tangents,
-            this->get_stream(f)
-        );
+            this->get_stream(f));
     }
     gpuErrchk(cudaDeviceSynchronize());
-
-
 };
 
 void AlchemicalStepper::get_du_dl(double *buf) {
     const int T = get_T();
     const int F = forces_.size();
-    cudaMemcpy(buf, d_du_dl_, T*F*sizeof(double), cudaMemcpyDeviceToHost);
+    cudaMemcpy(buf, d_du_dl_, T * F * sizeof(double), cudaMemcpyDeviceToHost);
 };
 
 void AlchemicalStepper::get_energies(double *buf) {
     const int T = get_T();
-    cudaMemcpy(buf, d_energies_, T*sizeof(double), cudaMemcpyDeviceToHost);
+    cudaMemcpy(buf, d_energies_, T * sizeof(double), cudaMemcpyDeviceToHost);
 };
 
-void AlchemicalStepper::set_du_dl_adjoint(
-    const int FT,
-    const double *adj) {
-    if(FT != lambda_schedule_.size()*get_F()) {
+void AlchemicalStepper::set_du_dl_adjoint(const int FT, const double *adj) {
+    if (FT != lambda_schedule_.size() * get_F()) {
         throw std::runtime_error("adjoint size not the same as lambda schedule size");
     }
     du_dl_adjoint_.resize(FT);
-    memcpy(&du_dl_adjoint_[0], adj, FT*sizeof(double));
+    memcpy(&du_dl_adjoint_[0], adj, FT * sizeof(double));
 };
 
-};
+}; // namespace timemachine


### PR DESCRIPTION
In #534 we added `clang-format` to the pre-commit config, but did not configure it to format cuda source files (`*.cu`, `*.cuh`). This PR configures the pre-commit hook to also format cuda files, and applies the formatting changes.