### PR TITLE
Factorizable Dummy Bonds

### DIFF
--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -104,8 +104,8 @@ def test_identify_dummy_groups():
 
     {D0, D1, D2}
 
-        D0-D1  D2
-       /       /  -> 1 dummy-anchor bond:
+        D0-D1--D2
+       /          -> 1 dummy-anchor bond:
       0-------1
 
     """

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,0 +1,358 @@
+import numpy as np
+from rdkit import Chem
+
+from timemachine.fe import dummy, dummy_draw
+from timemachine.fe.dummy import (
+    enumerate_anchor_groups,
+    enumerate_dummy_ixns,
+    flag_bonds,
+    identify_anchor_groups,
+    identify_dummy_groups,
+    identify_root_anchors,
+)
+from timemachine.ff import Forcefield
+from timemachine.ff.handlers.deserialize import deserialize_handlers
+
+
+def test_identify_root_anchors():
+    mol = Chem.MolFromSmiles("C1CCC1N")
+    core = [0, 1, 2, 3]
+    anchors = identify_root_anchors(mol, core, dummy_atom=4)
+    assert set(anchors) == set([3])
+
+    mol = Chem.MolFromSmiles("C1CC2NC2C1")
+    core = [0, 1, 2, 4, 5]
+    anchors = identify_root_anchors(mol, core, dummy_atom=3)
+    assert set(anchors) == set([2, 4])
+
+    mol = Chem.MolFromSmiles("C1OCC11CCCCC1")
+    core = [3, 4, 5, 6, 7, 8]
+    anchors = identify_root_anchors(mol, core, dummy_atom=0)
+    assert set(anchors) == set([3])
+    anchors = identify_root_anchors(mol, core, dummy_atom=1)
+    assert set(anchors) == set([3])
+    anchors = identify_root_anchors(mol, core, dummy_atom=2)
+    assert set(anchors) == set([3])
+
+    mol = Chem.MolFromSmiles("C1CC1.C1CCCCC1")
+    core = [3, 4, 5, 6, 7, 8]
+    anchors = identify_root_anchors(mol, core, dummy_atom=0)
+    assert set(anchors) == set()
+    anchors = identify_root_anchors(mol, core, dummy_atom=1)
+    assert set(anchors) == set()
+    anchors = identify_root_anchors(mol, core, dummy_atom=2)
+    assert set(anchors) == set()
+
+    mol = Chem.MolFromSmiles("C1CC2NC2C1")
+    core = [0, 1, 2, 5]
+    anchors = identify_root_anchors(mol, core, dummy_atom=3)
+    assert set(anchors) == set([2, 5])
+    anchors = identify_root_anchors(mol, core, dummy_atom=4)
+    assert set(anchors) == set([2, 5])
+
+    # cyclohexane with a nitrogen inside
+    mol = Chem.MolFromSmiles("C1C2CC3CC1N23")
+    core = [0, 1, 2, 3, 4, 5]
+    anchors = identify_root_anchors(mol, core, dummy_atom=6)
+    assert set(anchors) == set([1, 3, 5])
+
+
+def assert_set_equality(a_sets, b_sets):
+    frozen_a = [frozenset(a) for a in a_sets]
+    frozen_b = [frozenset(b) for b in b_sets]
+    assert frozenset(frozen_a) == frozenset(frozen_b)
+
+
+def test_identify_dummy_groups():
+
+    mol = Chem.MolFromSmiles("FC1CC1(F)N")
+    core = [1, 2, 3]
+    dg = identify_dummy_groups(mol, core)
+    assert_set_equality(dg, [{0}, {4, 5}])
+
+    mol = Chem.MolFromSmiles("FC1CC1(F)NN")
+    core = [1, 2, 3]
+    dg = identify_dummy_groups(mol, core)
+    assert_set_equality(dg, [{0}, {4, 5, 6}])
+
+    mol = Chem.MolFromSmiles("C1CC11OO1")
+    core = [0, 1, 2]
+    dg = identify_dummy_groups(mol, core)
+    assert_set_equality(dg, [{3, 4}])
+
+    mol = Chem.MolFromSmiles("C1CC2OOC12")
+    core = [0, 1, 2, 5]
+    dg = identify_dummy_groups(mol, core)
+    assert_set_equality(dg, [{3}, {4}])
+
+
+def assert_anchor_group_equality(a_groups, b_groups):
+    frozen_a = [tuple(a) for a in a_groups]
+    frozen_b = [tuple(b) for b in b_groups]
+    assert frozenset(frozen_a) == frozenset(frozen_b)
+
+
+def test_identify_anchor_groups():
+
+    mol = Chem.MolFromSmiles("C1CC1F")
+    core = [0, 1, 2]
+    groups_of_1, groups_of_2, groups_of_3 = identify_anchor_groups(mol, core, 0)
+    assert_anchor_group_equality(groups_of_1, [[0]])
+    assert_anchor_group_equality(groups_of_2, [[0, 1], [0, 2]])
+    assert_anchor_group_equality(groups_of_3, [[0, 1, 2], [0, 2, 1]])
+
+    groups_of_1, groups_of_2, groups_of_3 = identify_anchor_groups(mol, core, 1)
+    assert_anchor_group_equality(groups_of_1, [[1]])
+    assert_anchor_group_equality(groups_of_2, [[1, 0], [1, 2]])
+    assert_anchor_group_equality(groups_of_3, [[1, 0, 2], [1, 2, 0]])
+
+    groups_of_1, groups_of_2, groups_of_3 = identify_anchor_groups(mol, core, 2)
+    assert_anchor_group_equality(groups_of_1, [[2]])
+    assert_anchor_group_equality(groups_of_2, [[2, 1], [2, 0]])
+    assert_anchor_group_equality(groups_of_3, [[2, 1, 0], [2, 0, 1]])
+
+    mol = Chem.MolFromSmiles("NCCF")
+    core = [1, 2]
+    groups_of_1, groups_of_2, groups_of_3 = identify_anchor_groups(mol, core, 1)
+    assert_anchor_group_equality(groups_of_1, [[1]])
+    assert_anchor_group_equality(groups_of_2, [[1, 2]])
+    assert_anchor_group_equality(groups_of_3, [])
+
+    mol = Chem.MolFromSmiles("C(C)(C)(C)C")
+    core = [0]
+    groups_of_1, groups_of_2, groups_of_3 = identify_anchor_groups(mol, core, 0)
+    assert_anchor_group_equality(groups_of_1, [[0]])
+    assert_anchor_group_equality(groups_of_2, [])
+    assert_anchor_group_equality(groups_of_3, [])
+
+    mol = Chem.MolFromSmiles("C(C)(F)CC")
+    core = [1, 0, 4, 3]
+    groups_of_1, groups_of_2, groups_of_3 = identify_anchor_groups(mol, core, 0)
+    assert_anchor_group_equality(groups_of_1, [[0]])
+    assert_anchor_group_equality(groups_of_2, [[0, 1], [0, 3]])
+    assert_anchor_group_equality(groups_of_3, [[0, 3, 4]])
+
+
+def test_enumerate_anchor_groups():
+    mol = Chem.MolFromSmiles("C1CC2OOC12")
+    core = [0, 1, 2, 5]
+    groups_of_1, groups_of_2, groups_of_3 = enumerate_anchor_groups(mol, core, [3, 4])
+    assert_anchor_group_equality(groups_of_1, [[2], [5]])
+    assert_anchor_group_equality(groups_of_2, [[2, 1], [2, 5], [5, 0], [5, 2]])
+    assert_anchor_group_equality(groups_of_3, [[2, 1, 0], [2, 5, 0], [5, 0, 1], [5, 2, 1]])
+
+    # aspirin
+    mol = Chem.MolFromSmiles("CC(=O)OC1=CC=CC=C1C(=O)O")
+    core = [3, 4, 5, 6, 7, 8, 9, 10]
+    groups_of_1, groups_of_2, groups_of_3 = enumerate_anchor_groups(mol, core, [0, 1, 2, 11, 12])
+    assert_anchor_group_equality(groups_of_1, [[3], [10]])
+    assert_anchor_group_equality(groups_of_2, [[3, 4], [10, 9]])
+    assert_anchor_group_equality(groups_of_3, [[3, 4, 5], [3, 4, 9], [10, 9, 8], [10, 9, 4]])
+    groups_of_1, groups_of_2, groups_of_3 = enumerate_anchor_groups(mol, core, [0, 1, 2])
+    assert_anchor_group_equality(groups_of_1, [[3]])
+    assert_anchor_group_equality(groups_of_2, [[3, 4]])
+    assert_anchor_group_equality(groups_of_3, [[3, 4, 5], [3, 4, 9]])
+    groups_of_1, groups_of_2, groups_of_3 = enumerate_anchor_groups(mol, core, [11, 12])
+    assert_anchor_group_equality(groups_of_1, [[10]])
+    assert_anchor_group_equality(groups_of_2, [[10, 9]])
+    assert_anchor_group_equality(groups_of_3, [[10, 9, 8], [10, 9, 4]])
+
+
+def test_enumerate_allowed_dummy_ixns_3_anchors():
+    dummy_group = {0, 1, 5, 8}
+    anchor_group = [2, 3, 4]
+
+    allowed_ixns = enumerate_dummy_ixns(dummy_group, anchor_group)
+
+    for ixn in allowed_ixns:
+        assert len(ixn) == len(set(ixn))
+
+    assert (0, 1, 2, 3) in allowed_ixns
+    assert (0, 1, 2) in allowed_ixns
+    assert (1, 2) in allowed_ixns
+    assert (0, 2, 3) in allowed_ixns
+    assert (1, 0, 2, 3) in allowed_ixns
+    assert (3, 2, 1, 5) in allowed_ixns
+    assert (1, 5, 2) in allowed_ixns
+    assert (2, 0, 5) in allowed_ixns
+    assert (1, 5, 8) in allowed_ixns
+    assert (1, 5, 8) in allowed_ixns
+    assert (0, 8, 5, 1) in allowed_ixns
+    assert (5, 1, 0, 8) in allowed_ixns
+    assert (3, 2, 8, 5) in allowed_ixns
+    assert (1, 8, 2, 3) in allowed_ixns
+
+    assert (0, 1, 3) not in allowed_ixns
+    assert (0, 1, 4) not in allowed_ixns
+    assert (0, 2, 4) not in allowed_ixns
+    assert (0, 3) not in allowed_ixns
+    assert (0, 4) not in allowed_ixns
+    assert (5, 3, 4) not in allowed_ixns
+    assert (1, 5, 4) not in allowed_ixns
+    assert (5, 8, 2, 4) not in allowed_ixns
+    assert (1, 8, 3, 4) not in allowed_ixns
+
+
+def test_enumerate_allowed_dummy_ixns_2_anchors():
+    dummy_group = {0, 1}
+    anchor_group = [4, 5]
+    allowed_ixns = enumerate_dummy_ixns(dummy_group, anchor_group)
+
+    for ixn in allowed_ixns:
+        assert len(ixn) == len(set(ixn))
+    assert len(allowed_ixns) == 16
+
+    assert (0, 5) not in allowed_ixns
+    assert (1, 5) not in allowed_ixns
+
+    # 3 ixns
+    assert (0, 1) in allowed_ixns
+    assert (0, 4) in allowed_ixns
+    assert (1, 4) in allowed_ixns
+
+    # 7 ixns
+    assert (0, 1, 4) in allowed_ixns
+    assert (1, 0, 4) in allowed_ixns
+    assert (0, 4, 1) in allowed_ixns
+    assert (0, 4, 5) in allowed_ixns
+    assert (1, 4, 5) in allowed_ixns
+    assert (0, 5, 4) in allowed_ixns
+    assert (1, 5, 4) in allowed_ixns
+
+    # 6 ixns
+    assert (0, 1, 4, 5) in allowed_ixns
+    assert (1, 0, 4, 5) in allowed_ixns
+    assert (1, 0, 5, 4) in allowed_ixns
+    assert (0, 4, 5, 1) in allowed_ixns
+    assert (0, 5, 4, 1) in allowed_ixns
+    assert (0, 1, 5, 4) in allowed_ixns
+
+
+def test_enumerate_allowed_dummy_ixns_1_anchor():
+    dummy_group = {0, 1}
+    anchor_group = [4]
+    allowed_ixns = enumerate_dummy_ixns(dummy_group, anchor_group)
+    assert len(allowed_ixns) == 6
+    assert (0, 1) in allowed_ixns
+    assert (0, 4) in allowed_ixns
+    assert (1, 4) in allowed_ixns
+    assert (0, 1, 4) in allowed_ixns
+    assert (1, 0, 4) in allowed_ixns
+    assert (0, 4, 1) in allowed_ixns
+
+
+def test_flag_bonds():
+    mol = Chem.MolFromSmiles("BrOC1=CC(F)=CC=N1")
+    core = [2, 3, 4, 6, 7, 8]
+    bond_pairs = [
+        (1, [0, 1, 2]),  # H-O-C
+        (1, [1, 2, 3]),  # O-C-C
+        (1, [1, 2, 3, 4]),  # O-C-C-C
+        (0, [1, 2, 7]),  # O-C-N
+        (1, [2, 3, 4]),  # C-C-C
+        (1, [5, 4, 3, 2]),  # F-C-C-C
+        (1, [5, 4, 3]),  # F-C-C
+        (0, [5, 4, 6]),  # F-C-C
+    ]
+
+    expected_flags = [x[0] for x in bond_pairs]
+    bond_idxs = [x[1] for x in bond_pairs]
+
+    keep_flags = flag_bonds(mol, core, bond_idxs)
+    assert tuple(keep_flags) == tuple(expected_flags)
+
+    # flipping the ordering should give us identical results
+    bond_idxs = [x[::-1] for x in bond_idxs]
+    keep_flags = flag_bonds(mol, core, bond_idxs)
+    assert tuple(keep_flags) == tuple(expected_flags)
+
+
+def test_flag_bonds_core_hop():
+
+    mol = Chem.MolFromSmiles("FC1CO1")
+
+    #    F0       F
+    #    |        .
+    #   _C1  ->  .C
+    # 3O |      O |
+    #   \C2       C
+    core = [1, 2]
+    bond_pairs = [
+        (1, [0, 1]),
+        (1, [1, 2]),
+        (0, [2, 3]),
+        (1, [3, 1]),
+        (1, [0, 1, 2]),
+        (1, [0, 1, 3]),
+        (1, [3, 1, 2]),
+        (0, [1, 3, 2]),
+        (1, [1, 2, 3]),  # this last one is technically allowed
+    ]
+
+    # TBD: we can prune this to only terms where the bonds actually exist between ijk, ijkl, etc.
+
+    expected_flags = [x[0] for x in bond_pairs]
+    bond_idxs = [x[1] for x in bond_pairs]
+
+    keep_flags = flag_bonds(mol, core, bond_idxs)
+
+    assert tuple(keep_flags) == tuple(expected_flags)
+
+
+def _draw_impl(mol, core, ff, fname):
+
+    hb_params, hb_idxs = ff.hb_handle.parameterize(mol)
+    ha_params, ha_idxs = ff.ha_handle.parameterize(mol)
+    pt_params, pt_idxs = ff.pt_handle.parameterize(mol)
+    it_params, it_idxs = ff.it_handle.parameterize(mol)
+
+    bond_idxs = (
+        [tuple(x.tolist()) for x in hb_idxs]
+        + [tuple(x.tolist()) for x in ha_idxs]
+        + [tuple(x.tolist()) for x in pt_idxs]
+        + [tuple(x.tolist()) for x in it_idxs]
+    )
+
+    dgs, ags, ag_ixns = dummy.generate_optimal_dg_ag_pairs(mol, core, bond_idxs, strict=True)
+
+    for idx, (dummy_group, anchor_group, anchor_ixns) in enumerate(zip(dgs, ags, ag_ixns)):
+
+        matched_ixns = []
+        for idxs in bond_idxs:
+            if tuple(idxs) in anchor_ixns:
+                if np.all([ii in dummy_group for ii in idxs]):
+                    continue
+                elif np.all([ii in core for ii in idxs]):
+                    continue
+                matched_ixns.append(idxs)
+
+        res = dummy_draw.draw_dummy_core_ixns(mol, core, matched_ixns, dummy_group)
+
+        with open(fname + "_" + str(idx) + ".svg", "w") as fh:
+            fh.write(res)
+
+
+def test_parameterize_and_draw_interactions():
+
+    ff_handlers = deserialize_handlers(open("timemachine/ff/params/smirnoff_1_1_0_sc.py").read())
+    ff = Forcefield(ff_handlers)
+
+    mol = Chem.MolFromSmiles("CC(=O)OC1=CC=CC=C1C(=O)O")
+    core = [3, 4, 5, 6, 7, 8, 9, 10]
+
+    _draw_impl(mol, core, ff, "aspirin")
+
+    mol = Chem.MolFromSmiles("C(C1=CC=CC=C1)C1=CC=CC=C1")
+    core = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+
+    _draw_impl(mol, core, ff, "met_biphenyl")
+
+    mol = Chem.MolFromSmiles("F[C@](Cl)(Br)C1=CC=CC=C1")
+    core = [1, 4, 5, 6, 7, 8, 9]
+
+    _draw_impl(mol, core, ff, "toluene")
+
+    mol = Chem.MolFromSmiles("C1CC2=CC=CC=C12")
+    core = [2, 3, 4, 5, 6, 7]
+
+    _draw_impl(mol, core, ff, "ring_open")

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -104,7 +104,7 @@ def test_identify_dummy_groups():
 
     {D0, D1, D2}
 
-        D0-D1--D2
+        D0-D1..D2
        /          -> 1 dummy-anchor bond:
       0-------1
 

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -355,6 +355,9 @@ def test_flag_bonds_core_hop():
 
 def test_strict_mode_missing_ixns():
 
+    # tbd: strict is probably required after extensive offline
+    # discussion with jfass
+
     # test the following behavior for the molecule
     #    2
     #    |

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -14,6 +14,20 @@ from timemachine.fe.dummy import (
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
 
+# These tests check the various utilities used to turn off interactions
+# such that the end-states are separable. A useful glossary of terms is as follows.
+# The tests in this module do not test for numerical stability, but only checks for correctness.
+
+# Many of the tests here are tediously written by hand, but should hopefully be sufficiently documented.
+
+# dummy atom - an R-group atom that is inserted or deleted in an alchemical transformation
+# dummy group - a collection of dummy atoms (eg. multiple dummy hydrogen atoms on CH3 can belong to the same dummy group, with C being a core atom).
+# core atom - not a dummy atom
+# anchor/core anchor - a core atom that is allowed to interact with the atoms in a given dummy group
+# anchor group - a set of ordered anchor atoms (up to 3) that can be used to define bond, angle, torsion terms in specialized ways
+# root-anchor - first atom in an anchor group, also the anchor atom that has direct 1-2 bonds to dummy atoms.
+# partition - only applies to dummy groups, as we require that dummy groups disjointly partition dummy atoms.
+
 
 def test_identify_root_anchors():
     """
