### PR TITLE
Refactor memory management in nonbonded potentials

### DIFF
--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -1,17 +1,17 @@
 #include "device_buffer.hpp"
 #include "gpu_utils.cuh"
-#include <cstddef>
 
 namespace timemachine {
 
-template <typename T> T *allocate(const std::size_t length) {
-    T *buffer;
-    gpuErrchk(cudaMalloc(&buffer, length * sizeof(T)));
+void *allocate(const std::size_t size) {
+    void *buffer;
+    gpuErrchk(cudaMalloc(&buffer, size));
     return buffer;
 }
 
 template <typename T>
-DeviceBuffer<T>::DeviceBuffer(const std::size_t length) : size(length * sizeof(T)), data(allocate<T>(length)) {}
+DeviceBuffer<T>::DeviceBuffer(const std::size_t length)
+    : size(length * sizeof(T)), data(static_cast<T *>(allocate(size))) {}
 
 template <typename T> DeviceBuffer<T>::~DeviceBuffer() {
     // TODO: the file/line context reported by gpuErrchk on failure is

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -20,14 +20,41 @@ template <typename T> DeviceBuffer<T>::~DeviceBuffer() {
     gpuErrchk(cudaFree(data));
 }
 
-template <typename T> void DeviceBuffer<T>::copy_from(const T *host_buffer) const {
+template <typename T> void DeviceBuffer<T>::copy_from_host(const T *host_buffer) const {
     gpuErrchk(cudaMemcpy(data, host_buffer, size, cudaMemcpyHostToDevice));
 }
 
-template <typename T> void DeviceBuffer<T>::copy_to(T *host_buffer) const {
+template <typename T> void DeviceBuffer<T>::copy_to_host(T *host_buffer) const {
     gpuErrchk(cudaMemcpy(host_buffer, data, size, cudaMemcpyDeviceToHost));
 }
 
-template class DeviceBuffer<double>;
+template <typename T> void DeviceBuffer<T>::copy_from_device(const T *device_buffer) const {
+    gpuErrchk(cudaMemcpy(data, device_buffer, size, cudaMemcpyDeviceToDevice));
+}
+
+template <typename T> void DeviceBuffer<T>::copy_to_device(T *device_buffer) const {
+    gpuErrchk(cudaMemcpy(device_buffer, data, size, cudaMemcpyDeviceToDevice));
+}
+
+template <typename T> void DeviceBuffer<T>::copy_from_host_async(const T *host_buffer, cudaStream_t stream) const {
+    gpuErrchk(cudaMemcpyAsync(data, host_buffer, size, cudaMemcpyHostToDevice, stream));
+}
+
+template <typename T> void DeviceBuffer<T>::copy_to_host_async(T *host_buffer, cudaStream_t stream) const {
+    gpuErrchk(cudaMemcpyAsync(host_buffer, data, size, cudaMemcpyDeviceToHost, stream));
+}
+
+template <typename T> void DeviceBuffer<T>::copy_from_device_async(const T *device_buffer, cudaStream_t stream) const {
+    gpuErrchk(cudaMemcpyAsync(data, device_buffer, size, cudaMemcpyDeviceToDevice, stream));
+}
+
+template <typename T> void DeviceBuffer<T>::copy_to_device_async(T *device_buffer, cudaStream_t stream) const {
+    gpuErrchk(cudaMemcpyAsync(device_buffer, data, size, cudaMemcpyDeviceToDevice, stream));
+}
+
+template class DeviceBuffer<char>;
+template class DeviceBuffer<int>;
+template class DeviceBuffer<unsigned int>;
 template class DeviceBuffer<unsigned long long>;
+template class DeviceBuffer<double>;
 } // namespace timemachine

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -13,12 +13,7 @@ template <typename T>
 DeviceBuffer<T>::DeviceBuffer(const std::size_t length)
     : size(length * sizeof(T)), data(static_cast<T *>(allocate(size))) {}
 
-template <typename T> DeviceBuffer<T>::~DeviceBuffer() {
-    // TODO: the file/line context reported by gpuErrchk on failure is
-    // not very useful when it's called from here. Is there a way to
-    // report a stack trace?
-    gpuErrchk(cudaFree(data));
-}
+template <typename T> DeviceBuffer<T>::~DeviceBuffer() { gpuErrchk(cudaFree(data)); }
 
 template <typename T> void DeviceBuffer<T>::copy_from_host(const T *host_buffer) const {
     gpuErrchk(cudaMemcpy(data, host_buffer, size, cudaMemcpyHostToDevice));

--- a/timemachine/cpp/src/device_buffer.hpp
+++ b/timemachine/cpp/src/device_buffer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstddef>
+#include <cuda_runtime_api.h>
 
 namespace timemachine {
 
@@ -13,9 +14,23 @@ public:
 
     T *const data;
 
-    void copy_from(const T *host_buffer) const;
+    void copy_from_host(const T *host_buffer) const;
 
-    void copy_to(T *host_buffer) const;
+    void copy_to_host(T *host_buffer) const;
+
+    void copy_from_device(const T *device_buffer) const;
+
+    void copy_to_device(T *device_buffer) const;
+
+    // async API
+
+    void copy_from_host_async(const T *host_buffer, cudaStream_t stream) const;
+
+    void copy_to_host_async(T *host_buffer, cudaStream_t stream) const;
+
+    void copy_from_device_async(const T *device_buffer, cudaStream_t stream) const;
+
+    void copy_to_device_async(T *device_buffer, cudaStream_t stream) const;
 };
 
 } // namespace timemachine

--- a/timemachine/cpp/src/device_buffer.hpp
+++ b/timemachine/cpp/src/device_buffer.hpp
@@ -5,11 +5,11 @@ namespace timemachine {
 
 template <typename T> class DeviceBuffer {
 public:
-    DeviceBuffer(const size_t length);
+    DeviceBuffer(const std::size_t length);
 
     ~DeviceBuffer();
 
-    const size_t size;
+    const std::size_t size;
 
     T *const data;
 

--- a/timemachine/cpp/src/device_buffer.hpp
+++ b/timemachine/cpp/src/device_buffer.hpp
@@ -8,6 +8,12 @@ template <typename T> class DeviceBuffer {
 public:
     DeviceBuffer(const std::size_t length);
 
+    // Disable the copy constructor.
+    // A correct implementation of this would allocate a new buffer
+    // and copy data, but we generally don't want to do this.
+    // Disabling copies prevents accidental pass-by-value
+    DeviceBuffer(const DeviceBuffer &) = delete;
+
     ~DeviceBuffer();
 
     const std::size_t size;

--- a/timemachine/cpp/src/nonbonded_all_pairs.cu
+++ b/timemachine/cpp/src/nonbonded_all_pairs.cu
@@ -72,8 +72,8 @@ NonbondedAllPairs<RealType, Interpolated>::NonbondedAllPairs(
 
       d_w_(N_), d_dw_dl_(N_), d_sorted_w_(N_), d_sorted_dw_dl_(N_),
 
-      d_unsorted_p_(N_ * 3), d_sorted_p_(N_ * 3), d_unsorted_dp_dl_(N_ * 3), d_sorted_dp_dl_(N_ * 3),
-      d_sorted_du_dx_(N_ * 3), d_sorted_du_dp_(N_ * 3), d_du_dp_buffer_(N_ * 3),
+      d_sorted_p_(N_ * 3), d_sorted_dp_dl_(N_ * 3), d_sorted_du_dx_(N_ * 3), d_sorted_du_dp_(N_ * 3),
+      d_du_dp_buffer_(N_ * 3),
 
       d_nblist_x_(N_ * 3), d_nblist_box_(3 * 3), d_rebuild_nblist_(1),
 

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "device_buffer.hpp"
 #include "neighborlist.hpp"
 #include "potential.hpp"
 #include "vendored/jitify.hpp"
@@ -31,26 +32,26 @@ template <typename RealType, bool Interpolated> class NonbondedAllPairs : public
 private:
     std::array<k_nonbonded_fn, 16> kernel_ptrs_;
 
-    int *d_lambda_plane_idxs_;
-    int *d_lambda_offset_idxs_;
+    const unsigned int N_;
+
+    DeviceBuffer<int> d_lambda_plane_idxs_;
+    DeviceBuffer<int> d_lambda_offset_idxs_;
     int *p_ixn_count_; // pinned memory
 
     double beta_;
     double cutoff_;
     Neighborlist<RealType> nblist_;
 
-    const int N_;
-
     double nblist_padding_;
-    double *d_nblist_x_;    // coords which were used to compute the nblist
-    double *d_nblist_box_;  // box which was used to rebuild the nblist
-    int *d_rebuild_nblist_; // whether or not we have to rebuild the nblist
-    int *p_rebuild_nblist_; // pinned
+    DeviceBuffer<double> d_nblist_x_;    // coords which were used to compute the nblist
+    DeviceBuffer<double> d_nblist_box_;  // box which was used to rebuild the nblist
+    DeviceBuffer<int> d_rebuild_nblist_; // whether or not we have to rebuild the nblist
+    int *p_rebuild_nblist_;              // pinned
 
-    unsigned int *d_perm_; // hilbert curve permutation
+    DeviceBuffer<unsigned int> d_perm_; // hilbert curve permutation
 
-    double *d_w_; // 4D coordinates
-    double *d_dw_dl_;
+    DeviceBuffer<double> d_w_; // 4D coordinates
+    DeviceBuffer<double> d_dw_dl_;
 
     // "sorted" means
     // - if hilbert sorting enabled, atoms are sorted according to the
@@ -58,24 +59,24 @@ private:
     // - otherwise, atom ordering is preserved with respect to input
     //
     // "unsorted" means the atom ordering is preserved with respect to input
-    double *d_sorted_x_; // sorted coordinates
-    double *d_sorted_w_; // sorted 4D coordinates
-    double *d_sorted_dw_dl_;
-    double *d_sorted_p_;   // sorted parameters
-    double *d_unsorted_p_; // unsorted parameters
-    double *d_sorted_dp_dl_;
-    double *d_unsorted_dp_dl_;
-    unsigned long long *d_sorted_du_dx_;
-    unsigned long long *d_sorted_du_dp_;
-    unsigned long long *d_du_dp_buffer_;
+    DeviceBuffer<double> d_sorted_x_; // sorted coordinates
+    DeviceBuffer<double> d_sorted_w_; // sorted 4D coordinates
+    DeviceBuffer<double> d_sorted_dw_dl_;
+    DeviceBuffer<double> d_sorted_p_;   // sorted parameters
+    DeviceBuffer<double> d_unsorted_p_; // unsorted parameters
+    DeviceBuffer<double> d_sorted_dp_dl_;
+    DeviceBuffer<double> d_unsorted_dp_dl_;
+    DeviceBuffer<unsigned long long> d_sorted_du_dx_;
+    DeviceBuffer<unsigned long long> d_sorted_du_dp_;
+    DeviceBuffer<unsigned long long> d_du_dp_buffer_;
 
     // used for hilbert sorting
-    unsigned int *d_bin_to_idx_; // mapping from 256x256x256 grid to hilbert curve index
-    unsigned int *d_sort_keys_in_;
-    unsigned int *d_sort_keys_out_;
-    unsigned int *d_sort_vals_in_;
-    unsigned int *d_sort_storage_;
-    size_t d_sort_storage_bytes_;
+    DeviceBuffer<unsigned int> d_bin_to_idx_; // mapping from 256x256x256 grid to hilbert curve index
+    DeviceBuffer<unsigned int> d_sort_keys_in_;
+    DeviceBuffer<unsigned int> d_sort_keys_out_;
+    DeviceBuffer<unsigned int> d_sort_vals_in_;
+    std::unique_ptr<DeviceBuffer<char>> d_sort_storage_;
+    size_t sort_storage_bytes_;
 
     bool disable_hilbert_;
 

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -57,15 +57,11 @@ private:
     // - if hilbert sorting enabled, atoms are sorted according to the
     //   hilbert curve index
     // - otherwise, atom ordering is preserved with respect to input
-    //
-    // "unsorted" means the atom ordering is preserved with respect to input
     DeviceBuffer<double> d_sorted_x_; // sorted coordinates
     DeviceBuffer<double> d_sorted_w_; // sorted 4D coordinates
     DeviceBuffer<double> d_sorted_dw_dl_;
-    DeviceBuffer<double> d_sorted_p_;   // sorted parameters
-    DeviceBuffer<double> d_unsorted_p_; // unsorted parameters
+    DeviceBuffer<double> d_sorted_p_; // sorted parameters
     DeviceBuffer<double> d_sorted_dp_dl_;
-    DeviceBuffer<double> d_unsorted_dp_dl_;
     DeviceBuffer<unsigned long long> d_sorted_du_dx_;
     DeviceBuffer<unsigned long long> d_sorted_du_dp_;
     DeviceBuffer<unsigned long long> d_du_dp_buffer_;

--- a/timemachine/cpp/src/nonbonded_interaction_group.cu
+++ b/timemachine/cpp/src/nonbonded_interaction_group.cu
@@ -170,7 +170,7 @@ void NonbondedInteractionGroup<RealType, Interpolated>::disable_hilbert_sort() {
 template <typename RealType, bool Interpolated>
 void NonbondedInteractionGroup<RealType, Interpolated>::hilbert_sort(
     const unsigned int N,
-    const unsigned int *d_atom_idxs,
+    const DeviceBuffer<unsigned int> d_atom_idxs,
     const double *d_coords,
     const double *d_box,
     unsigned int *d_perm,
@@ -180,7 +180,7 @@ void NonbondedInteractionGroup<RealType, Interpolated>::hilbert_sort(
     const int B = ceil_divide(N, tpb);
 
     k_coords_to_kv_gather<<<B, tpb, 0, stream>>>(
-        N, d_atom_idxs, d_coords, d_box, d_bin_to_idx_.data, d_sort_keys_in_.data, d_sort_vals_in_.data);
+        N, d_atom_idxs.data, d_coords, d_box, d_bin_to_idx_.data, d_sort_keys_in_.data, d_sort_vals_in_.data);
 
     gpuErrchk(cudaPeekAtLastError());
 
@@ -266,8 +266,8 @@ void NonbondedInteractionGroup<RealType, Interpolated>::execute_device(
         // (ytz): update the permutation index before building neighborlist, as the neighborlist is tied
         // to a particular sort order
         if (!disable_hilbert_) {
-            this->hilbert_sort(NC_, d_col_atom_idxs_.data, d_x, d_box, d_perm_.data, stream);
-            this->hilbert_sort(NR_, d_row_atom_idxs_.data, d_x, d_box, d_perm_.data + NC_, stream);
+            this->hilbert_sort(NC_, d_col_atom_idxs_, d_x, d_box, d_perm_.data, stream);
+            this->hilbert_sort(NR_, d_row_atom_idxs_, d_x, d_box, d_perm_.data + NC_, stream);
         } else {
             d_col_atom_idxs_.copy_to_device(d_perm_.data);
             d_row_atom_idxs_.copy_to_device(d_perm_.data + NC_);

--- a/timemachine/cpp/src/nonbonded_interaction_group.cu
+++ b/timemachine/cpp/src/nonbonded_interaction_group.cu
@@ -77,8 +77,8 @@ NonbondedInteractionGroup<RealType, Interpolated>::NonbondedInteractionGroup(
 
       d_w_(N_), d_dw_dl_(N_), d_sorted_w_(N_), d_sorted_dw_dl_(N_),
 
-      d_unsorted_p_(N_ * 3), d_sorted_p_(N_ * 3), d_unsorted_dp_dl_(N_ * 3), d_sorted_dp_dl_(N_ * 3),
-      d_sorted_du_dx_(N_ * 3), d_sorted_du_dp_(N_ * 3), d_du_dp_buffer_(N_ * 3),
+      d_sorted_p_(N_ * 3), d_sorted_dp_dl_(N_ * 3), d_sorted_du_dx_(N_ * 3), d_sorted_du_dp_(N_ * 3),
+      d_du_dp_buffer_(N_ * 3),
 
       d_nblist_x_(N_ * 3), d_nblist_box_(3 * 3), d_rebuild_nblist_(1),
 

--- a/timemachine/cpp/src/nonbonded_interaction_group.hpp
+++ b/timemachine/cpp/src/nonbonded_interaction_group.hpp
@@ -86,7 +86,7 @@ private:
 
     void hilbert_sort(
         const unsigned int N,
-        const DeviceBuffer<unsigned int> d_atom_idxs,
+        const unsigned int *d_atom_idxs,
         const double *d_x,
         const double *d_box,
         unsigned int *d_perm,

--- a/timemachine/cpp/src/nonbonded_interaction_group.hpp
+++ b/timemachine/cpp/src/nonbonded_interaction_group.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "device_buffer.hpp"
 #include "neighborlist.hpp"
 #include "potential.hpp"
 #include "vendored/jitify.hpp"
@@ -30,17 +31,17 @@ typedef void (*k_nonbonded_fn)(
 template <typename RealType, bool Interpolated> class NonbondedInteractionGroup : public Potential {
 
 private:
-    const int N_;  // N_ = NC_ + NR_
-    const int NR_; // number of row atoms
-    const int NC_; // number of column atoms
+    const unsigned int N_;  // N_ = NC_ + NR_
+    const unsigned int NR_; // number of row atoms
+    const unsigned int NC_; // number of column atoms
 
     std::array<k_nonbonded_fn, 16> kernel_ptrs_;
 
-    unsigned int *d_col_atom_idxs_;
-    unsigned int *d_row_atom_idxs_;
+    DeviceBuffer<unsigned int> d_col_atom_idxs_;
+    DeviceBuffer<unsigned int> d_row_atom_idxs_;
 
-    int *d_lambda_plane_idxs_;
-    int *d_lambda_offset_idxs_;
+    DeviceBuffer<int> d_lambda_plane_idxs_;
+    DeviceBuffer<int> d_lambda_offset_idxs_;
     int *p_ixn_count_; // pinned memory
 
     double beta_;
@@ -48,15 +49,15 @@ private:
     Neighborlist<RealType> nblist_;
 
     double nblist_padding_;
-    double *d_nblist_x_;    // coords which were used to compute the nblist
-    double *d_nblist_box_;  // box which was used to rebuild the nblist
-    int *d_rebuild_nblist_; // whether or not we have to rebuild the nblist
-    int *p_rebuild_nblist_; // pinned
+    DeviceBuffer<double> d_nblist_x_;    // coords which were used to compute the nblist
+    DeviceBuffer<double> d_nblist_box_;  // box which was used to rebuild the nblist
+    DeviceBuffer<int> d_rebuild_nblist_; // whether or not we have to rebuild the nblist
+    int *p_rebuild_nblist_;              // pinned
 
-    unsigned int *d_perm_; // hilbert curve permutation
+    DeviceBuffer<unsigned int> d_perm_; // hilbert curve permutation
 
-    double *d_w_; // 4D coordinates
-    double *d_dw_dl_;
+    DeviceBuffer<double> d_w_; // 4D coordinates
+    DeviceBuffer<double> d_dw_dl_;
 
     // "sorted" means
     // - if hilbert sorting enabled, atoms are sorted into contiguous
@@ -66,29 +67,29 @@ private:
     //   interaction group, with arbitrary ordering within each block
     //
     // "unsorted" means the atom ordering is preserved with respect to input
-    double *d_sorted_x_; // sorted coordinates
-    double *d_sorted_w_; // sorted 4D coordinates
-    double *d_sorted_dw_dl_;
-    double *d_sorted_p_;   // sorted parameters
-    double *d_unsorted_p_; // unsorted parameters
-    double *d_sorted_dp_dl_;
-    double *d_unsorted_dp_dl_;
-    unsigned long long *d_sorted_du_dx_;
-    unsigned long long *d_sorted_du_dp_;
-    unsigned long long *d_du_dp_buffer_;
+    DeviceBuffer<double> d_sorted_x_; // sorted coordinates
+    DeviceBuffer<double> d_sorted_w_; // sorted 4D coordinates
+    DeviceBuffer<double> d_sorted_dw_dl_;
+    DeviceBuffer<double> d_sorted_p_;   // sorted parameters
+    DeviceBuffer<double> d_unsorted_p_; // unsorted parameters
+    DeviceBuffer<double> d_sorted_dp_dl_;
+    DeviceBuffer<double> d_unsorted_dp_dl_;
+    DeviceBuffer<unsigned long long> d_sorted_du_dx_;
+    DeviceBuffer<unsigned long long> d_sorted_du_dp_;
+    DeviceBuffer<unsigned long long> d_du_dp_buffer_;
 
     // used for hilbert sorting
-    unsigned int *d_bin_to_idx_; // mapping from 256x256x256 grid to hilbert curve index
-    unsigned int *d_sort_keys_in_;
-    unsigned int *d_sort_keys_out_;
-    unsigned int *d_sort_vals_in_;
-    unsigned int *d_sort_storage_;
-    size_t d_sort_storage_bytes_;
+    DeviceBuffer<unsigned int> d_bin_to_idx_; // mapping from 256x256x256 grid to hilbert curve index
+    DeviceBuffer<unsigned int> d_sort_keys_in_;
+    DeviceBuffer<unsigned int> d_sort_keys_out_;
+    DeviceBuffer<unsigned int> d_sort_vals_in_;
+    std::unique_ptr<DeviceBuffer<char>> d_sort_storage_;
+    size_t sort_storage_bytes_;
 
     bool disable_hilbert_;
 
     void hilbert_sort(
-        const int N,
+        const unsigned int N,
         const unsigned int *d_atom_idxs,
         const double *d_x,
         const double *d_box,
@@ -106,7 +107,7 @@ public:
     void disable_hilbert_sort();
 
     NonbondedInteractionGroup(
-        const std::set<int> &row_atom_idxs,
+        const std::set<unsigned int> &row_atom_idxs,
         const std::vector<int> &lambda_plane_idxs,  // N
         const std::vector<int> &lambda_offset_idxs, // N
         const double beta,

--- a/timemachine/cpp/src/nonbonded_interaction_group.hpp
+++ b/timemachine/cpp/src/nonbonded_interaction_group.hpp
@@ -65,15 +65,11 @@ private:
     //   independently
     // - otherwise, atoms are sorted into contiguous blocks by
     //   interaction group, with arbitrary ordering within each block
-    //
-    // "unsorted" means the atom ordering is preserved with respect to input
     DeviceBuffer<double> d_sorted_x_; // sorted coordinates
     DeviceBuffer<double> d_sorted_w_; // sorted 4D coordinates
     DeviceBuffer<double> d_sorted_dw_dl_;
-    DeviceBuffer<double> d_sorted_p_;   // sorted parameters
-    DeviceBuffer<double> d_unsorted_p_; // unsorted parameters
+    DeviceBuffer<double> d_sorted_p_; // sorted parameters
     DeviceBuffer<double> d_sorted_dp_dl_;
-    DeviceBuffer<double> d_unsorted_dp_dl_;
     DeviceBuffer<unsigned long long> d_sorted_du_dx_;
     DeviceBuffer<unsigned long long> d_sorted_du_dp_;
     DeviceBuffer<unsigned long long> d_du_dp_buffer_;

--- a/timemachine/cpp/src/nonbonded_interaction_group.hpp
+++ b/timemachine/cpp/src/nonbonded_interaction_group.hpp
@@ -86,7 +86,7 @@ private:
 
     void hilbert_sort(
         const unsigned int N,
-        const unsigned int *d_atom_idxs,
+        const DeviceBuffer<unsigned int> d_atom_idxs,
         const double *d_x,
         const double *d_box,
         unsigned int *d_perm,

--- a/timemachine/cpp/src/potential.cu
+++ b/timemachine/cpp/src/potential.cu
@@ -29,9 +29,9 @@ void Potential::execute_host(
     DeviceBuffer<double> d_p(P);
     DeviceBuffer<double> d_box(D * D);
 
-    d_x.copy_from(h_x);
-    d_p.copy_from(h_p);
-    d_box.copy_from(h_box);
+    d_x.copy_from_host(h_x);
+    d_p.copy_from_host(h_p);
+    d_box.copy_from_host(h_box);
 
     std::unique_ptr<DeviceBuffer<unsigned long long>> d_du_dx;
     std::unique_ptr<DeviceBuffer<unsigned long long>> d_du_dp;
@@ -71,16 +71,16 @@ void Potential::execute_host(
 
     // outputs
     if (h_du_dx) {
-        d_du_dx->copy_to(h_du_dx);
+        d_du_dx->copy_to_host(h_du_dx);
     }
     if (h_du_dp) {
-        d_du_dp->copy_to(h_du_dp);
+        d_du_dp->copy_to_host(h_du_dp);
     }
     if (h_du_dl) {
-        d_du_dl->copy_to(h_du_dl);
+        d_du_dl->copy_to_host(h_du_dl);
     }
     if (h_u) {
-        d_u->copy_to(h_u);
+        d_u->copy_to_host(h_u);
     }
 };
 

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -758,8 +758,8 @@ template <typename RealType, bool Interpolated> void declare_nonbonded_all_pairs
             py::arg("transform_lambda_w") = "lambda");
 }
 
-std::set<int> unique_idxs(const std::vector<int> &idxs) {
-    std::set<int> unique_idxs(idxs.begin(), idxs.end());
+std::set<unsigned int> unique_idxs(const std::vector<unsigned int> &idxs) {
+    std::set<unsigned int> unique_idxs(idxs.begin(), idxs.end());
     if (unique_idxs.size() < idxs.size()) {
         throw std::runtime_error("atom indices must be unique");
     }
@@ -786,9 +786,9 @@ void declare_nonbonded_interaction_group(py::module &m, const char *typestr) {
                         const std::string &transform_lambda_sigma = "lambda",
                         const std::string &transform_lambda_epsilon = "lambda",
                         const std::string &transform_lambda_w = "lambda") {
-                std::vector<int> row_atom_idxs(row_atom_idxs_i.size());
+                std::vector<unsigned int> row_atom_idxs(row_atom_idxs_i.size());
                 std::memcpy(row_atom_idxs.data(), row_atom_idxs_i.data(), row_atom_idxs_i.size() * sizeof(int));
-                std::set<int> unique_row_atom_idxs(unique_idxs(row_atom_idxs));
+                std::set<unsigned int> unique_row_atom_idxs(unique_idxs(row_atom_idxs));
 
                 std::vector<int> lambda_plane_idxs(lambda_plane_idxs_i.size());
                 std::memcpy(


### PR DESCRIPTION
- refactors memory management in nonbonded potentials using RAII style enabled by `DeviceBuffer`
- adds member functions to `DeviceBuffer` for async copies
- deletes `DeviceBuffer` copy constructor to prevent a potential pitfall of passing by value (demonstrated in e4c250d)