### PR TITLE
Improve bond canonicalization consistency in Improper Torsions

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -239,6 +239,9 @@ def test_improper_torsion():
     assert assigned_params.shape == (0, 3)
     assert improper_idxs.shape == (0, 4)
 
+    for idxs in improper_idxs:
+        assert idxs[0] < idxs[-1]
+
 
 def test_exclusions():
 

--- a/timemachine/ff/handlers/bonded.py
+++ b/timemachine/ff/handlers/bonded.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from timemachine.ff.handlers.serialize import SerializableMixIn
 from timemachine.ff.handlers.suffix import _SUFFIX
-from timemachine.ff.handlers.utils import match_smirks, sort_tuple
+from timemachine.ff.handlers.utils import canonicalize_bond, match_smirks
 
 
 def generate_vd_idxs(mol, smirks):
@@ -17,7 +17,7 @@ def generate_vd_idxs(mol, smirks):
     for p_idx, patt in enumerate(smirks):
         matches = match_smirks(mol, patt)
         for m in matches:
-            sorted_m = sort_tuple(m)
+            sorted_m = canonicalize_bond(m)
             vd[sorted_m] = p_idx
 
     bond_idxs = np.array(list(vd.keys()), dtype=np.int32)
@@ -212,7 +212,7 @@ class ImproperTorsionHandler(SerializableMixIn):
             center = atom_idxs[1]
             others = [atom_idxs[0], atom_idxs[2], atom_idxs[3]]
             for p in [(others[i], others[j], others[k]) for (i, j, k) in [(0, 1, 2), (1, 2, 0), (2, 0, 1)]]:
-                improper_idxs.append((center, p[0], p[1], p[2]))
+                improper_idxs.append(canonicalize_bond((center, p[0], p[1], p[2])))
                 param_idxs.append(p_idx)
 
         param_idxs = np.array(param_idxs)

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -12,8 +12,8 @@ from timemachine import constants
 from timemachine.ff.handlers.bcc_aromaticity import AromaticityModel
 from timemachine.ff.handlers.bcc_aromaticity import match_smirks as oe_match_smirks
 from timemachine.ff.handlers.serialize import SerializableMixIn
+from timemachine.ff.handlers.utils import canonicalize_bond
 from timemachine.ff.handlers.utils import match_smirks as rd_match_smirks
-from timemachine.ff.handlers.utils import sort_tuple
 from timemachine.graph_utils import convert_to_nx
 
 AM1_CHARGE_CACHE = "AM1Cache"
@@ -109,7 +109,7 @@ def generate_exclusion_idxs(mol, scale12, scale13, scale14):
                 else:
                     assert 0
 
-                exclusions[sort_tuple((src, dst))] = scale
+                exclusions[canonicalize_bond((src, dst))] = scale
 
     idxs = list(exclusions.keys())
     scales = list(exclusions.values())

--- a/timemachine/ff/handlers/utils.py
+++ b/timemachine/ff/handlers/utils.py
@@ -1,8 +1,23 @@
 from rdkit import Chem
 
 
-def sort_tuple(arr):
+def canonicalize_bond(arr):
+    """
+    Canonicalize a bonded interaction. If arr[0] < arr[-1] then arr is
+    returned, else if arr[0] > arr[-1], then arr[::-1] is returned. If
+    arr[0] == arr[-1] then an exception is thrown.
 
+    Parameters
+    ----------
+    arr: list of int
+        Bond indices.
+
+    Returns
+    -------
+    arr: list of int
+        Canonicalized bond indices.
+
+    """
     container_type = type(arr)
 
     if len(arr) == 0:
@@ -11,6 +26,8 @@ def sort_tuple(arr):
         return arr
     elif arr[0] > arr[-1]:
         return container_type(reversed(arr))
+    elif arr[0] == arr[-1]:
+        raise Exception("arr[0] == [-1]")
     else:
         return arr
 


### PR DESCRIPTION
Canonicalize improper torsions (after a discussion with @maxentile). Also rename `sort_tuple` to `canonicalize_bond`. Depending if this or #656 gets merged first, canonicalize bonds will be moved to a common_utils.py file.