### PR TITLE
Handle case of no SMIRKS matches in {Proper/Improper}TorsionHandler

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -175,6 +175,17 @@ def test_proper_torsion():
     mask = np.argwhere(torsion_params > 90)
     assert np.all(ff_adjoints[mask] == 0.0)
 
+    # assert expected shape when no matches are found
+    null_smirks = ["[#1:1]~[#1:2]~[#1:3]~[#1:4]"]  # should never match anything
+    null_params = np.zeros((len(null_smirks), 3))
+    null_counts = np.ones(len(null_smirks), dtype=int)
+
+    assigned_params, proper_idxs = bonded.ProperTorsionHandler.static_parameterize(
+        null_params, null_smirks, null_counts, mol
+    )
+    assert assigned_params.shape == (0, 3)
+    assert proper_idxs.shape == (0, 4)
+
 
 def test_improper_torsion():
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -220,6 +220,14 @@ def test_improper_torsion():
     mask = np.argwhere(torsion_params > 90)
     assert np.all(ff_adjoints[mask] == 0.0)
 
+    # assert expected shape when no matches are found
+    null_smirks = ["[#1:1]~[#1:2](~[#1:3])~[#1:4]"]  # should never match anything
+    null_params = np.zeros((len(null_smirks), 3))
+
+    assigned_params, improper_idxs = bonded.ImproperTorsionHandler.static_parameterize(null_params, null_smirks, mol)
+    assert assigned_params.shape == (0, 3)
+    assert improper_idxs.shape == (0, 4)
+
 
 def test_exclusions():
 

--- a/timemachine/ff/handlers/bonded.py
+++ b/timemachine/ff/handlers/bonded.py
@@ -135,7 +135,15 @@ class ProperTorsionHandler:
 
         scatter_idxs = np.array(scatter_idxs)
 
-        return params[scatter_idxs], np.repeat(torsion_idxs, repeats, axis=0).astype(np.int32)
+        # if no matches found, return arrays that can still be concatenated as expected
+        if len(param_idxs) > 0:
+            assigned_params = params[param_idxs]
+            proper_idxs = np.repeat(torsion_idxs, repeats, axis=0).astype(np.int32)
+        else:
+            assigned_params = params[[False] * len(params)]  # empty slice with same dtype, other dimensions
+            proper_idxs = np.zeros((0, 4), dtype=np.int32)
+
+        return assigned_params, proper_idxs
 
     def serialize(self):
         list_params = []

--- a/timemachine/ff/handlers/bonded.py
+++ b/timemachine/ff/handlers/bonded.py
@@ -137,7 +137,7 @@ class ProperTorsionHandler:
 
         # if no matches found, return arrays that can still be concatenated as expected
         if len(param_idxs) > 0:
-            assigned_params = params[param_idxs]
+            assigned_params = params[scatter_idxs]
             proper_idxs = np.repeat(torsion_idxs, repeats, axis=0).astype(np.int32)
         else:
             assigned_params = params[[False] * len(params)]  # empty slice with same dtype, other dimensions

--- a/timemachine/ff/handlers/bonded.py
+++ b/timemachine/ff/handlers/bonded.py
@@ -140,7 +140,7 @@ class ProperTorsionHandler:
             assigned_params = params[scatter_idxs]
             proper_idxs = np.repeat(torsion_idxs, repeats, axis=0).astype(np.int32)
         else:
-            assigned_params = params[[False] * len(params)]  # empty slice with same dtype, other dimensions
+            assigned_params = params[:0]  # empty slice with same dtype, other dimensions
             proper_idxs = np.zeros((0, 4), dtype=np.int32)
 
         return assigned_params, proper_idxs
@@ -222,7 +222,7 @@ class ImproperTorsionHandler(SerializableMixIn):
             assigned_params = params[param_idxs]
             improper_idxs = np.array(improper_idxs, dtype=np.int32)
         else:
-            assigned_params = params[[False] * len(params)]  # empty slice with same dtype, other dimensions
+            assigned_params = params[:0]  # empty slice with same dtype, other dimensions
             improper_idxs = np.zeros((0, 4), dtype=np.int32)
 
         return assigned_params, improper_idxs

--- a/timemachine/ff/handlers/bonded.py
+++ b/timemachine/ff/handlers/bonded.py
@@ -26,10 +26,6 @@ def generate_vd_idxs(mol, smirks):
     return bond_idxs, param_idxs
 
 
-def parameterize_ligand(params, param_idxs):
-    return params[param_idxs]
-
-
 # its trivial to re-use this for everything except the ImproperTorsions
 class ReversibleBondHandler(SerializableMixIn):
     def __init__(self, smirks, params, props):

--- a/timemachine/ff/handlers/bonded.py
+++ b/timemachine/ff/handlers/bonded.py
@@ -213,4 +213,12 @@ class ImproperTorsionHandler(SerializableMixIn):
 
         param_idxs = np.array(param_idxs)
 
-        return params[param_idxs], np.array(improper_idxs, dtype=np.int32)
+        # if no matches found, return arrays that can still be concatenated as expected
+        if len(param_idxs) > 0:
+            assigned_params = params[param_idxs]
+            improper_idxs = np.array(improper_idxs, dtype=np.int32)
+        else:
+            assigned_params = params[[False] * len(params)]  # empty slice with same dtype, other dimensions
+            improper_idxs = np.zeros((0, 4), dtype=np.int32)
+
+        return assigned_params, improper_idxs

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -155,10 +155,6 @@ def generate_nonbonded_idxs(mol, smirks):
     return param_idxs
 
 
-def parameterize_ligand(params, param_idxs):
-    return params[param_idxs]
-
-
 def compute_or_load_am1_charges(mol):
     """Unless already cached in mol's "AM1Cache" property, use OpenEye to compute AM1 partial charges."""
 


### PR DESCRIPTION
Resolves https://github.com/proteneer/timemachine/issues/623 , and applies the same patch for proper torsions while we're at it