### PR TITLE
Revert "Upgrade jax and jaxlib (#539)"

### DIFF
--- a/fe/loss.py
+++ b/fe/loss.py
@@ -21,7 +21,7 @@ def mybar_impl(w):
     return A
 
 
-def mybar_jvp(g, w):
+def mybar_vjp(g, w):
     return g * tmbar.dG_dw(w)
 
 
@@ -31,7 +31,7 @@ def mybar(x):
 
 mybar_p = core.Primitive("mybar")
 mybar_p.def_impl(mybar_impl)
-ad.defjvp(mybar_p, mybar_jvp)
+ad.defvjp(mybar_p, mybar_vjp)
 
 
 def BAR_leg(insertion_du_dls, deletion_du_dls, lambda_schedule):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ numpy==1.21.4
 scipy==1.6.0
 pymbar==3.0.5
 pyyaml==5.4.1
-jax==0.2.26
-jaxlib==0.1.75
+jax==0.2.9
+jaxlib==0.1.61
 hilbertcurve==1.0.5
 networkx==2.5
 

--- a/slow_tests/test_mtm.py
+++ b/slow_tests/test_mtm.py
@@ -73,7 +73,7 @@ def test_optimized_MTM():
         x_a = xvb_a.coords
         x_b = xvb_b.coords
         # double check this later
-        np.testing.assert_array_equal(x_a[:-num_ligand_atoms], x_b[:-num_ligand_atoms])
+        np.testing.assert_equal(x_a[:-num_ligand_atoms], x_b[:-num_ligand_atoms])
         return -proposal_U(x_b[-num_ligand_atoms:]) / kT
 
     def batch_log_Q_a_b_fn(xvbs_a, xvb_b):

--- a/tests/test_bonded.py
+++ b/tests/test_bonded.py
@@ -29,7 +29,7 @@ class TestBonded(GradientTest):
 
             # masses = np.random.rand(n_particles)
 
-            ref_nrg = functools.partial(
+            ref_nrg = jax.partial(
                 bonded.centroid_restraint,
                 # masses=masses,
                 group_a_idxs=gai,
@@ -77,7 +77,7 @@ class TestBonded(GradientTest):
                 kb = 10.0
                 b0 = 0.0
 
-                ref_nrg = functools.partial(bonded.centroid_restraint, group_a_idxs=gai, group_b_idxs=gbi, kb=kb, b0=b0)
+                ref_nrg = jax.partial(bonded.centroid_restraint, group_a_idxs=gai, group_b_idxs=gbi, kb=kb, b0=b0)
 
                 # we need to clear the du_dp buffer each time, so we need
                 # to instantiate test_nrg inside here


### PR DESCRIPTION
@badisa discovered the following problematic interaction between the current version of jax/jaxlib and rdkit:

```
(timemachine_3_7_11) ubuntu@ip-10-78-114-37:~/timemachine$ python -c "from rdkit import Chem; import jax"
(timemachine_3_7_11) ubuntu@ip-10-78-114-37:~/timemachine$ python -c "import jax; from rdkit import Chem"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/ubuntu/anaconda3/envs/timemachine_3_7_11/lib/python3.7/site-packages/rdkit/Chem/__init__.py", line 18, in <module>
    from rdkit import DataStructs
  File "/home/ubuntu/anaconda3/envs/timemachine_3_7_11/lib/python3.7/site-packages/rdkit/DataStructs/__init__.py", line 13, in <module>
    from rdkit.DataStructs import cDataStructs
ImportError: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by /home/ubuntu/anaconda3/envs/timemachine_3_7_11/lib/python3.7/site-packages/rdkit/DataStructs/cDataStructs.so)
(timemachine_3_7_11) ubuntu@ip-10-78-114-37:~/timemachine$ pip freeze | grep jax
jax==0.2.26
jaxlib==0.1.75
```

I.e., there is a fatal exception if jax is imported before rdkit, but not vice-versa.

So far this only appears to be an issue in the Ubuntu 18.04 environments.

This PR reverts the jax upgrade for now.