### PR TITLE
Wrap NonbondedAllPairs, NonbondedPairList

### DIFF
--- a/tests/nonbonded/conftest.py
+++ b/tests/nonbonded/conftest.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pytest
+from simtk.openmm import app
+
+from timemachine.fe.utils import to_md_units
+from timemachine.ff.handlers import openmm_deserializer
+from timemachine.lib import potentials
+
+
+@pytest.fixture(autouse=True)
+def set_random_seed():
+    np.random.seed(2022)
+    yield
+
+
+@pytest.fixture()
+def rng():
+    return np.random.default_rng(2022)
+
+
+@pytest.fixture
+def example_system():
+    pdb_path = "tests/data/5dfr_solv_equil.pdb"
+    host_pdb = app.PDBFile(pdb_path)
+    ff = app.ForceField("amber99sbildn.xml", "tip3p.xml")
+    return (
+        ff.createSystem(host_pdb.topology, nonbondedMethod=app.NoCutoff, constraints=None, rigidWater=False),
+        host_pdb.positions,
+        host_pdb.topology.getPeriodicBoxVectors(),
+    )
+
+
+@pytest.fixture
+def example_nonbonded_params(example_system):
+    host_system, _, _ = example_system
+    host_fns, _ = openmm_deserializer.deserialize_system(host_system, cutoff=1.0)
+
+    nonbonded_fn = None
+    for f in host_fns:
+        if isinstance(f, potentials.Nonbonded):
+            nonbonded_fn = f
+
+    assert nonbonded_fn is not None
+    return nonbonded_fn.params
+
+
+@pytest.fixture
+def example_conf(example_system):
+    _, host_conf, _ = example_system
+    return np.array([[to_md_units(x), to_md_units(y), to_md_units(z)] for x, y, z in host_conf])
+
+
+@pytest.fixture
+def example_box(example_system):
+    _, _, box = example_system
+    return np.asarray(box / box.unit)

--- a/tests/nonbonded/parameter_interpolation.py
+++ b/tests/nonbonded/parameter_interpolation.py
@@ -2,7 +2,7 @@ import numpy as np
 import numpy.typing as npt
 
 
-def gen_params(params_initial: npt.NDArray, rng: np.random.Generator, dcharge=0.01, dloglj=0.1):
+def gen_params(params_initial: npt.NDArray, rng: np.random.Generator, dcharge=0.01, dlogsig=0.1, dlogeps=0.1):
     """Given an initial set of nonbonded parameters, generate random
     final parameters and return the concatenation of the initial and
     final parameters"""
