### PR TITLE
Add method for potential-specific fixed- to floating-point conversion

### DIFF
--- a/timemachine/cpp/src/potential.cu
+++ b/timemachine/cpp/src/potential.cu
@@ -139,16 +139,16 @@ void Potential::fixed_to_float(
         du_dp_out[i] = du_dp[i]; // TODO: just a pass-thru for now; update when du_dp is fixed-point
     }
 
-    unsigned long long du_dl_sum_ull = 0;
+    unsigned long long du_dl_sum_fixed = 0;
     for (int i = 0; i < N; i++) {
-        du_dl_sum_ull += du_dl[i];
+        du_dl_sum_fixed += du_dl[i];
     }
-    *du_dl_sum = FIXED_TO_FLOAT<double>(du_dl_sum_ull);
+    *du_dl_sum = FIXED_TO_FLOAT<double>(du_dl_sum_fixed);
 
-    unsigned long long u_sum_ull = 0;
+    unsigned long long u_sum_fixed = 0;
     for (int i = 0; i < N; i++) {
-        u_sum_ull += u[i];
+        u_sum_fixed += u[i];
     }
-    *u_sum = FIXED_TO_FLOAT<double>(u_sum_ull);
+    *u_sum = FIXED_TO_FLOAT<double>(u_sum_fixed);
 }
 } // namespace timemachine