@@ -244,15 +258,18 @@ def test_enumerate_allowed_dummy_ixns_3_anchors_spot_check():
     assert (3, 2, 8, 5) in allowed_ixns
     assert (1, 8, 2, 3) in allowed_ixns
 
-    assert (0, 1, 3) not in allowed_ixns
-    assert (0, 1, 4) not in allowed_ixns
-    assert (0, 2, 4) not in allowed_ixns
-    assert (0, 3) not in allowed_ixns
-    assert (0, 4) not in allowed_ixns
-    assert (5, 3, 4) not in allowed_ixns
-    assert (1, 5, 4) not in allowed_ixns
-    assert (5, 8, 2, 4) not in allowed_ixns
-    assert (1, 8, 3, 4) not in allowed_ixns
+    # root anchor = 2
+    # second anchor = 3
+    # third anchor = 4
+    assert (0, 3) not in allowed_ixns  # dummy-bond only allowed to root anchor
+    assert (0, 4) not in allowed_ixns  # dummy-bond only allowed to root anchor
+    assert (0, 1, 3) not in allowed_ixns  # angles can't skip the root anchor
+    assert (0, 1, 4) not in allowed_ixns  # angles can't skip the root anchor
+    assert (0, 2, 4) not in allowed_ixns  # angles can't skip the second anchor
+    assert (5, 3, 4) not in allowed_ixns  # angles can't skip the root anchor
+    assert (1, 5, 4) not in allowed_ixns  # angles can't skip the root anchor
+    assert (5, 8, 2, 4) not in allowed_ixns  # torsion can't skip the second anchor
+    assert (1, 8, 3, 4) not in allowed_ixns  # torsion can't skip the root anchor
 
 
 def test_enumerate_allowed_dummy_ixns_3_anchors_exhaustive():

