### PR TITLE
Feature/neighborlist on host ligand

### DIFF
--- a/timemachine/cpp/src/math_utils.cuh
+++ b/timemachine/cpp/src/math_utils.cuh
@@ -1,9 +1,13 @@
 #pragma once
 
-__device__ __host__ double sign(double a) { return (a > 0) - (a < 0); }
+#include "surreal.cuh"
 
-__device__ __host__ float sign(float a) { return (a > 0) - (a < 0); }
+int __forceinline__ ceil_divide(int x, int y) { return (x + y - 1) / y; }
 
-__device__ __host__ double sign(Surreal<double> a) { return (a.real > 0) - (a.real < 0); }
+double __device__ __host__ __forceinline__ sign(double a) { return (a > 0) - (a < 0); }
 
-__device__ __host__ float sign(Surreal<float> a) { return (a.real > 0) - (a.real < 0); }
+float __device__ __host__ __forceinline__ sign(float a) { return (a > 0) - (a < 0); }
+
+double __device__ __host__ __forceinline__ sign(Surreal<double> a) { return (a.real > 0) - (a.real < 0); }
+
+float __device__ __host__ __forceinline__ sign(Surreal<float> a) { return (a.real > 0) - (a.real < 0); }

--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -38,28 +38,6 @@ template <typename RealType> Neighborlist<RealType>::~Neighborlist() {
     gpuErrchk(cudaFree(d_block_bounds_ext_));
 }
 