@@ -13,8 +13,8 @@ def gen_params(params_initial: npt.NDArray, rng: np.random.Generator, dcharge=0.
     charge_final = charge_init + rng.normal(0, dcharge, size=(num_atoms,))
 
     # perturb LJ parameters in log space to avoid negative result
-    sig_final = np.where(sig_init, np.exp(np.log(sig_init) + rng.normal(0, dloglj, size=(num_atoms,))), 0)
-    eps_final = np.where(eps_init, np.exp(np.log(eps_init) + rng.normal(0, dloglj, size=(num_atoms,))), 0)
+    sig_final = np.where(sig_init, np.exp(np.log(sig_init) + rng.normal(0, dlogsig, size=(num_atoms,))), 0)
+    eps_final = np.where(eps_init, np.exp(np.log(eps_init) + rng.normal(0, dlogeps, size=(num_atoms,))), 0)
 
     params_final = np.stack((charge_final, sig_final, eps_final), axis=1)
 

--- a/tests/nonbonded/parameter_interpolation.py
+++ b/tests/nonbonded/parameter_interpolation.py
@@ -1,0 +1,21 @@
+import numpy as np
+import numpy.typing as npt
+
+
+def gen_params(params_initial: npt.NDArray, rng: np.random.Generator, dcharge=0.01, dloglj=0.1):
+    """Given an initial set of nonbonded parameters, generate random
+    final parameters and return the concatenation of the initial and
+    final parameters"""
+
+    num_atoms, _ = params_initial.shape
+    charge_init, sig_init, eps_init = params_initial[:].T
+
+    charge_final = charge_init + rng.normal(0, dcharge, size=(num_atoms,))
+
+    # perturb LJ parameters in log space to avoid negative result
+    sig_final = np.where(sig_init, np.exp(np.log(sig_init) + rng.normal(0, dloglj, size=(num_atoms,))), 0)
+    eps_final = np.where(eps_init, np.exp(np.log(eps_init) + rng.normal(0, dloglj, size=(num_atoms,))), 0)
+
+    params_final = np.stack((charge_final, sig_final, eps_final), axis=1)
+
+    return np.concatenate((params_initial, params_final))

--- a/tests/nonbonded/test_nonbonded_all_pairs.py
+++ b/tests/nonbonded/test_nonbonded_all_pairs.py
@@ -1,0 +1,126 @@
+import functools
+
+import numpy as np
+import pytest
+from common import GradientTest
+
+from timemachine.lib.potentials import NonbondedAllPairs, NonbondedAllPairsInterpolated
+from timemachine.potentials import nonbonded
+
+
+def test_nonbonded_all_pairs_invalid_planes_offsets():
+    with pytest.raises(RuntimeError) as e:
+        NonbondedAllPairs([0], [0, 0], 2.0, 1.1).unbound_impl(np.float32)
+
+    assert "lambda offset idxs and plane idxs need to be equivalent" in str(e)
+
+
+def test_nonbonded_all_pairs_invalid_num_atoms():
+    potential = NonbondedAllPairs([0], [0], 2.0, 1.1).unbound_impl(np.float32)
+    with pytest.raises(RuntimeError) as e:
+        potential.execute(np.zeros((2, 3)), np.zeros((1, 3)), np.eye(3), 0)
+
+    assert "NonbondedAllPairs::execute_device(): expected N == N_, got N=2, N_=1" in str(e)
+
+
+def test_nonbonded_all_pairs_invalid_num_params():
+    potential = NonbondedAllPairs([0], [0], 2.0, 1.1).unbound_impl(np.float32)
+    with pytest.raises(RuntimeError) as e:
+        potential.execute(np.zeros((1, 3)), np.zeros((2, 3)), np.eye(3), 0)
+
+    assert "NonbondedAllPairs::execute_device(): expected P == M*N_*3, got P=6, M*N_*3=3" in str(e)
+
+    potential_interp = NonbondedAllPairsInterpolated([0], [0], 2.0, 1.1).unbound_impl(np.float32)
+    with pytest.raises(RuntimeError) as e:
+        potential_interp.execute(np.zeros((1, 3)), np.zeros((1, 3)), np.eye(3), 0)
+
+    assert "NonbondedAllPairs::execute_device(): expected P == M*N_*3, got P=3, M*N_*3=6" in str(e)
+
+
+def make_ref_potential(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff):
+    @functools.wraps(nonbonded.nonbonded_v3)
+    def wrapped(conf, params, box, lamb):
+        num_atoms, _ = conf
+        no_rescale = np.ones((num_atoms, num_atoms))
+        return nonbonded.nonbonded_v3(
+            conf,
+            params,
+            box,
+            lamb,
+            charge_rescale_mask=no_rescale,
+            lj_rescale_mask=no_rescale,
+            beta=beta,
+            cutoff=cutoff,
+            lambda_plane_idxs=lambda_plane_idxs,
+            lambda_offset_idxs=lambda_offset_idxs,
+        )
+
+    return wrapped
+
+
+@pytest.mark.parametrize("lamb", [0.0, 0.1])
+@pytest.mark.parametrize("beta", [2.0])
+@pytest.mark.parametrize("cutoff", [1.1])
+@pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 1e-8, 1e-8), (np.float32, 1e-4, 5e-4)])
+@pytest.mark.parametrize("num_atoms", [33, 65, 231, 1050, 4080])
+def test_nonbonded_all_pairs_correctness(
+    num_atoms,
+    precision,
+    rtol,
+    atol,
+    cutoff,
+    beta,
+    lamb,
+    example_nonbonded_params,
+    example_conf,
+    example_box,
+    rng: np.random.Generator,
+):
+    conf = example_conf[:num_atoms]
+    params = example_nonbonded_params[:num_atoms, :]
+
+    lambda_plane_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
+    lambda_offset_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
+
+    ref_potential = make_ref_potential(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff)
+    test_potential = NonbondedAllPairs(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff)
+
+    GradientTest().compare_forces(
+        conf, params, example_box, lamb, ref_potential, test_potential, precision=precision, rtol=rtol, atol=atol
+    )
+
+
+@pytest.mark.parametrize("lamb", [0.0, 0.1, 0.9, 1.0])
+@pytest.mark.parametrize("beta", [2.0])
+@pytest.mark.parametrize("cutoff", [1.1])
+@pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 1e-8, 1e-8), (np.float32, 1e-4, 5e-4)])
+@pytest.mark.parametrize("num_atoms", [33, 231, 4080])
+def test_nonbonded_all_pairs_interpolated_correctness(
+    num_atoms,
+    precision,
+    rtol,
+    atol,
+    cutoff,
+    beta,
+    lamb,
+    example_nonbonded_params,
+    example_conf,
+    example_box,
+    rng: np.random.Generator,
+):
+    "Compares with jax reference implementation."
+
+    conf = example_conf[:num_atoms]
+    params_initial = example_nonbonded_params[:num_atoms, :]
+    params_final = params_initial + rng.normal(0, 0.01, size=params_initial.shape)
+    params = np.concatenate((params_initial, params_final))
+
+    lambda_plane_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
+    lambda_offset_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
+
+    ref_potential = nonbonded.interpolated(make_ref_potential(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff))
+    test_potential = NonbondedAllPairsInterpolated(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff)
+
+    GradientTest().compare_forces(
+        conf, params, example_box, lamb, ref_potential, test_potential, precision=precision, rtol=rtol, atol=atol
+    )