--- a/timemachine/fe/dummy.py
+++ b/timemachine/fe/dummy.py
@@ -1,0 +1,583 @@
+import copy
+import itertools
+
+import networkx as nx
+import numpy as np
+
+from timemachine.graph_utils import convert_to_nx
+
+
+def _add_successors(mol, core, groups):
+    # (ytz): internal utility used for bfs
+    next_groups = []
+    for group in groups:
+        # grab the last node
+        last_node = group[-1]
+        for nbr in mol.GetAtomWithIdx(last_node).GetNeighbors():
+            new_group = copy.deepcopy(group)
+            nbr = nbr.GetIdx()
+            # ensure is core_atom and not already visited
+            if nbr in core and nbr not in new_group:
+                new_group.append(nbr)
+                next_groups.append(new_group)
+
+    return next_groups
+
+
+def identify_anchor_groups(mol, core, anchor):
+    """
+    Generate all choices for valid anchor groups. An anchor group
+    is an ordered sequence of core atoms starting with the anchor (a-b-c) that
+    are connected by bonds. In other words, an anchor group is a rooted subtree
+    with three nodes spanning from the anchor.
+
+    Parameters
+    ----------
+    mol: Chem.Mol
+        rdkit molecule
+
+    core: list or set or iterable
+        core atoms
+
+    anchor: int
+        atom we're initializing the search over
+
+    Returns
+    -------
+    3-tuple
+        Returns anchor groups of size 1, 2, and 3. Size 1 group will always
+        be [[anchor]]. Size 2 groups will be [[anchor, x], ...] and size 3
+        groups will be [[anchor,x,y,], ...]
+
+    """
+
+    assert anchor in core
+
+    # We perform a bfs of depth 3 starting from the anchor.
+    layer_1_groups = [[anchor]]
+    layer_2_groups = _add_successors(mol, core, layer_1_groups)
+    layer_3_groups = _add_successors(mol, core, layer_2_groups)
+
+    # sanity assertions to make sure we don't have duplicate idxs
+    for g in layer_2_groups:
+        assert len(set(g)) == len(g)
+
+    for g in layer_3_groups:
+        assert len(set(g)) == len(g)
+
+    return layer_1_groups, layer_2_groups, layer_3_groups
+
+
+def identify_root_anchors(mol, core, dummy_atom):
+    """
+    Identify the root anchor(s) for a given atom. A root anchor is defined as the starting atom
+    in an anchor group (comprised of up to 3 anchor atoms). If this returns multiple root anchors
+    then the dummy_atom is a bridge between multiple core atoms.
+
+    Parameters
+    ----------
+    mol: Chem.Mol
+        rdkit molecule
+
+    core: list or set or iterable
+        core atoms
+
+    dummy_atom: int
+        atom we're initializing the search over
+
+    Returns
+    -------
+    list of int
+        List of root anchors that the dummy atom is connected to.
+
+    """
+
+    assert len(set(core)) == len(core)
+
+    core = set(core)
+
+    assert dummy_atom not in core
+
+    # first convert to a dense graph
+    N = mol.GetNumAtoms()
+    dense_graph = np.zeros((N, N), dtype=np.int32)
+
+    for bond in mol.GetBonds():
+        i, j = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
+        dense_graph[i, j] = 1
+        dense_graph[j, i] = 1
+
+    # sparsify to simplify and speed up traversal code
+    sparse_graph = []
+    for row in dense_graph:
+        nbs = []
+        for col_idx, col in enumerate(row):
+            if col == 1:
+                nbs.append(col_idx)
+        sparse_graph.append(nbs)
+
+    def dfs(i, visited):
+        if i in visited:
+            return
+        else:
+            visited.add(i)
+            if i not in core:
+                for nb in sparse_graph[i]:
+                    dfs(nb, visited)
+            else:
+                return
+
+    visited = set()
+
+    dfs(dummy_atom, visited)
+    anchors = []
+
+    for a_idx in visited:
+        if a_idx in core:
+            anchors.append(a_idx)
+
+    return anchors
+
+
+def enumerate_anchor_groups(mol, core, dummy_group):
+    """
+    An anchor group is a set of core atoms that are allowed to interact with the dummy
+    atoms in a dummy group in a way that allows the partition function to be separated.
+    Unlike dummy groups, anchor groups do not partition the non-core atoms. They're allowed
+    to overlap core atom indices. In other words, anchor groups for any particular dummy
+    group is fully independent of other anchor groups for any other dummy group.
+
+    While the choices of atoms in an anchor group is arbitrary, one heuristic we use
+    to enumerate anchor groups is as follows. In order to determine:
+
+    1) the 1-2 bond anchor i, we find a core atom that is directly bonded a dummy atom
+    2) the 1-3 angle anchor j, we pick a core atom that is adjacent to i
+    3) the 1-4 torsion anchor k, we pick a core atom adjacent to j, but not equal to i.
+
+    Parameters
+    ----------
+    mol: Chem.Mol
+        Molecule of interest
+
+    core: list of int
+        core atoms
+
+    dummy_group: list of int
+        dummy atoms in a given group.
+
+    Returns
+    -------
+    tuple
+        Anchor groups of size 1, 2, and 3 atoms
+
+    """
+
+    anchors = set()
+
+    for dummy_atom in dummy_group:
+        for anchor_atom in identify_root_anchors(mol, core, dummy_atom):
+            anchors.add(anchor_atom)
+
+    l1s = []
+    l2s = []
+    l3s = []
+
+    for anchor in anchors:
+        l1, l2, l3 = identify_anchor_groups(mol, core, anchor)
+        l1s.extend(l1)
+        l2s.extend(l2)
+        l3s.extend(l3)
+
+    return l1s, l2s, l3s
+
+
+def identify_dummy_groups(mol, core):
+    """
+    A dummy group is a set of dummy atoms that are inserted or deleted in alchemical
+    free energy calculations. The bonded terms that involve dummy atoms need to be
+    judiciously pruned such that the partition function at the end-states remain
+    factorizable, and cancelleable. Dummy groups are subject to the following constraints:
+
+    1) They must not contain atoms in the core.
+    2) Dummy groups do not interact with other dummy groups.
+    3) Dummy groups interact with the core only through anchor atoms.
+
+    While the choices of dummy groups is arbitrary, this function partitions the dummy
+    atoms into multiple dummy groups using a heuristic:
+
+    1) Identify all 1-2, 1-3 edges between dummy atoms.
+    2) Generate an induced graph using edges from above set.
+    3) Disconnected components of the resulting induced graph are our dummy groups.
+
+    We limit ourselves to only 1-2 and 1-3 interactions in 1) because we're typically
+    guaranteed that there exists a direct bond or that they're at most one bond away.
+
+    For example:
+
+    ```
+    mol = Chem.MolFromSmiles("FC1CC1(F)N")
+    core = [1, 2, 3]
+    dg = identify_dummy_groups(mol, core)
+    assert_set_equality(dg, [{0}, {4, 5}])
+    ```
+
+    Returns
+    -------
+    List of set of ints:
+        eg: [{3,4}, {7,8,9}]
+
+    """
+
+    g = convert_to_nx(mol)
+    N = mol.GetNumAtoms()
+    induced_g = nx.Graph()
+
+    # add nodes and edges into the induced graph.
+    for i in range(N):
+        if i not in core:
+            induced_g.add_node(i)
+            for j in range(i + 1, N):
+                if j not in core:
+                    dist = nx.shortest_path_length(g, source=i, target=j)
+                    if dist <= 2:
+                        induced_g.add_edge(i, j)
+
+    cc = list(nx.connected_components(induced_g))
+
+    # check that we didn't miss any dummy atoms
+    assert np.sum([len(c) for c in cc]) == (N - len(core))
+
+    # refine based on rooted-anchor, this lets us deal with ring opening and closing:
+    #
+    #        D----D
+    #        |    |
+    #        C----C
+    #        |    |
+    #        C----C
+    #
+    # in this case, we want the dummy atoms to be in different groups.
+
+    dummy_groups = []
+
+    for dg in cc:
+        anchor_membership = []
+        dg = list(dg)
+        for dummy in dg:
+            # identify membership of the dummy
+            anchors = identify_root_anchors(mol, core, dummy)
+            # get distance to anchor
+            dists = []
+            for a in anchors:
+                dists.append(nx.shortest_path_length(g, source=dummy, target=a))
+            anchor_membership.append(np.argmin(dists))
+
+        anchor_kv = {}
+        for idx, anchor in enumerate(anchor_membership):
+            if anchor not in anchor_kv:
+                anchor_kv[anchor] = set()
+            anchor_kv[anchor].add(dg[idx])
+
+        for v in anchor_kv.values():
+            dummy_groups.append(v)
+
+    return dummy_groups
+
+
+def enumerate_dummy_ixns(dg, ag):
+    """
+    Enumerate the allowed set of interactions between
+    1) atoms within the dummy group
+    2) atoms in a dummy group and atoms in anchor group
+
+    Parameters
+    ----------
+    dg: set of int
+        dummy atoms in a dummy group
+
+    ag: list of int
+        ordered core anchor atoms
+
+    Returns
+    -------
+    set
+        Set of interactions containing, 1-2, 1-3, and 1-4 interactions
+        The bonds returned are ordered.
+
+    """
+
+    allowed_ixns = set()
+
+    nc1 = list(itertools.combinations(dg, 1))
+    nc2 = list(itertools.combinations(dg, 2))
+    nc3 = list(itertools.combinations(dg, 3))
+    nc4 = list(itertools.combinations(dg, 4))
+
+    # enumerate dummy-dummy ixns
+    for ijkl in nc4:
+        for i, j, k, l in itertools.permutations(ijkl):
+            allowed_ixns.add((i, j, k, l))
+    for ijk in nc3:
+        for i, j, k in itertools.permutations(ijk):
+            allowed_ixns.add((i, j, k))
+    for ij in nc2:
+        for i, j in itertools.permutations(ij):
+            allowed_ixns.add((i, j))
+
+    # enumerate dummy-anchor ixns
+    if len(ag) > 0:
+        a = ag[0]
+        for ijk in nc3:
+            for i, j, k in itertools.permutations(ijk):
+                allowed_ixns.add((a, i, j, k))
+                allowed_ixns.add((i, a, j, k))
+                allowed_ixns.add((i, j, a, k))
+                allowed_ixns.add((i, j, k, a))
+        for ij in nc2:
+            for i, j in itertools.permutations(ij):
+                allowed_ixns.add((a, i, j))
+                allowed_ixns.add((i, a, j))
+                allowed_ixns.add((i, j, a))
+
+        for (i,) in nc1:
+            allowed_ixns.add((i, a))
+            allowed_ixns.add((a, i))
+            # this is actually same as above
+            # included to please the symmetry gods
+
+        if len(ag) > 1:
+            b = ag[1]
+            for ij in nc2:
+                for i, j in itertools.permutations(ij):
+                    allowed_ixns.add((i, j, a, b))
+                    # this looks weird at first, but is actually valid
+                    # consider:
+                    # i j
+                    # |/
+                    # a-b
+                    # we can freely rotate i-j independently of a-b
+                    # in both of the following cases.
+                    allowed_ixns.add((i, a, b, j))
+                    allowed_ixns.add((a, b, i, j))
+
+                    # disallowed examples would be (i,a,j,b)
+
+            for (i,) in nc1:
+                allowed_ixns.add((i, a, b))
+                # consider
+                # i
+                # |
+                # a-b
+                # we're still allowed to have an angle term (a,b,i) without
+                # affecting the factorizability
+                allowed_ixns.add((a, b, i))
+
+                # disallowed examples would be (a,i,b)
+
+            if len(ag) > 2:
+                c = ag[2]
+                for (i,) in nc1:
+                    allowed_ixns.add((i, a, b, c))
+                    # this is also allowed (and encountered in a trefoil)
+                    # consider:
+                    #    i
+                    #   /
+                    #  / b--c
+                    # a-/
+                    allowed_ixns.add((a, b, c, i))
+
+    return make_bond_set(allowed_ixns)
+
+
+def find_ags_for_dg(mol, core, dg):
+    """
+    Find all possible anchor groups for a given dummy group.
+    """
+    anchors = []
+    for dummy_atom in dg:
+        anchors.extend(identify_root_anchors(mol, core, dummy_atom))
+    anchors = set(anchors)
+
+    anchor_groups = []
+    for anchor in anchors:
+        ag0, ag1, ag2 = identify_anchor_groups(mol, core, anchor)
+        anchor_groups.extend(ag0)
+        anchor_groups.extend(ag1)
+        anchor_groups.extend(ag2)
+
+    return anchor_groups
+
+
+def ordered_tuple(ixn):
+    if ixn[0] > ixn[-1]:
+        return tuple(ixn[::-1])
+    else:
+        return tuple(ixn)
+
+
+def make_bond_set(old_set):
+    """
+    Bond set has the requirement that indices are symmetrically
+    reversible. i.e. ij = ji, ijk = kji, ijkl = lkji
+    """
+    new_set = set()
+    for idxs in old_set:
+        new_set.add(ordered_tuple(idxs))
+    return new_set
+
+
+def flag_bonds(mol, core, bond_idxs):
+    """
+    Flags bonds based on minimizing the number of terms we have to
+    turn off.
+
+    Parameters
+    ----------
+    mol: Chem.Mol
+        rdkit molecule
+
+    core: list of int
+        idxs of core atoms
+
+    bond_idxs: list of list of int
+        list of 2-tuple, 3-tuple, 4-tuple
+
+    Returns
+    -------
+        boolean flags, 1: keep, 0: remove
+
+    """
+
+    # 1. process core bonds
+    keep_flags = np.zeros(len(bond_idxs), dtype=np.int32)
+
+    dummy_ixns = set()
+    for b_idx, atom_idxs in enumerate(bond_idxs):
+        if np.all([i in core for i in atom_idxs]):
+            keep_flags[b_idx] = 1
+        else:
+            dummy_ixns.add(tuple(atom_idxs))
+
+    dummy_ixns = make_bond_set(dummy_ixns)
+
+    # 2. process dummy bonds
+    dgs, ags, ag_ixns = generate_optimal_dg_ag_pairs(mol, core, bond_idxs)
+
+    allowed_ixns = set()
+
+    for ixns in ag_ixns:
+        allowed_ixns |= ixns
+
+    for b_idx, atom_idxs in enumerate(bond_idxs):
+        if tuple(ordered_tuple(atom_idxs)) in allowed_ixns:
+            keep_flags[b_idx] = 1
+
+    return keep_flags
+
+
+def generate_dg_ag_pairs(mol, core, bond_idxs, strict):
+    """
+    Generate optimal pairing of dummy group and anchor group atoms such that
+    bond_idxs is maximized.
+
+    Parameters
+    ----------
+    mol: Chem.Mol
+        rdkit molecule
+
+    core: list of int
+        idxs of core atoms
+
+    bond_idxs: list of list of int
+        list of 2-tuple, 3-tuple, 4-tuple used to compare
+
+    strict: bool
+
+    Returns
+    -------
+        list of (dummy_group, anchor_group) pairs
+
+    """
+    # 1. process core bonds
+    ff_core_ixns = set()
+    ff_dummy_ixns = set()
+    for atom_idxs in bond_idxs:
+        if np.all([i in core for i in atom_idxs]):
+            ff_core_ixns.add(tuple(atom_idxs))
+        else:
+            ff_dummy_ixns.add(tuple(atom_idxs))
+
+    ff_core_ixns = make_bond_set(ff_core_ixns)
+    ff_dummy_ixns = make_bond_set(ff_dummy_ixns)
+
+    # 2. process dummy bonds
+    dgs = identify_dummy_groups(mol, core)
+
+    all_agcs = []
+    all_agis = []
+
+    for dg in dgs:
+        anchor_group_candidates = find_ags_for_dg(mol, core, dg)
+        anchor_group_ixns = []
+        # enumerate over all interactions
+        for ag in anchor_group_candidates:
+            # set of all possible dummy interactions, without taking ff idxs into account
+            allowed_dummy_ixns = enumerate_dummy_ixns(dg, ag)
+            mutual_bonds = allowed_dummy_ixns.intersection(ff_dummy_ixns)
+            mutual_bonds |= ff_core_ixns
+
+            # do additional pruning by checking real bonds.
+            if strict:
+                bonds_12 = set()
+                bonds_13 = set()
+                bonds_14 = set()
+                for idxs in mutual_bonds:
+                    if len(idxs) == 2:
+                        bonds_12.add(idxs)
+                for idxs in mutual_bonds:
+                    if len(idxs) == 3:
+                        i, j, k = idxs
+                        if (ordered_tuple((i, j)) in bonds_12) and (ordered_tuple((j, k)) in bonds_12):
+                            bonds_13.add(idxs)
+                for idxs in mutual_bonds:
+                    if len(idxs) == 4:
+                        i, j, k, l = idxs
+                        if (
+                            (ordered_tuple((i, j)) in bonds_12)
+                            and (ordered_tuple((j, k)) in bonds_12)
+                            and (ordered_tuple((k, l)) in bonds_12)
+                            and (ordered_tuple((i, j, k)) in bonds_13)
+                            and (ordered_tuple((j, k, l)) in bonds_13)
+                        ):
+                            bonds_14.add(idxs)
+
+                mutual_bonds = bonds_12.union(bonds_13).union(bonds_14)
+
+            anchor_group_ixns.append(mutual_bonds)
+
+        all_agcs.append(anchor_group_candidates)
+        all_agis.append(anchor_group_ixns)
+
+    return dgs, all_agcs, all_agis
+
+
+def generate_optimal_dg_ag_pairs(mol, core, bond_idxs, strict=False):
+
+    dgs, all_agcs, all_agis = generate_dg_ag_pairs(mol, core, bond_idxs, strict)
+
+    picked_agcs = []
+    picked_agis = []
+
+    for agcs, agis in zip(all_agcs, all_agis):
+
+        counts = []
+        for mutual_bonds in agis:
+            bond_count = np.sum([len(idxs) == 2 for idxs in mutual_bonds])
+            angle_count = np.sum([len(idxs) == 3 for idxs in mutual_bonds])
+            torsion_count = np.sum([len(idxs) == 4 for idxs in mutual_bonds])
+            counts.append((bond_count, angle_count, torsion_count))
+
+        best_idx = sorted(zip(range(len(counts)), counts), reverse=True, key=lambda x: x[1])[0][0]
+        picked_agcs.append(agcs[best_idx])
+        picked_agis.append(agis[best_idx])
+
+    return dgs, picked_agcs, picked_agis

