### PR TITLE
Fix undefined symbol at runtime when compiled without optimization

### DIFF
--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -9,7 +9,7 @@ project(timemachine LANGUAGES CXX CUDA)
 find_package(PythonInterp 3.7 REQUIRED)
 find_package(PythonLibs 3.7 REQUIRED)
 
-string(APPEND CMAKE_CUDA_FLAGS "-Xptxas -v -O0 -lineinfo")
+string(APPEND CMAKE_CUDA_FLAGS "-Xptxas -v -O3 -lineinfo")
 message(${CMAKE_CUDA_FLAGS})
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -9,7 +9,7 @@ project(timemachine LANGUAGES CXX CUDA)
 find_package(PythonInterp 3.7 REQUIRED)
 find_package(PythonLibs 3.7 REQUIRED)
 
-string(APPEND CMAKE_CUDA_FLAGS "-Xptxas -v -O3 -lineinfo")
+string(APPEND CMAKE_CUDA_FLAGS "-Xptxas -v -O0 -lineinfo")
 message(${CMAKE_CUDA_FLAGS})
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/timemachine/cpp/src/potential.cu
+++ b/timemachine/cpp/src/potential.cu
@@ -7,6 +7,8 @@
 
 namespace timemachine {
 
+const int Potential::D = 3;
+
 void Potential::execute_host(
     const int N,
     const int P,

--- a/timemachine/cpp/src/potential.hpp
+++ b/timemachine/cpp/src/potential.hpp
@@ -10,7 +10,7 @@ class Potential {
 public:
     virtual ~Potential(){};
 
-    static const int D = 3;
+    static const int D;
 
     void execute_host(
         const int N,


### PR DESCRIPTION
Fixes the following runtime error when the custom ops library is compiled without optimization (`-O0`):

```
ImportError: /home/ubuntu/timemachine/timemachine/lib/custom_ops.cpython-37m-x86_64-linux-gnu.so: undefined symbol: _ZN11timemachine9Potential1DE
```
(example [here](https://jenkins.relaytxinternal.com/job/timemachine/job/PR-572/1/display/redirect))