--- a/timemachine/cpp/src/potential.cu
+++ b/timemachine/cpp/src/potential.cu
@@ -19,6 +19,8 @@ void Potential::execute_host(
     unsigned long long *h_du_dl, //
     unsigned long long *h_u) {
 
+    const int &D = Potential::D;
+
     double *d_x;
     double *d_p;
     double *d_box;
@@ -90,6 +92,8 @@ void Potential::execute_host_du_dx(
     const double lambda, // [1]
     unsigned long long *h_du_dx) {
 
+    const int &D = Potential::D;
+
     double *d_x;
     double *d_p;
     double *d_box;
@@ -130,6 +134,8 @@ void Potential::fixed_to_float(
     double *du_dp_out,
     double *du_dl_sum,
     double *u_sum) {
+
+    const int &D = Potential::D;
 
     for (int i = 0; i < N * D; i++) {
         du_dx_out[i] = FIXED_TO_FLOAT<double>(du_dx[i]);

--- a/timemachine/cpp/src/potential.cu
+++ b/timemachine/cpp/src/potential.cu
@@ -1,5 +1,6 @@
 #include <iostream>
 
+#include "fixed_point.hpp"
 #include "gpu_utils.cuh"
 #include "potential.hpp"
 #include "surreal.cuh"
@@ -21,8 +22,6 @@ void Potential::execute_host(
     double *d_x;
     double *d_p;
     double *d_box;
-
-    const int D = 3;
 
     gpuErrchk(cudaMalloc(&d_x, N * D * sizeof(double)));
     gpuErrchk(cudaMemcpy(d_x, h_x, N * D * sizeof(double), cudaMemcpyHostToDevice));
@@ -95,8 +94,6 @@ void Potential::execute_host_du_dx(
     double *d_p;
     double *d_box;
 
-    const int D = 3;
-
     gpuErrchk(cudaMalloc(&d_x, N * D * sizeof(double)));
     gpuErrchk(cudaMemcpy(d_x, h_x, N * D * sizeof(double), cudaMemcpyHostToDevice));
 
@@ -122,4 +119,36 @@ void Potential::execute_host_du_dx(
     gpuErrchk(cudaFree(d_box));
 };
 
+void Potential::fixed_to_float(
+    const int N,
+    const int P,
+    const unsigned long long *du_dx,
+    const double *du_dp,
+    const unsigned long long *du_dl,
+    const unsigned long long *u,
+    double *du_dx_out,
+    double *du_dp_out,
+    double *du_dl_sum,
+    double *u_sum) {
+
+    for (int i = 0; i < N * D; i++) {
+        du_dx_out[i] = FIXED_TO_FLOAT<double>(du_dx[i]);
+    }
+
+    for (int i = 0; i < P; i++) {
+        du_dp_out[i] = du_dp[i]; // TODO: just a pass-thru for now; update when du_dp is fixed-point
+    }
+
+    unsigned long long du_dl_sum_ = 0;
+    for (int i = 0; i < N; i++) {
+        du_dl_sum += du_dl[i];
+    }
+    *du_dl_sum = FIXED_TO_FLOAT<double>(du_dl_sum_);
+
+    unsigned long long u_sum_ = 0;
+    for (int i = 0; i < N; i++) {
+        u_sum_ += u[i];
+    }
+    *u_sum = FIXED_TO_FLOAT<double>(u_sum_);
+}
 } // namespace timemachine

--- a/timemachine/cpp/src/potential.cu
+++ b/timemachine/cpp/src/potential.cu
@@ -139,16 +139,16 @@ void Potential::fixed_to_float(
         du_dp_out[i] = du_dp[i]; // TODO: just a pass-thru for now; update when du_dp is fixed-point
     }
 
-    unsigned long long du_dl_sum_ = 0;
+    unsigned long long du_dl_sum_ull = 0;
     for (int i = 0; i < N; i++) {
-        du_dl_sum += du_dl[i];
+        du_dl_sum_ull += du_dl[i];
     }
-    *du_dl_sum = FIXED_TO_FLOAT<double>(du_dl_sum_);
+    *du_dl_sum = FIXED_TO_FLOAT<double>(du_dl_sum_ull);
 
-    unsigned long long u_sum_ = 0;
+    unsigned long long u_sum_ull = 0;
     for (int i = 0; i < N; i++) {
-        u_sum_ += u[i];
+        u_sum_ull += u[i];
     }
-    *u_sum = FIXED_TO_FLOAT<double>(u_sum_);
+    *u_sum = FIXED_TO_FLOAT<double>(u_sum_ull);
 }
 } // namespace timemachine

--- a/timemachine/cpp/src/potential.hpp
+++ b/timemachine/cpp/src/potential.hpp
@@ -10,6 +10,8 @@ class Potential {
 public:
     virtual ~Potential(){};
 
+    static const int D = 3;
+
     void execute_host(
         const int N,
         const int P,
@@ -43,6 +45,18 @@ public:
         unsigned long long *d_du_dl,
         unsigned long long *d_u,
         cudaStream_t stream) = 0;
+
+    virtual void fixed_to_float(
+        const int N,
+        const int P,
+        const unsigned long long *du_dx,
+        const double *du_dp,
+        const unsigned long long *du_dl,
+        const unsigned long long *u,
+        double *du_dx_out,
+        double *du_dp_out,
+        double *du_dl_sum,
+        double *u_sum);
 };
 
 } // namespace timemachine

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -374,33 +374,21 @@ void declare_potential(py::module &m) {
 
                 std::vector<unsigned long long> du_dx(N * D);
                 std::vector<double> du_dp(P);
-
-                // initialize to zero for the accumulator
-                std::vector<unsigned long long> du_dl(N, 0);
-                std::vector<unsigned long long> u(N, 0);
+                std::vector<unsigned long long> du_dl(N);
+                std::vector<unsigned long long> u(N);
 
                 pot.execute_host(
                     N, P, coords.data(), params.data(), box.data(), lambda, &du_dx[0], &du_dp[0], &du_dl[0], &u[0]);
 
                 py::array_t<double, py::array::c_style> py_du_dx({N, D});
-                for (int i = 0; i < du_dx.size(); i++) {
-                    // py_du_dx.mutable_data()[i] = static_cast<double>(static_cast<long long>(du_dx[i]))/FIXED_EXPONENT;
-                    py_du_dx.mutable_data()[i] = FIXED_TO_FLOAT<double>(du_dx[i]);
-                }
-
                 std::vector<ssize_t> pshape(params.shape(), params.shape() + params.ndim());
-
                 py::array_t<double, py::array::c_style> py_du_dp(pshape);
-                for (int i = 0; i < du_dp.size(); i++) {
-                    py_du_dp.mutable_data()[i] = du_dp[i];
-                }
+                double du_dl_sum;
+                double u_sum;
 
-                unsigned long long du_dl_sum =
-                    std::accumulate(du_dl.begin(), du_dl.end(), decltype(du_dl)::value_type(0));
-                unsigned long long u_sum = std::accumulate(u.begin(), u.end(), decltype(u)::value_type(0));
+                pot.fixed_to_float(N, P, &du_dx[0], &du_dp[0], &du_dl[0], &u[0], py_du_dx.mutable_data(), py_du_dp.mutable_data(), &du_dl_sum, &u_sum);
 
-                return py::make_tuple(
-                    py_du_dx, py_du_dp, FIXED_TO_FLOAT<double>(du_dl_sum), FIXED_TO_FLOAT<double>(u_sum));
+                return py::make_tuple(py_du_dx, py_du_dp, du_dl_sum, u_sum);
             },
             py::arg("coords"),
             py::arg("params"),

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -386,7 +386,17 @@ void declare_potential(py::module &m) {
                 double du_dl_sum;
                 double u_sum;
 
-                pot.fixed_to_float(N, P, &du_dx[0], &du_dp[0], &du_dl[0], &u[0], py_du_dx.mutable_data(), py_du_dp.mutable_data(), &du_dl_sum, &u_sum);
+                pot.fixed_to_float(
+                    N,
+                    P,
+                    &du_dx[0],
+                    &du_dp[0],
+                    &du_dl[0],
+                    &u[0],
+                    py_du_dx.mutable_data(),
+                    py_du_dp.mutable_data(),
+                    &du_dl_sum,
+                    &u_sum);
 
                 return py::make_tuple(py_du_dx, py_du_dp, du_dl_sum, u_sum);
             },

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -372,10 +372,11 @@ void declare_potential(py::module &m) {
                 const long unsigned int D = coords.shape()[1];
                 const long unsigned int P = params.size();
 
-                std::vector<unsigned long long> du_dx(N * D);
-                std::vector<double> du_dp(P);
-                std::vector<unsigned long long> du_dl(N);
-                std::vector<unsigned long long> u(N);
+                // initialize with junk values for debugging convenience (these should be overwritten by `execute_host`)
+                std::vector<unsigned long long> du_dx(N * D, 9999);
+                std::vector<double> du_dp(P, 9999.0);
+                std::vector<unsigned long long> du_dl(N, 9999);
+                std::vector<unsigned long long> u(N, 9999);
 
                 pot.execute_host(
                     N, P, coords.data(), params.data(), box.data(), lambda, &du_dx[0], &du_dp[0], &du_dl[0], &u[0]);

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -372,7 +372,7 @@ void declare_potential(py::module &m) {
                 const long unsigned int D = coords.shape()[1];
                 const long unsigned int P = params.size();
 
-                // initialize with junk values for debugging convenience (these should be overwritten by `execute_host`)
+                // initialize with fixed garbage values for debugging convenience (these should be overwritten by `execute_host`)
                 std::vector<unsigned long long> du_dx(N * D, 9999);
                 std::vector<double> du_dp(P, 9999.0);
                 std::vector<unsigned long long> du_dl(N, 9999);


### PR DESCRIPTION
Moves conversions from fixed- to floating-point that currently happen in the pybind11 wrapper to a new virtual method `Potential::fixed_to_floating`.

The motivation is that, once we transition to returning `du_dp`s in fixed point, we'll need potential-specific logic in the conversion (since parameter derivatives have different scales) and it will become awkward to handle the cases in the pybind11 wrapper. Since the fixed-to-floating conversion for parameter derivatives is currently handled in the Potential implementations, we don't need to override `fixed_to_floating` in subclasses yet (but we will need to do this in #556).