### PR TITLE
Add timeout to CI pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
   stages {
     stage('Execute CI') {
       options {
-        timeout(time: 3, unit: 'HOURS')
+        timeout(time: 1, unit: 'MINUTES')
       }
       steps {
         sh '/usr/local/bin/fab -f /opt/jenkins/jenkins_scripts/timemachine_ci_fab.py ci:'+env.WORKSPACE+','+env.GIT_COMMIT

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,9 @@ pipeline {
   agent any
   stages {
     stage('Execute CI') {
+      options {
+        timeout(time: 3, unit: 'HOURS')
+      }
       steps {
         sh '/usr/local/bin/fab -f /opt/jenkins/jenkins_scripts/timemachine_ci_fab.py ci:'+env.WORKSPACE+','+env.GIT_COMMIT
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
   stages {
     stage('Execute CI') {
       options {
-        timeout(time: 1, unit: 'MINUTES')
+        timeout(time: 3, unit: 'HOURS')
       }
       steps {
         sh '/usr/local/bin/fab -f /opt/jenkins/jenkins_scripts/timemachine_ci_fab.py ci:'+env.WORKSPACE+','+env.GIT_COMMIT


### PR DESCRIPTION
Adds 3-hour timout to the CI pipeline (meaning builds will automatically fail if they take longer than 3 hours).

The Jenkins config option `timeout` is documented [here](https://www.jenkins.io/doc/book/pipeline/syntax/#:~:text=set%20a%20timeout%20period%20for%20the%20pipeline%20run%2C%20after%20which%20jenkins%20should%20abort%20the%20pipeline).