### PR TITLE
Fix slow test setup using module-level fixtures

### DIFF
--- a/tests/test_nonbonded_interaction_group.py
+++ b/tests/test_nonbonded_interaction_group.py
@@ -13,20 +13,14 @@ from timemachine.lib import potentials
 from timemachine.lib.potentials import NonbondedInteractionGroup, NonbondedInteractionGroupInterpolated
 from timemachine.potentials import jax_utils, nonbonded
 
-
-@pytest.fixture(autouse=True)
-def set_random_seed():
-    np.random.seed(2022)
-    yield
-
-
-@pytest.fixture()
-def rng():
-    return np.random.default_rng(2022)
+# NOTE: For efficiency, we use module-scoped fixtures for expensive
+# setup. To prevent unintended mutation, these shouldn't be used in
+# tests directly. Instead, they are wrapped below by function-scoped
+# fixtures that return copies of the data.
 
 
-@pytest.fixture
-def example_system():
+@pytest.fixture(scope="module")
+def _example_system():
     pdb_path = "tests/data/5dfr_solv_equil.pdb"
     host_pdb = app.PDBFile(pdb_path)
     ff = app.ForceField("amber99sbildn.xml", "tip3p.xml")
@@ -37,9 +31,9 @@ def example_system():
     )
 
 
-@pytest.fixture
-def example_nonbonded_params(example_system):
-    host_system, _, _ = example_system
+@pytest.fixture(scope="module")
+def _example_nonbonded_params(_example_system):
+    host_system, _, _ = _example_system
     host_fns, _ = openmm_deserializer.deserialize_system(host_system, cutoff=1.0)
 
     nonbonded_fn = None
@@ -51,15 +45,36 @@ def example_nonbonded_params(example_system):
     return nonbonded_fn.params
 
 
-@pytest.fixture
-def example_conf(example_system):
-    _, host_conf, _ = example_system
+@pytest.fixture(scope="module")
+def _example_conf(_example_system):
+    _, host_conf, _ = _example_system
     return np.array([[to_md_units(x), to_md_units(y), to_md_units(z)] for x, y, z in host_conf])
 
 
-@pytest.fixture
-def example_box(example_system):
-    _, _, box = example_system
+@pytest.fixture(scope="function", autouse=True)
+def set_random_seed():
+    np.random.seed(2022)
+    yield
+
+
+@pytest.fixture(scope="function")
+def rng():
+    return np.random.default_rng(2022)
+
+
+@pytest.fixture(scope="function")
+def example_nonbonded_params(_example_nonbonded_params):
+    return _example_nonbonded_params[:]
+
+
+@pytest.fixture(scope="function")
+def example_conf(_example_conf):
+    return _example_conf[:]
+
+
+@pytest.fixture(scope="function")
+def example_box(_example_system):
+    _, _, box = _example_system
     return np.asarray(box / box.unit)
 
 


### PR DESCRIPTION
- Switches to using [module-level](https://docs.pytest.org/en/latest/how-to/fixtures.html#fixture-scopes) fixtures for expensive setup operations in `test_nonbonded_interaction_group.py`
- This cuts ~7 minutes from total CI time

----

As @badisa noticed, we're spending ~5 minutes of CI time on running test setup for tests in `test_nonbonded_interaction_group.py` (visible in [CI log](https://jenkins.relaytxinternal.com/blue/organizations/jenkins/timemachine/detail/PR-633/19/pipeline/)). The main cause of this appears to be regenerating the fixtures for each test and parameter set.

This PR switches to using [module-level](https://docs.pytest.org/en/latest/how-to/fixtures.html#fixture-scopes) fixtures for expensive setup operations. These are only generated once and shared between tests/param sets. To prevent accidental mutation of fixture data, the module-level fixtures are wrapped in function-level fixtures that return copies of the corresponding data.