### PR TITLE
Bugfix for charged molecules

### DIFF
--- a/fe/topology.py
+++ b/fe/topology.py
@@ -578,12 +578,22 @@ class DualTopologyStandardDecoupling(DualTopology):
 
         # both mol_a and mol_b are standardized.
         _, nb_potential = super().parameterize_nonbonded(ff_q_params, ff_lj_params)
-        mol_c = Chem.CombineMols(self.mol_a, self.mol_b)
-        qlj_params = standard_qlj_typer(mol_c)
 
-        # ligand is already decharged, and super-ligand state should have half the epsilons
-        src_qlj_params = jax.ops.index_update(qlj_params, jax.ops.index[:, 2], qlj_params[:, 2] * 0.5)
-        dst_qlj_params = qlj_params
+        qlj_params_a = standard_qlj_typer(self.mol_a)
+
+        src_qlj_params_a = jax.ops.index_update(qlj_params_a, jax.ops.index[:, 0], qlj_params_a[:, 0] * 0.5)
+        src_qlj_params_a = jax.ops.index_update(src_qlj_params_a, jax.ops.index[:, 2], src_qlj_params_a[:, 2] * 0.5)
+        dst_qlj_params_a = qlj_params_a
+
+        qlj_params_b = standard_qlj_typer(self.mol_b)
+        src_qlj_params_b = jax.ops.index_update(qlj_params_b, jax.ops.index[:, 0], qlj_params_b[:, 0] * 0.5)
+        src_qlj_params_b = jax.ops.index_update(src_qlj_params_b, jax.ops.index[:, 2], src_qlj_params_b[:, 2] * 0.5)
+        dst_qlj_params_b = qlj_params_b
+
+        qlj_params_b = standard_qlj_typer(self.mol_b)
+
+        src_qlj_params = jnp.concatenate([src_qlj_params_a, src_qlj_params_b])
+        dst_qlj_params = jnp.concatenate([dst_qlj_params_a, dst_qlj_params_b])
 
         combined_qlj_params = jnp.concatenate([src_qlj_params, dst_qlj_params])
 

--- a/fe/topology.py
+++ b/fe/topology.py
@@ -590,8 +590,6 @@ class DualTopologyStandardDecoupling(DualTopology):
         src_qlj_params_b = jax.ops.index_update(src_qlj_params_b, jax.ops.index[:, 2], src_qlj_params_b[:, 2] * 0.5)
         dst_qlj_params_b = qlj_params_b
 
-        qlj_params_b = standard_qlj_typer(self.mol_b)
-
         src_qlj_params = jnp.concatenate([src_qlj_params_a, src_qlj_params_b])
         dst_qlj_params = jnp.concatenate([dst_qlj_params_a, dst_qlj_params_b])
 

--- a/fe/topology.py
+++ b/fe/topology.py
@@ -581,6 +581,11 @@ class DualTopologyStandardDecoupling(DualTopology):
 
         qlj_params_a = standard_qlj_typer(self.mol_a)
 
+        # src_qlj_params corresponds to the super state where both ligands are interacting with the environment
+        # we scale down the charges and epsilons to half their values so as to roughly mimic net one molecule's
+        # worth of nonbonded interactions.
+
+        # dst_qlj_params corresponds to the end-state where only one of the molecule interacts with the binding pocket.
         src_qlj_params_a = jax.ops.index_update(qlj_params_a, jax.ops.index[:, 0], qlj_params_a[:, 0] * 0.5)
         src_qlj_params_a = jax.ops.index_update(src_qlj_params_a, jax.ops.index[:, 2], src_qlj_params_a[:, 2] * 0.5)
         dst_qlj_params_a = qlj_params_a

--- a/tests/test_rabfe_topology.py
+++ b/tests/test_rabfe_topology.py
@@ -173,16 +173,16 @@ def test_dual_topology_standard_decoupling_charged():
 
     mol_a = Chem.AddHs(Chem.MolFromSmiles("C1CC1[O-]"))
     mol_b = Chem.AddHs(Chem.MolFromSmiles("C1[O+]CCCCC1"))
-    mol_c = Chem.CombineMols(mol_a, mol_b)
+
     mol_top = topology.DualTopologyStandardDecoupling(mol_a, mol_b, ff)
 
     qlj_params, nonbonded_potential = mol_top.parameterize_nonbonded(ff.q_handle.params, ff.lj_handle.params)
 
     assert isinstance(nonbonded_potential, potentials.NonbondedInterpolated)
 
-    expected_qlj = topology.standard_qlj_typer(mol_c)
-    expected_qlj = np.array(expected_qlj)
+    expected_qlj = np.concatenate([topology.standard_qlj_typer(mol_a), topology.standard_qlj_typer(mol_b)])
 
+    # need to set the charges correctly, and manually
     N_A = mol_a.GetNumAtoms()
     N_B = mol_b.GetNumAtoms()
 


### PR DESCRIPTION
This PR fixes a bug introduced by #555 for the complex decoupling stage. Special thanks to @badisa for identifying this at our 1-on-1. This was due to how we applied `mol_c = CombineMols(mol_a, mol_b)` before applying the `standard_qlj_typer`. The end result of the bug was that:


1) If `mol_a` and `mol_b` both have `-1` charge. We introduced a super ligand with a combined charged of `-2`, which doesn't affect correctness but does affect efficiency as we'd like the binding pocket to feel effectively a `-1` amount of charge.
2) We introduced an end-state that no longer matched the conversion stages. Suppose `mol_a` had a `+1` charge, and `mol_b` had a `-1` charge, then the `standard_qlj_typer` on the combined mol would result in chargeless state, which would be incorrect, as the conversion stages would result in `+1/N_A` and `-1/N_B` uniform charges respectively for `mol_a` and `mol_b`. This affects the correctness of the method.



