### PR TITLE
Adds Durations to CI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 MKFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 CPP_DIR := $(MKFILE_DIR)timemachine/cpp/
 INSTALL_PREFIX := $(MKFILE_DIR)timemachine/
-PYTEST_CI_ARGS := --cov=. --cov-report=term-missing
+PYTEST_CI_ARGS := --cov=. --cov-report=term-missing --durations=100
 
 NPROCS = `nproc`
 


### PR DESCRIPTION
* Makes easier to determine where time is spent

Top couple from CI Run:
```
319.21s call     tests/test_md.py::test_reference_langevin_integrator_with_custom_ops
206.10s call     tests/test_rabfe.py::TestRABFEModels::test_predict_complex_decouple
180.40s call     tests/test_rabfe.py::TestRABFEModels::test_predict_complex_conversion
120.34s call     tests/test_md.py::test_reference_langevin_integrator
117.82s call     tests/test_nonbonded.py::TestNonbonded::test_nonbonded
```