### PR TITLE
Write out SDF results for RABFE Script

### DIFF
--- a/examples/hif2a/fit_to_multiple_rbfes.py
+++ b/examples/hif2a/fit_to_multiple_rbfes.py
@@ -185,7 +185,7 @@ def equilibrate_edges(datasets: List[Dataset], systems: List[Dict[str, Any]], nu
 
 
 if __name__ == "__main__":
-    default_output_path = f"results_{datetime.datetime.now().strftime('%Y_%m_%d_%H_%M_%S')}"
+    default_output_path = f"results_{datetime.datetime.utcnow().isoformat(timespec='seconds').replace(':', '_')}"
     parser = ArgumentParser(description="Fit Forcefield parameters to hif2a")
     parser.add_argument(
         "--num_gpus",

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -402,7 +402,7 @@ if __name__ == "__main__":
             "epoch": epoch,
         }
 
-    def predict_dG(results: dict):
+    def predict_dG(results: dict) -> RABFEResult:
         dG_complex_decouple, dG_complex_decouple_error = binding_model_complex_decouple.predict_from_futures(
             results["complex_decouple"][0],
             results["mol"],
@@ -433,19 +433,16 @@ if __name__ == "__main__":
         rabfe_result = RABFEResult(
             mol_name=mol_name,
             dG_complex_conversion=dG_complex_conversion,
+            dG_complex_conversion_error=dG_complex_conversion_error,
             dG_complex_decouple=dG_complex_decouple,
+            dG_complex_decouple_error=dG_complex_decouple_error,
             dG_solvent_conversion=dG_solvent_conversion,
+            dG_solvent_conversion_error=dG_solvent_conversion_error,
             dG_solvent_decouple=dG_solvent_decouple,
+            dG_solvent_decouple_error=dG_solvent_decouple_error,
         )
         rabfe_result.log()
-        dG_err = np.sqrt(
-            dG_complex_conversion_error ** 2
-            + dG_complex_decouple_error ** 2
-            + dG_solvent_conversion_error ** 2
-            + dG_solvent_decouple_error ** 2
-        )
-
-        return rabfe_result.dG_bind, dG_err
+        return rabfe_result
 
     runs = []
     for epoch in range(cmd_args.epochs):
@@ -479,7 +476,10 @@ if __name__ == "__main__":
                 print(f"Unable to find property {cmd_args.property_field}: {e}")
         print(f"Epoch: {epoch}, Processing Mol: {mol_name}, Label: {label_dG}")
         try:
-            dG, dG_err = predict_dG(run)
-            print(f"Epoch: {epoch}, Mol: {mol_name}, Predicted dG: {dG}, dG Err:" f" {dG_err}, Label: {label_dG}")
+            result = predict_dG(run)
+            print(
+                f"Epoch: {epoch}, Mol: {mol_name}, Predicted dG: {result.dG_bind}, dG Err:"
+                f" {result.dG_bind_err}, Label: {label_dG}"
+            )
         except Exception:
             logger.exception(f"Error processing Mol: {mol_name}")

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -94,7 +94,7 @@ def cache_wrapper(cache_path: str, fxn: callable, overwrite: bool = False) -> ca
 
 
 if __name__ == "__main__":
-    default_output_path = f"rabfe_{datetime.datetime.now().strftime('%Y_%m_%d_%H_%M_%S')}.sdf"
+    default_output_path = f"rabfe_{datetime.datetime.utcnow().isoformat(timespec='seconds').replace(':', '_')}.sdf"
 
     parser = argparse.ArgumentParser(
         description="Relatively absolute Binding Free Energy Testing",

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -119,50 +119,50 @@ if __name__ == "__main__":
     parser.add_argument("--num_gpus", type=int, help="number of gpus", default=get_gpu_count())
 
     parser.add_argument(
-        "--num_complex_conv_windows", type=int, help="number of lambda windows for complex conversion", required=True
+        "--num_complex_conv_windows", type=int, help="number of lambda windows for complex conversion", default=64
     )
 
-    parser.add_argument("--num_complex_windows", type=int, help="number of vacuum lambda windows", required=True)
+    parser.add_argument("--num_complex_windows", type=int, help="number of vacuum lambda windows", default=63)
 
     parser.add_argument(
-        "--num_solvent_conv_windows", type=int, help="number of lambda windows for solvent conversion", required=True
+        "--num_solvent_conv_windows", type=int, help="number of lambda windows for solvent conversion", default=64
     )
 
-    parser.add_argument("--num_solvent_windows", type=int, help="number of solvent lambda windows", required=True)
+    parser.add_argument("--num_solvent_windows", type=int, help="number of solvent lambda windows", default=64)
 
     parser.add_argument(
         "--num_complex_equil_steps",
         type=int,
         help="number of equilibration steps for each complex lambda window",
-        required=True,
+        default=50000,
     )
 
     parser.add_argument(
         "--num_complex_prod_steps",
         type=int,
         help="number of production steps for each complex lambda window",
-        required=True,
+        default=800000,
     )
 
     parser.add_argument(
         "--num_solvent_equil_steps",
         type=int,
         help="number of equilibration steps for each solvent lambda window",
-        required=True,
+        default=200000,
     )
 
     parser.add_argument(
         "--num_solvent_prod_steps",
         type=int,
         help="number of production steps for each solvent lambda window",
-        required=True,
+        default=800000,
     )
 
     parser.add_argument(
         "--num_complex_preequil_steps",
         type=int,
         help="number of pre-equilibration steps for each complex lambda window",
-        required=True,
+        default=200000,
     )
 
     parser.add_argument(

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -14,6 +14,7 @@
 import os
 import pickle
 import argparse
+import datetime
 import logging
 import numpy as np
 
@@ -93,11 +94,14 @@ def cache_wrapper(cache_path: str, fxn: callable, overwrite: bool = False) -> ca
 
 
 if __name__ == "__main__":
+    default_output_path = f"rabfe_{datetime.datetime.now().strftime('%Y_%m_%d_%H_%M_%S')}.sdf"
 
     parser = argparse.ArgumentParser(
         description="Relatively absolute Binding Free Energy Testing",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+
+    parser.add_argument("--output_path", default=default_output_path, help="Path to write out SDF")
 
     parser.add_argument("--epochs", default=1, help="Number of Epochs", type=int)
 
@@ -454,32 +458,42 @@ if __name__ == "__main__":
             except Exception as e:
                 mol_name = mol.GetProp("_Name")
                 logger.exception(f"Error simulating Mol: {mol_name}")
-    for i in range(len(runs)):
-        # Pop off futures to avoid accumulating memory.
-        run = runs.pop(0)
-        mol = run["mol"]
-        epoch = run["epoch"]
-        mol_name = mol.GetProp("_Name")
+    with Chem.SDWriter(cmd_args.output_path) as writer:
+        for i in range(len(runs)):
+            # Pop off futures to avoid accumulating memory.
+            run = runs.pop(0)
+            mol = run["mol"]
+            epoch = run["epoch"]
+            mol_name = mol.GetProp("_Name")
 
-        label_dG = "'N/A'"
-        if cmd_args.property_field is not None:
+            label_dG = "'N/A'"
+            if cmd_args.property_field is not None:
+                try:
+                    concentration = float(mol.GetProp(cmd_args.property_field))
+
+                    if cmd_args.property_units == "uM":
+                        label_dG = convert_uM_to_kJ_per_mole(concentration)
+                    elif cmd_args.property_units == "nM":
+                        label_dG = convert_uM_to_kJ_per_mole(concentration / 1000)
+                    else:
+                        assert 0, "Unknown property units"
+                except Exception as e:
+                    print(f"Unable to find property {cmd_args.property_field}: {e}")
+            print(f"Epoch: {epoch}, Processing Mol: {mol_name}, Label: {label_dG}")
             try:
-                concentration = float(mol.GetProp(cmd_args.property_field))
-
-                if cmd_args.property_units == "uM":
-                    label_dG = convert_uM_to_kJ_per_mole(concentration)
-                elif cmd_args.property_units == "nM":
-                    label_dG = convert_uM_to_kJ_per_mole(concentration / 1000)
-                else:
-                    assert 0, "Unknown property units"
-            except Exception as e:
-                print(f"Unable to find property {cmd_args.property_field}: {e}")
-        print(f"Epoch: {epoch}, Processing Mol: {mol_name}, Label: {label_dG}")
-        try:
-            result = predict_dG(run)
-            print(
-                f"Epoch: {epoch}, Mol: {mol_name}, Predicted dG: {result.dG_bind}, dG Err:"
-                f" {result.dG_bind_err}, Label: {label_dG}"
-            )
-        except Exception:
-            logger.exception(f"Error processing Mol: {mol_name}")
+                result = predict_dG(run)
+                print(
+                    f"Epoch: {epoch}, Mol: {mol_name}, Predicted dG: {result.dG_bind}, dG Err:"
+                    f" {result.dG_bind_err}, Label: {label_dG}"
+                )
+            except Exception:
+                logger.exception(f"Error processing Mol: {mol_name}")
+                continue
+            try:
+                result.apply_to_mol(mol)
+                mol.SetProp("Epoch", str(epoch))
+                writer.write(mol)
+                # Flush so that if the script fails, we still get mols
+                writer.flush()
+            except Exception:
+                logger.exception("Failed to write mol")

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -21,9 +21,13 @@ from dataclasses import dataclass
 class RABFEResult:
     mol_name: str
     dG_complex_conversion: float
+    dG_complex_conversion_error: float
     dG_complex_decouple: float
+    dG_complex_decouple_error: float
     dG_solvent_conversion: float
+    dG_solvent_conversion_error: float
     dG_solvent_decouple: float
+    dG_solvent_decouple_error: float
 
     def log(self):
         """print stage summary"""
@@ -32,12 +36,20 @@ class RABFEResult:
             self.mol_name,
             "dG_complex_conversion (K complex)",
             self.dG_complex_conversion,
+            "dG_complex_conversion_err",
+            self.dG_complex_conversion_error,
             "dG_complex_decouple (E0 + A0 + A1 + E1)",
             self.dG_complex_decouple,
+            "dG_complex_decouple_err",
+            self.dG_complex_decouple_error,
             "dG_solvent_conversion (K solvent)",
             self.dG_solvent_conversion,
+            "dG_solvent_conversion_err",
+            self.dG_solvent_conversion_error,
             "dG_solvent_decouple (D)",
             self.dG_solvent_decouple,
+            "dG_solvent_decouple_err",
+            self.dG_solvent_decouple_error,
         )
 
     @classmethod
@@ -64,6 +76,18 @@ class RABFEResult:
         """the final value we seek is the free energy of moving
         from the solvent into the complex"""
         return self.dG_solvent - self.dG_complex
+
+    @property
+    def dG_bind_err(self):
+        errors = np.asarray(
+            [
+                self.dG_complex_conversion_error,
+                self.dG_complex_decouple_error,
+                self.dG_solvent_conversion_error,
+                self.dG_solvent_decouple_error,
+            ]
+        )
+        return np.sqrt(np.sum(errors ** 2))
 
 
 class UnsupportedTopology(Exception):

--- a/fe/free_energy_rabfe.py
+++ b/fe/free_energy_rabfe.py
@@ -1,3 +1,4 @@
+import math
 from rdkit import Chem
 from collections import namedtuple
 from jax.config import config
@@ -14,10 +15,10 @@ from ff.handlers import openmm_deserializer
 from scipy.optimize import linear_sum_assignment
 from scipy.spatial.distance import cdist
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields, asdict
 
 
-@dataclass
+@dataclass(eq=False)
 class RABFEResult:
     mol_name: str
     dG_complex_conversion: float
@@ -52,14 +53,50 @@ class RABFEResult:
             self.dG_solvent_decouple_error,
         )
 
+    def __eq__(self, other: "RABFEResult") -> bool:
+        if not isinstance(other, RABFEResult):
+            return NotImplemented
+        equal = True
+        for field in fields(self):
+            self_val = getattr(self, field.name)
+            other_val = getattr(other, field.name)
+            # Python doesn't consider nan == nan to be true
+            if field.type is float and math.isnan(self_val) and math.isnan(other_val):
+                continue
+            equal &= self_val == other_val
+        return equal
+
     @classmethod
-    def from_log(cls, log_line):
-        """parse log line"""
-        mol_name, rest = log_line.split("stage summary for mol: ")[-1].split(" dG_complex_conversion (K complex) ")
-        tokens = rest.split()
-        value_strings = tokens[0], tokens[9], tokens[13], tokens[16]
-        values = list(map(float, value_strings))
-        return RABFEResult(mol_name, *values)
+    def _convert_field_to_sdf_field(cls, field_name: str) -> str:
+        if field_name == "mol_name":
+            cleaned_name = "_Name"
+        else:
+            cleaned_name = field_name.replace("_", " ")
+        return cleaned_name
+
+    @classmethod
+    def from_mol(cls, mol: Chem.Mol):
+        field_names = fields(cls)
+
+        kwargs = {}
+        for field in field_names:
+            field_name = cls._convert_field_to_sdf_field(field.name)
+            val = mol.GetProp(field_name)
+            val = field.type(val)
+            kwargs[field.name] = val
+        return RABFEResult(**kwargs)
+
+    def apply_to_mol(self, mol: Chem.Mol):
+        results_dict = asdict(self)
+        results_dict.update(
+            {
+                "dG_bind": self.dG_bind,
+                "dG_bind_err": self.dG_bind_err,
+            }
+        )
+        for field, val in results_dict.items():
+            field_name = self._convert_field_to_sdf_field(field)
+            mol.SetProp(field_name, str(val))
 
     @property
     def dG_complex(self):

--- a/tests/test_free_energy_rabfe.py
+++ b/tests/test_free_energy_rabfe.py
@@ -1,6 +1,4 @@
-import io
 import numpy as np
-from contextlib import redirect_stdout
 from fe.free_energy_rabfe import (
     RABFEResult,
     setup_relative_restraints_by_distance,
@@ -16,28 +14,6 @@ from rdkit import Chem
 from rdkit.Chem import AllChem, rdFMCS
 
 import pytest
-
-
-def capture_print(closure):
-    """capture anything printed when we call closure()"""
-
-    f = io.StringIO()
-    with redirect_stdout(f):
-        closure()
-    printed = f.getvalue()
-    return printed
-
-
-def test_rabfe_result_to_from_log():
-    """assert equality after round-trip to/from preferred terminal log format"""
-
-    result = RABFEResult("my mol", 1.0, 2.0, 3.0, 4.0)
-
-    printed = capture_print(result.log)
-    first_line = printed.splitlines()[0]
-
-    reconstructed = RABFEResult.from_log(first_line)
-    assert result == reconstructed
 
 
 def test_setting_up_restraints_using_distance():

--- a/tests/test_free_energy_rabfe.py
+++ b/tests/test_free_energy_rabfe.py
@@ -16,6 +16,28 @@ from rdkit.Chem import AllChem, rdFMCS
 import pytest
 
 
+def test_rabfe_result_to_from_mol():
+    """assert equality after round-trip to/from Mol SDF format"""
+    mol = Chem.MolFromSmiles("CCCONNN")
+
+    result = RABFEResult(
+        "my mol",
+        1.0,
+        float("nan"),
+        2.0,
+        2.1,
+        3.0,
+        3.1,
+        4.0,
+        4.1,
+    )
+
+    result.apply_to_mol(mol)
+
+    reconstructed = RABFEResult.from_mol(mol)
+    assert result == reconstructed
+
+
 def test_setting_up_restraints_using_distance():
     seed = 814
     smi_a = "CCCONNN"


### PR DESCRIPTION
This makes three sets of changes

- Sets reasonable defaults for RABFE, as it is too easy to fat finger the inputs
- Moves the computation of the dG error into the RABFEResult object, moves the logic out of the script
- Writes out an SDF file, with each compound containing all of the fields from the RABFEResult object

Can't attach an SDF file here (zipped to support uploading to github)
[example_hif2a.zip](https://github.com/proteneer/timemachine/files/7863802/example_hif2a.zip)

One field we may we want to tear off is the AM1 charge cache that we keep on the mol.