--- a/timemachine/fe/dummy_draw.py
+++ b/timemachine/fe/dummy_draw.py
@@ -1,0 +1,114 @@
+from rdkit import Chem
+from rdkit.Chem import Draw
+
+
+def rgb_to_decimal(x, y, z):
+    return x / 255, y / 255, z / 255
+
+
+def draw_dummy_core_ixns(mol, core, bonds, dummy_group, color_blind=False):
+    """
+    Draw a grid of molecules with interactions between atoms in dummy_group
+    and the core highlighted.
+    """
+
+    if color_blind:
+        COLOR_DUMMY_IXN = rgb_to_decimal(230, 159, 0)
+        COLOR_DUMMY_ACTIVE = rgb_to_decimal(240, 228, 66)
+        COLOR_DUMMY_INACTIVE = rgb_to_decimal(0, 158, 115)
+        COLOR_CORE_ACTIVE = rgb_to_decimal(213, 94, 0)
+        COLOR_CORE_INACTIVE = rgb_to_decimal(204, 121, 167)
+        COLOR_BOND = (0.96, 0.74, 0)
+    else:
+        COLOR_DUMMY_IXN = (0, 0.7, 0)
+        COLOR_DUMMY_ACTIVE = (0.6, 1, 0.6)
+        COLOR_DUMMY_INACTIVE = (0.188, 0.835, 0.784)
+        COLOR_CORE_ACTIVE = (0.9, 0.5, 0.5)
+        COLOR_CORE_INACTIVE = (1, 0.8, 0.8)
+        COLOR_BOND = (0.96, 0.74, 0)
+
+    assert len(set(core).intersection(set(dummy_group))) == 0
+
+    highlightAtomLists = []
+    highlightBondLists = []
+    highlightAtomColorsLists = []
+    highlightBondColorsLists = []
+    all_mols = []
+
+    bonds.sort(key=len)
+
+    legends = []
+
+    for atom_idxs in bonds:
+
+        mol_copy = Chem.Mol(mol)
+        highlightAtomColors = {}
+        highlightBondColors = {}
+        highlightAtoms = set()
+        highlightBonds = set()
+
+        # default colors
+        for a in range(mol_copy.GetNumAtoms()):
+            highlightAtoms.add(a)
+            if a in core:
+                highlightAtomColors[a] = COLOR_CORE_INACTIVE
+            elif a in dummy_group:
+                highlightAtomColors[a] = COLOR_DUMMY_ACTIVE
+            else:
+                highlightAtomColors[a] = COLOR_DUMMY_INACTIVE
+
+        # interacting atoms
+        for a in atom_idxs:
+            atom = mol_copy.GetAtomWithIdx(int(a))
+            atom.SetProp("molAtomMapNumber", str(atom.GetIdx()))
+            if a in core:
+                highlightAtomColors[a] = COLOR_CORE_ACTIVE
+            else:
+                highlightAtomColors[a] = COLOR_DUMMY_IXN
+
+        is_improper = False
+        for idx in range(len(atom_idxs)):
+            if idx != len(atom_idxs) - 1:
+                bond = mol_copy.GetBondBetweenAtoms(int(atom_idxs[idx]), int(atom_idxs[idx + 1]))
+
+                # this may be none if we have an improper torsion
+                if bond is None:
+                    if len(atom_idxs) == 4:
+                        # improper
+                        is_improper = True
+                    else:
+                        assert 0, "Bad idxs"
+
+                else:
+                    highlightBonds.add(bond.GetIdx())
+                    highlightBondColors[bond.GetIdx()] = COLOR_BOND
+
+        highlightAtomLists.append(list(range(mol_copy.GetNumAtoms())))
+        highlightBondLists.append(list(highlightBonds))
+        highlightAtomColorsLists.append(highlightAtomColors)
+        highlightBondColorsLists.append(highlightBondColors)
+        if is_improper:
+            label = "improper"
+        elif len(atom_idxs) == 2:
+            label = "bond"
+        elif len(atom_idxs) == 3:
+            label = "angle"
+        elif len(atom_idxs) == 4:
+            label = "proper"
+        else:
+            assert 0
+
+        all_mols.append(mol_copy)
+        legends.append(label + " " + repr([int(x) for x in atom_idxs]))
+
+    return Draw.MolsToGridImage(
+        all_mols,
+        molsPerRow=4,
+        highlightAtomLists=highlightAtomLists,
+        highlightAtomColors=highlightAtomColorsLists,
+        highlightBondLists=highlightBondLists,
+        highlightBondColors=highlightBondColorsLists,
+        subImgSize=(250, 250),
+        legends=legends,
+        useSVG=True,
+    )

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -14,24 +14,7 @@ from timemachine.ff.handlers.bcc_aromaticity import match_smirks as oe_match_smi
 from timemachine.ff.handlers.serialize import SerializableMixIn
 from timemachine.ff.handlers.utils import match_smirks as rd_match_smirks
 from timemachine.ff.handlers.utils import sort_tuple