--- a/tests/nonbonded/test_nonbonded_all_pairs.py
+++ b/tests/nonbonded/test_nonbonded_all_pairs.py
@@ -95,7 +95,7 @@ def test_nonbonded_all_pairs_correctness(
 @pytest.mark.parametrize("lamb", [0.0, 0.1, 0.9, 1.0])
 @pytest.mark.parametrize("beta", [2.0])
 @pytest.mark.parametrize("cutoff", [1.1])
-@pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 1e-8, 1e-8), (np.float32, 1e-4, 5e-4)])
+@pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 1e-8, 1e-8), (np.float32, 2e-4, 5e-4)])
 @pytest.mark.parametrize("num_atoms", [33, 231, 4080])
 def test_nonbonded_all_pairs_interpolated_correctness(
     num_atoms,

--- a/tests/nonbonded/test_nonbonded_all_pairs.py
+++ b/tests/nonbonded/test_nonbonded_all_pairs.py
@@ -40,7 +40,7 @@ def test_nonbonded_all_pairs_invalid_num_params():
 def make_ref_potential(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff):
     @functools.wraps(nonbonded.nonbonded_v3)
     def wrapped(conf, params, box, lamb):
-        num_atoms, _ = conf
+        num_atoms, _ = conf.shape
         no_rescale = np.ones((num_atoms, num_atoms))
         return nonbonded.nonbonded_v3(
             conf,

--- a/tests/nonbonded/test_nonbonded_all_pairs.py
+++ b/tests/nonbonded/test_nonbonded_all_pairs.py
@@ -114,7 +114,7 @@ def test_nonbonded_all_pairs_interpolated_correctness(
 
     conf = example_conf[:num_atoms]
     params_initial = example_nonbonded_params[:num_atoms, :]
-    params_final = params_initial + rng.normal(0, 0.01, size=params_initial.shape)
+    params_final = params_initial + np.where(params_initial, rng.normal(0, 0.01, size=params_initial.shape), 0)
     params = np.concatenate((params_initial, params_final))
 
     lambda_plane_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)

--- a/tests/nonbonded/test_nonbonded_all_pairs.py
+++ b/tests/nonbonded/test_nonbonded_all_pairs.py
@@ -76,6 +76,8 @@ def test_nonbonded_all_pairs_correctness(
     example_box,
     rng: np.random.Generator,
 ):
+    "Compares with jax reference implementation."
+
     conf = example_conf[:num_atoms]
     params = example_nonbonded_params[:num_atoms, :]
 
@@ -108,7 +110,7 @@ def test_nonbonded_all_pairs_interpolated_correctness(
     example_box,
     rng: np.random.Generator,
 ):
-    "Compares with jax reference implementation."
+    "Compares with jax reference implementation, with parameter interpolation."
 
     conf = example_conf[:num_atoms]
     params_initial = example_nonbonded_params[:num_atoms, :]

--- a/tests/nonbonded/test_nonbonded_all_pairs.py
+++ b/tests/nonbonded/test_nonbonded_all_pairs.py
@@ -3,6 +3,7 @@ import functools
 import numpy as np
 import pytest
 from common import GradientTest
+from parameter_interpolation import gen_params
 
 from timemachine.lib.potentials import NonbondedAllPairs, NonbondedAllPairsInterpolated
 from timemachine.potentials import nonbonded
@@ -114,8 +115,7 @@ def test_nonbonded_all_pairs_interpolated_correctness(
 
     conf = example_conf[:num_atoms]
     params_initial = example_nonbonded_params[:num_atoms, :]
-    params_final = params_initial + np.where(params_initial, rng.normal(0, 0.01, size=params_initial.shape), 0)
-    params = np.concatenate((params_initial, params_final))
+    params = gen_params(params_initial, rng)
 
     lambda_plane_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
     lambda_offset_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)

--- a/tests/nonbonded/test_nonbonded_interaction_group.py
+++ b/tests/nonbonded/test_nonbonded_interaction_group.py
@@ -5,62 +5,9 @@ jax.config.update("jax_enable_x64", True)
 import numpy as np
 import pytest
 from common import GradientTest, prepare_reference_nonbonded
-from simtk.openmm import app
 
-from timemachine.fe.utils import to_md_units
-from timemachine.ff.handlers import openmm_deserializer
-from timemachine.lib import potentials
 from timemachine.lib.potentials import NonbondedInteractionGroup, NonbondedInteractionGroupInterpolated
 from timemachine.potentials import jax_utils, nonbonded
-
-
-@pytest.fixture(autouse=True)
-def set_random_seed():
-    np.random.seed(2022)
-    yield
-
-
-@pytest.fixture()
-def rng():
-    return np.random.default_rng(2022)
-
-
-@pytest.fixture
-def example_system():
-    pdb_path = "tests/data/5dfr_solv_equil.pdb"
-    host_pdb = app.PDBFile(pdb_path)
-    ff = app.ForceField("amber99sbildn.xml", "tip3p.xml")
-    return (
-        ff.createSystem(host_pdb.topology, nonbondedMethod=app.NoCutoff, constraints=None, rigidWater=False),
-        host_pdb.positions,
-        host_pdb.topology.getPeriodicBoxVectors(),
-    )
-
-
-@pytest.fixture
-def example_nonbonded_params(example_system):
-    host_system, _, _ = example_system
-    host_fns, _ = openmm_deserializer.deserialize_system(host_system, cutoff=1.0)
-
-    nonbonded_fn = None
-    for f in host_fns:
-        if isinstance(f, potentials.Nonbonded):
-            nonbonded_fn = f
-
-    assert nonbonded_fn is not None
-    return nonbonded_fn.params
-
-
-@pytest.fixture
-def example_conf(example_system):
-    _, host_conf, _ = example_system
-    return np.array([[to_md_units(x), to_md_units(y), to_md_units(z)] for x, y, z in host_conf])
-
-
-@pytest.fixture
-def example_box(example_system):
-    _, _, box = example_system
-    return np.asarray(box / box.unit)
 
 
 def test_nonbonded_interaction_group_invalid_indices():

--- a/tests/nonbonded/test_nonbonded_interaction_group.py
+++ b/tests/nonbonded/test_nonbonded_interaction_group.py
@@ -5,6 +5,7 @@ jax.config.update("jax_enable_x64", True)
 import numpy as np
 import pytest
 from common import GradientTest, prepare_reference_nonbonded
+from parameter_interpolation import gen_params
 
 from timemachine.lib.potentials import NonbondedInteractionGroup, NonbondedInteractionGroupInterpolated
 from timemachine.potentials import jax_utils, nonbonded
@@ -146,8 +147,7 @@ def test_nonbonded_interaction_group_interpolated_correctness(
 
     conf = example_conf[:num_atoms]
     params_initial = example_nonbonded_params[:num_atoms, :]
-    params_final = params_initial + rng.normal(0, 0.01, size=params_initial.shape)
-    params = np.concatenate((params_initial, params_final))
+    params = gen_params(params_initial, rng)
 
     lambda_plane_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
     lambda_offset_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)

--- a/tests/nonbonded/test_nonbonded_pair_list.py
+++ b/tests/nonbonded/test_nonbonded_pair_list.py
@@ -7,6 +7,7 @@ import functools
 import numpy as np
 import pytest
 from common import GradientTest
+from parameter_interpolation import gen_params
 
 from timemachine.lib.potentials import NonbondedPairList, NonbondedPairListInterpolated
 from timemachine.potentials import jax_utils, nonbonded
@@ -123,10 +124,7 @@ def test_nonbonded_pair_list_interpolated_correctness(
     "Compares with jax reference implementation, with parameter interpolation."
 
     num_atoms, _ = example_conf.shape
-
-    params_initial = example_nonbonded_params
-    params_final = params_initial + rng.normal(0, 0.01, size=params_initial.shape)
-    params = np.concatenate((params_initial, params_final))
+    params = gen_params(example_nonbonded_params, rng)
 
     # randomly select 2 interaction groups and construct all pairwise interactions
     atom_idxs = rng.choice(

--- a/tests/nonbonded/test_nonbonded_pair_list.py
+++ b/tests/nonbonded/test_nonbonded_pair_list.py
@@ -50,9 +50,8 @@ def make_ref_potential(pair_idxs, scales, lambda_plane_idxs, lambda_offset_idxs,
 @pytest.mark.parametrize("beta", [2.0])
 @pytest.mark.parametrize("cutoff", [1.1])
 @pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 1e-8, 1e-8), (np.float32, 1e-4, 5e-4)])
-@pytest.mark.parametrize("num_atoms", [4080])
 @pytest.mark.parametrize("num_atoms_interacting", [1, 30, 1000])
-def test_nonbonded_interaction_group_correctness(
+def test_nonbonded_pair_list_correctness(
     num_atoms_interacting,
     precision,
     rtol,

--- a/tests/nonbonded/test_nonbonded_pair_list.py
+++ b/tests/nonbonded/test_nonbonded_pair_list.py
@@ -1,0 +1,102 @@
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import functools
+
+import numpy as np
+import pytest
+from common import GradientTest
+
+from timemachine.lib.potentials import NonbondedPairList
+from timemachine.potentials import jax_utils, nonbonded
+
+
+def test_nonbonded_pair_list_invalid_pair_idxs():
+    with pytest.raises(RuntimeError) as e:
+        NonbondedPairList([0], [0], [0], [0], 2.0, 1.1).unbound_impl(np.float32)
+
+    assert "pair_idxs.size() must be even, but got 1" in str(e)
+
+    with pytest.raises(RuntimeError) as e:
+        NonbondedPairList([(0, 0)], [(1, 1)], [0], [0], 2.0, 1.1).unbound_impl(np.float32)
+
+    assert "illegal pair with src == dst: 0, 0" in str(e)
+
+    with pytest.raises(RuntimeError) as e:
+        NonbondedPairList([(0, 1)], [(1, 1), (2, 2)], [0], [0], 2.0, 1.1).unbound_impl(np.float32)
+
+    assert "expected same number of pairs and scale tuples, but got 1 != 2" in str(e)
+
+
+def make_ref_potential(pair_idxs, scales, lambda_plane_idxs, lambda_offset_idxs, beta, cutoff):
+    @functools.wraps(nonbonded.nonbonded_v3_on_specific_pairs)
+    def wrapped(conf, params, box, lamb):
+
+        # compute 4d coordinates
+        w = jax_utils.compute_lifting_parameter(lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff)
+        conf_4d = jax_utils.augment_dim(conf, w)
+        box_4d = (1000 * jax.numpy.eye(4)).at[:3, :3].set(box)
+
+        vdW, electrostatics = nonbonded.nonbonded_v3_on_specific_pairs(
+            conf_4d, params, box_4d, pair_idxs[:, 0], pair_idxs[:, 1], beta, cutoff
+        )
+        return jax.numpy.sum(scales[:, 1] * vdW + scales[:, 0] * electrostatics)
+
+    return wrapped
+
+
+@pytest.mark.parametrize("lamb", [0.0, 0.1])
+@pytest.mark.parametrize("beta", [2.0])
+@pytest.mark.parametrize("cutoff", [1.1])
+@pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 1e-8, 1e-8), (np.float32, 1e-4, 5e-4)])
+@pytest.mark.parametrize("num_atoms", [4080])
+@pytest.mark.parametrize("num_atoms_interacting", [1, 30, 1000])
+def test_nonbonded_interaction_group_correctness(
+    num_atoms_interacting,
+    precision,
+    rtol,
+    atol,
+    cutoff,
+    beta,
+    lamb,
+    example_nonbonded_params,
+    example_conf,
+    example_box,
+    rng: np.random.Generator,
+):
+    "Compares with jax reference implementation."
+
+    num_atoms, _ = example_conf.shape
+
+    atom_idxs = rng.choice(
+        num_atoms,
+        size=(
+            2,
+            num_atoms_interacting,
+        ),
+        replace=False,
+    ).astype(np.int32)
+
+    pair_idxs = np.stack(np.meshgrid(atom_idxs[0, :], atom_idxs[1, :])).reshape(2, -1).T
+    num_pairs, _ = pair_idxs.shape
+
+    scales = rng.uniform(0, 1, size=(num_pairs, 2))
+
+    lambda_plane_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
+    lambda_offset_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
+
+    ref_potential = make_ref_potential(pair_idxs, scales, lambda_plane_idxs, lambda_offset_idxs, beta, cutoff)
+    test_potential = NonbondedPairList(pair_idxs, scales, lambda_plane_idxs, lambda_offset_idxs, beta, cutoff)
+
+    GradientTest().compare_forces(
+        example_conf,
+        example_nonbonded_params,
+        example_box,
+        lamb,
+        ref_potential,
+        test_potential,
+        precision=precision,
+        rtol=rtol,
+        atol=atol,
+    )

--- a/tests/nonbonded/test_nonbonded_pair_list.py
+++ b/tests/nonbonded/test_nonbonded_pair_list.py
@@ -50,9 +50,9 @@ def make_ref_potential(pair_idxs, scales, lambda_plane_idxs, lambda_offset_idxs,
 @pytest.mark.parametrize("beta", [2.0])
 @pytest.mark.parametrize("cutoff", [1.1])
 @pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 1e-8, 1e-8), (np.float32, 1e-4, 5e-4)])
