### PR TITLE
Implement nonbonded exclusions as summed potential term

### DIFF
--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -763,7 +763,6 @@ void __global__ k_nonbonded_exclusions(
     const double *__restrict__ dp_dl,
     const double *__restrict__ coords_w, // 4D coords
     const double *__restrict__ dw_dl,    // 4D derivatives
-    const double lambda,
     const int *__restrict__ exclusion_idxs, // [E, 2] pair-list of atoms to be excluded
     const double *__restrict__ scales,      // [E]
     const double beta,
@@ -841,7 +840,6 @@ void __global__ k_nonbonded_exclusions(
     unsigned long long g_sigj = 0;
     unsigned long long g_epsj = 0;
 
-    RealType real_lambda = static_cast<RealType>(lambda);
     RealType real_beta = static_cast<RealType>(beta);
 
     RealType real_cutoff = static_cast<RealType>(cutoff);

--- a/timemachine/cpp/src/nonbonded.cu
+++ b/timemachine/cpp/src/nonbonded.cu
@@ -427,7 +427,6 @@ void Nonbonded<RealType, Interpolated>::execute_device(
             Interpolated ? d_unsorted_dp_dl_ : d_sorted_dp_dl_,
             d_w_,
             d_dw_dl_,
-            lambda,
             d_exclusion_idxs_,
             d_scales_,
             beta_,


### PR DESCRIPTION
Note: work in progress

Currently exclusions are computed internally in the nonbonded potential ([here](https://github.com/proteneer/timemachine/blob/54068f0e7cdfe063f067f684d6f1dfa3947db996/timemachine/cpp/src/kernels/k_nonbonded.cuh#L758)). This PR will move computation of the exclusion terms into a separate potential, and recover the existing nonbonded potential as a sum (using `SummedPotential` added in #537). This will increase flexibility and modularity of the code.