### PR TITLE
Moves grpcio-tools to a dev requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 bootstrapped==0.0.2
 grpcio==1.30.0
-grpcio-tools==1.30.0
 protobuf==3.15.0
 numpy==1.21.4
 scipy==1.6.0

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,6 @@ setup(
     install_requires=[
         "bootstrapped",
         "grpcio",
-        "grpcio-tools",
         "hilbertcurve",
         "jax",
         "jaxlib>0.1.74",
@@ -94,7 +93,7 @@ setup(
         "scipy",
     ],
     extras_require={
-        "dev": ["black==21.10b0", "isort==5.10.1", "flake8==4.0.1", "pre-commit"],
+        "dev": ["black==21.10b0", "isort==5.10.1", "flake8==4.0.1", "pre-commit", "grpcio-tools==1.30.0"],
         "test": ["pytest", "pytest-cov"],
     },
     package_data={


### PR DESCRIPTION
* Only used for converting .proto files to python

In part this change is to test that the CI will rebuild the container environment, it should also show if this requirement is necessary in the tests