### PR TITLE
Disambiguate magic numbers in neighborlist

### DIFF
--- a/timemachine/cpp/src/kernels/k_gbsa.cuh
+++ b/timemachine/cpp/src/kernels/k_gbsa.cuh
@@ -4,8 +4,6 @@
 #include <iostream>
 #include <stdexcept>
 
-#define WARPSIZE 32
-
 #include <cooperative_groups.h>
 
 // since we need to do a full O(N^2) computing and we don't need to broadcast the forces,
@@ -147,7 +145,7 @@ __global__ void k_compute_born_radii(
             }
         }
 
-        const int srcLane = (threadIdx.x + 1) % WARPSIZE;
+        const int srcLane = (threadIdx.x + 1) % warp_size;
         scaledRadiusJ = __shfl_sync(0xffffffff, scaledRadiusJ, srcLane);
         atom_j_idx = __shfl_sync(0xffffffff, atom_j_idx, srcLane);
         for (int d = 0; d < 3; d++) {
@@ -313,7 +311,7 @@ void __global__ k_compute_born_first_loop_gpu(
             born_force_i_accum += sw * dGpol_dalpha2_ij * born_radii_j;
         }
 
-        const int srcLane = (threadIdx.x + 1) % WARPSIZE;
+        const int srcLane = (threadIdx.x + 1) % warp_size;
         atom_j_idx = __shfl_sync(0xffffffff, atom_j_idx, srcLane);
         qj = __shfl_sync(0xffffffff, qj, srcLane);
         born_radii_j = __shfl_sync(0xffffffff, born_radii_j, srcLane);
@@ -620,7 +618,7 @@ __global__ void k_compute_born_energy_and_forces(
             }
         }
 
