### PR TITLE
Include isort, flake8 in dev extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         "scipy",
     ],
     extras_require={
-        "dev": ["black==21.10b0", "pre-commit", "grpcio==1.43.0"],
+        "dev": ["black==21.10b0", "isort==5.10.1", "pre-commit", "grpcio==1.43.0"],
         "test": ["pytest", "pytest-cov"],
     },
     # package_data={

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         "scipy",
     ],
     extras_require={
-        "dev": ["black==21.10b0", "isort==5.10.1", "pre-commit", "grpcio==1.43.0"],
+        "dev": ["black==21.10b0", "isort==5.10.1", "flake8==4.0.1", "pre-commit", "grpcio==1.43.0"],
         "test": ["pytest", "pytest-cov"],
     },
     # package_data={


### PR DESCRIPTION
Small quality of life improvement: includes `isort==5.10.1` and `flake8==4.0.1` (the same versions used by pre-commit) in dev extras so that the proper versions can be installed locally as part of

```
pip install -e .[dev]
```

(this isn't necessary for the pre-commit hook, but is useful to use `isort` or `flake8` independently, e.g. for editor integration)