### PR TITLE
Add isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,16 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 
+-   repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)
+
 -   repo: https://github.com/psf/black
     rev: 21.10b0
     hooks:
     -   id: black
-        exclude: '^versioneer.py$|^timemachine/_version.py'
 
 -   repo: https://github.com/pycqa/flake8
     rev: 4.0.1
@@ -35,3 +40,5 @@ exclude: >
   | ^attic/
   | ^timemachine/parallel/grpc/
   | ^timemachine/ff/params/
+  | ^versioneer\.py$
+  | ^timemachine/_version\.py$

--- a/docking/dock_and_equilibrate.py
+++ b/docking/dock_and_equilibrate.py
@@ -1,21 +1,18 @@
 """Solvates a host, inserts guest(s) into solvated host, equilibrates
 """
 import os
-import time
 import tempfile
+import time
 
 import numpy as np
-
 from rdkit import Chem
 
-from timemachine.md import builders, minimizer
-from timemachine.fe import pdb_writer, free_energy
-
+from docking import report
+from timemachine.fe import free_energy, pdb_writer
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
-from timemachine.lib import custom_ops, LangevinIntegrator
-
-from docking import report
+from timemachine.lib import LangevinIntegrator, custom_ops
+from timemachine.md import builders, minimizer
 
 
 def dock_and_equilibrate(

--- a/docking/pose_dock.py
+++ b/docking/pose_dock.py
@@ -2,20 +2,16 @@ import os
 import time
 
 import numpy as np
-
+from rdkit import Chem
 from simtk.openmm import app
 from simtk.openmm.app import PDBFile
 
-from rdkit import Chem
-
-from timemachine.fe.utils import to_md_units
-from timemachine.fe import free_energy
-from timemachine.ff.handlers.deserialize import deserialize_handlers
-from timemachine.ff import Forcefield
-from timemachine.lib import LangevinIntegrator
-from timemachine.lib import custom_ops
-
 from docking import report
+from timemachine.fe import free_energy
+from timemachine.fe.utils import to_md_units
+from timemachine.ff import Forcefield
+from timemachine.ff.handlers.deserialize import deserialize_handlers
+from timemachine.lib import LangevinIntegrator, custom_ops
 
 
 def pose_dock(

--- a/docking/relative_docking.py
+++ b/docking/relative_docking.py
@@ -6,25 +6,18 @@
 """
 import os
 import time
-import numpy as np
 
+import numpy as np
 from rdkit import Chem
 from rdkit.Chem import rdFMCS
 
-from timemachine.md import builders, minimizer
+from docking import report
 from timemachine.fe import free_energy, topology
-from timemachine.fe.atom_mapping import (
-    get_core_by_geometry,
-    get_core_by_mcs,
-    get_core_by_smarts,
-    mcs_map,
-)
+from timemachine.fe.atom_mapping import get_core_by_geometry, get_core_by_mcs, get_core_by_smarts, mcs_map
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
-from timemachine.lib import custom_ops, LangevinIntegrator
-
-from docking import report
-
+from timemachine.lib import LangevinIntegrator, custom_ops
+from timemachine.md import builders, minimizer
 
 MAX_LAMBDA = 1.0
 MIN_LAMBDA = 0.0

--- a/docking/report.py
+++ b/docking/report.py
@@ -1,10 +1,10 @@
 """Solvates a host, inserts guest(s) into solvated host, equilibrates
 """
 import os
+
 import numpy as np
 from rdkit.Chem.rdmolfiles import PDBWriter, SDWriter
 from rdkit.Geometry import Point3D
-
 
 MAX_NORM_FORCE = 20000
 

--- a/docking/rigorous_work.py
+++ b/docking/rigorous_work.py
@@ -3,21 +3,19 @@
 2. Creates a water box, inserts guest(s) into water box, equilibrates, spins off deletion jobs, calculates work
 """
 import os
-import time
 import tempfile
+import time
 from collections import defaultdict
-import numpy as np
 
+import numpy as np
 from rdkit import Chem
 
-from timemachine.md import builders, minimizer
-from timemachine.fe import pdb_writer, free_energy
+from docking import report
+from timemachine.fe import free_energy, pdb_writer
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
-
-from timemachine.lib import custom_ops, LangevinIntegrator
-
-from docking import report
+from timemachine.lib import LangevinIntegrator, custom_ops
+from timemachine.md import builders, minimizer
 
 DELETION_MAX_LAMBDA = 1.0
 MIN_LAMBDA = 0.0

--- a/examples/ahfe.py
+++ b/examples/ahfe.py
@@ -1,24 +1,17 @@
 # absolute hydration free energy
 
+import jax
 import numpy as np
-
 from rdkit import Chem
 from rdkit.Chem import AllChem
-from timemachine.fe import pdb_writer
-from timemachine.fe import topology
+
+from timemachine.fe import pdb_writer, topology
 from timemachine.fe.utils import get_romol_conf
-from timemachine.md import builders
-
-from timemachine.lib import potentials, custom_ops
-from timemachine.lib import LangevinIntegrator
-
-import jax
-
 from timemachine.ff import Forcefield
-
 from timemachine.ff.handlers import openmm_deserializer
-
 from timemachine.ff.handlers.deserialize import deserialize_handlers
+from timemachine.lib import LangevinIntegrator, custom_ops, potentials
+from timemachine.md import builders
 
 # 1. build water box
 # 2. build ligand

--- a/examples/estimator_variance.py
+++ b/examples/estimator_variance.py
@@ -17,23 +17,21 @@
 
 
 from functools import partial
-
-# parallelization across multiple GPUs
-from timemachine.parallel.client import CUDAPoolClient
-from timemachine.parallel.utils import get_gpu_count
+from pathlib import Path
+from time import time
 
 import numpy as np
 from rdkit import Chem
 
-from timemachine.fe import topology, free_energy
+from timemachine.fe import free_energy, topology
 from timemachine.fe.free_energy import construct_lambda_schedule
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
 from timemachine.md import builders, minimizer
 
-from time import time
-
-from pathlib import Path
+# parallelization across multiple GPUs
+from timemachine.parallel.client import CUDAPoolClient
+from timemachine.parallel.utils import get_gpu_count
 
 root = Path(__file__).parent.parent
 path_to_ligand = str(root.joinpath("tests/data/ligands_40.sdf"))

--- a/examples/hif2a/fit_to_multiple_rbfes.py
+++ b/examples/hif2a/fit_to_multiple_rbfes.py
@@ -1,47 +1,40 @@
 # Fit to multiple relative binding free energy edges
+import datetime
 import sys
 from argparse import ArgumentParser
+from collections import defaultdict, namedtuple
+from pathlib import Path
+from pickle import dump, load
+from time import time
+from typing import Any, Dict, List, Tuple, Union
+
 import jax
-from jax import numpy as jnp
 import numpy as np
-import datetime
+from jax import numpy as jnp
+
 import timemachine
-from timemachine.training.dataset import Dataset
+from timemachine.fe.estimator import SimulationResult
+
+# free energy classes
+from timemachine.fe.free_energy import RBFETransformIndex, RelativeFreeEnergy, construct_lambda_schedule
+from timemachine.fe.loss import pseudo_huber_loss  # , l1_loss, flat_bottom_loss
+from timemachine.fe.model import RBFEModel
 
 # forcefield handlers
 from timemachine.ff import Forcefield
-from timemachine.ff.handlers.serialize import serialize_handlers
 from timemachine.ff.handlers.deserialize import deserialize_handlers
 from timemachine.ff.handlers.nonbonded import AM1CCCHandler, LennardJonesHandler
-
-# free energy classes
-from timemachine.fe.free_energy import (
-    RelativeFreeEnergy,
-    construct_lambda_schedule,
-    RBFETransformIndex,
-)
-from timemachine.fe.estimator import SimulationResult
-from timemachine.fe.model import RBFEModel
-from timemachine.fe.loss import pseudo_huber_loss  # , l1_loss, flat_bottom_loss
+from timemachine.ff.handlers.serialize import serialize_handlers
 
 # MD initialization
 from timemachine.md import builders
+from timemachine.optimize.step import truncated_step
+from timemachine.optimize.utils import flatten_and_unflatten
 
 # parallelization across multiple GPUs
 from timemachine.parallel.client import CUDAPoolClient, GRPCClient
 from timemachine.parallel.utils import get_gpu_count
-
-from collections import namedtuple, defaultdict
-
-from pickle import load, dump
-
-from timemachine.optimize.step import truncated_step
-from timemachine.optimize.utils import flatten_and_unflatten
-
-from typing import Tuple, Dict, List, Union, Any
-
-from pathlib import Path
-from time import time
+from timemachine.training.dataset import Dataset
 
 array = Union[np.array, jnp.array]
 

--- a/examples/hif2a/generate_star_map.py
+++ b/examples/hif2a/generate_star_map.py
@@ -1,34 +1,31 @@
 # Construct a star map for the fep-benchmark hif2a ligands
 import sys
 from argparse import ArgumentParser
-from pathlib import Path
 from functools import partial
-from typing import Dict, Any, List, Optional
-
+from pathlib import Path
 from pickle import dump
+from typing import Any, Dict, List, Optional
 
-from timemachine.parser import TimemachineConfig
+import numpy as np
+from rdkit import Chem
+from rdkit.Chem import rdFMCS
 
 from timemachine.fe import topology
-from timemachine.fe.utils import convert_uIC50_to_kJ_per_mole
+from timemachine.fe.atom_mapping import (
+    get_core_by_geometry,
+    get_core_by_mcs,
+    get_star_map,
+    mcs_map,
+    transformation_size,
+)
 from timemachine.fe.free_energy import RelativeFreeEnergy
 from timemachine.fe.topology import AtomMappingError
+from timemachine.fe.utils import convert_uIC50_to_kJ_per_mole
 
 # 0. Get force field
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
-
-from rdkit import Chem
-from rdkit.Chem import rdFMCS
-
-import numpy as np
-from timemachine.fe.atom_mapping import (
-    get_core_by_geometry,
-    get_core_by_mcs,
-    mcs_map,
-    transformation_size,
-    get_star_map,
-)
+from timemachine.parser import TimemachineConfig
 
 
 def get_mol_id(mol, mol_prop):

--- a/examples/npt_equilibration.py
+++ b/examples/npt_equilibration.py
@@ -1,31 +1,23 @@
 # Run a simulation at constant temperature and pressure, at a variety of values of lambda
 
-import numpy as np
-from simtk import unit
-
-from timemachine.testsystems.relative import hif2a_ligand_pair
-
-from timemachine.md.builders import build_water_system
-from timemachine.md.minimizer import minimize_host_4d
-
-from timemachine.md.ensembles import PotentialEnergyModel, NPTEnsemble
-
-from timemachine.md.thermostat.utils import sample_velocities
-
-from timemachine.md.barostat.utils import get_bond_list, get_group_indices
-from timemachine.md.barostat.moves import MonteCarloBarostat
-
-from timemachine.md.thermostat.moves import UnadjustedLangevinMove
-
-from timemachine.md.states import CoordsVelBox
-from timemachine.md.utils import simulate_npt_traj
-
-from timemachine.fe.free_energy import AbsoluteFreeEnergy, construct_lambda_schedule
-
-from timemachine.lib import LangevinIntegrator
 from functools import partial
 
 import matplotlib.pyplot as plt
+import numpy as np
+from simtk import unit
+
+from timemachine.fe.free_energy import AbsoluteFreeEnergy, construct_lambda_schedule
+from timemachine.lib import LangevinIntegrator
+from timemachine.md.barostat.moves import MonteCarloBarostat
+from timemachine.md.barostat.utils import get_bond_list, get_group_indices
+from timemachine.md.builders import build_water_system
+from timemachine.md.ensembles import NPTEnsemble, PotentialEnergyModel
+from timemachine.md.minimizer import minimize_host_4d
+from timemachine.md.states import CoordsVelBox
+from timemachine.md.thermostat.moves import UnadjustedLangevinMove
+from timemachine.md.thermostat.utils import sample_velocities
+from timemachine.md.utils import simulate_npt_traj
+from timemachine.testsystems.relative import hif2a_ligand_pair
 
 # simulation parameters
 n_lambdas = 40

--- a/examples/overlap_test.py
+++ b/examples/overlap_test.py
@@ -3,21 +3,18 @@ import os
 from jax.config import config
 
 config.update("jax_enable_x64", True)
-from rdkit import Chem
-
+import functools
 import multiprocessing
-
 
 import jax
 import jax.numpy as np
-import functools
 import numpy as onp
-
-from timemachine.ff.handlers.deserialize import deserialize_handlers
+from rdkit import Chem
 
 from timemachine.ff import handlers
-from timemachine.potentials import bonded, shape
+from timemachine.ff.handlers.deserialize import deserialize_handlers
 from timemachine.integrator import langevin_coefficients
+from timemachine.potentials import bonded, shape
 
 
 def pmi_restraints_new(conf, params, box, lamb, a_idxs, b_idxs, masses, angle_force, com_force):

--- a/examples/potential_energy.py
+++ b/examples/potential_energy.py
@@ -1,6 +1,9 @@
+from jax import grad
+from jax import numpy as np
+from jax import value_and_grad
+
 from timemachine.fe.functional import construct_differentiable_interface
 from timemachine.testsystems.relative import hif2a_ligand_pair
-from jax import grad, value_and_grad, numpy as np
 
 ff_params = hif2a_ligand_pair.ff.get_ordered_params()
 unbound_potentials, sys_params, _, coords = hif2a_ligand_pair.prepare_vacuum_edge(ff_params)

--- a/examples/rbfe_single.py
+++ b/examples/rbfe_single.py
@@ -4,23 +4,21 @@
 
 
 import argparse
-import numpy as np
-import jax
 
+import jax
+import numpy as np
+
+from timemachine.fe import model
 from timemachine.fe.free_energy import construct_lambda_schedule
 from timemachine.fe.utils import convert_uIC50_to_kJ_per_mole
-from timemachine.fe import model
-from timemachine.md import builders
-
-from timemachine.testsystems.relative import hif2a_ligand_pair
-
-from timemachine.ff.handlers.serialize import serialize_handlers
 from timemachine.ff.handlers.nonbonded import AM1CCCHandler, LennardJonesHandler
-from timemachine.parallel.client import CUDAPoolClient
-from timemachine.parallel.utils import get_gpu_count
-
+from timemachine.ff.handlers.serialize import serialize_handlers
+from timemachine.md import builders
 from timemachine.optimize.step import truncated_step
 from timemachine.optimize.utils import flatten_and_unflatten
+from timemachine.parallel.client import CUDAPoolClient
+from timemachine.parallel.utils import get_gpu_count
+from timemachine.testsystems.relative import hif2a_ligand_pair
 
 if __name__ == "__main__":
 

--- a/examples/rhfe_dual.py
+++ b/examples/rhfe_dual.py
@@ -1,26 +1,17 @@
 # relative hydration free energy
 
+import jax
 import numpy as np
-
 from rdkit import Chem
 from rdkit.Chem import AllChem
-from timemachine.fe import pdb_writer
-from timemachine.fe import topology
+
+from timemachine.fe import pdb_writer, topology
 from timemachine.fe.utils import get_romol_conf
-from timemachine.md import builders
-from timemachine.md import minimizer
-
-from timemachine.lib import potentials, custom_ops
-from timemachine.lib import LangevinIntegrator
-
-import jax
-
 from timemachine.ff import Forcefield
-
 from timemachine.ff.handlers import openmm_deserializer
-
 from timemachine.ff.handlers.deserialize import deserialize_handlers
-
+from timemachine.lib import LangevinIntegrator, custom_ops, potentials
+from timemachine.md import builders, minimizer
 
 # construct an RDKit molecule of aspirin
 # note: not using OpenFF Molecule because want to avoid the dependency (YTZ?)

--- a/examples/rhfe_single.py
+++ b/examples/rhfe_single.py
@@ -4,22 +4,18 @@
 # 2) Relative free energy with full atom-mapping
 # 3) Relative free energy with partial atom-mapping (4D-decoupling)
 
-import os
 import argparse
-import numpy as np
+import functools
+import multiprocessing
+import os
 
+import numpy as np
 from rdkit import Chem
 
 from timemachine.fe import free_energy, topology
-from timemachine.md import builders
-from timemachine.md import minimizer
-
-import functools
-
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
-
-import multiprocessing
+from timemachine.md import builders, minimizer
 
 
 def wrap_method(args, fn):

--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -11,40 +11,37 @@
 # For the solvent setup, we proceed as follows:
 # 1) Conversion of the ligand parameters into a ff-independent state.
 # 2) Run an absolute hydration free energy of the ff-independent state.
-import os
-import pickle
+
 import argparse
 import datetime
 import logging
-import numpy as np
-
+import os
+import pickle
 from pathlib import Path
 
+import numpy as np
+from rdkit import Chem
+
+import timemachine
+from timemachine.fe import model_rabfe
+from timemachine.fe.frames import all_frames, endpoint_frames_only, no_frames
 from timemachine.fe.free_energy_rabfe import (
+    RABFEResult,
     construct_absolute_lambda_schedule_complex,
     construct_absolute_lambda_schedule_solvent,
     construct_conversion_lambda_schedule,
     get_romol_conf,
     setup_relative_restraints_by_distance,
-    RABFEResult,
 )
-from timemachine.fe.utils import convert_uM_to_kJ_per_mole
-from timemachine.fe import model_rabfe
 from timemachine.fe.model_utils import verify_rabfe_pair
-from timemachine.fe.frames import endpoint_frames_only, all_frames, no_frames
-
+from timemachine.fe.utils import convert_uM_to_kJ_per_mole
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
+from timemachine.md import builders, minimizer
 from timemachine.parallel.client import CUDAPoolClient, GRPCClient
 from timemachine.parallel.utils import get_gpu_count
-
-
-from timemachine.training.dataset import Dataset
-from rdkit import Chem
-
-import timemachine
 from timemachine.potentials import rmsd
-from timemachine.md import builders, minimizer
+from timemachine.training.dataset import Dataset
 
 ALL_FRAMES = "all"
 ENDPOINTS_ONLY = "endpoints"

--- a/examples/validate_relative_hydration.py
+++ b/examples/validate_relative_hydration.py
@@ -3,25 +3,24 @@
 # against the relative difference.
 
 import argparse
-import numpy as np
+import multiprocessing
 
+import numpy as np
+from rdkit import Chem
+
+from timemachine.fe import model_rabfe
 from timemachine.fe.free_energy_rabfe import (
     construct_absolute_lambda_schedule_solvent,
     construct_relative_lambda_schedule,
-    setup_relative_restraints_by_distance,
     get_romol_conf,
+    setup_relative_restraints_by_distance,
 )
-from timemachine.fe import model_rabfe
-from timemachine.md import builders, minimizer
-
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
+from timemachine.md import builders, minimizer
 from timemachine.parallel.client import CUDAPoolClient, GRPCClient
 from timemachine.parallel.utils import get_gpu_count
-
-import multiprocessing
 from timemachine.training.dataset import Dataset
-from rdkit import Chem
 
 if __name__ == "__main__":
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,13 @@ extend-exclude = '''
   )
 '''
 
+[tool.isort]
+profile = "black"
+line_length = 120
+skip_gitignore = true
+honor_noqa = true      # allow overriding with `# noqa`
+multi_line_output = 3  # https://pycqa.github.io/isort/docs/configuration/multi_line_output_modes.html
+
 [build-system]
 requires = ["setuptools>=43.0.0", "wheel", "cmake==3.22.1", "versioneer-518"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,16 @@
 Adapted from https://github.com/pypa/sampleproject/blob/main/setup.py
 """
 
-from setuptools import Extension, find_packages, setup
-from setuptools.command.build_ext import build_ext
-
 import os
 import pathlib
 import subprocess
 import sys
+
+from setuptools import Extension, find_packages, setup
+from setuptools.command.build_ext import build_ext
+
 import versioneer
+
 
 # CMake configuration adapted from https://github.com/pybind/cmake_example
 class CMakeExtension(Extension):

--- a/slow_tests/test_barostat.py
+++ b/slow_tests/test_barostat.py
@@ -1,24 +1,19 @@
 import os
 import platform
+
 import numpy as np
+import pytest
 from simtk import unit
 
-import pytest
-
-from timemachine.testsystems.relative import hif2a_ligand_pair
-
+from timemachine.constants import BOLTZ, DISTANCE_UNIT, ENERGY_UNIT
+from timemachine.fe.free_energy import AbsoluteFreeEnergy
+from timemachine.lib import LangevinIntegrator, custom_ops
+from timemachine.md.barostat.moves import CentroidRescaler
+from timemachine.md.barostat.utils import compute_box_center, compute_box_volume, get_bond_list, get_group_indices
 from timemachine.md.builders import build_water_system
 from timemachine.md.minimizer import minimize_host_4d
-
-from timemachine.fe.free_energy import AbsoluteFreeEnergy
-
-from timemachine.md.barostat.moves import CentroidRescaler
-from timemachine.md.barostat.utils import get_bond_list, get_group_indices, compute_box_volume, compute_box_center
 from timemachine.md.thermostat.utils import sample_velocities
-
-from timemachine.lib import LangevinIntegrator, custom_ops
-
-from timemachine.constants import BOLTZ, ENERGY_UNIT, DISTANCE_UNIT
+from timemachine.testsystems.relative import hif2a_ligand_pair
 
 
 def test_barostat_zero_interval():

--- a/slow_tests/test_barostat_water_density.py
+++ b/slow_tests/test_barostat_water_density.py
@@ -2,28 +2,23 @@
 # Analogous to https://github.com/openmm/openmm/blob/master/tests/TestMonteCarloBarostat.h#L204-L269
 # Expected runtime: ~ 10 minutes (10 replicates where each takes < 1 minute)
 
+from functools import partial
+
 import numpy as np
 from simtk import unit
 
-from timemachine.testsystems.relative import hif2a_ligand_pair
-
-from timemachine.md.builders import build_water_system
-from timemachine.md.minimizer import minimize_host_4d
-
 from timemachine.fe.free_energy import AbsoluteFreeEnergy
-
-from timemachine.md.ensembles import PotentialEnergyModel, NPTEnsemble
+from timemachine.lib import LangevinIntegrator
 from timemachine.md.barostat.moves import MonteCarloBarostat
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
+from timemachine.md.builders import build_water_system
+from timemachine.md.ensembles import NPTEnsemble, PotentialEnergyModel
+from timemachine.md.minimizer import minimize_host_4d
 from timemachine.md.states import CoordsVelBox
-from timemachine.md.utils import simulate_npt_traj
 from timemachine.md.thermostat.moves import UnadjustedLangevinMove
 from timemachine.md.thermostat.utils import sample_velocities
-
-from timemachine.lib import LangevinIntegrator
-
-from functools import partial
-
+from timemachine.md.utils import simulate_npt_traj
+from timemachine.testsystems.relative import hif2a_ligand_pair
 
 if __name__ == "__main__":
     # simulation parameters

--- a/slow_tests/test_benchmark.py
+++ b/slow_tests/test_benchmark.py
@@ -3,21 +3,18 @@ and running an intermediate lambda window "rbfe" MD for a
 relative binding free energy edge from the HIF2A test system"""
 
 import time
+
 import numpy as np
-
-from timemachine.ff.handlers import openmm_deserializer
-from timemachine.ff.handlers.deserialize import deserialize_handlers
-from timemachine.ff import Forcefield
-
 from simtk.openmm import app
 
-from timemachine.lib import custom_ops, LangevinIntegrator, MonteCarloBarostat
-
-from timemachine.fe.utils import to_md_units
-from timemachine.fe.model_utils import apply_hmr
 from timemachine.fe import free_energy
+from timemachine.fe.model_utils import apply_hmr
 from timemachine.fe.topology import SingleTopology
-
+from timemachine.fe.utils import to_md_units
+from timemachine.ff import Forcefield
+from timemachine.ff.handlers import openmm_deserializer
+from timemachine.ff.handlers.deserialize import deserialize_handlers
+from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, custom_ops
 from timemachine.md import builders, minimizer
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 

--- a/slow_tests/test_determinism.py
+++ b/slow_tests/test_determinism.py
@@ -1,11 +1,9 @@
 import numpy as np
 
+from timemachine.ff import Forcefield
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.ff.handlers.deserialize import deserialize_handlers
-from timemachine.ff import Forcefield
-
-from timemachine.lib import custom_ops, LangevinIntegrator, MonteCarloBarostat
-
+from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, custom_ops
 from timemachine.md import builders, minimizer
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.testsystems.relative import hif2a_ligand_pair as testsystem

--- a/slow_tests/test_docking.py
+++ b/slow_tests/test_docking.py
@@ -1,11 +1,12 @@
 """
 Tests for the timemachine/docking/ files
 """
-import unittest
 import tempfile
+import unittest
 from pathlib import Path
+
+from docking import dock_and_equilibrate, pose_dock, relative_docking, rigorous_work
 from timemachine.testsystems.relative import hif2a_ligand_pair
-from docking import pose_dock, dock_and_equilibrate, rigorous_work, relative_docking
 
 
 class TestDocking(unittest.TestCase):

--- a/slow_tests/test_endpoint_correction.py
+++ b/slow_tests/test_endpoint_correction.py
@@ -1,22 +1,21 @@
 from jax.config import config
 
 config.update("jax_enable_x64", True)
-import jax
-
 import copy
 import functools
+from pathlib import Path
 
+import jax
+import numpy as np
 from rdkit import Chem
+
+from timemachine import constants
 from timemachine.fe import endpoint_correction
+from timemachine.fe.utils import get_romol_conf
+from timemachine.ff import Forcefield
+from timemachine.ff.handlers.deserialize import deserialize_handlers
 from timemachine.integrator import langevin_coefficients
 from timemachine.potentials import bonded
-from timemachine import constants
-import numpy as np
-
-from pathlib import Path
-from timemachine.ff.handlers.deserialize import deserialize_handlers
-from timemachine.ff import Forcefield
-from timemachine.fe.utils import get_romol_conf
 
 
 def setup_system():

--- a/slow_tests/test_free_energy.py
+++ b/slow_tests/test_free_energy.py
@@ -1,25 +1,19 @@
-from jax import grad, value_and_grad, config, jacfwd, jacrev
+from jax import config, grad, jacfwd, jacrev, value_and_grad
 
 config.update("jax_enable_x64", True)
 
 import numpy as np
-
 from rdkit import Chem
-from scipy.optimize import minimize, check_grad
+from scipy.optimize import check_grad, minimize
 
+from timemachine.fe import estimator, free_energy, topology
+from timemachine.fe.functional import construct_differentiable_interface, construct_differentiable_interface_fast
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
-
-from timemachine.fe import topology, estimator, free_energy
-
-from timemachine.parallel.client import CUDAPoolClient
-
-from timemachine.md import builders, minimizer
-
 from timemachine.lib import LangevinIntegrator, MonteCarloBarostat
-
-from timemachine.fe.functional import construct_differentiable_interface, construct_differentiable_interface_fast
+from timemachine.md import builders, minimizer
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
+from timemachine.parallel.client import CUDAPoolClient
 from timemachine.testsystems.relative import hif2a_ligand_pair
 
 

--- a/slow_tests/test_minimizer.py
+++ b/slow_tests/test_minimizer.py
@@ -1,9 +1,8 @@
 from rdkit import Chem
 
-from timemachine.md import minimizer, builders
-
-from timemachine.ff.handlers.deserialize import deserialize_handlers
 from timemachine.ff import Forcefield
+from timemachine.ff.handlers.deserialize import deserialize_handlers
+from timemachine.md import builders, minimizer
 
 
 def test_minimizer():

--- a/slow_tests/test_mtm.py
+++ b/slow_tests/test_mtm.py
@@ -1,28 +1,23 @@
 from jax.config import config
 
 config.update("jax_enable_x64", True)
-import jax
-
+import copy
+import functools
 from typing import List
 
-from timemachine.md.states import CoordsVelBox
-from timemachine.md import enhanced
-from timemachine.md.moves import NPTMove, ReferenceMTMMove, OptimizedMTMMove
-
-import functools
-
-from timemachine.potentials import nonbonded
-from timemachine.constants import BOLTZ
-
-import numpy as np
-from tests import test_ligands
-import copy
-
-from timemachine.ff import Forcefield
-from timemachine.ff.handlers.deserialize import deserialize_handlers
-
+import jax
 import jax.numpy as jnp
 import jax.random as jrandom
+import numpy as np
+
+from tests import test_ligands
+from timemachine.constants import BOLTZ
+from timemachine.ff import Forcefield
+from timemachine.ff.handlers.deserialize import deserialize_handlers
+from timemachine.md import enhanced
+from timemachine.md.moves import NPTMove, OptimizedMTMMove, ReferenceMTMMove
+from timemachine.md.states import CoordsVelBox
+from timemachine.potentials import nonbonded
 
 
 def get_ff_am1ccc():

--- a/slow_tests/test_mtm_condensed.py
+++ b/slow_tests/test_mtm_condensed.py
@@ -1,31 +1,27 @@
-from jax.config import config
-
-from scipy.special import logsumexp
-import pickle
 import os
+import pickle
+
+from jax.config import config
+from scipy.special import logsumexp
 
 config.update("jax_enable_x64", True)
-import jax
-import jax.numpy as jnp
-
-from timemachine.md import enhanced
-from timemachine.md.moves import NPTMove, OptimizedMTMMove
-
+import copy
 import functools
 
-from timemachine.potentials import bonded, nonbonded
-from timemachine.constants import BOLTZ
-
+import jax
+import jax.numpy as jnp
 import numpy as np
-from tests import test_ligands
-import copy
+import pytest
 
+from tests import test_ligands
+from timemachine.constants import BOLTZ
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
+from timemachine.md import enhanced
+from timemachine.md.moves import NPTMove, OptimizedMTMMove
+from timemachine.potentials import bonded, nonbonded
 
 # (ytz): useful for visualization, so please leave this comment here!
-
-import pytest
 
 
 def get_ff_am1cc():

--- a/slow_tests/test_rbfe.py
+++ b/slow_tests/test_rbfe.py
@@ -2,12 +2,12 @@ import os
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from timemachine.md import builders
-from timemachine.fe.model import RBFEModel
 from timemachine.fe.free_energy import construct_lambda_schedule
-from timemachine.testsystems.relative import hif2a_ligand_pair
+from timemachine.fe.model import RBFEModel
+from timemachine.md import builders
 from timemachine.parallel.client import CUDAPoolClient
 from timemachine.parallel.utils import get_gpu_count
+from timemachine.testsystems.relative import hif2a_ligand_pair
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "tests", "data")
 NUM_GPUS = get_gpu_count()

--- a/slow_tests/test_reference_langevin_integrator.py
+++ b/slow_tests/test_reference_langevin_integrator.py
@@ -1,7 +1,8 @@
 from itertools import product
 
 import numpy as np
-from jax import numpy as jnp, jit, grad
+from jax import grad, jit
+from jax import numpy as jnp
 
 from timemachine.constants import BOLTZ
 from timemachine.integrator import LangevinIntegrator

--- a/slow_tests/test_vacuum_importance_sampling.py
+++ b/slow_tests/test_vacuum_importance_sampling.py
@@ -11,13 +11,13 @@ from jax.config import config
 config.update("jax_enable_x64", True)
 import jax
 import numpy as np
+import pytest
 
-from timemachine.md import enhanced
-from timemachine.potentials import bonded
 from tests import test_ligands
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
-import pytest
+from timemachine.md import enhanced
+from timemachine.potentials import bonded
 
 
 def get_ff_am1ccc():

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,22 +1,21 @@
+import contextlib
+import functools
+import itertools
 import os
 import unittest
-import numpy as np
-import jax
-import functools
-import contextlib
-from tempfile import TemporaryDirectory
-from timemachine.constants import ONE_4PI_EPS0
-import timemachine
 from pathlib import Path
-from timemachine.ff.handlers.deserialize import deserialize_handlers
-from timemachine.ff import Forcefield
+from tempfile import TemporaryDirectory
 
-from timemachine.potentials import bonded, nonbonded
-from timemachine.lib import potentials
-
+import jax
+import numpy as np
 from hilbertcurve.hilbertcurve import HilbertCurve
 
-import itertools
+import timemachine
+from timemachine.constants import ONE_4PI_EPS0
+from timemachine.ff import Forcefield
+from timemachine.ff.handlers.deserialize import deserialize_handlers
+from timemachine.lib import potentials
+from timemachine.potentials import bonded, nonbonded
 
 
 @contextlib.contextmanager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@
 # https://docs.pytest.org/en/latest/how-to/fixtures.html#scope-sharing-fixtures-across-classes-modules-packages-or-session
 
 import gc
+
 import pytest
+
 from timemachine.lib import custom_ops
 
 

--- a/tests/dual_topology.py
+++ b/tests/dual_topology.py
@@ -3,21 +3,17 @@
 
 import argparse
 import os
+from multiprocessing import Pool
+
 import numpy as np
 from rdkit import Chem
 from rdkit.Chem import AllChem
 
-from timemachine.lib import custom_ops
-from timemachine.lib import LangevinIntegrator
-
-from timemachine.ff.handlers.deserialize import deserialize_handlers
-
-from timemachine.fe.utils import get_romol_conf
 from timemachine.fe import rbfe
-from timemachine.md import Recipe
-from timemachine.md import builders
-
-from multiprocessing import Pool
+from timemachine.fe.utils import get_romol_conf
+from timemachine.ff.handlers.deserialize import deserialize_handlers
+from timemachine.lib import LangevinIntegrator, custom_ops
+from timemachine.md import Recipe, builders
 
 
 def run(args):

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -4,12 +4,12 @@
 # TODO: test distance atom mapping
 
 from timemachine.fe.atom_mapping import (
-    mcs_map,
-    transformation_size,
     compute_all_pairs_mcs,
     compute_transformation_size_matrix,
-    get_core_by_mcs,
     get_core_by_geometry,
+    get_core_by_mcs,
+    mcs_map,
+    transformation_size,
 )
 from timemachine.testsystems.relative import hif2a_ligand_pair
 

--- a/tests/test_bonded.py
+++ b/tests/test_bonded.py
@@ -4,11 +4,11 @@ from jax.config import config
 config.update("jax_enable_x64", True)
 import functools
 
+import pytest
 from common import GradientTest
+
 from timemachine.lib import potentials
 from timemachine.potentials import bonded, rmsd
-
-import pytest
 
 
 class TestBonded(GradientTest):

--- a/tests/test_centroid_rescaler.py
+++ b/tests/test_centroid_rescaler.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from timemachine.md.barostat.moves import CentroidRescaler
 from timemachine.md.barostat.utils import compute_intramolecular_distances
 

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -1,10 +1,9 @@
-from timemachine.md.ensembles import NVTEnsemble, NPTEnsemble
-from simtk.unit import kelvin, atmosphere, kilojoule_per_mole, nanometer
-
-from simtk import unit
 import numpy as np
+from simtk import unit
+from simtk.unit import atmosphere, kelvin, kilojoule_per_mole, nanometer
 
-from timemachine.constants import ENERGY_UNIT, DISTANCE_UNIT
+from timemachine.constants import DISTANCE_UNIT, ENERGY_UNIT
+from timemachine.md.ensembles import NPTEnsemble, NVTEnsemble
 
 
 def _compute_reduced_potential(potential_energy, temperature, volume, pressure):

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -1,10 +1,9 @@
 import numpy as np
 
-
 from timemachine.fe import estimator_abfe
-from timemachine.lib import LangevinIntegrator, potentials, MonteCarloBarostat
-from timemachine.parallel.client import CUDAPoolClient
+from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, potentials
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
+from timemachine.parallel.client import CUDAPoolClient
 
 
 def get_harmonic_bond(n_atoms, n_bonds):

--- a/tests/test_fe_utils.py
+++ b/tests/test_fe_utils.py
@@ -1,11 +1,9 @@
 import numpy as np
 import pytest
-
 from rdkit import Chem
-from timemachine.fe.model_utils import verify_rabfe_pair
 
 from timemachine.fe import utils
-from timemachine.fe.model_utils import image_molecule
+from timemachine.fe.model_utils import image_molecule, verify_rabfe_pair
 
 
 def test_sanitize_energies():

--- a/tests/test_forcefields.py
+++ b/tests/test_forcefields.py
@@ -1,4 +1,5 @@
 from glob import glob
+
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
 

--- a/tests/test_frame_filters.py
+++ b/tests/test_frame_filters.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from timemachine.fe.estimator_abfe import SimulationResult
-from timemachine.fe.frames import endpoint_frames_only, all_frames, no_frames
+from timemachine.fe.frames import all_frames, endpoint_frames_only, no_frames
 
 
 def make_dummy_sim_result(val):

--- a/tests/test_free_energy_rabfe.py
+++ b/tests/test_free_energy_rabfe.py
@@ -1,19 +1,18 @@
 import numpy as np
-from timemachine.fe.free_energy_rabfe import (
-    RABFEResult,
-    setup_relative_restraints_by_distance,
-    setup_relative_restraints_using_smarts,
-    validate_lambda_schedule,
-    interpolate_pre_optimized_protocol,
-    construct_pre_optimized_absolute_lambda_schedule_solvent,
-)
-from timemachine.fe.atom_mapping import CompareDistNonterminal
-from timemachine.fe.utils import get_romol_conf
-
+import pytest
 from rdkit import Chem
 from rdkit.Chem import AllChem, rdFMCS
 
-import pytest
+from timemachine.fe.atom_mapping import CompareDistNonterminal
+from timemachine.fe.free_energy_rabfe import (
+    RABFEResult,
+    construct_pre_optimized_absolute_lambda_schedule_solvent,
+    interpolate_pre_optimized_protocol,
+    setup_relative_restraints_by_distance,
+    setup_relative_restraints_using_smarts,
+    validate_lambda_schedule,
+)
+from timemachine.fe.utils import get_romol_conf
 
 
 def test_rabfe_result_to_from_mol():

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,18 +1,17 @@
 from jax.config import config
 
 config.update("jax_enable_x64", True)
+import functools
+
 import jax
-
-import pytest
 import numpy as np
-
+import pytest
 from rdkit import Chem
 from rdkit.Chem import AllChem
-from timemachine.ff.handlers import nonbonded, bonded
-from timemachine.ff.handlers.deserialize import deserialize_handlers
-from timemachine.ff.charges import AM1CCC_CHARGES
 
-import functools
+from timemachine.ff.charges import AM1CCC_CHARGES
+from timemachine.ff.handlers import bonded, nonbonded
+from timemachine.ff.handlers.deserialize import deserialize_handlers
 
 
 def test_harmonic_bond():

--- a/tests/test_jax_nonbonded.py
+++ b/tests/test_jax_nonbonded.py
@@ -3,24 +3,24 @@ import jax
 jax.config.update("jax_enable_x64", True)
 
 import numpy as onp
-from numpy.random import randn, rand, randint, seed
+from numpy.random import rand, randint, randn, seed
 
 seed(2021)
 
+from functools import partial
+from typing import Callable, Tuple
+
+from jax import jit
+from jax import numpy as np
+from jax import value_and_grad, vmap
+from jax.ops import index, index_update
 from scipy.optimize import minimize
-
-from jax import numpy as np, value_and_grad, jit, vmap
-
-from jax.ops import index_update, index
-from timemachine.potentials.nonbonded import nonbonded_v3, nonbonded_v3_on_specific_pairs, nonbonded_block
-from timemachine.potentials.jax_utils import convert_to_4d, get_all_pairs_indices, get_group_group_indices, distance
-from timemachine.md import builders
-from timemachine.ff.handlers import openmm_deserializer
-
 from simtk import unit
 
-from functools import partial
-from typing import Tuple, Callable
+from timemachine.ff.handlers import openmm_deserializer
+from timemachine.md import builders
+from timemachine.potentials.jax_utils import convert_to_4d, distance, get_all_pairs_indices, get_group_group_indices
+from timemachine.potentials.nonbonded import nonbonded_block, nonbonded_v3, nonbonded_v3_on_specific_pairs
 
 Conf = Params = Box = ChargeMask = LJMask = LambdaPlaneIdxs = LambdaOffsetIdxs = np.array
 Lamb = Beta = Cutoff = Energy = float

--- a/tests/test_jax_utils.py
+++ b/tests/test_jax_utils.py
@@ -2,19 +2,21 @@ import jax
 
 jax.config.update("jax_enable_x64", True)
 
-from jax import numpy as np, jit, vmap
 import numpy as onp
+from jax import jit
+from jax import numpy as np
+from jax import vmap
 
 onp.random.seed(2021)
 
 from timemachine.potentials.jax_utils import (
+    augment_dim,
+    batched_neighbor_inds,
+    compute_lifting_parameter,
     delta_r,
     distance_on_pairs,
     get_all_pairs_indices,
     get_group_group_indices,
-    compute_lifting_parameter,
-    augment_dim,
-    batched_neighbor_inds,
 )
 
 

--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 
 from timemachine.md.builders import build_water_system
 from timemachine.md.minimizer import minimize_host_4d
-
 from timemachine.testsystems.relative import hif2a_ligand_pair
 
 

--- a/tests/test_lambda_potential.py
+++ b/tests/test_lambda_potential.py
@@ -1,15 +1,15 @@
 import unittest
+
 from jax.config import config
 
 config.update("jax_enable_x64", True)
 
 import functools
+
 import numpy as np
+from common import GradientTest, prepare_water_system
 
-from common import GradientTest
 from timemachine.lib import potentials
-
-from common import prepare_water_system
 
 
 def lambda_potential(conf, params, box, lamb, multiplier, offset, u_fn):

--- a/tests/test_ligands.py
+++ b/tests/test_ligands.py
@@ -1,5 +1,5 @@
-from rdkit import Chem
 import numpy as np
+from rdkit import Chem
 
 
 def get_biphenyl():

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -1,5 +1,6 @@
 import numpy as np
-from timemachine.fe.loss import l1_loss, pseudo_huber_loss, flat_bottom_loss, truncated_residuals
+
+from timemachine.fe.loss import flat_bottom_loss, l1_loss, pseudo_huber_loss, truncated_residuals
 
 np.random.seed(2021)
 

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -1,16 +1,14 @@
 import unittest
 
 import numpy as np
-
 from jax.config import config
 
 config.update("jax_enable_x64", True)
 import jax
-
-from timemachine.lib import custom_ops, potentials
-from timemachine.integrator import langevin_coefficients
-
 from common import prepare_nb_system
+
+from timemachine.integrator import langevin_coefficients
+from timemachine.lib import custom_ops, potentials
 
 
 class TestContext(unittest.TestCase):

--- a/tests/test_nblist.py
+++ b/tests/test_nblist.py
@@ -1,10 +1,10 @@
-import pytest
 import numpy as np
+import pytest
+from hilbertcurve.hilbertcurve import HilbertCurve
 
+from timemachine.fe.utils import get_romol_conf
 from timemachine.lib import custom_ops
 from timemachine.md.builders import build_water_system
-from timemachine.fe.utils import get_romol_conf
-from hilbertcurve.hilbertcurve import HilbertCurve
 from timemachine.testsystems.relative import hif2a_ligand_pair
 
 

--- a/tests/test_nonbonded.py
+++ b/tests/test_nonbonded.py
@@ -3,30 +3,26 @@
 
 import copy
 import gzip
-
 import pickle
 import unittest
+
 from jax.config import config
 
 config.update("jax_enable_x64", True)
 
-import numpy as np
-
 import functools
 import itertools
 
-from common import GradientTest
-from common import prepare_water_system, prepare_reference_nonbonded
+import numpy as np
+from common import GradientTest, prepare_reference_nonbonded, prepare_water_system
+from hilbertcurve.hilbertcurve import HilbertCurve
+from simtk.openmm import app
 
-from timemachine.potentials import nonbonded
+from timemachine.fe.utils import to_md_units
+from timemachine.ff.handlers import openmm_deserializer
 from timemachine.lib import potentials
 from timemachine.md import builders
-
-from hilbertcurve.hilbertcurve import HilbertCurve
-from timemachine.fe.utils import to_md_units
-
-from timemachine.ff.handlers import openmm_deserializer
-from simtk.openmm import app
+from timemachine.potentials import nonbonded
 
 np.set_printoptions(linewidth=500)
 

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,12 +1,12 @@
+import numpy as onp
+from common import get_110_ccc_ff
+from jax import config, grad
+from jax import numpy as jnp
+from jax import tree_util
+
+from timemachine.optimize.precondition import learning_rates_like_params
 from timemachine.optimize.step import truncated_step
 from timemachine.optimize.utils import flatten_and_unflatten
-from timemachine.optimize.precondition import learning_rates_like_params
-
-from common import get_110_ccc_ff
-
-import numpy as onp
-
-from jax import tree_util, grad, config, numpy as jnp
 
 config.update("jax_enable_x64", True)
 

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,22 +1,18 @@
 # tests for parallel execution
-import numpy as np
+import concurrent
+import os
 import random
-
+import unittest
 from tempfile import NamedTemporaryFile
+from unittest.mock import patch
 
+import jax.numpy as jnp
+import numpy as np
+
+import grpc
 from timemachine import parallel
 from timemachine.parallel import client, worker
 from timemachine.parallel.utils import get_gpu_count
-
-import os
-import unittest
-from unittest.mock import patch
-
-
-import grpc
-import concurrent
-
-import jax.numpy as jnp
 
 
 def jax_fn(x):

--- a/tests/test_parameter_interpolation.py
+++ b/tests/test_parameter_interpolation.py
@@ -3,13 +3,12 @@ from jax.config import config
 config.update("jax_enable_x64", True)
 import copy
 import functools
-import numpy as np
+
 import jax.numpy as jnp
+import numpy as np
+from common import GradientTest, prepare_water_system
 
-from common import GradientTest
 from timemachine.lib import potentials
-
-from common import prepare_water_system
 
 
 def interpolated_potential(conf, params, box, lamb, u_fn):

--- a/tests/test_pdb_writer.py
+++ b/tests/test_pdb_writer.py
@@ -1,12 +1,11 @@
-import pytest
-import numpy as np
-
 from tempfile import NamedTemporaryFile
+
+import numpy as np
+import pytest
 
 from timemachine.fe.pdb_writer import PDBWriter, convert_single_topology_mols
 from timemachine.fe.topology import SingleTopology
 from timemachine.md import builders
-
 from timemachine.testsystems.relative import hif2a_ligand_pair
 
 

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+import pytest
 
 from timemachine.lib import custom_ops, potentials
 

--- a/tests/test_protocol_optimization.py
+++ b/tests/test_protocol_optimization.py
@@ -1,15 +1,14 @@
-from timemachine.optimize.protocol import (
-    rebalance_initial_protocol,
-    log_weights_from_mixture,
-    linear_u_kn_interpolant,
-    construct_work_stddev_estimator,
-)
-
+import numpy as np
 from pymbar import MBAR
 from pymbar.testsystems import HarmonicOscillatorsTestCase
-
-import numpy as np
 from scipy.special import logsumexp
+
+from timemachine.optimize.protocol import (
+    construct_work_stddev_estimator,
+    linear_u_kn_interpolant,
+    log_weights_from_mixture,
+    rebalance_initial_protocol,
+)
 
 np.random.seed(2021)
 

--- a/tests/test_rabfe.py
+++ b/tests/test_rabfe.py
@@ -2,25 +2,23 @@ import os
 from unittest import TestCase
 
 import numpy as np
+from common import temporary_working_dir
 
-from timemachine.md import builders, minimizer
-from timemachine.fe.model_rabfe import RelativeBindingModel, AbsoluteConversionModel, AbsoluteStandardHydrationModel
+from timemachine.fe.frames import all_frames
 from timemachine.fe.free_energy import construct_lambda_schedule
 from timemachine.fe.free_energy_rabfe import (
-    setup_relative_restraints_by_distance,
-    get_romol_conf,
-    RelativeFreeEnergy,
     AbsoluteFreeEnergy,
+    RelativeFreeEnergy,
+    get_romol_conf,
+    setup_relative_restraints_by_distance,
 )
-from timemachine.fe.frames import all_frames
-from timemachine.potentials import rmsd
-from timemachine.lib.potentials import NonbondedInterpolated, Nonbonded
-from timemachine.testsystems.relative import hif2a_ligand_pair
-
+from timemachine.fe.model_rabfe import AbsoluteConversionModel, AbsoluteStandardHydrationModel, RelativeBindingModel
+from timemachine.lib.potentials import Nonbonded, NonbondedInterpolated
+from timemachine.md import builders, minimizer
 from timemachine.parallel.client import CUDAPoolClient
 from timemachine.parallel.utils import get_gpu_count
-
-from common import temporary_working_dir
+from timemachine.potentials import rmsd
+from timemachine.testsystems.relative import hif2a_ligand_pair
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 NUM_GPUS = get_gpu_count()

--- a/tests/test_rabfe_topology.py
+++ b/tests/test_rabfe_topology.py
@@ -2,13 +2,12 @@
 from jax.config import config
 
 config.update("jax_enable_x64", True)
-from timemachine.ff import Forcefield
-from timemachine.ff.handlers.deserialize import deserialize_handlers
+import numpy as np
+from rdkit import Chem
 
 from timemachine.fe import topology
-from rdkit import Chem
-import numpy as np
-
+from timemachine.ff import Forcefield
+from timemachine.ff.handlers.deserialize import deserialize_handlers
 from timemachine.lib import potentials
 
 

--- a/tests/test_rmsd_align.py
+++ b/tests/test_rmsd_align.py
@@ -1,11 +1,10 @@
 # test the custom_op for rmsd alignment
 
-from timemachine.lib import custom_ops
-
-from timemachine.potentials import rmsd
 import numpy as np
+from scipy.stats import ortho_group, special_ortho_group
 
-from scipy.stats import special_ortho_group, ortho_group
+from timemachine.lib import custom_ops
+from timemachine.potentials import rmsd
 
 
 def test_rmsd_align_proper():

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -4,9 +4,9 @@ config.update("jax_enable_x64", True)
 
 import numpy as np
 
-from timemachine.ff.handlers import nonbonded, bonded
-from timemachine.ff.handlers.serialize import bin_to_str
+from timemachine.ff.handlers import bonded, nonbonded
 from timemachine.ff.handlers.deserialize import deserialize_handlers
+from timemachine.ff.handlers.serialize import bin_to_str
 
 
 def test_harmonic_bond():

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -2,17 +2,15 @@ from jax.config import config
 
 config.update("jax_enable_x64", True)
 
+import functools
+
+import numpy as np
+import pytest
+from common import GradientTest
 from rdkit import Chem
 
-import functools
-import numpy as np
-
-from timemachine.potentials import shape
 from timemachine.lib import potentials
-
-from common import GradientTest
-
-import pytest
+from timemachine.potentials import shape
 
 
 def recenter(conf):

--- a/tests/test_standard_state.py
+++ b/tests/test_standard_state.py
@@ -1,11 +1,9 @@
-import numpy as np
 import functools
 
-from timemachine.fe import standard_state
-
+import numpy as np
 import scipy.integrate
 
-
+from timemachine.fe import standard_state
 from timemachine.potentials import rmsd
 
 

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -3,16 +3,15 @@ from jax.config import config
 config.update("jax_enable_x64", True)
 
 import unittest
+
+import jax
 import numpy as np
-
-from timemachine.fe import topology
-
 from rdkit import Chem
 
+from timemachine.fe import topology
+from timemachine.fe.utils import get_romol_conf
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
-from timemachine.fe.utils import get_romol_conf
-import jax
 
 
 class BenzenePhenolSparseTest(unittest.TestCase):

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -2,9 +2,8 @@ import unittest
 
 import numpy as np
 
-from timemachine.training.dataset import Dataset
-
 from timemachine.testsystems.relative import hif2a_ligand_pair
+from timemachine.training.dataset import Dataset
 
 
 class TestDataset(unittest.TestCase):

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -1,10 +1,9 @@
 from typing import Optional
 
+import matplotlib.pyplot as plt
 import numpy as np
 from rdkit import Chem
 from rdkit.Chem import rdFMCS
-
-import matplotlib.pyplot as plt
 
 from timemachine.fe.topology import AtomMappingError
 from timemachine.fe.utils import core_from_distances, simple_geometry_mapping

--- a/timemachine/fe/bar.py
+++ b/timemachine/fe/bar.py
@@ -1,7 +1,7 @@
-import jax.numpy as jnp
-from jax.scipy.special import logsumexp
-import pymbar
 import jax
+import jax.numpy as jnp
+import pymbar
+from jax.scipy.special import logsumexp
 
 
 def EXP(w_raw):

--- a/timemachine/fe/endpoint_correction.py
+++ b/timemachine/fe/endpoint_correction.py
@@ -1,11 +1,12 @@
 import functools
-
 from typing import Tuple
+
 import jax
-import numpy as np
 import jax.numpy as jnp
-from timemachine.potentials import bonded, rmsd
+import numpy as np
 from scipy.stats import special_ortho_group
+
+from timemachine.potentials import bonded, rmsd
 
 
 def exp_u(rotation, k, beta):

--- a/timemachine/fe/estimator.py
+++ b/timemachine/fe/estimator.py
@@ -1,16 +1,13 @@
-from collections import namedtuple
-
 import copy
+import dataclasses
+from collections import namedtuple
+from typing import List, Tuple
+
 import numpy as np
 
-from timemachine.lib import potentials, custom_ops
-
-from typing import Tuple, List
-
-import dataclasses
-
-from timemachine.parallel.client import SerialClient
+from timemachine.lib import custom_ops, potentials
 from timemachine.md.states import CoordsVelBox
+from timemachine.parallel.client import SerialClient
 
 
 @dataclasses.dataclass

--- a/timemachine/fe/estimator_abfe.py
+++ b/timemachine/fe/estimator_abfe.py
@@ -1,18 +1,16 @@
-import pymbar
-from timemachine.fe import endpoint_correction, standard_state
-from collections import namedtuple
-
+import copy
 import dataclasses
 import time
-import copy
+from collections import namedtuple
+from typing import List, Tuple
+
 import numpy as np
+import pymbar
+
+from timemachine.fe import endpoint_correction, standard_state
+from timemachine.fe.utils import extract_delta_Us_from_U_knk, sanitize_energies
+from timemachine.lib import custom_ops, potentials
 from timemachine.md import minimizer
-
-from typing import Tuple, List
-
-from timemachine.fe.utils import sanitize_energies, extract_delta_Us_from_U_knk
-
-from timemachine.lib import potentials, custom_ops
 
 
 @dataclasses.dataclass

--- a/timemachine/fe/frames.py
+++ b/timemachine/fe/frames.py
@@ -1,5 +1,4 @@
-from typing import Any, List, Tuple, Generator
-
+from typing import Any, Generator, List, Tuple
 
 SimulationResult = Any
 FrameIterator = Generator[Tuple[int, SimulationResult], None, None]

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -1,17 +1,16 @@
 from typing import List
+
 from jax.config import config
 
 config.update("jax_enable_x64", True)
 
 import numpy as np
+from rdkit.Chem import MolToSmiles
 
 from timemachine.fe import topology
 from timemachine.fe.utils import get_romol_conf
-from timemachine.lib import LangevinIntegrator
-
 from timemachine.ff.handlers import openmm_deserializer
-
-from rdkit.Chem import MolToSmiles
+from timemachine.lib import LangevinIntegrator
 
 
 class BaseFreeEnergy:

--- a/timemachine/fe/free_energy_rabfe.py
+++ b/timemachine/fe/free_energy_rabfe.py
@@ -1,20 +1,19 @@
 import math
-from rdkit import Chem
+
 from jax.config import config
+from rdkit import Chem
 
 config.update("jax_enable_x64", True)
 
+from dataclasses import asdict, dataclass, fields
+
 import numpy as np
-
-from timemachine.fe import topology
-from timemachine.fe.utils import get_romol_conf
-
-from timemachine.ff.handlers import openmm_deserializer
-
 from scipy.optimize import linear_sum_assignment
 from scipy.spatial.distance import cdist
 
-from dataclasses import dataclass, fields, asdict
+from timemachine.fe import topology
+from timemachine.fe.utils import get_romol_conf
+from timemachine.ff.handlers import openmm_deserializer
 
 
 @dataclass(eq=False)

--- a/timemachine/fe/functional.py
+++ b/timemachine/fe/functional.py
@@ -2,7 +2,8 @@ from jax import config
 
 config.update("jax_enable_x64", True)
 
-from jax import custom_jvp, numpy as np
+from jax import custom_jvp
+from jax import numpy as np
 
 from timemachine.lib.potentials import SummedPotential
 

--- a/timemachine/fe/loss.py
+++ b/timemachine/fe/loss.py
@@ -1,13 +1,12 @@
-from jax import core
 import jax.numpy as jnp
-
-from jax.interpreters import ad
-
-from timemachine.fe import bar as tmbar, math_utils
 import pymbar
+from jax import core
+from jax.interpreters import ad
+from simtk import unit
 
 from timemachine.constants import kB
-from simtk import unit
+from timemachine.fe import bar as tmbar
+from timemachine.fe import math_utils
 
 
 # (ytz): the AD override trick is taken from:

--- a/timemachine/fe/model.py
+++ b/timemachine/fe/model.py
@@ -1,21 +1,19 @@
 import os
-import numpy as np
-import jax.numpy as jnp
 from pickle import dump, load
+from typing import List, Optional, Tuple
 
-from simtk import openmm
+import jax.numpy as jnp
+import numpy as np
 from rdkit import Chem
+from simtk import openmm
 
-from timemachine.md import minimizer
-from timemachine.lib import LangevinIntegrator, MonteCarloBarostat
-from timemachine.fe import free_energy, topology, estimator
+from timemachine.fe import estimator, free_energy, topology
 from timemachine.fe.model_utils import apply_hmr
 from timemachine.ff import Forcefield
+from timemachine.lib import LangevinIntegrator, MonteCarloBarostat
+from timemachine.md import minimizer
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
-
-
 from timemachine.parallel.client import AbstractClient, SerialClient
-from typing import Optional, List, Tuple
 
 
 class RBFEModel:

--- a/timemachine/fe/model_rabfe.py
+++ b/timemachine/fe/model_rabfe.py
@@ -1,20 +1,17 @@
 from abc import ABC
+from typing import Any, List, Optional, Tuple
 
 import numpy as np
-
-from simtk import openmm
 from rdkit import Chem
+from simtk import openmm
 
-from timemachine.lib import potentials, LangevinIntegrator, MonteCarloBarostat
 from timemachine import constants
+from timemachine.fe import estimator_abfe, free_energy_rabfe, model_utils, topology
 from timemachine.fe.frames import endpoint_frames_only
-from timemachine.fe import free_energy_rabfe, topology, estimator_abfe, model_utils
 from timemachine.ff import Forcefield
-
+from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, potentials
+from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.parallel.client import AbstractClient, _MockFuture
-from typing import Optional, Tuple, Any, List
-
-from timemachine.md.barostat.utils import get_group_indices, get_bond_list
 
 
 class AbsoluteModel(ABC):

--- a/timemachine/fe/model_utils.py
+++ b/timemachine/fe/model_utils.py
@@ -1,9 +1,8 @@
 import tempfile
 
 import numpy as np
-
-from simtk.openmm import app
 from rdkit import Chem
+from simtk.openmm import app
 
 
 def assert_mol_has_all_hydrogens(mol: Chem.Mol):

--- a/timemachine/fe/pdb_writer.py
+++ b/timemachine/fe/pdb_writer.py
@@ -1,8 +1,10 @@
-import numpy as np
-
 import tempfile
+
+import numpy as np
+from rdkit import Chem
 from simtk.openmm import app
 from simtk.openmm.app import PDBFile
+
 from timemachine.fe.topology import SingleTopology
 
 # class PDBWriter():
@@ -35,9 +37,6 @@ from timemachine.fe.topology import SingleTopology
 #     def close(self):
 #         PDBFile.writeFooter(self.topology, self.outfile)
 #         self.outfile.flush()
-
-
-from rdkit import Chem
 
 
 def convert_single_topology_mols(coords: np.ndarray, topo: SingleTopology) -> np.ndarray:

--- a/timemachine/fe/standard_state.py
+++ b/timemachine/fe/standard_state.py
@@ -1,7 +1,8 @@
+import functools
+
 import numpy as np
 import scipy.integrate
 
-import functools
 from timemachine.potentials import rmsd
 
 

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -1,12 +1,12 @@
 from abc import ABC
-from rdkit.Chem import rdmolops
 
-import numpy as np
 import jax
 import jax.numpy as jnp
+import numpy as np
+from rdkit.Chem import rdmolops
 
-from timemachine.lib import potentials
 from timemachine.ff.handlers import nonbonded
+from timemachine.lib import potentials
 
 _SCALE_12 = 1.0
 _SCALE_13 = 1.0

--- a/timemachine/fe/utils.py
+++ b/timemachine/fe/utils.py
@@ -1,9 +1,8 @@
-import numpy as np
-import simtk.unit
+from typing import List
 
 import networkx as nx
-
-from typing import List
+import numpy as np
+import simtk.unit
 
 
 def to_md_units(q):

--- a/timemachine/ff/__init__.py
+++ b/timemachine/ff/__init__.py
@@ -1,4 +1,4 @@
-from timemachine.ff.handlers import nonbonded, bonded
+from timemachine.ff.handlers import bonded, nonbonded
 
 
 class Forcefield:

--- a/timemachine/ff/compare_forcefields.py
+++ b/timemachine/ff/compare_forcefields.py
@@ -1,9 +1,7 @@
-import os
 import ast
+import os
 import sys
-
 from argparse import ArgumentParser
-
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="Compare Timemachine FFs")

--- a/timemachine/ff/handlers/__init__.py
+++ b/timemachine/ff/handlers/__init__.py
@@ -1,10 +1,10 @@
-from timemachine.ff.handlers.bonded import HarmonicBondHandler
-from timemachine.ff.handlers.bonded import HarmonicAngleHandler
-from timemachine.ff.handlers.bonded import ProperTorsionHandler
-from timemachine.ff.handlers.bonded import ImproperTorsionHandler
-
-from timemachine.ff.handlers.nonbonded import AM1CCCHandler
-from timemachine.ff.handlers.nonbonded import LennardJonesHandler
+from timemachine.ff.handlers.bonded import (
+    HarmonicAngleHandler,
+    HarmonicBondHandler,
+    ImproperTorsionHandler,
+    ProperTorsionHandler,
+)
+from timemachine.ff.handlers.nonbonded import AM1CCCHandler, LennardJonesHandler
 
 __all__ = [
     "HarmonicBondHandler",

--- a/timemachine/ff/handlers/bcc_aromaticity.py
+++ b/timemachine/ff/handlers/bcc_aromaticity.py
@@ -2,10 +2,11 @@
 # https://raw.githubusercontent.com/openforcefield/openff-recharge/5384eddb00e594c14c925b2d72956cfa3e51a874/openff/recharge/charges/bcc.py
 # (ytz): we should just vendor this later.
 
-import re
-from openeye import oechem
-from typing import Any, Dict, List, Callable, Type, TypeVar
 import logging
+import re
+from typing import Any, Callable, Dict, List, Type, TypeVar
+
+from openeye import oechem
 
 T = TypeVar("T")
 

--- a/timemachine/ff/handlers/bonded.py
+++ b/timemachine/ff/handlers/bonded.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-from timemachine.ff.handlers.utils import match_smirks, sort_tuple
 from timemachine.ff.handlers.serialize import SerializableMixIn
 from timemachine.ff.handlers.suffix import _SUFFIX
+from timemachine.ff.handlers.utils import match_smirks, sort_tuple
 
 
 def generate_vd_idxs(mol, smirks):

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -1,20 +1,19 @@
-import numpy as np
-import jax.numpy as jnp
-import networkx as nx
+import base64
 import pickle
 from collections import Counter
 
+import jax.numpy as jnp
+import networkx as nx
+import numpy as np
+from jax import ops
 from rdkit import Chem
-from timemachine.ff.handlers.utils import sort_tuple, match_smirks as rd_match_smirks
-from timemachine.ff.handlers.bcc_aromaticity import match_smirks as oe_match_smirks
-from timemachine.ff.handlers.serialize import SerializableMixIn
-from timemachine.ff.handlers.bcc_aromaticity import AromaticityModel
 
 from timemachine import constants
-
-from jax import ops
-
-import base64
+from timemachine.ff.handlers.bcc_aromaticity import AromaticityModel
+from timemachine.ff.handlers.bcc_aromaticity import match_smirks as oe_match_smirks
+from timemachine.ff.handlers.serialize import SerializableMixIn
+from timemachine.ff.handlers.utils import match_smirks as rd_match_smirks
+from timemachine.ff.handlers.utils import sort_tuple
 
 
 def convert_to_nx(mol):

--- a/timemachine/ff/handlers/openmm_deserializer.py
+++ b/timemachine/ff/handlers/openmm_deserializer.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from simtk import openmm as mm
 from simtk import unit
 

--- a/timemachine/ff/handlers/serialize.py
+++ b/timemachine/ff/handlers/serialize.py
@@ -1,5 +1,6 @@
 import io
 import pprint
+
 import numpy as np
 
 from timemachine.ff.handlers.suffix import _SUFFIX

--- a/timemachine/ff/smirnoff_converter.py
+++ b/timemachine/ff/smirnoff_converter.py
@@ -3,12 +3,13 @@ import ast
 import operator as op
 import pprint
 from argparse import ArgumentParser
-
-from simtk import unit
 from xml.dom import minidom
+
 import numpy as np
+from simtk import unit
 
 from timemachine.ff.charges import AM1CCC_CHARGES
+
 
 # (ytz): lol i think i wrote this originally
 def _ast_eval(node):

--- a/timemachine/integrator.py
+++ b/timemachine/integrator.py
@@ -1,8 +1,10 @@
-from timemachine.constants import BOLTZ
-import numpy as np
-import jax
-from jax import random as jrandom
 import time
+
+import jax
+import numpy as np
+from jax import random as jrandom
+
+from timemachine.constants import BOLTZ
 
 
 def langevin_coefficients(temperature, dt, friction, masses):

--- a/timemachine/lib/__init__.py
+++ b/timemachine/lib/__init__.py
@@ -1,5 +1,5 @@
-from timemachine.lib import custom_ops
 from timemachine.integrator import langevin_coefficients
+from timemachine.lib import custom_ops
 
 # safe to pickle!
 

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -1,7 +1,9 @@
-import numpy as np
-from timemachine.lib import custom_ops
 from typing import List
+
+import numpy as np
 from numpy.typing import NDArray
+
+from timemachine.lib import custom_ops
 
 # (ytz): classes in this class wrap custom_ops but have the added benefit
 # of being pickleable.

--- a/timemachine/md/barostat/moves.py
+++ b/timemachine/md/barostat/moves.py
@@ -1,16 +1,16 @@
-from jax import config, numpy as jnp
+from jax import config
+from jax import numpy as jnp
 from jax.ops import segment_sum
 
 config.update("jax_enable_x64", True)
 
+from typing import Iterable, List, Tuple
+
 import numpy as onp
 
-from timemachine.md.states import CoordsVelBox
-from timemachine.md.barostat.utils import compute_box_volume, compute_box_center
-
+from timemachine.md.barostat.utils import compute_box_center, compute_box_volume
 from timemachine.md.moves import MonteCarloMove
-
-from typing import List, Iterable, Tuple
+from timemachine.md.states import CoordsVelBox
 
 
 def compute_centroid(group):

--- a/timemachine/md/barostat/utils.py
+++ b/timemachine/md/barostat/utils.py
@@ -1,7 +1,9 @@
-import numpy as np
-import networkx as nx
-from scipy.spatial.distance import pdist
 from typing import List, Tuple
+
+import networkx as nx
+import numpy as np
+from scipy.spatial.distance import pdist
+
 from timemachine.lib.potentials import HarmonicBond
 
 

--- a/timemachine/md/builders.py
+++ b/timemachine/md/builders.py
@@ -1,6 +1,6 @@
 import numpy as np
 from simtk import unit
-from simtk.openmm import app, Vec3
+from simtk.openmm import Vec3, app
 
 
 def strip_units(coords):

--- a/timemachine/md/enhanced.py
+++ b/timemachine/md/enhanced.py
@@ -2,29 +2,25 @@
 
 # This file contains utility functions to generate samples in the gas-phase.
 
-import os
-import jax
-
 import multiprocessing
+import os
+
+import jax
 import numpy as np
-from scipy.special import logsumexp
 from jax.scipy.special import logsumexp as jlogsumexp
-
-from timemachine.fe import topology, free_energy
-from timemachine.fe.utils import get_romol_conf
-
-from timemachine.integrator import simulate
-from timemachine.potentials import bonded, nonbonded, rmsd
-from timemachine.constants import BOLTZ
-from timemachine import lib
-from timemachine.lib import custom_ops
-
-from timemachine.md.states import CoordsVelBox
-from timemachine.md import minimizer
-from timemachine.md import builders
-
 from rdkit import Chem
 from rdkit.Chem import rdMolDescriptors
+from scipy.special import logsumexp
+
+from timemachine import lib
+from timemachine.constants import BOLTZ
+from timemachine.fe import free_energy, topology
+from timemachine.fe.utils import get_romol_conf
+from timemachine.integrator import simulate
+from timemachine.lib import custom_ops
+from timemachine.md import builders, minimizer
+from timemachine.md.states import CoordsVelBox
+from timemachine.potentials import bonded, nonbonded, rmsd
 
 
 def identify_rotatable_bonds(mol):
@@ -449,7 +445,7 @@ def get_solvent_phase_system(mol, ff):
     return ubps, params, masses, coords, water_box
 
 
-from timemachine.md.barostat.utils import get_group_indices, get_bond_list
+from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 
 
 def equilibrate_solvent_phase(

--- a/timemachine/md/ensembles.py
+++ b/timemachine/md/ensembles.py
@@ -1,10 +1,11 @@
+from typing import Union
+
 import numpy as np
 from jax import numpy as jnp
 from simtk import unit
-from timemachine.md.barostat.utils import compute_box_volume
-from timemachine.constants import kB, ENERGY_UNIT, DISTANCE_UNIT
 
-from typing import Union
+from timemachine.constants import DISTANCE_UNIT, ENERGY_UNIT, kB
+from timemachine.md.barostat.utils import compute_box_volume
 
 non_unitted = Union[float, np.ndarray, jnp.ndarray]  # raw value without simtk unit attached
 

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -1,18 +1,13 @@
 import numpy as np
-
-from timemachine.fe import topology, model_utils
-from timemachine.fe.utils import get_romol_conf
-
-from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, custom_ops
-
-from timemachine.ff import Forcefield
-from timemachine.ff.handlers import openmm_deserializer
-
-from timemachine.md.barostat.utils import get_group_indices, get_bond_list
-
 from rdkit import Chem
 from simtk import openmm
 
+from timemachine.fe import model_utils, topology
+from timemachine.fe.utils import get_romol_conf
+from timemachine.ff import Forcefield
+from timemachine.ff.handlers import openmm_deserializer
+from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, custom_ops
+from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.md.fire import fire_descent
 
 

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -1,16 +1,17 @@
-from timemachine.md.states import CoordsVelBox
+from functools import partial
 from typing import List, Tuple
-import numpy as np
-from scipy.special import logsumexp
 
-from jax.scipy.special import logsumexp as jlogsumexp
-from timemachine.lib import custom_ops
-from timemachine.md.barostat.utils import get_group_indices, get_bond_list
-from timemachine import lib
 import jax
 import jax.numpy as jnp
 import jax.random as jrandom
-from functools import partial
+import numpy as np
+from jax.scipy.special import logsumexp as jlogsumexp
+from scipy.special import logsumexp
+
+from timemachine import lib
+from timemachine.lib import custom_ops
+from timemachine.md.barostat.utils import get_bond_list, get_group_indices
+from timemachine.md.states import CoordsVelBox
 
 
 class MonteCarloMove:

--- a/timemachine/md/thermostat/moves.py
+++ b/timemachine/md/thermostat/moves.py
@@ -1,7 +1,8 @@
+import numpy as np
+
+from timemachine.lib import custom_ops
 from timemachine.md.moves import MonteCarloMove
 from timemachine.md.states import CoordsVelBox
-from timemachine.lib import custom_ops
-import numpy as np
 
 
 class UnadjustedLangevinMove(MonteCarloMove):

--- a/timemachine/md/thermostat/utils.py
+++ b/timemachine/md/thermostat/utils.py
@@ -1,6 +1,7 @@
 import numpy as np
-from timemachine.constants import BOLTZ
 from simtk.unit import Quantity, kelvin
+
+from timemachine.constants import BOLTZ
 
 
 def sample_velocities(masses: Quantity, temperature: Quantity) -> np.array:

--- a/timemachine/md/utils.py
+++ b/timemachine/md/utils.py
@@ -1,14 +1,12 @@
+from typing import Dict, List, Tuple
+
 import numpy as np
 
-from typing import Tuple, Dict, List
-
-from timemachine.md.states import CoordsVelBox
-from timemachine.md.moves import CompoundMove
-
-from timemachine.md.thermostat.moves import UnadjustedLangevinMove
 from timemachine.md.barostat.moves import MonteCarloBarostat
-
 from timemachine.md.barostat.utils import compute_box_volume
+from timemachine.md.moves import CompoundMove
+from timemachine.md.states import CoordsVelBox
+from timemachine.md.thermostat.moves import UnadjustedLangevinMove
 
 
 def simulate_npt_traj(

--- a/timemachine/observables/rmsd.py
+++ b/timemachine/observables/rmsd.py
@@ -1,8 +1,8 @@
 # This is ported from Matt Harrigan's TF code:
 # https://github.com/mdtraj/tftraj/blob/master/tftraj/rmsd.py
 
-import jax.scipy
 import jax.numpy as np
+import jax.scipy
 
 
 @jax.jit

--- a/timemachine/optimize/precondition.py
+++ b/timemachine/optimize/precondition.py
@@ -1,11 +1,12 @@
 import numpy as np
+
 from timemachine.ff.handlers.bonded import (
     HarmonicAngleHandler,
     HarmonicBondHandler,
     ImproperTorsionHandler,
     ProperTorsionHandler,
 )
-from timemachine.ff.handlers.nonbonded import LennardJonesHandler, AM1CCCHandler
+from timemachine.ff.handlers.nonbonded import AM1CCCHandler, LennardJonesHandler
 
 default_learning_rates = {
     HarmonicBondHandler: np.zeros(2),  # k, length

--- a/timemachine/optimize/protocol.py
+++ b/timemachine/optimize/protocol.py
@@ -45,11 +45,13 @@ import jax
 
 jax.config.update("jax_enable_x64", True)
 
-from jax import jit, vmap, numpy as np
+from typing import Callable
+
+from jax import jit
+from jax import numpy as np
+from jax import vmap
 from jax.scipy.special import logsumexp
 from scipy.optimize import bisect
-
-from typing import Callable
 
 Float = float
 Array = np.array

--- a/timemachine/optimize/step.py
+++ b/timemachine/optimize/step.py
@@ -1,8 +1,9 @@
+from typing import Optional, Union
+
 import numpy as np
 from jax import numpy as jnp
-from timemachine.ff import nonbonded
 
-from typing import Union, Optional
+from timemachine.ff import nonbonded
 
 try:
     from scipy.optimize import root_scalar

--- a/timemachine/optimize/utils.py
+++ b/timemachine/optimize/utils.py
@@ -1,6 +1,8 @@
-from jax import tree_util, numpy as np
+from typing import Callable, Tuple
+
 import numpy as onp
-from typing import Tuple, Callable
+from jax import numpy as np
+from jax import tree_util
 
 
 def get_shape(x):

--- a/timemachine/parallel/client.py
+++ b/timemachine/parallel/client.py
@@ -1,17 +1,13 @@
-from typing import List, Optional, Any, Union
-
 import multiprocessing
-
-import pickle
-import grpc
-
-from timemachine.parallel.grpc import service_pb2_grpc, service_pb2
-from timemachine.parallel.utils import get_gpu_count
-from timemachine.parallel.constants import DEFAULT_GRPC_OPTIONS
-
-from concurrent import futures
-
 import os
+import pickle
+from concurrent import futures
+from typing import Any, List, Optional, Union
+
+import grpc
+from timemachine.parallel.constants import DEFAULT_GRPC_OPTIONS
+from timemachine.parallel.grpc import service_pb2, service_pb2_grpc
+from timemachine.parallel.utils import get_gpu_count
 
 # (ytz): The classes in this file are designed to help provide a consistent API between
 # multiprocessing (typically for local cluster use) and gRPC (distributed and multi-node).

--- a/timemachine/parallel/utils.py
+++ b/timemachine/parallel/utils.py
@@ -1,4 +1,5 @@
 from subprocess import check_output
+
 from timemachine.parallel.grpc.service_pb2 import StatusResponse
 
 

--- a/timemachine/parallel/worker.py
+++ b/timemachine/parallel/worker.py
@@ -1,17 +1,14 @@
 import argparse
-
-from datetime import datetime
-import os
-
 import logging
+import os
 import pickle
 from concurrent import futures
-
-from timemachine.parallel.grpc import service_pb2, service_pb2_grpc
-from timemachine.parallel.utils import get_worker_status
-from timemachine.parallel.constants import DEFAULT_GRPC_OPTIONS
+from datetime import datetime
 
 import grpc
+from timemachine.parallel.constants import DEFAULT_GRPC_OPTIONS
+from timemachine.parallel.grpc import service_pb2, service_pb2_grpc
+from timemachine.parallel.utils import get_worker_status
 
 
 class Worker(service_pb2_grpc.WorkerServicer):

--- a/timemachine/parser.py
+++ b/timemachine/parser.py
@@ -1,6 +1,6 @@
-from typing import Optional, Dict, Any, List
 from dataclasses import dataclass, fields
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 from yaml import safe_load
 

--- a/timemachine/potentials/evp.py
+++ b/timemachine/potentials/evp.py
@@ -1,7 +1,6 @@
-import numpy as onp
 import jax
 import jax.numpy as np
-
+import numpy as onp
 from jax.config import config
 
 config.update("jax_enable_x64", True)

--- a/timemachine/potentials/gbsa.py
+++ b/timemachine/potentials/gbsa.py
@@ -2,7 +2,8 @@
 # https://github.com/openforcefield/bayes-implicit-solvent/blob/propertycalculator/bayes_implicit_solvent/gb_models/jax_gb_models.py
 
 import jax.numpy as np
-from timemachine.potentials.jax_utils import distance, convert_to_4d
+
+from timemachine.potentials.jax_utils import convert_to_4d, distance
 
 
 def step(x):

--- a/timemachine/potentials/jax_utils.py
+++ b/timemachine/potentials/jax_utils.py
@@ -1,9 +1,9 @@
+from typing import Tuple
+
+import jax
 import jax.numpy as np
 import numpy as onp
-import jax
 from jax import vmap
-
-from typing import Tuple
 
 Array = onp.array
 

--- a/timemachine/potentials/nonbonded.py
+++ b/timemachine/potentials/nonbonded.py
@@ -1,7 +1,8 @@
 import jax.numpy as np
+from jax.ops import index, index_update
 from jax.scipy.special import erfc
-from jax.ops import index_update, index
-from timemachine.potentials.jax_utils import distance_on_pairs, distance, convert_to_4d, delta_r
+
+from timemachine.potentials.jax_utils import convert_to_4d, delta_r, distance, distance_on_pairs
 
 
 def switch_fn(dij, cutoff):

--- a/timemachine/potentials/pmi.py
+++ b/timemachine/potentials/pmi.py
@@ -2,8 +2,8 @@
 # ported from Numerical diagonalization of 3x3 matrcies (sic), v1.1
 # https://www.mpi-hd.mpg.de/personalhomes/globes/3x3/index.html
 import jax
-import numpy as onp
 import jax.numpy as np
+import numpy as onp
 
 DBL_EPSILON = 2.2204460492503131e-16
 

--- a/timemachine/testsystems/relative.py
+++ b/timemachine/testsystems/relative.py
@@ -1,5 +1,7 @@
 # construct a relative transformation
 
+from pathlib import Path
+
 import numpy as np
 from rdkit import Chem
 
@@ -7,8 +9,6 @@ import timemachine
 from timemachine.fe import free_energy, topology
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
-
-from pathlib import Path
 
 root = Path(timemachine.__file__).parent.parent
 

--- a/timemachine/training/dataset.py
+++ b/timemachine/training/dataset.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Tuple, Any, List
+from typing import Any, List, Tuple
 
 import numpy as np
 


### PR DESCRIPTION
Experiment with adding [`isort`](https://github.com/PyCQA/isort) to the pre-commit configuration.

`isort` automatically tidies imports, including
- removing duplicate imports
- categorizing in sections by stdlib, 3rd-party, 1st-party (configurable)
- sorting alphabetically

In this PR `isort` is configured with pre-commit, so it could be enabled as a git hook and would enforced in CI. There are also [editor plugins](https://github.com/pycqa/isort/wiki/isort-Plugins) available to sort imports on file save (looks like VS Code, Sublime, and Emacs are among the supported editors).

This PR configures `honor_noqa = true`, so tidying can be disabled with a `# noqa` comment on the import line