-
-AM1_CHARGE_CACHE = "AM1Cache"
-BOND_SMIRK_MATCH_CACHE = "BondSmirkMatchCache"
-
-
-def convert_to_nx(mol):
-    """
-    Convert an ROMol into a networkx graph.
-    """
-    g = nx.Graph()
-
-    for atom in mol.GetAtoms():
-        g.add_node(atom.GetIdx())
-
-    for bond in mol.GetBonds():
-        g.add_edge(bond.GetBeginAtomIdx(), bond.GetEndAtomIdx())
-
-    return g
+from timemachine.graph_utils import convert_to_nx
 
 
 def convert_to_oe(mol):

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -16,6 +16,9 @@ from timemachine.ff.handlers.utils import match_smirks as rd_match_smirks
 from timemachine.ff.handlers.utils import sort_tuple
 from timemachine.graph_utils import convert_to_nx
 
+AM1_CHARGE_CACHE = "AM1Cache"
+BOND_SMIRK_MATCH_CACHE = "BondSmirkMatchCache"
+
 
 def convert_to_oe(mol):
     """Convert an ROMol into an OEMol"""

--- a/timemachine/graph_utils.py
+++ b/timemachine/graph_utils.py
@@ -1,0 +1,16 @@
+import networkx as nx
+
+
+def convert_to_nx(mol):
+    """
+    Convert an ROMol into a networkx graph.
+    """
+    g = nx.Graph()
+    for atom in mol.GetAtoms():
+        g.add_node(atom.GetIdx())
+
+    for bond in mol.GetBonds():
+        src, dst = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
+        g.add_edge(src, dst)
+
+    return g


