### PR TITLE
Fix importlib resources usage

### DIFF
--- a/timemachine/datasets/utils.py
+++ b/timemachine/datasets/utils.py
@@ -5,7 +5,6 @@ from rdkit import Chem
 
 
 def fetch_freesolv() -> List[Chem.Mol]:
-    with resources.path("timemachine", "datasets") as datasets_path:
-        freesolv_path = str(datasets_path / "freesolv" / "freesolv.sdf")
-        supplier = Chem.SDMolSupplier(freesolv_path, removeHs=False)
-        return [mol for mol in supplier]
+    freesolv_path = resources.files(__package__) / "freesolv" / "freesolv.sdf"
+    supplier = Chem.SDMolSupplier(str(freesolv_path), removeHs=False)
+    return [mol for mol in supplier]


### PR DESCRIPTION
`importlib.resources.path` is not intended to work with directories; this works coincidentally in Python 3.7 but will break in future versions. See https://bugs.python.org/issue44162