-bool is_pow_2(int x) { return (x & (x - 1)) == 0; }
-
-int log2_int(int v) {
-    int bits = 0;
-    while (v >>= 1)
-        ++bits;
-    return bits;
-}
-
-int pow_int(int x, int p) {
-    if (p == 0)
-        return 1;
-    if (p == 1)
-        return x;
-
-    int tmp = pow_int(x, p / 2);
-    if (p % 2 == 0)
-        return tmp * tmp;
-    else
-        return x * tmp * tmp;
-}
-
 template <typename RealType>
 void Neighborlist<RealType>::compute_block_bounds_host(
     const int N,

--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -8,23 +8,37 @@
 
 namespace timemachine {
 
-template <typename RealType> Neighborlist<RealType>::Neighborlist(int N) : N_(N) {
+template <typename RealType> Neighborlist<RealType>::Neighborlist(const int NC, const int NR) : NC_(NC), NR_(NR) {
 
-    const int B = this->B(); //(N+32-1)/32;
-    const int Y = this->Y(); //(B+32-1)/32;
+    // NR must be less than NC
+    if (NR > NC) {
+        throw std::runtime_error("NR is greater than NC");
+    }
+    const int tpb = 32;
+    const int column_blocks = this->column_blocks();
+    const int row_blocks = this->B();
+    const int Y = this->Y();
 
-    unsigned long long MAX_TILE_BUFFER = B * B;
-    unsigned long long MAX_ATOM_BUFFER = B * B * 32;
+    unsigned long long MAX_TILE_BUFFER = row_blocks * column_blocks;
+    unsigned long long MAX_ATOM_BUFFER = MAX_TILE_BUFFER * tpb;
 
     // interaction buffers
     gpuErrchk(cudaMalloc(&d_ixn_count_, 1 * sizeof(*d_ixn_count_)));
     gpuErrchk(cudaMalloc(&d_ixn_tiles_, MAX_TILE_BUFFER * sizeof(*d_ixn_tiles_)));
     gpuErrchk(cudaMalloc(&d_ixn_atoms_, MAX_ATOM_BUFFER * sizeof(*d_ixn_atoms_)));
-    gpuErrchk(cudaMalloc(&d_trim_atoms_, B * Y * 32 * sizeof(*d_trim_atoms_)));
+    gpuErrchk(cudaMalloc(&d_trim_atoms_, column_blocks * Y * tpb * sizeof(*d_trim_atoms_)));
 
     // bounding box buffers
-    gpuErrchk(cudaMalloc(&d_block_bounds_ctr_, B * 3 * sizeof(*d_block_bounds_ctr_)));
-    gpuErrchk(cudaMalloc(&d_block_bounds_ext_, B * 3 * sizeof(*d_block_bounds_ext_)));
+    gpuErrchk(cudaMalloc(&d_col_block_bounds_ctr_, column_blocks * 3 * sizeof(*d_col_block_bounds_ctr_)));
+    gpuErrchk(cudaMalloc(&d_col_block_bounds_ext_, column_blocks * 3 * sizeof(*d_col_block_bounds_ext_)));
+    if (this->compute_full_matrix()) {
+        gpuErrchk(cudaMalloc(&d_row_block_bounds_ctr_, row_blocks * 3 * sizeof(*d_row_block_bounds_ctr_)));
+        gpuErrchk(cudaMalloc(&d_row_block_bounds_ext_, row_blocks * 3 * sizeof(*d_row_block_bounds_ext_)));
+    } else {
+        // If we are using the column as the row, use the block bounds ptr as the row as well
+        d_row_block_bounds_ctr_ = d_col_block_bounds_ctr_;
+        d_row_block_bounds_ext_ = d_col_block_bounds_ext_;
+    }
 }
 
 template <typename RealType> Neighborlist<RealType>::~Neighborlist() {
@@ -34,13 +48,17 @@ template <typename RealType> Neighborlist<RealType>::~Neighborlist() {
     gpuErrchk(cudaFree(d_ixn_atoms_));
     gpuErrchk(cudaFree(d_trim_atoms_));
 
-    gpuErrchk(cudaFree(d_block_bounds_ctr_));
-    gpuErrchk(cudaFree(d_block_bounds_ext_));
+    gpuErrchk(cudaFree(d_col_block_bounds_ctr_));
+    gpuErrchk(cudaFree(d_col_block_bounds_ext_));
+    if (this->compute_full_matrix()) {
+        gpuErrchk(cudaFree(d_row_block_bounds_ctr_));
+        gpuErrchk(cudaFree(d_row_block_bounds_ext_));
+    }
 }
 
 template <typename RealType>
 void Neighborlist<RealType>::compute_block_bounds_host(
-    const int N,
+    const int NC,
     const int D,
     const int block_size,
     const double *h_coords,
@@ -48,40 +66,58 @@ void Neighborlist<RealType>::compute_block_bounds_host(
     double *h_bb_ctrs,
     double *h_bb_exts) {
 
-    assert(N == N_);
-    assert(D == 3);
-
-    double *d_coords = gpuErrchkCudaMallocAndCopy(h_coords, N * 3 * sizeof(double));
+    double *d_coords = gpuErrchkCudaMallocAndCopy(h_coords, NC * 3 * sizeof(double));
     double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3 * 3 * sizeof(double));
 
-    this->compute_block_bounds_device(N, D, d_coords, d_box, static_cast<cudaStream_t>(0));
+    this->compute_block_bounds_device(NC, 0, D, d_coords, nullptr, d_box, static_cast<cudaStream_t>(0));
     gpuErrchk(cudaDeviceSynchronize());
 
     gpuErrchk(cudaMemcpy(
-        h_bb_ctrs, d_block_bounds_ctr_, this->B() * 3 * sizeof(*d_block_bounds_ctr_), cudaMemcpyDeviceToHost));
+        h_bb_ctrs, d_col_block_bounds_ctr_, this->B() * 3 * sizeof(*d_col_block_bounds_ctr_), cudaMemcpyDeviceToHost));
     gpuErrchk(cudaMemcpy(
-        h_bb_exts, d_block_bounds_ext_, this->B() * 3 * sizeof(*d_block_bounds_ext_), cudaMemcpyDeviceToHost));
+        h_bb_exts, d_col_block_bounds_ext_, this->B() * 3 * sizeof(*d_col_block_bounds_ext_), cudaMemcpyDeviceToHost));
 
     gpuErrchk(cudaFree(d_coords));
     gpuErrchk(cudaFree(d_box));
 }
 
 template <typename RealType>