-        const int srcLane = (threadIdx.x + 1) % WARPSIZE;
+        const int srcLane = (threadIdx.x + 1) % warp_size;
         atom_j_idx = __shfl_sync(0xffffffff, atom_j_idx, srcLane);
         born_radii_j = __shfl_sync(0xffffffff, born_radii_j, srcLane);
         radiusJ = __shfl_sync(0xffffffff, radiusJ, srcLane);

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -178,8 +178,8 @@ void __global__ k_find_blocks_with_ixns(
     const int indexInWarp = threadIdx.x % warp_size;
     const int warpMask = (1 << indexInWarp) - 1;
 
-    __shared__ int ixn_j_buffer
-        [64]; // we can probably get away with using only 32 if we do some fancier remainder tricks, but this isn't a huge save
+    // we can probably get away with using only 32 if we do some fancier remainder tricks, but this isn't a huge save
+    __shared__ int ixn_j_buffer[2 * warp_size];
 
     // initialize
     ixn_j_buffer[threadIdx.x] = NC;

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -146,8 +146,8 @@ This is launched with a threadblock size of 32, (i.e. one warp).
 
 Each block proceeds as follows:
 
-1. Loads its own row block (32 atoms).
-2. Compare the row block against 32 other column blocks via bounding box tests.
+1. Loads its own row block (tile_size = 32 atoms).
+2. Compare the row block against tile_size = 32 other column blocks via bounding box tests.
 3. Determine which blocks potentially interact using warp-level programming.
 4. Loop over each interacting block j, and see which row block atoms may interact with j's bbox.
 5. For atoms that interact, do a fine-grained comparison of each row block again against each col block atom.

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -173,7 +173,7 @@ void __global__ k_find_blocks_with_ixns(
     unsigned int *__restrict__ trim_atoms,       // the left-over trims that will later be compacted
     const double cutoff) {
 
-    static_assert(tile_size == warp_size, "must have tile_size == warp_size");
+    static_assert(tile_size == warp_size, "tile_size != warp_size is not currently supported");
 
     const int indexInWarp = threadIdx.x % warp_size;
     const int warpMask = (1 << indexInWarp) - 1;

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -168,7 +168,7 @@ void __global__ k_find_blocks_with_ixns(
     const double *__restrict__ box,
     unsigned int *__restrict__ interactionCount, // number of tiles that have interactions
     int *__restrict__ interactingTiles,          // the row block idx of the tile that is interacting
-    unsigned int *__restrict__ interactingAtoms, // the col block of the atoms that are interacting
+    unsigned int *__restrict__ interactingAtoms, // [NR * warp_size] atom indices interacting with each row block
     unsigned int *__restrict__ trim_atoms,       // the left-over trims that will later be compacted
     const double cutoff) {
 

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -3,7 +3,8 @@
 #include "kernel_utils.cuh"
 
 #define FULL_MASK 0xffffffff
-#define TILESIZE 32
+
+const int tile_size = 32;
 
 template <typename RealType>
 void __global__ k_find_block_bounds(
@@ -32,7 +33,7 @@ void __global__ k_find_block_bounds(
     const RealType inv_bx = 1 / bx;
     const RealType inv_by = 1 / by;
     const RealType inv_bz = 1 / bz;
-    const int base = index * TILESIZE;
+    const int base = index * tile_size;
 
     RealType pos_x = coords[base * 3 + 0];
     RealType pos_y = coords[base * 3 + 1];
@@ -46,7 +47,7 @@ void __global__ k_find_block_bounds(
     RealType maxPos_y = pos_y;
     RealType maxPos_z = pos_z;
 
-    const int last = min(base + TILESIZE, N);
+    const int last = min(base + tile_size, N);
     for (int i = base + 1; i < last; i++) {
         pos_x = coords[i * 3 + 0];
         pos_y = coords[i * 3 + 1];
@@ -203,7 +204,7 @@ void __global__ k_find_blocks_with_ixns(
     RealType pos_i_y = atom_i_idx < NR ? row_coords[atom_i_idx * 3 + 1] : 0;
     RealType pos_i_z = atom_i_idx < NR ? row_coords[atom_i_idx * 3 + 2] : 0;
 
-    const int NUM_COL_BLOCKS = (NC + TILESIZE - 1) / TILESIZE;
+    const int NUM_COL_BLOCKS = (NC + tile_size - 1) / tile_size;
 
     RealType bx = box[0 * 3 + 0];
     RealType by = box[1 * 3 + 1];
@@ -232,7 +233,7 @@ void __global__ k_find_blocks_with_ixns(
 
     const RealType cutoff_squared = static_cast<RealType>(cutoff) * static_cast<RealType>(cutoff);
 
-    int col_block_base = blockIdx.y * TILESIZE;
+    int col_block_base = blockIdx.y * tile_size;
 
     int col_block_idx = col_block_base + indexInWarp;
     bool include_col_block = (col_block_idx < NUM_COL_BLOCKS) && (!UPPER_TRIAG || col_block_idx >= row_block_idx);

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -4,7 +4,7 @@
 
 #define FULL_MASK 0xffffffff
 
-const int tile_size = 32;
+const int tile_size = warp_size;
 
 template <typename RealType>
 void __global__ k_find_block_bounds(
@@ -172,6 +172,8 @@ void __global__ k_find_blocks_with_ixns(
     unsigned int *__restrict__ interactingAtoms, // [NR * warp_size] atom indices interacting with each row block
     unsigned int *__restrict__ trim_atoms,       // the left-over trims that will later be compacted
     const double cutoff) {
+
+    static_assert(tile_size == warp_size, "must have tile_size == warp_size");
 
     const int indexInWarp = threadIdx.x % warp_size;
     const int warpMask = (1 << indexInWarp) - 1;

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -87,8 +87,9 @@ void __global__ k_compact_trim_atoms(
     int *__restrict__ interactingTiles,
     unsigned int *__restrict__ interactingAtoms) {
 
-    __shared__ int ixn_j_buffer
-        [64]; // we can probably get away with using only 32 if we do some fancier remainder tricks, but this isn't a huge save
+    // we can probably get away with using only 32 if we do some fancier remainder tricks, but this isn't a huge save
+    __shared__ int ixn_j_buffer[2 * warp_size];
+
     ixn_j_buffer[threadIdx.x] = NC;
     ixn_j_buffer[warp_size + threadIdx.x] = NC;
 

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "kernel_utils.cuh"
+
 #define FULL_MASK 0xffffffff
 #define TILESIZE 32
-#define WARPSIZE 32
 
 template <typename RealType>
 void __global__ k_find_block_bounds(
@@ -88,9 +89,9 @@ void __global__ k_compact_trim_atoms(
     __shared__ int ixn_j_buffer
         [64]; // we can probably get away with using only 32 if we do some fancier remainder tricks, but this isn't a huge save
     ixn_j_buffer[threadIdx.x] = NC;
-    ixn_j_buffer[WARPSIZE + threadIdx.x] = NC;
+    ixn_j_buffer[warp_size + threadIdx.x] = NC;
 
-    const int indexInWarp = threadIdx.x % WARPSIZE;
+    const int indexInWarp = threadIdx.x % warp_size;
     const int warpMask = (1 << indexInWarp) - 1;
     const int row_block_idx = blockIdx.x;
 
@@ -99,7 +100,7 @@ void __global__ k_compact_trim_atoms(
 
     for (int trim_block_idx = 0; trim_block_idx < Y; trim_block_idx++) {
 
-        int atom_j_idx = trim_atoms[row_block_idx * Y * WARPSIZE + trim_block_idx * WARPSIZE + threadIdx.x];
+        int atom_j_idx = trim_atoms[row_block_idx * Y * warp_size + trim_block_idx * warp_size + threadIdx.x];
         bool interacts = atom_j_idx < NC;
 
         int includeAtomFlags = __ballot_sync(FULL_MASK, interacts);
@@ -111,18 +112,18 @@ void __global__ k_compact_trim_atoms(
         }
         neighborsInBuffer += __popc(includeAtomFlags);
 
-        if (neighborsInBuffer > WARPSIZE) {
+        if (neighborsInBuffer > warp_size) {
             int tilesToStore = 1;
             if (indexInWarp == 0) {
                 sync_start[0] = atomicAdd(interactionCount, tilesToStore);
             }
             __syncwarp();
             interactingTiles[sync_start[0]] = row_block_idx; // IS THIS CORRECT? CONTESTED
-            interactingAtoms[sync_start[0] * WARPSIZE + threadIdx.x] = ixn_j_buffer[threadIdx.x];
+            interactingAtoms[sync_start[0] * warp_size + threadIdx.x] = ixn_j_buffer[threadIdx.x];
 
-            ixn_j_buffer[threadIdx.x] = ixn_j_buffer[WARPSIZE + threadIdx.x];
-            ixn_j_buffer[WARPSIZE + threadIdx.x] = NC; // reset old values
-            neighborsInBuffer -= WARPSIZE;
+            ixn_j_buffer[threadIdx.x] = ixn_j_buffer[warp_size + threadIdx.x];
+            ixn_j_buffer[warp_size + threadIdx.x] = NC; // reset old values
+            neighborsInBuffer -= warp_size;
         }
     }
 
@@ -133,7 +134,7 @@ void __global__ k_compact_trim_atoms(
         }
         __syncwarp();
         interactingTiles[sync_start[0]] = row_block_idx;
-        interactingAtoms[sync_start[0] * WARPSIZE + threadIdx.x] = ixn_j_buffer[threadIdx.x];
+        interactingAtoms[sync_start[0] * warp_size + threadIdx.x] = ixn_j_buffer[threadIdx.x];
     }
 }
 
@@ -171,7 +172,7 @@ void __global__ k_find_blocks_with_ixns(
     unsigned int *__restrict__ trim_atoms,       // the left-over trims that will later be compacted
     const double cutoff) {
 
-    const int indexInWarp = threadIdx.x % WARPSIZE;
+    const int indexInWarp = threadIdx.x % warp_size;
     const int warpMask = (1 << indexInWarp) - 1;
 
     __shared__ int ixn_j_buffer
@@ -179,7 +180,7 @@ void __global__ k_find_blocks_with_ixns(
 
     // initialize
     ixn_j_buffer[threadIdx.x] = NC;
-    ixn_j_buffer[WARPSIZE + threadIdx.x] = NC;
+    ixn_j_buffer[warp_size + threadIdx.x] = NC;
 
     __shared__ volatile int sync_start[1];
 
@@ -285,7 +286,7 @@ void __global__ k_find_blocks_with_ixns(
         includeBlockFlags &= includeBlockFlags - 1;
 
         int col_block = col_block_base + offset;
-        int atom_j_idx = col_block * WARPSIZE + threadIdx.x; // each thread loads a different atom
+        int atom_j_idx = col_block * warp_size + threadIdx.x; // each thread loads a different atom
 
         // Compute overlap between column bounding box and row atom
         RealType col_bb_ctr_x = col_bb_ctr[col_block * 3 + 0];
@@ -387,22 +388,22 @@ void __global__ k_find_blocks_with_ixns(
         }
         neighborsInBuffer += __popc(includeAtomFlags);
 
-        if (neighborsInBuffer > WARPSIZE) {
+        if (neighborsInBuffer > warp_size) {
             int tilesToStore = 1;
             if (indexInWarp == 0) {
                 sync_start[0] = atomicAdd(interactionCount, tilesToStore);
             }
             __syncwarp();
             interactingTiles[sync_start[0]] = row_block_idx;
-            interactingAtoms[sync_start[0] * WARPSIZE + threadIdx.x] = ixn_j_buffer[threadIdx.x];
+            interactingAtoms[sync_start[0] * warp_size + threadIdx.x] = ixn_j_buffer[threadIdx.x];
 
-            ixn_j_buffer[threadIdx.x] = ixn_j_buffer[WARPSIZE + threadIdx.x];
-            ixn_j_buffer[WARPSIZE + threadIdx.x] = NC; // reset old values
-            neighborsInBuffer -= WARPSIZE;
+            ixn_j_buffer[threadIdx.x] = ixn_j_buffer[warp_size + threadIdx.x];
+            ixn_j_buffer[warp_size + threadIdx.x] = NC; // reset old values
+            neighborsInBuffer -= warp_size;
         }
     }
 
     // store trim
     const int Y = gridDim.y;
-    trim_atoms[blockIdx.x * Y * WARPSIZE + blockIdx.y * WARPSIZE + threadIdx.x] = ixn_j_buffer[threadIdx.x];
+    trim_atoms[blockIdx.x * Y * warp_size + blockIdx.y * warp_size + threadIdx.x] = ixn_j_buffer[threadIdx.x];
 }

--- a/timemachine/cpp/src/kernels/k_nonbonded_dense.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_dense.cuh
@@ -4,7 +4,6 @@
 #include "kernel_utils.cuh"
 #include "nonbonded_common.cuh"
 #include "surreal.cuh"
-#define WARPSIZE 32
 
 // generate kv values from coordinates to be radix sorted
 void __global__ k_coords_to_kv(
@@ -382,7 +381,7 @@ void __device__ v_nonbonded_unified(
 
     RealType real_beta = static_cast<RealType>(beta);
 
-    const int srcLane = (threadIdx.x + 1) % WARPSIZE; // fixed
+    const int srcLane = (threadIdx.x + 1) % warp_size; // fixed
     // #pragma unroll
     for (int round = 0; round < 32; round++) {
 

--- a/timemachine/cpp/src/kernels/kernel_utils.cuh
+++ b/timemachine/cpp/src/kernels/kernel_utils.cuh
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdio>
-#define WARP_SIZE 32
 
 #define HESS_3N3N(i, j, N, di, dj) (di * N * 3 * N + i * 3 * N + dj * N + j)
 #define HESS_N3N3(i, j, N, di, dj) (i * 3 * N * 3 + di * N * 3 + j * 3 + dj)
@@ -31,6 +30,8 @@
 // #define MP_IDX_ND(p,i,N,d,D) (p*D*N + d*N + i)
 
 #define ONE_4PI_EPS0 138.935456
+
+static const int warp_size = 32;
 
 inline __device__ int linearize(int i, int j, int d) { return d * (d - 1) / 2 - (d - i) * (d - i - 1) / 2 + j; }
 

--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -14,7 +14,7 @@ template <typename RealType> Neighborlist<RealType>::Neighborlist(const int NC, 
     if (NR > NC) {
         throw std::runtime_error("NR is greater than NC");
     }
-    const int tpb = 32;
+    const int tpb = warp_size;
     const int column_blocks = this->column_blocks();
     const int row_blocks = this->B();
     const int Y = this->Y();
@@ -111,7 +111,7 @@ std::vector<std::vector<int>> Neighborlist<RealType>::get_nblist_host(
     this->build_nblist_device(NC, NR, d_col_coords, d_row_coords, d_box, cutoff, static_cast<cudaStream_t>(0));
 
     cudaDeviceSynchronize();
-    const int tpb = 32;
+    const int tpb = warp_size;
     const int column_blocks = this->column_blocks();
     const int row_blocks = this->B();
     const int Y = this->Y();
@@ -167,7 +167,7 @@ void Neighborlist<RealType>::build_nblist_device(
     const int D = 3;
     this->compute_block_bounds_device(NC, NR, D, d_col_coords, d_row_coords, d_box, stream);
 
-    const int tpb = 32;
+    const int tpb = warp_size;
     const int column_blocks = this->column_blocks();
     const int row_blocks = this->B();
     const int Y = this->Y();
@@ -256,7 +256,7 @@ void Neighborlist<RealType>::compute_block_bounds_device(
 
     const bool compute_row_bounds = this->compute_full_matrix();
 
-    const int tpb = 32;
+    const int tpb = warp_size;
     const int column_blocks = this->column_blocks(); // total number of blocks we need to process
 
     k_find_block_bounds<RealType><<<column_blocks, tpb, 0, stream>>>(

--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -225,6 +225,10 @@ void Neighborlist<RealType>::build_nblist_device(
     this->build_nblist_device(NC, 0, d_coords, nullptr, d_box, cutoff, stream);
 }
 
+template <typename RealType> int Neighborlist<RealType>::B() const {
+    return ceil_divide(this->compute_full_matrix() ? NR_ : NC_, tile_size);
+}
+
 template <typename RealType>
 void Neighborlist<RealType>::compute_block_bounds_device(
     const int NC,               // Number of atoms in column
@@ -265,6 +269,14 @@ void Neighborlist<RealType>::compute_block_bounds_device(
             NR, D, row_blocks, d_row_coords, d_box, d_row_block_bounds_ctr_, d_row_block_bounds_ext_);
         gpuErrchk(cudaPeekAtLastError());
     }
+};
+
+template <typename RealType> bool Neighborlist<RealType>::compute_full_matrix() const { return NR_ > 0; };
+
+template <typename RealType> int Neighborlist<RealType>::column_blocks() const { return ceil_divide(NC_, tile_size); };
+
+template <typename RealType> int Neighborlist<RealType>::Y() const {
+    return ceil_divide(this->column_blocks(), warp_size);
 };
 
 template class Neighborlist<double>;

--- a/timemachine/cpp/src/neighborlist.hpp
+++ b/timemachine/cpp/src/neighborlist.hpp
@@ -68,16 +68,17 @@ public:
     unsigned int *get_ixn_count() { return d_ixn_count_; }
 
     // get max number of row blocks
-    int B() const { return ceil_divide(this->compute_full_matrix() ? NR_ : NC_, 32); }
+    int B() const;
 
 private:
     // Indicates that should compute interactions of all rows and columns
     // when a row is provided, otherwise only compute upper triangle of the ixn matrix.
-    bool compute_full_matrix() const { return NR_ > 0; }
+    bool compute_full_matrix() const;
 
-    int column_blocks() const { return ceil_divide(NC_, 32); }
+    int column_blocks() const;
+
     // The number of column blocks divided by warp size. Each thread handles a block
-    int Y() const { return ceil_divide(this->column_blocks(), 32); }
+    int Y() const;
 
     void compute_block_bounds_device(
         const int NC,

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -52,6 +52,7 @@ template <typename RealType> void declare_neighborlist(py::module &m, const char
                const py::array_t<double, py::array::c_style> &box,
                const int block_size) -> py::tuple {
                 if (block_size != 32) {
+                    // The neighborlist kernel implementation assumes that block size is fixed to the CUDA warpSize
                     throw std::runtime_error("Block size must be 32.");
                 }
 


### PR DESCRIPTION
There are 3 constants defined in the neighborlist code that typically take the value 32, but have different interpretations:
- `WARPSIZE`: the number of threads in a warp, fixed to be 32 in current device architectures
- `TILESIZE`: the number of atoms in a neighborlist row (column) block
- `tpb`: the number of threads per thread block. Usually a multiple of warp size; we currently set it equal to warp size for simplicity

This PR aims to replace all uses of the literal `32` referring to one of the above concepts with the appropriate named constant.