### PR TITLE
Disable concurrent builds in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,7 @@
 pipeline {
+  options {
+    disableConcurrentBuilds()
+  }
   agent any
   stages {
     stage('Execute CI') {


### PR DESCRIPTION
We're seeing some CI failures that seem potentially related to build concurrency. [Example](https://gist.github.com/mcwitt/43536464675229a972230558494f15cb):

```
[10.78.114.37] out: tests/test_rabfe.py::TestRABFEModels::test_predict_complex_conversion building a protein system with 1758 protein atoms and 7047 water atoms
[10.78.114.37] out: ========= Invalid __global__ read of size 4
[10.78.114.37] out: =========     at 0x00000f10 in void generate_seed_pseudo<rng_config<curandStateXORWOW, curandOrdering=101>>(__int64, __int64, __int64, curandOrdering, curandStateXORWOW*, unsigned int*)
[10.78.114.37] out: =========     by thread (31,0,0) in block (39,0,0)
[10.78.114.37] out: =========     Address 0x7f3b2e202890 is out of bounds
[10.78.114.37] out: =========     Device Frame:void generate_seed_pseudo<rng_config<curandStateXORWOW, curandOrdering=101>>(__int64, __int64, __int64, curandOrdering, curandStateXORWOW*, unsigned int*) (void generate_seed_pseudo<rng_config<curandStateXORWOW, curandOrdering=101>>(__int64, __int64, __int64, curandOrdering, curandStateXORWOW*, unsigned int*) : 0xf10)
[10.78.114.37] out: =========     Saved host backtrace up to driver entry point at kernel launch time
...
[10.78.114.37] out: /home/ubuntu/anaconda3/envs/timemachine_3_7_11/lib/python3.7/multiprocessing/semaphore_tracker.py:144: UserWarning: semaphore_tracker: There appear to be 5 leaked semaphores to clean up at shutdown
[10.78.114.37] out:   len(cache))
[10.78.114.37] out: ========= ERROR SUMMARY: 2042 errors
```

This disables concurrent builds in Jenkins.

[Jenkins config syntax reference](https://www.jenkins.io/doc/book/pipeline/syntax)