-@pytest.mark.parametrize("num_atoms_interacting", [1, 30, 1000])
+@pytest.mark.parametrize("ixn_group_size", [2, 33, 231])
 def test_nonbonded_pair_list_correctness(
-    num_atoms_interacting,
+    ixn_group_size,
     precision,
     rtol,
     atol,
@@ -68,11 +68,12 @@ def test_nonbonded_pair_list_correctness(
 
     num_atoms, _ = example_conf.shape
 
+    # randomly select 2 interaction groups and construct all pairwise interactions
     atom_idxs = rng.choice(
         num_atoms,
         size=(
             2,
-            num_atoms_interacting,
+            ixn_group_size,
         ),
         replace=False,
     ).astype(np.int32)

--- a/timemachine/cpp/src/nonbonded_pair_list.cu
+++ b/timemachine/cpp/src/nonbonded_pair_list.cu
@@ -24,19 +24,22 @@ NonbondedPairList<RealType, Negated, Interpolated>::NonbondedPairList(
           kernel_cache_.program(kernel_src.c_str()).kernel("k_add_du_dp_interpolated").instantiate()) {
 
     if (pair_idxs.size() % 2 != 0) {
-        throw std::runtime_error("pair_idxs.size() must be exactly 2*M");
+        throw std::runtime_error("pair_idxs.size() must be even, but got " + std::to_string(pair_idxs.size()));
     }
 
     for (int i = 0; i < M_; i++) {
         auto src = pair_idxs[i * 2 + 0];
         auto dst = pair_idxs[i * 2 + 1];
         if (src == dst) {
-            throw std::runtime_error("illegal pair with src == dst");
+            throw std::runtime_error(
+                "illegal pair with src == dst: " + std::to_string(src) + ", " + std::to_string(dst));
         }
     }
 
     if (scales.size() / 2 != M_) {
-        throw std::runtime_error("bad scales size!");
+        throw std::runtime_error(
+            "expected same number of pairs and scale tuples, but got " + std::to_string(M_) +
+            " != " + std::to_string(scales.size() / 2));
     }
 
     gpuErrchk(cudaMalloc(&d_pair_idxs_, M_ * 2 * sizeof(*d_pair_idxs_)));

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -706,6 +706,58 @@ template <typename RealType, bool Interpolated> void declare_nonbonded(py::modul
             py::arg("transform_lambda_w") = "lambda");
 }
 
+template <typename RealType, bool Interpolated> void declare_nonbonded_all_pairs(py::module &m, const char *typestr) {
+
+    using Class = timemachine::NonbondedAllPairs<RealType, Interpolated>;
+    std::string pyclass_name = std::string("NonbondedAllPairs_") + typestr;
+    py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+        m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+        .def("set_nblist_padding", &timemachine::NonbondedAllPairs<RealType, Interpolated>::set_nblist_padding)
+        .def("disable_hilbert_sort", &timemachine::NonbondedAllPairs<RealType, Interpolated>::disable_hilbert_sort)
+        .def(
+            py::init([](const py::array_t<int, py::array::c_style> &lambda_plane_idxs_i,
+                        const py::array_t<int, py::array::c_style> &lambda_offset_idxs_i,
+                        const double beta,
+                        const double cutoff,
+                        const std::string &transform_lambda_charge = "lambda",
+                        const std::string &transform_lambda_sigma = "lambda",
+                        const std::string &transform_lambda_epsilon = "lambda",
+                        const std::string &transform_lambda_w = "lambda") {
+                std::vector<int> lambda_plane_idxs(lambda_plane_idxs_i.size());
+                std::memcpy(
+                    lambda_plane_idxs.data(), lambda_plane_idxs_i.data(), lambda_plane_idxs_i.size() * sizeof(int));
+
+                std::vector<int> lambda_offset_idxs(lambda_offset_idxs_i.size());
+                std::memcpy(
+                    lambda_offset_idxs.data(), lambda_offset_idxs_i.data(), lambda_offset_idxs_i.size() * sizeof(int));
+
+                std::string dir_path = dirname(__FILE__);
+                std::string kernel_dir = dir_path + "/kernels";
+                std::string src_path = kernel_dir + "/k_lambda_transformer_jit.cuh";
+                std::ifstream t(src_path);
+                std::string source_str((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
+                source_str = std::regex_replace(source_str, std::regex("KERNEL_DIR"), kernel_dir);
+                source_str =
+                    std::regex_replace(source_str, std::regex("CUSTOM_EXPRESSION_CHARGE"), transform_lambda_charge);
+                source_str =
+                    std::regex_replace(source_str, std::regex("CUSTOM_EXPRESSION_SIGMA"), transform_lambda_sigma);
+                source_str =
+                    std::regex_replace(source_str, std::regex("CUSTOM_EXPRESSION_EPSILON"), transform_lambda_epsilon);
+                source_str = std::regex_replace(source_str, std::regex("CUSTOM_EXPRESSION_W"), transform_lambda_w);
+
+                return new timemachine::NonbondedAllPairs<RealType, Interpolated>(
+                    lambda_plane_idxs, lambda_offset_idxs, beta, cutoff, source_str);
+            }),
+            py::arg("lambda_plane_idxs_i"),
+            py::arg("lambda_offset_idxs_i"),
+            py::arg("beta"),
+            py::arg("cutoff"),
+            py::arg("transform_lambda_charge") = "lambda",
+            py::arg("transform_lambda_sigma") = "lambda",
+            py::arg("transform_lambda_epsilon") = "lambda",
+            py::arg("transform_lambda_w") = "lambda");
+}
+
 std::set<int> unique_idxs(const std::vector<int> &idxs) {
     std::set<int> unique_idxs(idxs.begin(), idxs.end());
     if (unique_idxs.size() < idxs.size()) {
@@ -764,6 +816,66 @@ void declare_nonbonded_interaction_group(py::module &m, const char *typestr) {
                     unique_row_atom_idxs, lambda_plane_idxs, lambda_offset_idxs, beta, cutoff, source_str);
             }),
             py::arg("row_atom_idxs_i"),
+            py::arg("lambda_plane_idxs_i"),
+            py::arg("lambda_offset_idxs_i"),
+            py::arg("beta"),
+            py::arg("cutoff"),
+            py::arg("transform_lambda_charge") = "lambda",
+            py::arg("transform_lambda_sigma") = "lambda",
+            py::arg("transform_lambda_epsilon") = "lambda",
+            py::arg("transform_lambda_w") = "lambda");
+}
+
+template <typename RealType, bool Interpolated> void declare_nonbonded_pair_list(py::module &m, const char *typestr) {
+    const bool Negated = false;
+    using Class = timemachine::NonbondedPairList<RealType, Negated, Interpolated>;
+    std::string pyclass_name = std::string("NonbondedPairList_") + typestr;
+    py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+        m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+        .def(
+            py::init([](const py::array_t<int, py::array::c_style> &pair_idxs_i,
+                        const py::array_t<double, py::array::c_style> &scales_i,
+                        const py::array_t<int, py::array::c_style> &lambda_plane_idxs_i,
+                        const py::array_t<int, py::array::c_style> &lambda_offset_idxs_i,
+                        const double beta,
+                        const double cutoff,
+                        const std::string &transform_lambda_charge = "lambda",
+                        const std::string &transform_lambda_sigma = "lambda",
+                        const std::string &transform_lambda_epsilon = "lambda",
+                        const std::string &transform_lambda_w = "lambda") {
+                std::vector<int> pair_idxs(pair_idxs_i.size());
+                std::memcpy(pair_idxs.data(), pair_idxs_i.data(), pair_idxs_i.size() * sizeof(int));
+
+                std::vector<double> scales(scales_i.size());
+                std::memcpy(scales.data(), scales_i.data(), scales_i.size() * sizeof(double));
+
+                std::vector<int> lambda_plane_idxs(lambda_plane_idxs_i.size());
+                std::memcpy(
+                    lambda_plane_idxs.data(), lambda_plane_idxs_i.data(), lambda_plane_idxs_i.size() * sizeof(int));
+
+                std::vector<int> lambda_offset_idxs(lambda_offset_idxs_i.size());
+                std::memcpy(
+                    lambda_offset_idxs.data(), lambda_offset_idxs_i.data(), lambda_offset_idxs_i.size() * sizeof(int));
+
+                std::string dir_path = dirname(__FILE__);
+                std::string kernel_dir = dir_path + "/kernels";
+                std::string src_path = kernel_dir + "/k_lambda_transformer_jit.cuh";
+                std::ifstream t(src_path);
+                std::string source_str((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
+                source_str = std::regex_replace(source_str, std::regex("KERNEL_DIR"), kernel_dir);
+                source_str =
+                    std::regex_replace(source_str, std::regex("CUSTOM_EXPRESSION_CHARGE"), transform_lambda_charge);
+                source_str =
+                    std::regex_replace(source_str, std::regex("CUSTOM_EXPRESSION_SIGMA"), transform_lambda_sigma);
+                source_str =
+                    std::regex_replace(source_str, std::regex("CUSTOM_EXPRESSION_EPSILON"), transform_lambda_epsilon);
+                source_str = std::regex_replace(source_str, std::regex("CUSTOM_EXPRESSION_W"), transform_lambda_w);
+
+                return new timemachine::NonbondedPairList<RealType, Negated, Interpolated>(
+                    pair_idxs, scales, lambda_plane_idxs, lambda_offset_idxs, beta, cutoff, source_str);
+            }),
+            py::arg("pair_idxs_i"),
+            py::arg("scales_i"),
             py::arg("lambda_plane_idxs_i"),
             py::arg("lambda_offset_idxs_i"),
             py::arg("beta"),
@@ -879,11 +991,23 @@ PYBIND11_MODULE(custom_ops, m) {
     declare_nonbonded<double, false>(m, "f64");
     declare_nonbonded<float, false>(m, "f32");
 
+    declare_nonbonded_all_pairs<double, true>(m, "f64_interpolated");
+    declare_nonbonded_all_pairs<float, true>(m, "f32_interpolated");
+
+    declare_nonbonded_all_pairs<double, false>(m, "f64");
+    declare_nonbonded_all_pairs<float, false>(m, "f32");
+
     declare_nonbonded_interaction_group<double, true>(m, "f64_interpolated");
     declare_nonbonded_interaction_group<float, true>(m, "f32_interpolated");
 
     declare_nonbonded_interaction_group<double, false>(m, "f64");
     declare_nonbonded_interaction_group<float, false>(m, "f32");
+
+    declare_nonbonded_pair_list<double, true>(m, "f64_interpolated");
+    declare_nonbonded_pair_list<float, true>(m, "f32_interpolated");
+
+    declare_nonbonded_pair_list<double, false>(m, "f64");
+    declare_nonbonded_pair_list<float, false>(m, "f32");
 
     declare_context(m);
 }

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -280,6 +280,23 @@ class NonbondedInterpolated(Nonbonded):
         return custom_ctor(*self.args)
 
 
+class NonbondedAllPairs(CustomOpWrapper):
+    pass
+
+
+class NonbondedAllPairsInterpolated(NonbondedAllPairs):
+    def unbound_impl(self, precision):
+        cls_name_base = "NonbondedAllPairs"
+        if precision == np.float64:
+            cls_name_base += "_f64_interpolated"
+        else:
+            cls_name_base += "_f32_interpolated"
+
+        custom_ctor = getattr(custom_ops, cls_name_base)
+
+        return custom_ctor(*self.args)
+
+
 class NonbondedInteractionGroup(CustomOpWrapper):
     pass
 
@@ -287,6 +304,23 @@ class NonbondedInteractionGroup(CustomOpWrapper):
 class NonbondedInteractionGroupInterpolated(NonbondedInteractionGroup):
     def unbound_impl(self, precision):
         cls_name_base = "NonbondedInteractionGroup"
+        if precision == np.float64:
+            cls_name_base += "_f64_interpolated"
+        else:
+            cls_name_base += "_f32_interpolated"
+
+        custom_ctor = getattr(custom_ops, cls_name_base)
+
+        return custom_ctor(*self.args)
+
+
+class NonbondedPairList(CustomOpWrapper):
+    pass
+
+
+class NonbondedPairListInterpolated(NonbondedPairList):
+    def unbound_impl(self, precision):
+        cls_name_base = "NonbondedPairList"
         if precision == np.float64:
             cls_name_base += "_f64_interpolated"
         else:


### PR DESCRIPTION
- Exposes `NonbondedAllPairs` and `NonbondedPairList` in the Python API
- Adds tests for both potentials
- Reorganizes new nonbonded tests under `tests/nonbonded` to allow sharing fixtures
- Improves some error messages

Note: this does not yet add the consistency check

```
U = U_A + U_B + U_AB
```

since this requires updating `NonbondedAllPairs` to accept a subset of atom indices. I'm planning to add this and the consistency check in an upcoming PR.