### PR TITLE
Make summed potential interface consistent with other custom ops

### DIFF
--- a/fe/functional.py
+++ b/fe/functional.py
@@ -69,9 +69,7 @@ def construct_differentiable_interface_fast(unbound_potentials, params, precisio
 
     This implementation computes the sum of the component potentials in C++ using the SummedPotential custom op
     """
-    impls = [ubp.unbound_impl(precision) for ubp in unbound_potentials]
-    sizes = [ps.size for ps in params]
-    impl = SummedPotential(impls, sizes)
+    impl = SummedPotential(unbound_potentials, params).unbound_impl(precision)
 
     def pack(params):
         return np.concatenate([ps.reshape(-1) for ps in params])

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -1,0 +1,11 @@
+import pytest
+
+import timemachine.lib.potentials as ps
+
+
+def test_summed_potential_raises_on_inconsistent_lengths():
+
+    with pytest.raises(ValueError) as excinfo:
+        ps.SummedPotential([ps.HarmonicBond()], [])
+
+    assert str(excinfo.value) == "number of potentials != number of parameter arrays"

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -952,7 +952,8 @@ void declare_summed_potential(py::module &m) {
                 return new timemachine::SummedPotential(potentials, params_sizes);
             }),
             py::arg("potentials"),
-            py::arg("params_sizes"));
+            py::arg("params_sizes"),
+            py::keep_alive<1, 2>());
 }
 
 const py::array_t<double, py::array::c_style>

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -36,25 +36,15 @@ class CustomOpWrapper:
         return custom_ops.BoundPotential(self.unbound_impl(precision), self.params)
 
 
-class SummedPotential:
+class SummedPotential(CustomOpWrapper):
     def __init__(self, potentials: List[CustomOpWrapper], params_init: List[NDArray]):
         self._potentials = potentials
         self._sizes = [ps.size for ps in params_init]
         self.params = None
 
-    def bind(self, params: List[NDArray]) -> "SummedPotential":
-        self.params = params
-        return self
-
-    def unbound_impl(self, precision: str) -> custom_ops.SummedPotential:
+    def unbound_impl(self, precision: str):
         impls = [p.unbound_impl(precision) for p in self._potentials]
         return custom_ops.SummedPotential(impls, self._sizes)
-
-    def bound_impl(self, precision: str) -> custom_ops.BoundPotential:
-        if self.params is None:
-            raise ValueError("This op has not been bound to parameters.")
-
-        return custom_ops.BoundPotential(self.unbound_impl(precision), self.params)
 
 
 # should not be used for Nonbonded Potentials

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -42,7 +42,7 @@ class SummedPotential(CustomOpWrapper):
         self._sizes = [ps.size for ps in params_init]
         self.params = None
 
-    def unbound_impl(self, precision: str):
+    def unbound_impl(self, precision):
         impls = [p.unbound_impl(precision) for p in self._potentials]
         return custom_ops.SummedPotential(impls, self._sizes)
 

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -44,7 +44,7 @@ class SummedPotential:
 
     def bind(self, params: List[NDArray]) -> "SummedPotential":
         self.params = params
-        pass
+        return self
 
     def unbound_impl(self, precision: str) -> custom_ops.SummedPotential:
         impls = [p.unbound_impl(precision) for p in self._potentials]

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -38,6 +38,10 @@ class CustomOpWrapper:
 
 class SummedPotential(CustomOpWrapper):
     def __init__(self, potentials: List[CustomOpWrapper], params_init: List[NDArray]):
+
+        if len(potentials) != len(params_init):
+            raise ValueError("number of potentials != number of parameter arrays")
+
         self._potentials = potentials
         self._sizes = [ps.size for ps in params_init]
         self.params = None


### PR DESCRIPTION
Modifies the `SummedPotential` Python interface for consistency with other custom ops and easier composition of potentials:

- `SummedPotential` inherits from `CustomOpWrapper`
- constructor accepts a list of `CustomOpWrapper` objects
- sub-potentials initialized with consistent precision

This also removes the hack previously used to prevent deallocation of the sub-potentials when direct references from Python go out of scope, instead passing the [keep_alive call policy](https://pybind11.readthedocs.io/en/stable/advanced/functions.html#keep-alive) in the binding code.

This will be useful for implementing the full nonbonded potential as a sum of raw and exclusion components in #542.