### PR TITLE
Fix np.testing.assert_almost_equal usage

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -432,6 +432,7 @@ class GradientTest(unittest.TestCase):
         ref_du_dx, ref_du_dp, ref_du_dl = grad_fn(x, params, box, lamb)
 
         for combo in itertools.product([False, True], repeat=4):
+
             (compute_du_dx, compute_du_dp, compute_du_dl, compute_u) = combo
 
             # do each computation twice to check determinism

--- a/tests/common.py
+++ b/tests/common.py
@@ -443,9 +443,9 @@ class GradientTest(unittest.TestCase):
             if compute_du_dx:
                 self.assert_equal_vectors(np.array(ref_du_dx), np.array(test_du_dx), rtol)
             if compute_du_dl:
-                np.testing.assert_almost_equal(ref_du_dl, test_du_dl, rtol)
+                np.testing.assert_allclose(ref_du_dl, test_du_dl, rtol=rtol)
             if compute_du_dp:
-                np.testing.assert_almost_equal(ref_du_dp, test_du_dp, rtol)
+                np.testing.assert_allclose(ref_du_dp, test_du_dp, rtol=rtol)
 
             test_du_dx_2, test_du_dp_2, test_du_dl_2, test_u_2 = test_impl.execute_selective(
                 x, params, box, lamb, compute_du_dx, compute_du_dp, compute_du_dl, compute_u

--- a/tests/common.py
+++ b/tests/common.py
@@ -445,7 +445,7 @@ class GradientTest(unittest.TestCase):
             if compute_du_dl:
                 np.testing.assert_allclose(ref_du_dl, test_du_dl, rtol=rtol)
             if compute_du_dp:
-                np.testing.assert_allclose(ref_du_dp, test_du_dp, rtol=rtol)
+                np.testing.assert_allclose(ref_du_dp, test_du_dp, rtol=rtol, atol=atol)
 
             test_du_dx_2, test_du_dp_2, test_du_dl_2, test_u_2 = test_impl.execute_selective(
                 x, params, box, lamb, compute_du_dx, compute_du_dp, compute_du_dl, compute_u

--- a/tests/test_bonded.py
+++ b/tests/test_bonded.py
@@ -152,7 +152,7 @@ class TestBonded(GradientTest):
         box = np.eye(3) * 100
 
         # specific to harmonic bond force
-        relative_tolerance_at_precision = {np.float32: 2e-5, np.float64: 1e-9}
+        relative_tolerance_at_precision = {np.float64: 1e-7, np.float32: 2e-5}
 
         for precision, rtol in relative_tolerance_at_precision.items():
             test_potential = potentials.HarmonicBond(bond_idxs)

--- a/tests/test_nonbonded.py
+++ b/tests/test_nonbonded.py
@@ -184,9 +184,10 @@ class TestNonbondedDHFR(GradientTest):
         """
         Test against the reference jax platform for correctness.
         """
-
         # we can't go bigger than this due to memory limitations in the the reference platform.
         for N in [33, 65, 231, 1050, 4080]:
+
+            np.random.seed(2022)
 
             test_conf = self.host_conf[:N]
 
@@ -218,7 +219,7 @@ class TestNonbondedDHFR(GradientTest):
                 self.cutoff,
             )
 
-            for precision, rtol in [(np.float64, 1e-8), (np.float32, 1e-4)]:
+            for precision, rtol, atol in [(np.float64, 1e-8, 1e-8), (np.float32, 1e-4, 5e-4)]:
 
                 self.compare_forces(
                     test_conf,
@@ -227,7 +228,8 @@ class TestNonbondedDHFR(GradientTest):
                     self.lamb,
                     ref_nonbonded_fn,
                     test_nonbonded_fn,
-                    rtol,
+                    rtol=rtol,
+                    atol=atol,
                     precision=precision,
                 )
 

--- a/tests/test_nonbonded.py
+++ b/tests/test_nonbonded.py
@@ -308,7 +308,7 @@ class TestNonbondedWater(GradientTest):
         # the rebuild is triggered as long as the box *changes*.
         for test_box in [big_box, box]:
 
-            for precision, rtol in [(np.float64, 1e-8), (np.float32, 1e-4)]:
+            for precision, rtol, atol in [(np.float64, 1e-8, 1e-10), (np.float32, 1e-4, 3e-5)]:
 
                 self.compare_forces(
                     host_conf,
@@ -317,7 +317,8 @@ class TestNonbondedWater(GradientTest):
                     lamb,
                     ref_nonbonded_fn,
                     test_nonbonded_fn,
-                    rtol,
+                    rtol=rtol,
+                    atol=atol,
                     precision=precision,
                 )
 
@@ -459,7 +460,7 @@ class TestNonbonded(GradientTest):
             lambda_plane_idxs = np.random.randint(low=-2, high=2, size=N, dtype=np.int32)
             lambda_offset_idxs = np.random.randint(low=-2, high=2, size=N, dtype=np.int32)
 
-            for precision, rtol in [(np.float64, 1e-8), (np.float32, 1e-4)]:
+            for precision, rtol, atol in [(np.float64, 1e-8, 3e-11), (np.float32, 1e-4, 3e-5)]:
 
                 for cutoff in [1.0]:
                     # E = 0 # DEBUG!
@@ -472,7 +473,15 @@ class TestNonbonded(GradientTest):
                         print("lambda", lamb, "cutoff", cutoff, "precision", precision, "xshape", coords.shape)
 
                         self.compare_forces(
-                            coords, charge_params, box, lamb, ref_potential, test_potential, rtol, precision=precision
+                            coords,
+                            charge_params,
+                            box,
+                            lamb,
+                            ref_potential,
+                            test_potential,
+                            rtol=rtol,
+                            atol=atol,
+                            precision=precision,
                         )
 
     def test_nonbonded_with_box_smaller_than_cutoff(self):

--- a/tests/test_parameter_interpolation.py
+++ b/tests/test_parameter_interpolation.py
@@ -42,7 +42,7 @@ class TestInterpolatedPotential(GradientTest):
         lambda_offset_idxs = np.random.randint(low=0, high=2, size=N, dtype=np.int32)
 
         for lamb in [0.0, 0.2, 1.0]:
-            for precision, rtol in [(np.float64, 1e-8), (np.float32, 1e-4)]:
+            for precision, rtol, atol in [(np.float64, 1e-8, 3e-11), (np.float32, 1e-4, 3e-6)]:
 
                 # E = 0 # DEBUG!
                 qlj_src, ref_potential, test_potential = prepare_water_system(
@@ -68,7 +68,8 @@ class TestInterpolatedPotential(GradientTest):
                     lamb,
                     ref_interpolated_potential,
                     test_interpolated_potential,
-                    rtol,
+                    rtol=rtol,
+                    atol=atol,
                     precision=precision,
                 )
 
@@ -128,7 +129,7 @@ class TestInterpolatedPotential(GradientTest):
             qlj = interpolate_params(lamb, qlj_src, qlj_dst)
             return ref_potential(x, qlj, box, lamb)
 
-        for precision, rtol in [(np.float64, 1e-8), (np.float32, 1e-4)]:
+        for precision, rtol, atol in [(np.float64, 1e-8, 1e-11), (np.float32, 1e-4, 1e-6)]:
 
             for lamb in [0.0, 0.2, 0.6, 0.7, 0.8, 1.0]:
 
@@ -147,5 +148,13 @@ class TestInterpolatedPotential(GradientTest):
                 )
 
                 self.compare_forces(
-                    coords, qlj, box, lamb, u_reference, test_interpolated_potential, rtol, precision=precision
+                    coords,
+                    qlj,
+                    box,
+                    lamb,
+                    u_reference,
+                    test_interpolated_potential,
+                    rtol=rtol,
+                    atol=atol,
+                    precision=precision,
                 )


### PR DESCRIPTION
[np.testing.assert_almost_equal](https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_almost_equal.html) expects a number of decimals to check as its 3rd argument, but we instead pass `rtol` in tests for `du_dl` and `du_dp` in `GradientTest.compare_forces`.

It appears that `decimal` between 0 and 1 is interpreted as 0 rather than raising an error. For example, the following succeeds:
```python
np.testing.assert_almost_equal(0.1, 0.2, 1e-4)
```

#### To do
- [x] Investigate cases where we needed to modify tests to pass