### PR TITLE
Add setters for velocities and box

### DIFF
--- a/md/states.py
+++ b/md/states.py
@@ -1,5 +1,19 @@
 # Sampler states
 
 from collections import namedtuple
+from timemachine.lib import custom_ops
 
 CoordsVelBox = namedtuple("CoordsVelBox", ["coords", "velocities", "box"])
+
+
+def set_coords_vel_box(ctxt: custom_ops.Context, x: CoordsVelBox):
+    ctxt.set_x_t(x.coords)
+    ctxt.set_v_t(x.velocities)
+    ctxt.set_box(x.box)
+
+
+def get_coords_vel_box(ctxt: custom_ops.Context) -> CoordsVelBox:
+    x_t = ctxt.get_x_t()
+    v_t = ctxt.get_v_t()
+    box = ctxt.get_box()
+    return CoordsVelBox(x_t, v_t, box)

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -64,9 +64,17 @@ class TestContext(unittest.TestCase):
         np.testing.assert_equal(ctxt.get_box(), box)
 
         new_x = np.random.rand(N, 3)
+        new_v = np.random.rand(N, 3)
+        new_box = np.random.rand(3, 3)
         ctxt.set_x_t(new_x)
+        ctxt.set_v_t(new_v)
+        ctxt.set_box(new_box)
+
 
         np.testing.assert_equal(ctxt.get_x_t(), new_x)
+        np.testing.assert_equal(ctxt.get_v_t(), new_v)
+        np.testing.assert_equal(ctxt.get_box(), new_box)
+
 
     def test_fwd_mode(self):
         """

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -70,11 +70,9 @@ class TestContext(unittest.TestCase):
         ctxt.set_v_t(new_v)
         ctxt.set_box(new_box)
 
-
         np.testing.assert_equal(ctxt.get_x_t(), new_x)
         np.testing.assert_equal(ctxt.get_v_t(), new_v)
         np.testing.assert_equal(ctxt.get_box(), new_box)
-
 
     def test_fwd_mode(self):
         """

--- a/timemachine/cpp/src/context.cu
+++ b/timemachine/cpp/src/context.cu
@@ -304,6 +304,14 @@ void Context::set_x_t(const double *in_buffer) {
     gpuErrchk(cudaMemcpy(d_x_t_, in_buffer, N_ * 3 * sizeof(*in_buffer), cudaMemcpyHostToDevice));
 }
 
+void Context::set_v_t(const double *in_buffer) {
+    gpuErrchk(cudaMemcpy(d_v_t_, in_buffer, N_ * 3 * sizeof(*in_buffer), cudaMemcpyHostToDevice));
+}
+
+void Context::set_box(const double *in_buffer) {
+    gpuErrchk(cudaMemcpy(d_box_t_, in_buffer, 3 * 3 * sizeof(*in_buffer), cudaMemcpyHostToDevice));
+}
+
 void Context::get_du_dx_t_minus_1(unsigned long long *out_buffer) const {
     gpuErrchk(cudaMemcpy(out_buffer, d_du_dx_t_, N_ * 3 * sizeof(*out_buffer), cudaMemcpyDeviceToHost));
 }

--- a/timemachine/cpp/src/context.hpp
+++ b/timemachine/cpp/src/context.hpp
@@ -41,6 +41,10 @@ public:
 
     void set_x_t(const double *in_buffer);
 
+    void set_v_t(const double *in_buffer);
+
+    void set_box(const double *in_buffer);
+
     void get_x_t(double *out_buffer) const;
 
     void get_v_t(double *out_buffer) const;

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -232,6 +232,16 @@ void declare_context(py::module &m) {
                 ctxt.set_x_t(new_x_t.data());
             })
         .def(
+            "set_v_t",
+            [](timemachine::Context &ctxt, const py::array_t<double, py::array::c_style> new_v_t) {
+                ctxt.set_v_t(new_v_t.data());
+            })
+        .def(
+            "set_box",
+            [](timemachine::Context &ctxt, const py::array_t<double, py::array::c_style> new_box) {
+                ctxt.set_box(new_box.data());
+            })
+        .def(
             "get_x_t",
             [](timemachine::Context &ctxt) -> py::array_t<double, py::array::c_style> {
                 unsigned int N = ctxt.num_atoms();


### PR DESCRIPTION
Currently, to run MD from new initial conditions (x, v, box), we create a new context with the desired initial conditions. This is because the context doesn't have setters for v and box (although it has a setter for x).

The overhead for context creation in timemachine is very small (~0.2 ms), but it might still be preferable to have setters for v and box. Would this break anything / make any kinds of user errors more likely?