### PR TITLE
Pin numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ bootstrapped==0.0.2
 grpcio==1.30.0
 grpcio-tools==1.30.0
 protobuf==3.12.2
-numpy==1.18.5
+numpy==1.21.4
 scipy==1.6.0
 pymbar==3.0.5
 pyyaml==5.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ bootstrapped==0.0.2
 grpcio==1.30.0
 grpcio-tools==1.30.0
 protobuf==3.12.2
+numpy==1.18.5
 scipy==1.6.0
 pymbar==3.0.5
 pyyaml==5.4.1


### PR DESCRIPTION
The version of numpy currently used in CI is `1.18.5`, but a fresh install of the environment currently yields `1.21.4`.

Ideally, we could update numpy to a current version (not sure if that's feasible at the moment); in any case, it seems like it'd be useful to pin the version in the requirements so we can easily reproduce the environment in CI.