### PR DESCRIPTION
This PR lays out much of the ground work for generating factorizable dummy bonds. Given a fixed partitioning of the molecule into core and dummy regions, this code identifies which bonded terms (`1-2, 1-3, 1-4`) can be safely left on without affecting the factorizability of the partition function (such that complex-solvent, or solvent-vacuum edges can cancel out). In particular, the function `flag_bonds(mol, core, bond_idxs)` will return a boolean array of `len(bond_idxs)` indicating which of the terms must be turned off and which of the terms must be turned on. The implementation is technically correct for any choice of core atoms (including those involved in possible ring/opening closing). While the efficiency of the transformation is not guaranteed, an heuristic is made in the form of minimizing the number of interactions that need to be turned off. 

The logic of the code is as follows:
1) Partition dummy atoms into disjoint groups using a heuristic
2) Identify optimal anchoring core atoms for each dummy group. Note that there are many possible choices, and we only apply a heuristic in picking the optimal one.
3) Loop over bond_idxs to see which ones can be safely turned off. 

The code is a little bit terse as-is, and example test cases are welcomed. There are further generalizations one can make later on to support virtual sites etc. 

Glossary of Terms:
-------------------------
dummy atom - an R-group atom that is inserted or deleted in an alchemical transformation
dummy group - a collection of dummy atoms (eg. multiple dummy hydrogen atoms on CH3 can belong to the same dummy group, with C being a core atom).
core atom - not a dummy atom
anchor/core anchor - a core atom that is allowed to interact with the atoms in a given dummy group
anchor group - a set of ordered anchor atoms (up to 3) that can be used to define bond, angle, torsion terms in specialized ways
root-anchor - first atom in an anchor group, also the anchor atom that has direct 1-2 bonds to dummy atoms.
partition - only applies to dummy groups, as we require that dummy groups disjointly partition dummy atoms.

