### PR TITLE
Add DeviceBuffer, refactor execute_host

### DIFF
--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -55,6 +55,7 @@ pybind11_add_module(${LIBRARY_NAME} SHARED NO_EXTRAS
   src/barostat.cu
   src/rmsd_align.cpp
   src/summed_potential.cu
+  src/device_buffer.cu
   src/kernels/nonbonded_common.cu
 )
 

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -15,6 +15,14 @@ DeviceBuffer<T>::DeviceBuffer(const std::size_t length) : size(length * sizeof(T
 
 template <typename T> DeviceBuffer<T>::~DeviceBuffer() { gpuErrchk(cudaFree(data)); }
 
+template <typename T> void DeviceBuffer<T>::copy_from(const T *host_buffer) const {
+    gpuErrchk(cudaMemcpy(data, host_buffer, size, cudaMemcpyHostToDevice));
+}
+
+template <typename T> void DeviceBuffer<T>::copy_to(T *host_buffer) const {
+    gpuErrchk(cudaMemcpy(host_buffer, data, size, cudaMemcpyDeviceToHost));
+}
+
 template class DeviceBuffer<double>;
 template class DeviceBuffer<unsigned long long>;
 } // namespace timemachine

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -4,14 +4,14 @@
 
 namespace timemachine {
 
-template <typename T> T *allocate(const std::size_t size) {
+template <typename T> T *allocate(const std::size_t length) {
     T *buffer;
-    gpuErrchk(cudaMalloc(&buffer, size));
+    gpuErrchk(cudaMalloc(&buffer, length * sizeof(T)));
     return buffer;
 }
 
 template <typename T>
-DeviceBuffer<T>::DeviceBuffer(const std::size_t length) : size(length * sizeof(T)), data(allocate<T>(size)) {}
+DeviceBuffer<T>::DeviceBuffer(const std::size_t length) : size(length * sizeof(T)), data(allocate<T>(length)) {}
 
 template <typename T> DeviceBuffer<T>::~DeviceBuffer() { gpuErrchk(cudaFree(data)); }
 

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -4,16 +4,16 @@
 
 namespace timemachine {
 
-template <typename T>
-DeviceBuffer<T>::DeviceBuffer(const std::size_t length) : size(length * sizeof(T)), data(allocate_(size)) {}
-
-template <typename T> DeviceBuffer<T>::~DeviceBuffer() { gpuErrchk(cudaFree(data)); }
-
-template <typename T> T *DeviceBuffer<T>::allocate_(const std::size_t size) {
+template <typename T> T *allocate(const std::size_t size) {
     T *buffer;
     gpuErrchk(cudaMalloc(&buffer, size));
     return buffer;
 }
+
+template <typename T>
+DeviceBuffer<T>::DeviceBuffer(const std::size_t length) : size(length * sizeof(T)), data(allocate<T>(size)) {}
+
+template <typename T> DeviceBuffer<T>::~DeviceBuffer() { gpuErrchk(cudaFree(data)); }
 
 template class DeviceBuffer<double>;
 template class DeviceBuffer<unsigned long long>;

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -13,11 +13,11 @@ template <typename T> DeviceBuffer<T>::~DeviceBuffer() {
     }
 }
 
-template <typename T> void DeviceBuffer<T>::ensure_allocated() {
+template <typename T> void DeviceBuffer<T>::allocate() {
     if (!data_) {
         gpuErrchk(cudaMalloc(&data_, size));
     } else {
-        throw std::runtime_error("attempted to reallocate an allocated buffer");
+        throw std::runtime_error("called allocate on an allocated buffer");
     }
 }
 

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -13,7 +13,12 @@ template <typename T> T *allocate(const std::size_t length) {
 template <typename T>
 DeviceBuffer<T>::DeviceBuffer(const std::size_t length) : size(length * sizeof(T)), data(allocate<T>(length)) {}
 
-template <typename T> DeviceBuffer<T>::~DeviceBuffer() { gpuErrchk(cudaFree(data)); }
+template <typename T> DeviceBuffer<T>::~DeviceBuffer() {
+    // TODO: the file/line context reported by gpuErrchk on failure is
+    // not very useful when it's called from here. Is there a way to
+    // report a stack trace?
+    gpuErrchk(cudaFree(data));
+}
 
 template <typename T> void DeviceBuffer<T>::copy_from(const T *host_buffer) const {
     gpuErrchk(cudaMemcpy(data, host_buffer, size, cudaMemcpyHostToDevice));

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -9,8 +9,6 @@ DeviceBuffer<T>::DeviceBuffer(const std::size_t length) : size(length * sizeof(T
 
 template <typename T> DeviceBuffer<T>::~DeviceBuffer() { gpuErrchk(cudaFree(data)); }
 
-template <typename T> void DeviceBuffer<T>::memset(T x) { gpuErrchk(cudaMemset(data, x, size)); }
-
 template <typename T> T *DeviceBuffer<T>::allocate_(const std::size_t size) {
     T *data;
     gpuErrchk(cudaMalloc(&data, size));

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -1,0 +1,36 @@
+#include "device_buffer.hpp"
+#include "gpu_utils.cuh"
+#include <cstddef>
+
+namespace timemachine {
+
+template <typename T>
+DeviceBuffer<T>::DeviceBuffer(const std::size_t length) : size(length * sizeof(T)), data_(nullptr) {}
+
+template <typename T> DeviceBuffer<T>::~DeviceBuffer() {
+    if (data_) {
+        gpuErrchk(cudaFree(data_));
+    }
+}
+
+template <typename T> void DeviceBuffer<T>::ensure_allocated() {
+    if (!data_) {
+        gpuErrchk(cudaMalloc(&data_, size));
+    } else {
+        throw std::runtime_error("attempted to reallocate an allocated buffer");
+    }
+}
+
+template <typename T> T *DeviceBuffer<T>::data() { return data_; }
+
+template <typename T> void DeviceBuffer<T>::memset(T x) {
+    if (data_) {
+        gpuErrchk(cudaMemset(data_, x, size));
+    } else {
+        throw std::runtime_error("called memset on unallocated buffer");
+    }
+}
+
+template class DeviceBuffer<double>;
+template class DeviceBuffer<unsigned long long>;
+} // namespace timemachine

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -10,9 +10,9 @@ DeviceBuffer<T>::DeviceBuffer(const std::size_t length) : size(length * sizeof(T
 template <typename T> DeviceBuffer<T>::~DeviceBuffer() { gpuErrchk(cudaFree(data)); }
 
 template <typename T> T *DeviceBuffer<T>::allocate_(const std::size_t size) {
-    T *data;
-    gpuErrchk(cudaMalloc(&data, size));
-    return data;
+    T *buffer;
+    gpuErrchk(cudaMalloc(&buffer, size));
+    return buffer;
 }
 
 template class DeviceBuffer<double>;

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -5,30 +5,16 @@
 namespace timemachine {
 
 template <typename T>
-DeviceBuffer<T>::DeviceBuffer(const std::size_t length) : size(length * sizeof(T)), data_(nullptr) {}
+DeviceBuffer<T>::DeviceBuffer(const std::size_t length) : size(length * sizeof(T)), data(allocate_(size)) {}
 
-template <typename T> DeviceBuffer<T>::~DeviceBuffer() {
-    if (data_) {
-        gpuErrchk(cudaFree(data_));
-    }
-}
+template <typename T> DeviceBuffer<T>::~DeviceBuffer() { gpuErrchk(cudaFree(data)); }
 
-template <typename T> void DeviceBuffer<T>::allocate() {
-    if (!data_) {
-        gpuErrchk(cudaMalloc(&data_, size));
-    } else {
-        throw std::runtime_error("called allocate on an allocated buffer");
-    }
-}
+template <typename T> void DeviceBuffer<T>::memset(T x) { gpuErrchk(cudaMemset(data, x, size)); }
 
-template <typename T> T *DeviceBuffer<T>::data() { return data_; }
-
-template <typename T> void DeviceBuffer<T>::memset(T x) {
-    if (data_) {
-        gpuErrchk(cudaMemset(data_, x, size));
-    } else {
-        throw std::runtime_error("called memset on unallocated buffer");
-    }
+template <typename T> T *DeviceBuffer<T>::allocate_(const std::size_t size) {
+    T *data;
+    gpuErrchk(cudaMalloc(&data, size));
+    return data;
 }
 
 template class DeviceBuffer<double>;

--- a/timemachine/cpp/src/device_buffer.hpp
+++ b/timemachine/cpp/src/device_buffer.hpp
@@ -12,7 +12,7 @@ public:
 
     const size_t size;
 
-    void ensure_allocated();
+    void allocate();
 
     T *data();
 

--- a/timemachine/cpp/src/device_buffer.hpp
+++ b/timemachine/cpp/src/device_buffer.hpp
@@ -13,8 +13,6 @@ public:
 
     T *const data;
 
-    void memset(T x);
-
 private:
     T *allocate_(size_t size);
 };

--- a/timemachine/cpp/src/device_buffer.hpp
+++ b/timemachine/cpp/src/device_buffer.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <cstdlib>
+
+namespace timemachine {
+
+template <typename T> class DeviceBuffer {
+
+public:
+    DeviceBuffer(const std::size_t length);
+
+    ~DeviceBuffer();
+
+    const size_t size;
+
+    void ensure_allocated();
+
+    T *data();
+
+    void memset(T x);
+
+private:
+    T *data_;
+};
+
+} // namespace timemachine

--- a/timemachine/cpp/src/device_buffer.hpp
+++ b/timemachine/cpp/src/device_buffer.hpp
@@ -12,6 +12,10 @@ public:
     const size_t size;
 
     T *const data;
+
+    void copy_from(const T *host_buffer) const;
+
+    void copy_to(T *host_buffer) const;
 };
 
 } // namespace timemachine

--- a/timemachine/cpp/src/device_buffer.hpp
+++ b/timemachine/cpp/src/device_buffer.hpp
@@ -1,25 +1,22 @@
 #pragma once
-#include <cstdlib>
+#include <cstddef>
 
 namespace timemachine {
 
 template <typename T> class DeviceBuffer {
-
 public:
-    DeviceBuffer(const std::size_t length);
+    DeviceBuffer(const size_t length);
 
     ~DeviceBuffer();
 
     const size_t size;
 
-    void allocate();
-
-    T *data();
+    T *const data;
 
     void memset(T x);
 
 private:
-    T *data_;
+    T *allocate_(size_t size);
 };
 
 } // namespace timemachine

--- a/timemachine/cpp/src/device_buffer.hpp
+++ b/timemachine/cpp/src/device_buffer.hpp
@@ -12,9 +12,6 @@ public:
     const size_t size;
 
     T *const data;
-
-private:
-    T *allocate_(size_t size);
 };
 
 } // namespace timemachine

--- a/timemachine/cpp/src/potential.cu
+++ b/timemachine/cpp/src/potential.cu
@@ -41,19 +41,19 @@ void Potential::execute_host(
     // very important that these are initialized to zero since the kernels themselves just accumulate
     if (h_du_dx) {
         d_du_dx.reset(new DeviceBuffer<unsigned long long>(N * D));
-        d_du_dx->memset(0);
+        gpuErrchk(cudaMemset(d_du_dx->data, 0, d_du_dx->size));
     }
     if (h_du_dp) {
         d_du_dp.reset(new DeviceBuffer<unsigned long long>(P));
-        d_du_dp->memset(0);
+        gpuErrchk(cudaMemset(d_du_dp->data, 0, d_du_dp->size));
     }
     if (h_du_dl) {
         d_du_dl.reset(new DeviceBuffer<unsigned long long>(N));
-        d_du_dl->memset(0);
+        gpuErrchk(cudaMemset(d_du_dl->data, 0, d_du_dl->size));
     }
     if (h_u) {
         d_u.reset(new DeviceBuffer<unsigned long long>(N));
-        d_u->memset(0);
+        gpuErrchk(cudaMemset(d_u->data, 0, d_u->size));
     }
 
     this->execute_device(

--- a/timemachine/cpp/src/potential.cu
+++ b/timemachine/cpp/src/potential.cu
@@ -28,9 +28,9 @@ void Potential::execute_host(
     DeviceBuffer<double> d_p(P);
     DeviceBuffer<double> d_box(D * D);
 
-    d_x.ensure_allocated();
-    d_p.ensure_allocated();
-    d_box.ensure_allocated();
+    d_x.allocate();
+    d_p.allocate();
+    d_box.allocate();
 
     gpuErrchk(cudaMemcpy(d_x.data(), h_x, d_x.size, cudaMemcpyHostToDevice));
     gpuErrchk(cudaMemcpy(d_p.data(), h_p, d_p.size, cudaMemcpyHostToDevice));
@@ -43,19 +43,19 @@ void Potential::execute_host(
 
     // very important that these are initialized to zero since the kernels themselves just accumulate
     if (h_du_dx) {
-        d_du_dx.ensure_allocated();
+        d_du_dx.allocate();
         d_du_dx.memset(0);
     }
     if (h_du_dp) {
-        d_du_dp.ensure_allocated();
+        d_du_dp.allocate();
         d_du_dp.memset(0);
     }
     if (h_du_dl) {
-        d_du_dl.ensure_allocated();
+        d_du_dl.allocate();
         d_du_dl.memset(0);
     }
     if (h_u) {
-        d_u.ensure_allocated();
+        d_u.allocate();
         d_u.memset(0);
     }
 

--- a/timemachine/cpp/src/potential.cu
+++ b/timemachine/cpp/src/potential.cu
@@ -1,5 +1,6 @@
 #include <iostream>
 
+#include "device_buffer.hpp"
 #include "fixed_point.hpp"
 #include "gpu_utils.cuh"
 #include "potential.hpp"
@@ -23,66 +24,67 @@ void Potential::execute_host(
 
     const int &D = Potential::D;
 
-    double *d_x;
-    double *d_p;
-    double *d_box;
+    DeviceBuffer<double> d_x(N * D);
+    DeviceBuffer<double> d_p(P);
+    DeviceBuffer<double> d_box(D * D);
 
-    gpuErrchk(cudaMalloc(&d_x, N * D * sizeof(double)));
-    gpuErrchk(cudaMemcpy(d_x, h_x, N * D * sizeof(double), cudaMemcpyHostToDevice));
+    d_x.ensure_allocated();
+    d_p.ensure_allocated();
+    d_box.ensure_allocated();
 
-    gpuErrchk(cudaMalloc(&d_p, P * sizeof(double)));
-    gpuErrchk(cudaMemcpy(d_p, h_p, P * sizeof(double), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_x.data(), h_x, d_x.size, cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_p.data(), h_p, d_p.size, cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(d_box.data(), h_box, d_box.size, cudaMemcpyHostToDevice));
 
-    gpuErrchk(cudaMalloc(&d_box, D * D * sizeof(double)));
-    gpuErrchk(cudaMemcpy(d_box, h_box, D * D * sizeof(double), cudaMemcpyHostToDevice));
-
-    unsigned long long *d_du_dx = nullptr;
-    unsigned long long *d_du_dp = nullptr;
-    unsigned long long *d_du_dl = nullptr;
-    unsigned long long *d_u = nullptr;
+    DeviceBuffer<unsigned long long> d_du_dx(N * D);
+    DeviceBuffer<unsigned long long> d_du_dp(P);
+    DeviceBuffer<unsigned long long> d_du_dl(N);
+    DeviceBuffer<unsigned long long> d_u(N);
 
     // very important that these are initialized to zero since the kernels themselves just accumulate
     if (h_du_dx) {
-        gpuErrchk(cudaMalloc(&d_du_dx, N * D * sizeof(unsigned long long)));
-        gpuErrchk(cudaMemset(d_du_dx, 0, N * D * sizeof(unsigned long long)));
+        d_du_dx.ensure_allocated();
+        d_du_dx.memset(0);
     }
     if (h_du_dp) {
-        gpuErrchk(cudaMalloc(&d_du_dp, P * sizeof(unsigned long long)));
-        gpuErrchk(cudaMemset(d_du_dp, 0, P * sizeof(unsigned long long)));
+        d_du_dp.ensure_allocated();
+        d_du_dp.memset(0);
     }
     if (h_du_dl) {
-        gpuErrchk(cudaMalloc(&d_du_dl, N * sizeof(*d_du_dl)));
-        gpuErrchk(cudaMemset(d_du_dl, 0, N * sizeof(*d_du_dl)));
+        d_du_dl.ensure_allocated();
+        d_du_dl.memset(0);
     }
     if (h_u) {
-        gpuErrchk(cudaMalloc(&d_u, N * sizeof(*d_u)));
-        gpuErrchk(cudaMemset(d_u, 0, N * sizeof(*d_u)));
+        d_u.ensure_allocated();
+        d_u.memset(0);
     }
 
-    this->execute_device(N, P, d_x, d_p, d_box, lambda, d_du_dx, d_du_dp, d_du_dl, d_u, static_cast<cudaStream_t>(0));
+    this->execute_device(
+        N,
+        P,
+        d_x.data(),
+        d_p.data(),
+        d_box.data(),
+        lambda,
+        d_du_dx.data(),
+        d_du_dp.data(),
+        d_du_dl.data(),
+        d_u.data(),
+        static_cast<cudaStream_t>(0));
 
     // outputs
     if (h_du_dx) {
-        gpuErrchk(cudaMemcpy(h_du_dx, d_du_dx, N * D * sizeof(*h_du_dx), cudaMemcpyDeviceToHost));
-        gpuErrchk(cudaFree(d_du_dx));
+        gpuErrchk(cudaMemcpy(h_du_dx, d_du_dx.data(), d_du_dx.size, cudaMemcpyDeviceToHost));
     }
     if (h_du_dp) {
-        gpuErrchk(cudaMemcpy(h_du_dp, d_du_dp, P * sizeof(*h_du_dp), cudaMemcpyDeviceToHost));
-        gpuErrchk(cudaFree(d_du_dp));
+        gpuErrchk(cudaMemcpy(h_du_dp, d_du_dp.data(), d_du_dp.size, cudaMemcpyDeviceToHost));
     }
     if (h_du_dl) {
-        gpuErrchk(cudaMemcpy(h_du_dl, d_du_dl, N * sizeof(*h_du_dl), cudaMemcpyDeviceToHost));
-        gpuErrchk(cudaFree(d_du_dl));
+        gpuErrchk(cudaMemcpy(h_du_dl, d_du_dl.data(), d_du_dl.size, cudaMemcpyDeviceToHost));
     }
     if (h_u) {
-        gpuErrchk(cudaMemcpy(h_u, d_u, N * sizeof(*h_u), cudaMemcpyDeviceToHost));
-        gpuErrchk(cudaFree(d_u));
+        gpuErrchk(cudaMemcpy(h_u, d_u.data(), d_u.size, cudaMemcpyDeviceToHost));
     }
-
-    // inputs
-    gpuErrchk(cudaFree(d_x));
-    gpuErrchk(cudaFree(d_p));
-    gpuErrchk(cudaFree(d_box));
 };
 
 void Potential::execute_host_du_dx(

--- a/timemachine/cpp/src/potential.cu
+++ b/timemachine/cpp/src/potential.cu
@@ -29,9 +29,9 @@ void Potential::execute_host(
     DeviceBuffer<double> d_p(P);
     DeviceBuffer<double> d_box(D * D);
 
-    gpuErrchk(cudaMemcpy(d_x.data, h_x, d_x.size, cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(d_p.data, h_p, d_p.size, cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(d_box.data, h_box, d_box.size, cudaMemcpyHostToDevice));
+    d_x.copy_from(h_x);
+    d_p.copy_from(h_p);
+    d_box.copy_from(h_box);
 
     std::unique_ptr<DeviceBuffer<unsigned long long>> d_du_dx;
     std::unique_ptr<DeviceBuffer<unsigned long long>> d_du_dp;
@@ -71,16 +71,16 @@ void Potential::execute_host(
 
     // outputs
     if (h_du_dx) {
-        gpuErrchk(cudaMemcpy(h_du_dx, d_du_dx->data, d_du_dx->size, cudaMemcpyDeviceToHost));
+        d_du_dx->copy_to(h_du_dx);
     }
     if (h_du_dp) {
-        gpuErrchk(cudaMemcpy(h_du_dp, d_du_dp->data, d_du_dp->size, cudaMemcpyDeviceToHost));
+        d_du_dp->copy_to(h_du_dp);
     }
     if (h_du_dl) {
-        gpuErrchk(cudaMemcpy(h_du_dl, d_du_dl->data, d_du_dl->size, cudaMemcpyDeviceToHost));
+        d_du_dl->copy_to(h_du_dl);
     }
     if (h_u) {
-        gpuErrchk(cudaMemcpy(h_u, d_u->data, d_u->size, cudaMemcpyDeviceToHost));
+        d_u->copy_to(h_u);
     }
 };
 


### PR DESCRIPTION
Prototypes an RAII-like approach to managing device memory and uses it to fix a memory leak in `Potential::execute_host` (where device memory allocated for local variables is not freed if `execute_device` throws an exception).

A simpler fix for the above issue is 8d06402, but the approach in this PR might be desirable in the long run.

Note: there at least a few other places in the code that I think would benefit from `DeviceBuffer`, e.g.
- [Potential::execute_host_du_dx](https://github.com/proteneer/timemachine/blob/6593d22a23709b52117b3ff99f78d032c216ccb9/timemachine/cpp/src/potential.cu#L87)
- [BoundPotential::execute_host](https://github.com/proteneer/timemachine/blob/10f8d2b6ddd6d89807436f24a329774e9c99bf98/timemachine/cpp/src/bound_potential.cu#L20)
- [Context::multiple_steps](https://github.com/proteneer/timemachine/blob/10f8d2b6ddd6d89807436f24a329774e9c99bf98/timemachine/cpp/src/context.cu#L56)
- [Context::multiple_steps_U](https://github.com/proteneer/timemachine/blob/10f8d2b6ddd6d89807436f24a329774e9c99bf98/timemachine/cpp/src/context.cu#L131)

I opted to convert just `Potential::execute_host` for now as a proof of concept; once the interface is solidified, I'm open to converting the others to use DeviceBuffer as well in this PR or a follow-up.

#### Todo
- [x] Open enhancement issue to refactor memory management more broadly using `DeviceBuffer` (#577)