-std::vector<std::vector<int>>
-Neighborlist<RealType>::get_nblist_host(int N, const double *h_coords, const double *h_box, const double cutoff) {
+std::vector<std::vector<int>> Neighborlist<RealType>::get_nblist_host(
+    const int NC,
+    const int NR,
+    const double *h_column_coords,
+    const double *h_row_coords,
+    const double *h_box,
+    const double cutoff) {
 
-    // assert(N==N_);
+    if (NC != NC_) {
+        throw std::runtime_error("NC != NC_");
+    }
+    if (NR != NR_) {
+        throw std::runtime_error("NR != NR_");
+    }
+    if (NR == 0 && h_row_coords != nullptr) {
+        throw std::runtime_error("NR == 0, but row coords provided");
+    } else if (h_row_coords == nullptr && NR != 0) {
+        throw std::runtime_error("No row coords provided, but NR != 0");
+    }
+    double *d_col_coords = gpuErrchkCudaMallocAndCopy(h_column_coords, NC * 3 * sizeof(double));
 
-    double *d_coords = gpuErrchkCudaMallocAndCopy(h_coords, N * 3 * sizeof(double));
+    double *d_row_coords =
+        this->compute_full_matrix() ? gpuErrchkCudaMallocAndCopy(h_row_coords, NR * 3 * sizeof(double)) : nullptr;
+
     double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3 * 3 * sizeof(double));
 
-    this->build_nblist_device(N, d_coords, d_box, cutoff, static_cast<cudaStream_t>(0));
+    this->build_nblist_device(NC, NR, d_col_coords, d_row_coords, d_box, cutoff, static_cast<cudaStream_t>(0));
 
     cudaDeviceSynchronize();
-    const int B = this->B(); //(N+32-1)/32;
+    const int tpb = 32;
+    const int column_blocks = this->column_blocks();
+    const int row_blocks = this->B();
+    const int Y = this->Y();
 
-    unsigned long long MAX_TILE_BUFFER = B * B;
-    unsigned long long MAX_ATOM_BUFFER = B * B * 32;
+    unsigned long long MAX_TILE_BUFFER = row_blocks * column_blocks;
+    unsigned long long MAX_ATOM_BUFFER = MAX_TILE_BUFFER * tpb;
 
     unsigned int h_ixn_count;
     gpuErrchk(cudaMemcpy(&h_ixn_count, d_ixn_count_, 1 * sizeof(*d_ixn_count_), cudaMemcpyDeviceToHost));
@@ -91,80 +127,144 @@ Neighborlist<RealType>::get_nblist_host(int N, const double *h_coords, const dou
     gpuErrchk(
         cudaMemcpy(&h_ixn_atoms[0], d_ixn_atoms_, MAX_ATOM_BUFFER * sizeof(unsigned int), cudaMemcpyDeviceToHost));
 
-    std::vector<std::vector<int>> ixn_list(B, std::vector<int>());
-
+    std::vector<std::vector<int>> ixn_list(row_blocks, std::vector<int>());
     for (int i = 0; i < h_ixn_count; i++) {
         int tile_idx = h_ixn_tiles[i];
-        for (int j = 0; j < 32; j++) {
-            int atom_j_idx = h_ixn_atoms[i * 32 + j];
-            if (atom_j_idx < N) {
+        for (int j = 0; j < tpb; j++) {
+            int atom_j_idx = h_ixn_atoms[i * tpb + j];
+            if (atom_j_idx < NC) {
                 ixn_list[tile_idx].push_back(atom_j_idx);
             }
         }
     }
-
-    gpuErrchk(cudaFree(d_coords));
+    gpuErrchk(cudaFree(d_col_coords));
+    if (this->compute_full_matrix()) {
+        gpuErrchk(cudaFree(d_row_coords));
+    }
     gpuErrchk(cudaFree(d_box));
 
     return ixn_list;
 }
 
 template <typename RealType>
+std::vector<std::vector<int>>
+Neighborlist<RealType>::get_nblist_host(int NC, const double *h_coords, const double *h_box, const double cutoff) {
+    // Call into the impl that takes column and row coords
+    return this->get_nblist_host(NC, 0, h_coords, nullptr, h_box, cutoff);
+}
+
+template <typename RealType>
 void Neighborlist<RealType>::build_nblist_device(
-    const int N, const double *d_coords, const double *d_box, const double cutoff, cudaStream_t stream) {
-
-    // assert(N == N_);
-
-    // reset the interaction count
+    const int NC,
+    const int NR,
+    const double *d_col_coords,
+    const double *d_row_coords,
+    const double *d_box,
+    const double cutoff,
+    cudaStream_t stream) {
     gpuErrchk(cudaMemsetAsync(d_ixn_count_, 0, 1 * sizeof(*d_ixn_count_), stream));
 
     const int D = 3;
-    this->compute_block_bounds_device(N, D, d_coords, d_box, stream);
+    this->compute_block_bounds_device(NC, NR, D, d_col_coords, d_row_coords, d_box, stream);
 
-    int tpb = 32;
-    const int B = this->B(); // (N+32-1)/32;
-    const int Y = this->Y(); // (B+32-1)/32;
+    const int tpb = 32;
+    const int column_blocks = this->column_blocks();
+    const int row_blocks = this->B();
+    const int Y = this->Y();
 
-    dim3 dimGrid(B, Y, 1); // block x, y, z dims
+    dim3 dimGrid(row_blocks, Y, 1); // block x, y, z dims
 
     // (ytz): TBD shared memory, stream
-    k_find_blocks_with_ixns<RealType><<<dimGrid, tpb, 0, stream>>>(
-        N,
-        d_block_bounds_ctr_,
-        d_block_bounds_ext_,
-        d_coords,
-        d_box,
-        d_ixn_count_,
-        d_ixn_tiles_,
-        d_ixn_atoms_,
-        d_trim_atoms_,
-        cutoff);
+    if (!this->compute_full_matrix()) {
+        // Compute only the upper triangle as rows and cols are the same
+        // pass duplicates of column coords and the bounding boxes
+        k_find_blocks_with_ixns<RealType, true><<<dimGrid, tpb, 0, stream>>>(
+            NC,
+            NC,
+            d_col_block_bounds_ctr_,
+            d_col_block_bounds_ext_,
+            d_col_block_bounds_ctr_,
+            d_col_block_bounds_ext_,
+            d_col_coords,
+            d_col_coords,
+            d_box,
+            d_ixn_count_,
+            d_ixn_tiles_,
+            d_ixn_atoms_,
+            d_trim_atoms_,
+            cutoff);
+    } else {
+        k_find_blocks_with_ixns<RealType, false><<<dimGrid, tpb, 0, stream>>>(
+            NC,
+            NR,
+            d_col_block_bounds_ctr_,
+            d_col_block_bounds_ext_,
+            d_row_block_bounds_ctr_,
+            d_row_block_bounds_ext_,
+            d_col_coords,
+            d_row_coords,
+            d_box,
+            d_ixn_count_,
+            d_ixn_tiles_,
+            d_ixn_atoms_,
+            d_trim_atoms_,
+            cutoff);
+    }
 
     gpuErrchk(cudaPeekAtLastError());
-
-    k_compact_trim_atoms<<<B, tpb, 0, stream>>>(N, Y, d_trim_atoms_, d_ixn_count_, d_ixn_tiles_, d_ixn_atoms_);
+    k_compact_trim_atoms<<<row_blocks, tpb, 0, stream>>>(
+        NC, Y, d_trim_atoms_, d_ixn_count_, d_ixn_tiles_, d_ixn_atoms_);
 
     gpuErrchk(cudaPeekAtLastError());
 }
 
 template <typename RealType>
+void Neighborlist<RealType>::build_nblist_device(
+    const int NC, const double *d_coords, const double *d_box, const double cutoff, cudaStream_t stream) {
+
+    this->build_nblist_device(NC, 0, d_coords, nullptr, d_box, cutoff, stream);
+}
+
+template <typename RealType>
 void Neighborlist<RealType>::compute_block_bounds_device(
-    const int N,            // Number of atoms
-    const int D,            // Box dimensions
-    const double *d_coords, // [N*3]
-    const double *d_box,    // [D*3]
+    const int NC,               // Number of atoms in column
+    const int NR,               // Number of atoms in row
+    const int D,                // Box dimensions
+    const double *d_col_coords, // [N*3]
+    const double *d_row_coords, // [K*3]
+    const double *d_box,        // [D*3]
     cudaStream_t stream) {
 
-    assert(N == N_);
-    assert(D == 3);
+    if (NC != NC_) {
+        throw std::runtime_error("NC != NC_");
+    }
+    if (NR != NR_) {
+        throw std::runtime_error("NR != NR_");
+    }
+    if (D != 3) {
+        throw std::runtime_error("D != 3");
+    }
+    if (NR == 0 && d_row_coords != nullptr) {
+        throw std::runtime_error("NR == 0, but row coords provided");
+    } else if (d_row_coords == nullptr && NR != 0) {
+        throw std::runtime_error("No row coords provided, but NR != 0");
+    }
+
+    const bool compute_row_bounds = this->compute_full_matrix();
 
     const int tpb = 32;
-    const int B = (N + tpb - 1) / tpb; // total number of blocks we need to process
+    const int column_blocks = this->column_blocks(); // total number of blocks we need to process
 
-    k_find_block_bounds<RealType>
-        <<<B, tpb, 0, stream>>>(N, D, B, d_coords, d_box, d_block_bounds_ctr_, d_block_bounds_ext_);
-
+    k_find_block_bounds<RealType><<<column_blocks, tpb, 0, stream>>>(
+        NC, D, column_blocks, d_col_coords, d_box, d_col_block_bounds_ctr_, d_col_block_bounds_ext_);
     gpuErrchk(cudaPeekAtLastError());
+
+    if (this->compute_full_matrix()) {
+        const int row_blocks = this->B();
+        k_find_block_bounds<RealType><<<row_blocks, tpb, 0, stream>>>(
+            NR, D, row_blocks, d_row_coords, d_box, d_row_block_bounds_ctr_, d_row_block_bounds_ext_);
+        gpuErrchk(cudaPeekAtLastError());
+    }
 };
 
 template class Neighborlist<double>;

--- a/timemachine/cpp/src/neighborlist.hpp
+++ b/timemachine/cpp/src/neighborlist.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "math_utils.cuh"
 #include <vector>
 
 namespace timemachine {
@@ -8,10 +9,14 @@ namespace timemachine {
 template <typename RealType> class Neighborlist {
 
 private:
-    const int N_;
+    const int NC_;
+    const int NR_;
 
-    double *d_block_bounds_ctr_;
-    double *d_block_bounds_ext_;
+    double *d_col_block_bounds_ctr_;
+    double *d_col_block_bounds_ext_;
+
+    double *d_row_block_bounds_ctr_;
+    double *d_row_block_bounds_ext_;
 
     unsigned int *d_ixn_count_;
     int *d_ixn_tiles_;
@@ -20,18 +25,35 @@ private:
 
 public:
     // N - number of atoms
-    Neighborlist(int N);
+    Neighborlist(const int NC, const int NR = 0);
 
     ~Neighborlist();
 
     std::vector<std::vector<int>>
-    get_nblist_host(int N, const double *h_coords, const double *h_box, const double cutoff);
+    get_nblist_host(const int NC, const double *h_coords, const double *h_box, const double cutoff);
+
+    std::vector<std::vector<int>> get_nblist_host(
+        const int NC,
+        const int NR,
+        const double *h_column_coords,
+        const double *h_row_coords,
+        const double *h_box,
+        const double cutoff);
 
     void build_nblist_device(
-        const int N, const double *d_coords, const double *d_box, const double cutoff, cudaStream_t stream);
+        const int NC, const double *d_coords, const double *d_box, const double cutoff, cudaStream_t stream);
+
+    void build_nblist_device(
+        const int NC,
+        const int NR,
+        const double *d_col_coords,
+        const double *d_row_coords,
+        const double *d_box,
+        const double cutoff,
+        cudaStream_t stream);
 
     void compute_block_bounds_host(
-        const int N,
+        const int NC,
         const int D,
         const int block_size,
         const double *h_coords,
@@ -45,13 +67,26 @@ public:
 
     unsigned int *get_ixn_count() { return d_ixn_count_; }
 
-    // get max number of blocks
-    int B() const { return (N_ + 32 - 1) / 32; }
+    // get max number of row blocks
+    int B() const { return ceil_divide(this->compute_full_matrix() ? NR_ : NC_, 32); }
 
 private:
-    int Y() const { return (this->B() + 32 - 1) / 32; }
+    // Indicates that should compute interactions of all rows and columns
+    // when a row is provided, otherwise only compute upper triangle of the ixn matrix.
+    bool compute_full_matrix() const { return NR_ > 0; }
 
-    void compute_block_bounds_device(int N, int D, const double *coords, const double *box, cudaStream_t stream);
+    int column_blocks() const { return ceil_divide(NC_, 32); }
+    // The number of column blocks divided by warp size. Each thread handles a block
+    int Y() const { return ceil_divide(this->column_blocks(), 32); }
+
+    void compute_block_bounds_device(
+        const int NC,
+        const int NR,
+        const int D,
+        const double *d_col_coords,
+        const double *d_row_coords,
+        const double *d_box,
+        cudaStream_t stream);
 };
 
 } // namespace timemachine

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -38,13 +38,18 @@ template <typename RealType> void declare_neighborlist(py::module &m, const char
     using Class = timemachine::Neighborlist<RealType>;
     std::string pyclass_name = std::string("Neighborlist_") + typestr;
     py::class_<Class>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
-        .def(py::init([](int N) { return new timemachine::Neighborlist<RealType>(N); }))
+        .def(
+            py::init([](int NC, std::optional<int> NR) {
+                return new timemachine::Neighborlist<RealType>(NC, NR.has_value() ? NR.value() : 0);
+            }),
+            py::arg("NC"),
+            py::arg("NR") = py::none())
         .def(
             "compute_block_bounds",
             [](timemachine::Neighborlist<RealType> &nblist,
                const py::array_t<double, py::array::c_style> &coords,
                const py::array_t<double, py::array::c_style> &box,
-               int block_size) -> py::tuple {
+               const int block_size) -> py::tuple {
                 if (block_size != 32) {
                     throw std::runtime_error("Block size must be 32.");
                 }
@@ -71,6 +76,22 @@ template <typename RealType> void declare_neighborlist(py::module &m, const char
                 int D = coords.shape()[1];
 
                 std::vector<std::vector<int>> ixn_list = nblist.get_nblist_host(N, coords.data(), box.data(), cutoff);
+
+                return ixn_list;
+            })
+        .def(
+            "get_nblist_host_ligand",
+            [](timemachine::Neighborlist<RealType> &nblist,
+               const py::array_t<double, py::array::c_style> &coords,
+               const py::array_t<double, py::array::c_style> &row_coords,
+               const py::array_t<double, py::array::c_style> &box,
+               const double cutoff) -> std::vector<std::vector<int>> {
+                const int N = coords.shape()[0];
+                const int K = row_coords.shape()[0];
+                const int D = coords.shape()[1];
+
+                std::vector<std::vector<int>> ixn_list =
+                    nblist.get_nblist_host(N, K, coords.data(), row_coords.data(), box.data(), cutoff);
 
                 return ixn_list;
             });

--- a/timemachine/potentials/jax_utils.py
+++ b/timemachine/potentials/jax_utils.py
@@ -91,9 +91,8 @@ def delta_r(ri, rj, box=None):
 
     # box is None for harmonic bonds, not None for nonbonded terms
     if box is not None:
-        for d in range(dims):
-            diff -= box[d] * np.floor(np.expand_dims(diff[..., d], axis=-1) / box[d][d] + 0.5)
-
+        box_diag = np.diag(box)
+        diff -= box_diag * np.floor(diff / box_diag + 0.5)
     return diff
 
 


### PR DESCRIPTION
This PR extends our Neighborlist to support construct from two sets of coordinates. This will be necessary for eventuating host-ligand interactions.

The performance is unchanged from what is currently on master.

Current Benchmarks on A4000
```
CUDA Kernel Statistics:

 Time(%)  Total Time (ns)  Instances  Average (ns)  Minimum (ns)  Maximum (ns)  StdDev (ns)                                                  Name                                                
 -------  ---------------  ---------  ------------  ------------  ------------  -----------  ----------------------------------------------------------------------------------------------------
    64.6        1,808,224         12     150,685.3         7,680       294,208    136,109.5  void k_find_blocks_with_ixns<double>(int, const double *, const double *, const double *, const dou…
    20.6          575,296         12      47,941.3         5,024       101,120     41,874.3  void k_find_blocks_with_ixns<float>(int, const double *, const double *, const double *, const doub…
     8.1          227,422         12      18,951.8        16,864        22,528      2,351.4  void k_find_block_bounds<double>(int, int, int, const double *, const double *, double *, double *) 
     4.3          121,057         12      10,088.1         7,104        13,600      3,051.8  void k_find_block_bounds<float>(int, int, int, const double *, const double *, double *, double *)  
     2.4           67,230         24       2,801.3         2,592         3,040        158.5  k_compact_trim_atoms(int, int, unsigned int *, unsigned int *, int *, unsigned int *)   

dhfr-apo: N=23558 speed: 216.82ns/day dt: 1.5fs (ran 100000 steps in 59.78s)
dhfr-apo-barostat-interval-25: N=23558 speed: 193.24ns/day dt: 1.5fs (ran 100000 steps in 67.07s)
dhfr-apo-hmr-barostat-interval-25: N=23558 speed: 319.22ns/day dt: 2.5fs (ran 100000 steps in 67.67s)
building a protein system with 1758 protein atoms and 7047 water atoms
WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
hif2a-apo: N=8805 speed: 478.39ns/day dt: 1.5fs (ran 100000 steps in 27.10s)
hif2a-apo-barostat-interval-25: N=8805 speed: 418.24ns/day dt: 1.5fs (ran 100000 steps in 30.99s)
hif2a-rbfe-with-du-dp: N=8840 speed: 360.66ns/day dt: 1.5fs (ran 100000 steps in 35.94s)
hif2a-rbfe-du-dl-interval-0: N=8840 speed: 362.89ns/day dt: 1.5fs (ran 100000 steps in 35.72s)
hif2a-rbfe-du-dl-interval-1: N=8840 speed: 350.11ns/day dt: 1.5fs (ran 100000 steps in 37.02s)
hif2a-rbfe-du-dl-interval-5: N=8840 speed: 358.71ns/day dt: 1.5fs (ran 100000 steps in 36.13s)
solvent-apo: N=6282 speed: 631.52ns/day dt: 1.5fs (ran 100000 steps in 20.53s)
solvent-apo-barostat-interval-25: N=6282 speed: 579.31ns/day dt: 1.5fs (ran 100000 steps in 22.38s)
solvent-rbfe-with-du-dp: N=6317 speed: 469.03ns/day dt: 1.5fs (ran 100000 steps in 27.64s)
solvent-rbfe-du-dl-interval-0: N=6317 speed: 471.42ns/day dt: 1.5fs (ran 100000 steps in 27.50s)
solvent-rbfe-du-dl-interval-1: N=6317 speed: 457.64ns/day dt: 1.5fs (ran 100000 steps in 28.32s)
solvent-rbfe-du-dl-interval-5: N=6317 speed: 467.04ns/day dt: 1.5fs (ran 100000 steps in 27.75s)
```

The changes in the PR
```
CUDA Kernel Statistics:

 Time(%)  Total Time (ns)  Instances  Average (ns)  Minimum (ns)  Maximum (ns)  StdDev (ns)                                                  Name                                                
 -------  ---------------  ---------  ------------  ------------  ------------  -----------  ----------------------------------------------------------------------------------------------------
    65.8        1,840,324         12     153,360.3         7,616       299,393    138,820.0  void k_find_blocks_with_ixns<double, (bool)1>(int, int, const double *, const double *, const doubl…
    19.6          549,059         12      45,754.9         4,448        96,545     40,152.3  void k_find_blocks_with_ixns<float, (bool)1>(int, int, const double *, const double *, const double…
     8.1          225,792         12      18,816.0        16,800        21,792      2,310.7  void k_find_block_bounds<double>(int, int, int, const double *, const double *, double *, double *) 
     4.0          113,089         12       9,424.1         6,752        12,832      2,874.9  void k_find_block_bounds<float>(int, int, int, const double *, const double *, double *, double *)  
     2.4           66,528         24       2,772.0         2,496         4,000        337.9  k_compact_trim_atoms(int, int, unsigned int *, unsigned int *, int *, unsigned int *) 


dhfr-apo: N=23558 speed: 216.85ns/day dt: 1.5fs (ran 100000 steps in 59.77s)
dhfr-apo-barostat-interval-25: N=23558 speed: 194.38ns/day dt: 1.5fs (ran 100000 steps in 66.68s)
dhfr-apo-hmr-barostat-interval-25: N=23558 speed: 319.71ns/day dt: 2.5fs (ran 100000 steps in 67.57s)
building a protein system with 1758 protein atoms and 7047 water atoms
WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
hif2a-apo: N=8805 speed: 476.93ns/day dt: 1.5fs (ran 100000 steps in 27.18s)
hif2a-apo-barostat-interval-25: N=8805 speed: 418.21ns/day dt: 1.5fs (ran 100000 steps in 30.99s)
hif2a-rbfe-with-du-dp: N=8840 speed: 360.70ns/day dt: 1.5fs (ran 100000 steps in 35.93s)
hif2a-rbfe-du-dl-interval-0: N=8840 speed: 361.52ns/day dt: 1.5fs (ran 100000 steps in 35.85s)
hif2a-rbfe-du-dl-interval-1: N=8840 speed: 350.61ns/day dt: 1.5fs (ran 100000 steps in 36.97s)
hif2a-rbfe-du-dl-interval-5: N=8840 speed: 358.75ns/day dt: 1.5fs (ran 100000 steps in 36.13s)
solvent-apo: N=6282 speed: 631.58ns/day dt: 1.5fs (ran 100000 steps in 20.52s)
solvent-apo-barostat-interval-25: N=6282 speed: 581.07ns/day dt: 1.5fs (ran 100000 steps in 22.31s)
solvent-rbfe-with-du-dp: N=6317 speed: 469.30ns/day dt: 1.5fs (ran 100000 steps in 27.62s)
solvent-rbfe-du-dl-interval-0: N=6317 speed: 472.75ns/day dt: 1.5fs (ran 100000 steps in 27.42s)
solvent-rbfe-du-dl-interval-1: N=6317 speed: 456.27ns/day dt: 1.5fs (ran 100000 steps in 28.41s)
solvent-rbfe-du-dl-interval-5: N=6317 speed: 464.34ns/day dt: 1.5fs (ran 100000 steps in 27.92s)
```