Correctness vs Efficiency vs Numerical Stability 
---------------------------------------------------------------
`enumerate_dummy_ixns` generates interactions that are formally correct, but may be numerically unstable or inefficient.
`flag_bonds` uses a heuristic for efficiency, by first maximizing the number of 1-2 interactions, then the number of 1-3 interactions, and finally the number of 1-4 interactions. 
`verify_compatibility` checks that dummy atom interactions at the end-states are numerically stable. One example we want to avoid is if we allowed a dummy-anchor torsion into a nitrile group (which would result in collinear bonds)

The PR also adds some annotation/drawing code to render the allowed interactions, where the core is defined in (dark/light red), and dummy atoms are everything else. The highlighted bonds show the *allowed* interactions. 

![toluene_0](https://user-images.githubusercontent.com/2280724/154806466-d60873d6-1c0e-445c-87c4-1821d78ce3d2.svg)
![met_biphenyl_0](https://user-images.githubusercontent.com/2280724/154806468-084edc1d-4bd1-486e-b73c-971117ddd2c8.svg)
![aspirin_1](https://user-images.githubusercontent.com/2280724/154806469-d8f860fb-cf51-4351-8c57-a9d89b87724b.svg)
![aspirin_0](https://user-images.githubusercontent.com/2280724/154806470-32835123-1c0a-463f-91c6-47de1f16ef1b.svg)

Note that some of them are very tricky, remember that highlighted bonded interactions are the *only* ones left on between dummy-anchor ixns. Below, while 1-2 terms are annihlated between atoms 0 and 7, the 1-3, 1-4 terms can still span 0-7 without affecting the correctness (though they may affect numerical stability in MD if angle terms don't concomitantly have all the bond terms turned on), but this is very tricky for improper terms!

![ring_open_0](https://user-images.githubusercontent.com/2280724/154806467-f84e0e39-6a5c-4f93-98e3-6e2ed18a4b85.svg)

We can remove these extra interactions (and impropers) by turning on strict mode:
![ring_open_0](https://user-images.githubusercontent.com/2280724/154816759-afa64a64-11fb-489c-be20-99fb3c51a790.svg)

