### PR TITLE
Removes unused version of grpcio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         "scipy",
     ],
     extras_require={
-        "dev": ["black==21.10b0", "isort==5.10.1", "flake8==4.0.1", "pre-commit", "grpcio==1.43.0"],
+        "dev": ["black==21.10b0", "isort==5.10.1", "flake8==4.0.1", "pre-commit"],
         "test": ["pytest", "pytest-cov"],
     },
     package_data={


### PR DESCRIPTION
I had mistakenly added this version to the `setup.py`, but it was unused as it was only installed with `[dev]`. It overrides the value set in the requirements.txt which is our preferred place for pinning versions.

Verified that there is no change made to the grpc code between versions, there are also no changes between 1.43.0 and 1.30.0 that seem important to us (IE no security issues)