### PR TITLE
Use smart pointers for memory management in SummedPotential

### DIFF
--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -1,11 +1,34 @@
 import pytest
+import numpy as np
 
-import timemachine.lib.potentials as ps
+from timemachine.lib import potentials
 
 
-def test_summed_potential_raises_on_inconsistent_lengths():
+@pytest.fixture
+def harmonic_bond():
+    bond_idxs = np.array([[0, 1], [0, 2]], dtype=np.int32)
+    params = np.ones(shape=(2, 2), dtype=np.float32)
+    return potentials.HarmonicBond(bond_idxs).bind(params)
+
+
+@pytest.fixture
+def summed_potential(harmonic_bond):
+    return potentials.SummedPotential([harmonic_bond], [harmonic_bond.params]).bind([harmonic_bond.params])
+
+
+def test_summed_potential_raises_on_inconsistent_lengths(harmonic_bond):
 
     with pytest.raises(ValueError) as excinfo:
-        ps.SummedPotential([ps.HarmonicBond()], [])
+        potentials.SummedPotential([harmonic_bond], [])
 
     assert str(excinfo.value) == "number of potentials != number of parameter arrays"
+
+
+def test_summed_potential_keeps_referenced_potentials_alive(summed_potential):
+    coords = np.zeros(shape=(3, 3), dtype=np.float32)
+    box = np.diag(np.ones(3))
+    lam = 1
+
+    # segfaults if Potentials referenced by summed_potential have been
+    # deallocated prematurely
+    summed_potential.bound_impl(np.float32).execute(coords, box, lam)

--- a/timemachine/cpp/src/summed_potential.cu
+++ b/timemachine/cpp/src/summed_potential.cu
@@ -1,9 +1,10 @@
 #include "summed_potential.hpp"
+#include <memory>
 #include <stdexcept>
 
 namespace timemachine {
 
-SummedPotential::SummedPotential(std::vector<Potential *> potentials, std::vector<int> params_sizes)
+SummedPotential::SummedPotential(std::vector<std::shared_ptr<Potential>> potentials, std::vector<int> params_sizes)
     : potentials_(potentials), params_sizes_(params_sizes) {
     if (potentials_.size() != params_sizes_.size()) {
         throw std::runtime_error("number of potentials != number of parameter sizes");

--- a/timemachine/cpp/src/summed_potential.cu
+++ b/timemachine/cpp/src/summed_potential.cu
@@ -1,10 +1,9 @@
 #include "summed_potential.hpp"
-#include <memory>
 #include <stdexcept>
 
 namespace timemachine {
 
-SummedPotential::SummedPotential(std::vector<std::shared_ptr<Potential>> potentials, std::vector<int> params_sizes)
+SummedPotential::SummedPotential(std::vector<Potential *> potentials, std::vector<int> params_sizes)
     : potentials_(potentials), params_sizes_(params_sizes) {
     if (potentials_.size() != params_sizes_.size()) {
         throw std::runtime_error("number of potentials != number of parameter sizes");

--- a/timemachine/cpp/src/summed_potential.hpp
+++ b/timemachine/cpp/src/summed_potential.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "potential.hpp"
+#include <memory>
 #include <vector>
 
 namespace timemachine {
@@ -8,11 +9,11 @@ namespace timemachine {
 class SummedPotential : public Potential {
 
 private:
-    const std::vector<Potential *> potentials_;
+    const std::vector<std::shared_ptr<Potential>> potentials_;
     const std::vector<int> params_sizes_;
 
 public:
-    SummedPotential(std::vector<Potential *> potentials, std::vector<int> params_sizes);
+    SummedPotential(std::vector<std::shared_ptr<Potential>> potentials, std::vector<int> params_sizes);
 
     virtual void execute_device(
         const int N,

--- a/timemachine/cpp/src/summed_potential.hpp
+++ b/timemachine/cpp/src/summed_potential.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "potential.hpp"
-#include <memory>
 #include <vector>
 
 namespace timemachine {
@@ -9,11 +8,11 @@ namespace timemachine {
 class SummedPotential : public Potential {
 
 private:
-    const std::vector<std::shared_ptr<Potential>> potentials_;
+    const std::vector<Potential *> potentials_;
     const std::vector<int> params_sizes_;
 
 public:
-    SummedPotential(std::vector<std::shared_ptr<Potential>> potentials, std::vector<int> params_sizes);
+    SummedPotential(std::vector<Potential *> potentials, std::vector<int> params_sizes);
 
     virtual void execute_device(
         const int N,

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -969,12 +969,12 @@ void declare_summed_potential(py::module &m) {
     py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
         m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
         .def(
-            py::init([](std::vector<timemachine::Potential *> potentials, std::vector<int> params_sizes) {
-                return new timemachine::SummedPotential(potentials, params_sizes);
-            }),
+            py::init(
+                [](std::vector<std::shared_ptr<timemachine::Potential>> potentials, std::vector<int> params_sizes) {
+                    return new timemachine::SummedPotential(potentials, params_sizes);
+                }),
             py::arg("potentials"),
-            py::arg("params_sizes"),
-            py::keep_alive<1, 2>());
+            py::arg("params_sizes"));
 }
 
 const py::array_t<double, py::array::c_style>

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -969,12 +969,12 @@ void declare_summed_potential(py::module &m) {
     py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
         m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
         .def(
-            py::init(
-                [](std::vector<std::shared_ptr<timemachine::Potential>> potentials, std::vector<int> params_sizes) {
-                    return new timemachine::SummedPotential(potentials, params_sizes);
-                }),
+            py::init([](std::vector<timemachine::Potential *> potentials, std::vector<int> params_sizes) {
+                return new timemachine::SummedPotential(potentials, params_sizes);
+            }),
             py::arg("potentials"),
-            py::arg("params_sizes"));
+            py::arg("params_sizes"),
+            py::keep_alive<1, 2>());
 }
 
 const py::array_t<double, py::array::c_style>


### PR DESCRIPTION
This is a more principled/robust fix for the issue of potentials referenced by a `SummedPotential` being deallocated before the `SummedPotential` instance is deallocated. (This seems to be what we're already doing for `BoundPotential`s).

### Issue

In our pybind11 wrappers, we declare `Potential` to have a ["holder" type](https://pybind11.readthedocs.io/en/stable/advanced/smart_ptrs.html#std-shared-ptr) of `shared_ptr`. I think this means that Potentials will be deallocated when the shared pointer reference count (including Python + CXX references) reaches zero. `BoundPotential` seems to handle this properly by declaring its reference to the underlying Potential to be of type `shared_ptr`, so the underlying Potential should not be freed before BoundPotential.

But in the current implementation of `SummedPotential`, the vector of references to underlying potentials just holds bare pointers (type `vector<Potential *>`), which I think means that SummedPotential doesn't contribute to the reference count of the underlying potentials and the latter can be deallocated prematurely.

### Solution

This PR changes the type of `SummedPotential::potentials_` to use `shared_ptr`. This should prevent potentials from being prematurely deallocated. It also removes the `keep_alive` annotation, which is no longer necessary.