### PR TITLE
Allow computing all-pairs potential on subset of atoms, add consistency check

### DIFF
--- a/tests/nonbonded/conftest.py
+++ b/tests/nonbonded/conftest.py
@@ -25,7 +25,7 @@ def _example_system():
 
 
 @pytest.fixture(scope="module")
-def _example_nonbonded_params(_example_system):
+def _example_nonbonded_potential(_example_system):
     host_system, _, _ = _example_system
     host_fns, _ = openmm_deserializer.deserialize_system(host_system, cutoff=1.0)
 
@@ -35,7 +35,12 @@ def _example_nonbonded_params(_example_system):
             nonbonded_fn = f
 
     assert nonbonded_fn is not None
-    return nonbonded_fn.params
+    return nonbonded_fn
+
+
+@pytest.fixture()
+def _example_nonbonded_params(_example_nonbonded_potential):
+    return _example_nonbonded_potential.params
 
 
 @pytest.fixture(scope="module")
@@ -57,7 +62,17 @@ def rng():
 
 @pytest.fixture(scope="function")
 def example_nonbonded_params(_example_nonbonded_params):
-    return _example_nonbonded_params[:]
+    return np.array(_example_nonbonded_params)
+
+
+@pytest.fixture()
+def example_nonbonded_exclusion_idxs(_example_nonbonded_potential):
+    return _example_nonbonded_potential.get_exclusion_idxs()
+
+
+@pytest.fixture()
+def example_nonbonded_exclusion_scales(_example_nonbonded_potential):
+    return _example_nonbonded_potential.get_scale_factors()
 
 
 @pytest.fixture(scope="function")

--- a/tests/nonbonded/test_consistency.py
+++ b/tests/nonbonded/test_consistency.py
@@ -1,0 +1,144 @@
+from typing import Iterable, Tuple
+
+import numpy as np
+import pytest
+from parameter_interpolation import gen_params
+
+from timemachine.lib.potentials import (
+    FanoutSummedPotential,
+    Nonbonded,
+    NonbondedAllPairs,
+    NonbondedAllPairsInterpolated,
+    NonbondedInteractionGroup,
+    NonbondedInteractionGroupInterpolated,
+    NonbondedInterpolated,
+    NonbondedPairListNegated,
+    NonbondedPairListNegatedInterpolated,
+)
+
+
+def filter_valid_exclusions(
+    num_atoms: int, exclusions: Iterable[Tuple[int, int]], scales: Iterable[Tuple[float, float]]
+) -> Tuple[np.ndarray, np.ndarray]:
+    filtered_pairs = (((i, j), scales) for (i, j), scales in zip(exclusions, scales) if i < num_atoms and j < num_atoms)
+    idxs, scales = zip(*filtered_pairs)
+    return np.array(idxs, dtype=np.int32), np.array(scales)
+
+
+@pytest.mark.parametrize("lamb", [0.0, 0.1])
+@pytest.mark.parametrize("beta", [2.0])
+@pytest.mark.parametrize("cutoff", [1.1])
+@pytest.mark.parametrize("precision", [np.float64, np.float32])
+@pytest.mark.parametrize("num_atoms,num_atoms_ligand", [(33, 1), (4080, 1050)])
+@pytest.mark.parametrize("interpolated", [False, True])
+@pytest.mark.parametrize("disable_hilbert_sort", [False, True])
+def test_nonbonded_consistency(
+    disable_hilbert_sort,
+    interpolated,
+    num_atoms_ligand,
+    num_atoms,
+    precision,
+    cutoff,
+    beta,
+    lamb,
+    example_nonbonded_params,
+    example_nonbonded_exclusion_idxs,
+    example_nonbonded_exclusion_scales,
+    example_conf,
+    example_box,
+    rng: np.random.Generator,
+):
+    conf = example_conf[:num_atoms, :]
+    params_initial = example_nonbonded_params[:num_atoms, :]
+    params = gen_params(params_initial, rng) if interpolated else params_initial
+
+    exclusion_idxs, exclusion_scales = filter_valid_exclusions(
+        num_atoms, example_nonbonded_exclusion_idxs, example_nonbonded_exclusion_scales
+    )
+
+    lambda_plane_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
+    lambda_offset_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
+
+    ligand_idxs = rng.choice(num_atoms, size=(num_atoms_ligand,), replace=False).astype(np.int32)
+    host_idxs = np.setdiff1d(np.arange(num_atoms), ligand_idxs).astype(np.int32)
+
+    make_ref_potential = NonbondedInterpolated if interpolated else Nonbonded
+    ref_impl = make_ref_potential(
+        exclusion_idxs, exclusion_scales, lambda_plane_idxs, lambda_offset_idxs, beta, cutoff
+    ).unbound_impl(precision)
+
+    if disable_hilbert_sort:
+        ref_impl.disable_hilbert_sort()
+
+    def make_allpairs_potential(atom_idxs):
+        make_potential = NonbondedAllPairsInterpolated if interpolated else NonbondedAllPairs
+        return make_potential(
+            lambda_plane_idxs,
+            lambda_offset_idxs,
+            beta,
+            cutoff,
+            atom_idxs,
+            disable_hilbert_sort=disable_hilbert_sort,
+        )
+
+    def make_ixngroup_potential(ligand_idxs):
+        make_potential = NonbondedInteractionGroupInterpolated if interpolated else NonbondedInteractionGroup
+        return make_potential(
+            ligand_idxs,
+            lambda_plane_idxs,
+            lambda_offset_idxs,
+            beta,
+            cutoff,
+            disable_hilbert_sort=disable_hilbert_sort,
+        )
+
+    def make_pairlist_potential(exclusion_idxs, exclusion_scales):
+        make_potential = NonbondedPairListNegatedInterpolated if interpolated else NonbondedPairListNegated
+        return make_potential(exclusion_idxs, exclusion_scales, lambda_plane_idxs, lambda_offset_idxs, beta, cutoff)
+
+    test_impl = FanoutSummedPotential(
+        [
+            make_allpairs_potential(host_idxs),
+            make_allpairs_potential(ligand_idxs),
+            make_ixngroup_potential(ligand_idxs),
+            make_pairlist_potential(exclusion_idxs, exclusion_scales),
+        ]
+    ).unbound_impl(precision)
+
+    du_dx_ref, du_dp_ref, du_dl_ref, u_ref = ref_impl.execute(conf, params, example_box, lamb)
+    du_dx_test, du_dp_test, du_dl_test, u_test = test_impl.execute(conf, params, example_box, lamb)
+
+    np.testing.assert_array_equal(du_dx_test, du_dx_ref)
+
+    if interpolated:
+        # NOTE: bitwise equivalence is not currently possible for the
+        # interpolated case. To see this, note that the interpolated
+        # energy is given by
+        #
+        #   u(p0, p1) = (1 - lam) * F(p0) + lam * F(p1)
+        #
+        # In particular,
+        #
+        #   du_dp1 = lam * f(p1)
+        #
+        # where f(p) = F'(p). The reference potential effectively sums
+        # over interactions before multiplication by \lambda
+        #
+        #   du_dp1_ref = lam * fixed_sum(f_host(p1), f_ligand(p1), f_host_ligand(p1))
+        #
+        # while the test potential (because it's implemented using
+        # SummedPotential), effectively distributes multiplication by
+        # \lambda into the sum
+        #
+        #   du_dp1_test = fixed_sum(lam * f_host(p1), lam * f_ligand(p1), lam * f_host_ligand(p1))
+        #
+        # Since `c * fixed_sum(x, y)` is not bitwise equivalent to
+        # `fixed_sum(c * x, c * y)` in general, the reference and test
+        # du_dps are not guaranteed to be bitwise equivalent in the
+        # interpolated case.
+        np.testing.assert_allclose(du_dp_test, du_dp_ref, rtol=1e-8, atol=1e-8)
+    else:
+        np.testing.assert_array_equal(du_dp_test, du_dp_ref)
+
+    np.testing.assert_array_equal(du_dl_test, du_dl_ref)
+    assert u_test == u_ref

--- a/tests/nonbonded/test_nonbonded_all_pairs.py
+++ b/tests/nonbonded/test_nonbonded_all_pairs.py
@@ -18,6 +18,13 @@ def test_nonbonded_all_pairs_invalid_planes_offsets():
     assert "lambda offset idxs and plane idxs need to be equivalent" in str(e)
 
 
+def test_nonbonded_all_pairs_invalid_atom_idxs():
+    with pytest.raises(RuntimeError) as e:
+        NonbondedAllPairs([0, 1], [0], 2.0, 1.1, [0, 0]).unbound_impl(np.float32)
+
+    assert "atom indices must be unique" in str(e)
+
+
 def test_nonbonded_all_pairs_invalid_num_atoms():
     potential = NonbondedAllPairs([0], [0], 2.0, 1.1).unbound_impl(np.float32)
     with pytest.raises(RuntimeError) as e:
@@ -40,34 +47,98 @@ def test_nonbonded_all_pairs_invalid_num_params():
     assert "NonbondedAllPairs::execute_device(): expected P == M*N_*3, got P=3, M*N_*3=6" in str(e)
 
 
-def make_ref_potential(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff):
+def make_ref_potential(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff, atom_idxs, interpolated):
+
+    s = atom_idxs if atom_idxs is not None else slice(None)
+
     @functools.wraps(nonbonded.nonbonded_v3)
     def wrapped(conf, params, box, lamb):
-        num_atoms, _ = conf.shape
+        conf_ = conf[s, :]
+        num_atoms, _ = conf_.shape
         no_rescale = np.ones((num_atoms, num_atoms))
         return nonbonded.nonbonded_v3(
-            conf,
-            params,
+            conf_,
+            params[s, :],
             box,
             lamb,
             charge_rescale_mask=no_rescale,
             lj_rescale_mask=no_rescale,
             beta=beta,
             cutoff=cutoff,
-            lambda_plane_idxs=lambda_plane_idxs,
-            lambda_offset_idxs=lambda_offset_idxs,
+            lambda_plane_idxs=lambda_plane_idxs[s],
+            lambda_offset_idxs=lambda_offset_idxs[s],
         )
 
-    return wrapped
+    return nonbonded.interpolated(wrapped) if interpolated else wrapped
+
+
+def test_nonbonded_all_pairs_singleton_subset(rng: np.random.Generator):
+    """Checks that energy and derivatives are all zero when called with a single-atom subset"""
+    num_atoms = 231
+    beta = 2.0
+    lamb = 0.1
+    cutoff = 1.1
+    box = 3.0 * np.eye(3)
+    conf = rng.uniform(0, 1, size=(num_atoms, 3))
+    params = rng.uniform(0, 1, size=(num_atoms, 3))
+
+    lambda_plane_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
+    lambda_offset_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
+
+    for idx in rng.choice(num_atoms, size=(10,)):
+        atom_idxs = np.array([idx], dtype=np.int32)
+        potential = NonbondedAllPairs(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff, atom_idxs)
+        du_dx, du_dp, du_dl, u = potential.unbound_impl(np.float64).execute(conf, params, box, lamb)
+
+        assert (du_dx == 0).all()
+        assert (du_dp == 0).all()
+        assert du_dl == 0
+        assert u == 0
+
+
+def test_nonbonded_all_pairs_improper_subset(rng: np.random.Generator):
+    """Checks for bitwise equivalence of the following cases:
+    1. atom_idxs = None
+    2. atom_idxs = range(num_atoms)
+    """
+    num_atoms = 231
+    beta = 2.0
+    lamb = 0.1
+    cutoff = 1.1
+    box = 3.0 * np.eye(3)
+    conf = rng.uniform(0, 1, size=(num_atoms, 3))
+    params = rng.uniform(0, 1, size=(num_atoms, 3))
+
+    lambda_plane_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
+    lambda_offset_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
+
+    def test_impl(atom_idxs):
+        return (
+            NonbondedAllPairs(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff, atom_idxs)
+            .unbound_impl(np.float64)
+            .execute(conf, params, box, lamb)
+        )
+
+    du_dx_1, du_dp_1, du_dl_1, u_1 = test_impl(None)
+    du_dx_2, du_dp_2, du_dl_2, u_2 = test_impl(np.arange(num_atoms, dtype=np.int32))
+
+    np.testing.assert_array_equal(du_dx_1, du_dx_2)
+    np.testing.assert_array_equal(du_dp_1, du_dp_2)
+    np.testing.assert_array_equal(du_dl_1, du_dl_2)
+    assert u_1 == u_2
 
 
 @pytest.mark.parametrize("lamb", [0.0, 0.1])
 @pytest.mark.parametrize("beta", [2.0])
 @pytest.mark.parametrize("cutoff", [1.1])
 @pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 1e-8, 1e-8), (np.float32, 1e-4, 5e-4)])
-@pytest.mark.parametrize("num_atoms", [33, 65, 231, 1050, 4080])
+@pytest.mark.parametrize("num_atoms_subset", [None, 33])
+@pytest.mark.parametrize("num_atoms", [33, 65, 231])
+@pytest.mark.parametrize("interpolated", [False, True])
 def test_nonbonded_all_pairs_correctness(
+    interpolated,
     num_atoms,
+    num_atoms_subset,
     precision,
     rtol,
     atol,
@@ -82,48 +153,20 @@ def test_nonbonded_all_pairs_correctness(
     "Compares with jax reference implementation."
 
     conf = example_conf[:num_atoms]
-    params = example_nonbonded_params[:num_atoms, :]
+    params_initial = example_nonbonded_params[:num_atoms, :]
+    params = gen_params(params_initial, rng) if interpolated else params_initial
 
     lambda_plane_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
     lambda_offset_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
 
-    ref_potential = make_ref_potential(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff)
-    test_potential = NonbondedAllPairs(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff)
-
-    GradientTest().compare_forces(
-        conf, params, example_box, lamb, ref_potential, test_potential, precision=precision, rtol=rtol, atol=atol
+    atom_idxs = (
+        rng.choice(num_atoms, size=(num_atoms_subset,), replace=False).astype(np.int32) if num_atoms_subset else None
     )
 
+    ref_potential = make_ref_potential(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff, atom_idxs, interpolated)
 
-@pytest.mark.parametrize("lamb", [0.0, 0.1, 0.9, 1.0])
-@pytest.mark.parametrize("beta", [2.0])
-@pytest.mark.parametrize("cutoff", [1.1])
-@pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 1e-8, 1e-8), (np.float32, 2e-4, 5e-4)])
-@pytest.mark.parametrize("num_atoms", [33, 231, 4080])
-def test_nonbonded_all_pairs_interpolated_correctness(
-    num_atoms,
-    precision,
-    rtol,
-    atol,
-    cutoff,
-    beta,
-    lamb,
-    example_nonbonded_params,
-    example_conf,
-    example_box,
-    rng: np.random.Generator,
-):
-    "Compares with jax reference implementation, with parameter interpolation."
-
-    conf = example_conf[:num_atoms]
-    params_initial = example_nonbonded_params[:num_atoms, :]
-    params = gen_params(params_initial, rng)
-
-    lambda_plane_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
-    lambda_offset_idxs = rng.integers(-2, 3, size=(num_atoms,), dtype=np.int32)
-
-    ref_potential = nonbonded.interpolated(make_ref_potential(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff))
-    test_potential = NonbondedAllPairsInterpolated(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff)
+    make_test_potential = NonbondedAllPairsInterpolated if interpolated else NonbondedAllPairs
+    test_potential = make_test_potential(lambda_plane_idxs, lambda_offset_idxs, beta, cutoff, atom_idxs)
 
     GradientTest().compare_forces(
         conf, params, example_box, lamb, ref_potential, test_potential, precision=precision, rtol=rtol, atol=atol

--- a/timemachine/cpp/src/kernels/k_lambda_transformer_jit.cuh
+++ b/timemachine/cpp/src/kernels/k_lambda_transformer_jit.cuh
@@ -58,7 +58,8 @@ void __global__ k_gather_interpolated(
     const double lambda,
     const int N,
     const unsigned int *__restrict__ idxs,
-    const double *__restrict__ d_p,
+    const double *__restrict__ d_p0, // [P] initial parameters
+    const double *__restrict__ d_p1, // [P] final parameters
     double *__restrict__ d_gathered_p,
     double *__restrict__ d_gathered_dp_dl) {
 
@@ -69,8 +70,6 @@ void __global__ k_gather_interpolated(
     if (idx >= N) {
         return;
     }
-
-    int size = N * stride;
 
     int source_idx = idx * stride + stride_idx;
     int target_idx = idxs[idx] * stride + stride_idx;
@@ -94,8 +93,8 @@ void __global__ k_gather_interpolated(
         f_lambda_grad = (transform_lambda_epsilon(lambda_surreal).imag) / step;
     }
 
-    d_gathered_p[source_idx] = (1 - f_lambda) * d_p[target_idx] + f_lambda * d_p[size + target_idx];
-    d_gathered_dp_dl[source_idx] = f_lambda_grad * (d_p[size + target_idx] - d_p[target_idx]);
+    d_gathered_p[source_idx] = (1 - f_lambda) * d_p0[target_idx] + f_lambda * d_p1[target_idx];
+    d_gathered_dp_dl[source_idx] = f_lambda_grad * (d_p1[target_idx] - d_p0[target_idx]);
 }
 
 void __global__ k_add_du_dp_interpolated(

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -85,6 +85,53 @@ void __global__ k_check_rebuild_coords_and_box(
     }
 }
 
+// TODO: DRY with k_check_rebuild_coords_and_box
+template <typename RealType>
+void __global__ k_check_rebuild_coords_and_box_gather(
+    const int N,
+    const unsigned int *atom_idxs,
+    const double *__restrict__ new_coords,
+    const double *__restrict__ old_coords,
+    const double *__restrict__ new_box,
+    const double *__restrict__ old_box,
+    const double padding,
+    int *rebuild) {
+
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (idx < 9) {
+        // (ytz): box vectors have exactly 9 components
+        // we can probably derive a looser bound later on.
+        if (old_box[idx] != new_box[idx]) {
+            rebuild[0] = 1;
+        }
+    }
+
+    if (idx >= N) {
+        return;
+    }
+
+    const int atom_idx = atom_idxs[idx];
+
+    RealType xi = old_coords[atom_idx * 3 + 0];
+    RealType yi = old_coords[atom_idx * 3 + 1];
+    RealType zi = old_coords[atom_idx * 3 + 2];
+
+    RealType xj = new_coords[atom_idx * 3 + 0];
+    RealType yj = new_coords[atom_idx * 3 + 1];
+    RealType zj = new_coords[atom_idx * 3 + 2];
+
+    RealType dx = xi - xj;
+    RealType dy = yi - yj;
+    RealType dz = zi - zj;
+
+    RealType d2ij = dx * dx + dy * dy + dz * dz;
+    if (d2ij > static_cast<RealType>(0.25) * padding * padding) {
+        // (ytz): this is *safe* but technically is a race condition
+        rebuild[0] = 1;
+    }
+}
+
 template <typename RealType>
 void __global__ k_copy_nblist_coords_and_box(
     const int N,

--- a/timemachine/cpp/src/nonbonded_all_pairs.cu
+++ b/timemachine/cpp/src/nonbonded_all_pairs.cu
@@ -84,10 +84,8 @@ NonbondedAllPairs<RealType, Interpolated>::NonbondedAllPairs(
     gpuErrchk(cudaMalloc(&d_sorted_w_, N_ * sizeof(*d_sorted_w_)));
     gpuErrchk(cudaMalloc(&d_sorted_dw_dl_, N_ * sizeof(*d_sorted_dw_dl_)));
 
-    gpuErrchk(cudaMalloc(&d_unsorted_p_, N_ * 3 * sizeof(*d_unsorted_p_)));         // interpolated
-    gpuErrchk(cudaMalloc(&d_sorted_p_, N_ * 3 * sizeof(*d_sorted_p_)));             // interpolated
-    gpuErrchk(cudaMalloc(&d_unsorted_dp_dl_, N_ * 3 * sizeof(*d_unsorted_dp_dl_))); // interpolated
-    gpuErrchk(cudaMalloc(&d_sorted_dp_dl_, N_ * 3 * sizeof(*d_sorted_dp_dl_)));     // interpolated
+    gpuErrchk(cudaMalloc(&d_sorted_p_, N_ * 3 * sizeof(*d_sorted_p_)));         // interpolated
+    gpuErrchk(cudaMalloc(&d_sorted_dp_dl_, N_ * 3 * sizeof(*d_sorted_dp_dl_))); // interpolated
     gpuErrchk(cudaMalloc(&d_sorted_du_dx_, N_ * 3 * sizeof(*d_sorted_du_dx_)));
     gpuErrchk(cudaMalloc(&d_sorted_du_dp_, N_ * 3 * sizeof(*d_sorted_du_dp_)));
     gpuErrchk(cudaMalloc(&d_du_dp_buffer_, N_ * 3 * sizeof(*d_du_dp_buffer_)));
@@ -148,9 +146,7 @@ template <typename RealType, bool Interpolated> NonbondedAllPairs<RealType, Inte
     gpuErrchk(cudaFree(d_dw_dl_));
     gpuErrchk(cudaFree(d_sorted_w_));
     gpuErrchk(cudaFree(d_sorted_dw_dl_));
-    gpuErrchk(cudaFree(d_unsorted_p_));
     gpuErrchk(cudaFree(d_sorted_p_));
-    gpuErrchk(cudaFree(d_unsorted_dp_dl_));
     gpuErrchk(cudaFree(d_sorted_dp_dl_));
     gpuErrchk(cudaFree(d_sorted_du_dx_));
     gpuErrchk(cudaFree(d_sorted_du_dp_));

--- a/timemachine/cpp/src/nonbonded_all_pairs.cu
+++ b/timemachine/cpp/src/nonbonded_all_pairs.cu
@@ -36,30 +36,33 @@ NonbondedAllPairs<RealType, Interpolated>::NonbondedAllPairs(
     // const std::string &transform_lambda_epsilon,
     // const std::string &transform_lambda_w
     )
-    : N_(lambda_offset_idxs.size()), K_(atom_idxs ? atom_idxs->size() : N_), cutoff_(cutoff), d_atom_idxs_(nullptr),
-      nblist_(lambda_offset_idxs.size()), beta_(beta), d_sort_storage_(nullptr), d_sort_storage_bytes_(0),
-      nblist_padding_(0.1), disable_hilbert_(false), kernel_ptrs_({// enumerate over every possible kernel combination
-                                                                   // U: Compute U
-                                                                   // X: Compute DU_DL
-                                                                   // L: Compute DU_DX
-                                                                   // P: Compute DU_DP
-                                                                   //                             U  X  L  P
-                                                                   &k_nonbonded_unified<RealType, 0, 0, 0, 0>,
-                                                                   &k_nonbonded_unified<RealType, 0, 0, 0, 1>,
-                                                                   &k_nonbonded_unified<RealType, 0, 0, 1, 0>,
-                                                                   &k_nonbonded_unified<RealType, 0, 0, 1, 1>,
-                                                                   &k_nonbonded_unified<RealType, 0, 1, 0, 0>,
-                                                                   &k_nonbonded_unified<RealType, 0, 1, 0, 1>,
-                                                                   &k_nonbonded_unified<RealType, 0, 1, 1, 0>,
-                                                                   &k_nonbonded_unified<RealType, 0, 1, 1, 1>,
-                                                                   &k_nonbonded_unified<RealType, 1, 0, 0, 0>,
-                                                                   &k_nonbonded_unified<RealType, 1, 0, 0, 1>,
-                                                                   &k_nonbonded_unified<RealType, 1, 0, 1, 0>,
-                                                                   &k_nonbonded_unified<RealType, 1, 0, 1, 1>,
-                                                                   &k_nonbonded_unified<RealType, 1, 1, 0, 0>,
-                                                                   &k_nonbonded_unified<RealType, 1, 1, 0, 1>,
-                                                                   &k_nonbonded_unified<RealType, 1, 1, 1, 0>,
-                                                                   &k_nonbonded_unified<RealType, 1, 1, 1, 1>}),
+    : N_(lambda_offset_idxs.size()), K_(atom_idxs ? atom_idxs->size() : N_), beta_(beta), cutoff_(cutoff),
+      d_atom_idxs_(nullptr), nblist_(lambda_offset_idxs.size()), nblist_padding_(0.1), d_sort_storage_(nullptr),
+      d_sort_storage_bytes_(0), disable_hilbert_(false),
+
+      kernel_ptrs_({// enumerate over every possible kernel combination
+                    // U: Compute U
+                    // X: Compute DU_DL
+                    // L: Compute DU_DX
+                    // P: Compute DU_DP
+                    //                             U  X  L  P
+                    &k_nonbonded_unified<RealType, 0, 0, 0, 0>,
+                    &k_nonbonded_unified<RealType, 0, 0, 0, 1>,
+                    &k_nonbonded_unified<RealType, 0, 0, 1, 0>,
+                    &k_nonbonded_unified<RealType, 0, 0, 1, 1>,
+                    &k_nonbonded_unified<RealType, 0, 1, 0, 0>,
+                    &k_nonbonded_unified<RealType, 0, 1, 0, 1>,
+                    &k_nonbonded_unified<RealType, 0, 1, 1, 0>,
+                    &k_nonbonded_unified<RealType, 0, 1, 1, 1>,
+                    &k_nonbonded_unified<RealType, 1, 0, 0, 0>,
+                    &k_nonbonded_unified<RealType, 1, 0, 0, 1>,
+                    &k_nonbonded_unified<RealType, 1, 0, 1, 0>,
+                    &k_nonbonded_unified<RealType, 1, 0, 1, 1>,
+                    &k_nonbonded_unified<RealType, 1, 1, 0, 0>,
+                    &k_nonbonded_unified<RealType, 1, 1, 0, 1>,
+                    &k_nonbonded_unified<RealType, 1, 1, 1, 0>,
+                    &k_nonbonded_unified<RealType, 1, 1, 1, 1>}),
+
       compute_w_coords_instance_(kernel_cache_.program(kernel_src.c_str()).kernel("k_compute_w_coords").instantiate()),
       compute_gather_interpolated_(
           kernel_cache_.program(kernel_src.c_str()).kernel("k_gather_interpolated").instantiate()),

--- a/timemachine/cpp/src/nonbonded_all_pairs.cu
+++ b/timemachine/cpp/src/nonbonded_all_pairs.cu
@@ -37,8 +37,8 @@ NonbondedAllPairs<RealType, Interpolated>::NonbondedAllPairs(
     // const std::string &transform_lambda_w
     )
     : N_(lambda_offset_idxs.size()), K_(atom_idxs ? atom_idxs->size() : N_), beta_(beta), cutoff_(cutoff),
-      d_atom_idxs_(nullptr), nblist_(lambda_offset_idxs.size()), nblist_padding_(0.1), d_sort_storage_(nullptr),
-      d_sort_storage_bytes_(0), disable_hilbert_(false),
+      d_atom_idxs_(nullptr), nblist_(K_), nblist_padding_(0.1), d_sort_storage_(nullptr), d_sort_storage_bytes_(0),
+      disable_hilbert_(false),
 
       kernel_ptrs_({// enumerate over every possible kernel combination
                     // U: Compute U
@@ -87,19 +87,21 @@ NonbondedAllPairs<RealType, Interpolated>::NonbondedAllPairs(
         gpuErrchk(cudaMemcpy(d_atom_idxs_, &atom_idxs_v[0], K_ * sizeof(*d_atom_idxs_), cudaMemcpyHostToDevice));
     }
 
-    gpuErrchk(cudaMalloc(&d_sorted_atom_idxs_, N_ * sizeof(*d_sorted_atom_idxs_)));
+    gpuErrchk(cudaMalloc(&d_sorted_atom_idxs_, K_ * sizeof(*d_sorted_atom_idxs_)));
 
-    gpuErrchk(cudaMalloc(&d_gathered_x_, N_ * 3 * sizeof(*d_gathered_x_)));
+    gpuErrchk(cudaMalloc(&d_gathered_x_, K_ * 3 * sizeof(*d_gathered_x_)));
 
     gpuErrchk(cudaMalloc(&d_w_, N_ * sizeof(*d_w_)));
     gpuErrchk(cudaMalloc(&d_dw_dl_, N_ * sizeof(*d_dw_dl_)));
-    gpuErrchk(cudaMalloc(&d_gathered_w_, N_ * sizeof(*d_gathered_w_)));
-    gpuErrchk(cudaMalloc(&d_gathered_dw_dl_, N_ * sizeof(*d_gathered_dw_dl_)));
 
-    gpuErrchk(cudaMalloc(&d_gathered_p_, N_ * 3 * sizeof(*d_gathered_p_)));         // interpolated
-    gpuErrchk(cudaMalloc(&d_gathered_dp_dl_, N_ * 3 * sizeof(*d_gathered_dp_dl_))); // interpolated
-    gpuErrchk(cudaMalloc(&d_gathered_du_dx_, N_ * 3 * sizeof(*d_gathered_du_dx_)));
-    gpuErrchk(cudaMalloc(&d_gathered_du_dp_, N_ * 3 * sizeof(*d_gathered_du_dp_)));
+    gpuErrchk(cudaMalloc(&d_gathered_w_, K_ * sizeof(*d_gathered_w_)));
+    gpuErrchk(cudaMalloc(&d_gathered_dw_dl_, K_ * sizeof(*d_gathered_dw_dl_)));
+
+    gpuErrchk(cudaMalloc(&d_gathered_p_, K_ * 3 * sizeof(*d_gathered_p_)));         // interpolated
+    gpuErrchk(cudaMalloc(&d_gathered_dp_dl_, K_ * 3 * sizeof(*d_gathered_dp_dl_))); // interpolated
+    gpuErrchk(cudaMalloc(&d_gathered_du_dx_, K_ * 3 * sizeof(*d_gathered_du_dx_)));
+    gpuErrchk(cudaMalloc(&d_gathered_du_dp_, K_ * 3 * sizeof(*d_gathered_du_dp_)));
+
     gpuErrchk(cudaMalloc(&d_du_dp_buffer_, N_ * 3 * sizeof(*d_du_dp_buffer_)));
 
     gpuErrchk(cudaMallocHost(&p_ixn_count_, 1 * sizeof(*p_ixn_count_)));
@@ -111,9 +113,9 @@ NonbondedAllPairs<RealType, Interpolated>::NonbondedAllPairs(
     gpuErrchk(cudaMalloc(&d_rebuild_nblist_, 1 * sizeof(*d_rebuild_nblist_)));
     gpuErrchk(cudaMallocHost(&p_rebuild_nblist_, 1 * sizeof(*p_rebuild_nblist_)));
 
-    gpuErrchk(cudaMalloc(&d_sort_keys_in_, N_ * sizeof(d_sort_keys_in_)));
-    gpuErrchk(cudaMalloc(&d_sort_keys_out_, N_ * sizeof(d_sort_keys_out_)));
-    gpuErrchk(cudaMalloc(&d_sort_vals_in_, N_ * sizeof(d_sort_vals_in_)));
+    gpuErrchk(cudaMalloc(&d_sort_keys_in_, K_ * sizeof(d_sort_keys_in_)));
+    gpuErrchk(cudaMalloc(&d_sort_keys_out_, K_ * sizeof(d_sort_keys_out_)));
+    gpuErrchk(cudaMalloc(&d_sort_vals_in_, K_ * sizeof(d_sort_vals_in_)));
 
     // initialize hilbert curve
     std::vector<unsigned int> bin_to_idx(256 * 256 * 256);
@@ -138,13 +140,7 @@ NonbondedAllPairs<RealType, Interpolated>::NonbondedAllPairs(
 
     // estimate size needed to do radix sorting, this can use uninitialized data.
     cub::DeviceRadixSort::SortPairs(
-        d_sort_storage_,
-        d_sort_storage_bytes_,
-        d_sort_keys_in_,
-        d_sort_keys_out_,
-        d_sort_vals_in_,
-        d_sorted_atom_idxs_,
-        N_);
+        nullptr, d_sort_storage_bytes_, d_sort_keys_in_, d_sort_keys_out_, d_sort_vals_in_, d_sorted_atom_idxs_, K_);
 
     gpuErrchk(cudaPeekAtLastError());
     gpuErrchk(cudaMalloc(&d_sort_storage_, d_sort_storage_bytes_));
@@ -201,9 +197,15 @@ void NonbondedAllPairs<RealType, Interpolated>::hilbert_sort(
     const double *d_coords, const double *d_box, cudaStream_t stream) {
 
     const int tpb = 32;
-    const int B = (N_ + tpb - 1) / tpb;
+    const int B = ceil_divide(K_, tpb);
 
-    k_coords_to_kv<<<B, tpb, 0, stream>>>(N_, d_coords, d_box, d_bin_to_idx_, d_sort_keys_in_, d_sort_vals_in_);
+    if (d_atom_idxs_) {
+        k_coords_to_kv_gather<<<B, tpb, 0, stream>>>(
+            K_, d_atom_idxs_, d_coords, d_box, d_bin_to_idx_, d_sort_keys_in_, d_sort_vals_in_);
+    } else {
+        // N_ == K_
+        k_coords_to_kv<<<B, tpb, 0, stream>>>(K_, d_coords, d_box, d_bin_to_idx_, d_sort_keys_in_, d_sort_vals_in_);
+    }
 
     gpuErrchk(cudaPeekAtLastError());
 
@@ -214,7 +216,7 @@ void NonbondedAllPairs<RealType, Interpolated>::hilbert_sort(
         d_sort_keys_out_,
         d_sort_vals_in_,
         d_sorted_atom_idxs_,
-        N_,
+        K_,
         0,                            // begin bit
         sizeof(*d_sort_keys_in_) * 8, // end bit
         stream                        // cudaStream
@@ -270,13 +272,15 @@ void NonbondedAllPairs<RealType, Interpolated>::execute_device(
     // identify which tiles contain interpolated parameters
 
     const int tpb = 32;
-    const int B = (N + tpb - 1) / tpb;
-
-    dim3 dimGrid(B, 3, 1);
 
     // (ytz) see if we need to rebuild the neighborlist.
-    k_check_rebuild_coords_and_box<RealType>
-        <<<B, tpb, 0, stream>>>(N, d_x, d_nblist_x_, d_box, d_nblist_box_, nblist_padding_, d_rebuild_nblist_);
+    if (d_atom_idxs_) {
+        k_check_rebuild_coords_and_box_gather<RealType><<<ceil_divide(K_, tpb), tpb, 0, stream>>>(
+            K_, d_atom_idxs_, d_x, d_nblist_x_, d_box, d_nblist_box_, nblist_padding_, d_rebuild_nblist_);
+    } else {
+        k_check_rebuild_coords_and_box<RealType><<<ceil_divide(K_, tpb), tpb, 0, stream>>>(
+            K_, d_x, d_nblist_x_, d_box, d_nblist_box_, nblist_padding_, d_rebuild_nblist_);
+    }
     gpuErrchk(cudaPeekAtLastError());
 
     // we can optimize this away by doing the check on the GPU directly.
@@ -291,14 +295,20 @@ void NonbondedAllPairs<RealType, Interpolated>::execute_device(
         if (!disable_hilbert_) {
             this->hilbert_sort(d_x, d_box, stream);
         } else {
-            k_arange<<<B, tpb, 0, stream>>>(N, d_sorted_atom_idxs_);
-            gpuErrchk(cudaPeekAtLastError());
+            if (d_atom_idxs_) {
+                gpuErrchk(cudaMemcpyAsync(
+                    d_sorted_atom_idxs_, d_atom_idxs_, K_ * sizeof(*d_atom_idxs_), cudaMemcpyDeviceToDevice, stream));
+                gpuErrchk(cudaPeekAtLastError());
+            } else {
+                // N_ == K_
+                k_arange<<<ceil_divide(K_, tpb), tpb, 0, stream>>>(K_, d_sorted_atom_idxs_);
+            }
         }
 
         // compute new coordinates, new lambda_idxs, new_plane_idxs
-        k_gather<<<dimGrid, tpb, 0, stream>>>(N, d_sorted_atom_idxs_, d_x, d_gathered_x_);
+        k_gather<<<dim3(ceil_divide(K_, tpb), 3, 1), tpb, 0, stream>>>(K_, d_sorted_atom_idxs_, d_x, d_gathered_x_);
         gpuErrchk(cudaPeekAtLastError());
-        nblist_.build_nblist_device(N, d_gathered_x_, d_box, cutoff_ + nblist_padding_, stream);
+        nblist_.build_nblist_device(K_, d_gathered_x_, d_box, cutoff_ + nblist_padding_, stream);
         gpuErrchk(cudaMemcpyAsync(
             p_ixn_count_, nblist_.get_ixn_count(), 1 * sizeof(*p_ixn_count_), cudaMemcpyDeviceToHost, stream));
 
@@ -328,41 +338,43 @@ void NonbondedAllPairs<RealType, Interpolated>::execute_device(
         gpuErrchk(cudaMemcpyAsync(d_nblist_x_, d_x, N * 3 * sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
         gpuErrchk(cudaMemcpyAsync(d_nblist_box_, d_box, 3 * 3 * sizeof(*d_box), cudaMemcpyDeviceToDevice, stream));
     } else {
-        k_gather<<<dimGrid, tpb, 0, stream>>>(N, d_sorted_atom_idxs_, d_x, d_gathered_x_);
+        k_gather<<<dim3(ceil_divide(K_, tpb), 3, 1), tpb, 0, stream>>>(K_, d_sorted_atom_idxs_, d_x, d_gathered_x_);
         gpuErrchk(cudaPeekAtLastError());
     }
 
     // do parameter interpolation here
     if (Interpolated) {
-        CUresult result = compute_gather_interpolated_.configure(dimGrid, tpb, 0, stream)
-                              .launch(lambda, N, d_sorted_atom_idxs_, d_p, d_gathered_p_, d_gathered_dp_dl_);
+        CUresult result =
+            compute_gather_interpolated_.configure(dim3(ceil_divide(K_, tpb), 3, 1), tpb, 0, stream)
+                .launch(lambda, K_, d_sorted_atom_idxs_, d_p, d_p + N * 3, d_gathered_p_, d_gathered_dp_dl_);
         if (result != 0) {
             throw std::runtime_error("Driver call to k_gather_interpolated failed");
         }
     } else {
-        k_gather<<<dimGrid, tpb, 0, stream>>>(N, d_sorted_atom_idxs_, d_p, d_gathered_p_);
+        k_gather<<<dim3(ceil_divide(K_, tpb), 3, 1), tpb, 0, stream>>>(K_, d_sorted_atom_idxs_, d_p, d_gathered_p_);
         gpuErrchk(cudaPeekAtLastError());
-        gpuErrchk(cudaMemsetAsync(d_gathered_dp_dl_, 0, N * 3 * sizeof(*d_gathered_dp_dl_), stream))
+        gpuErrchk(cudaMemsetAsync(d_gathered_dp_dl_, 0, K_ * 3 * sizeof(*d_gathered_dp_dl_), stream))
     }
 
     // reset buffers and sorted accumulators
     if (d_du_dx) {
-        gpuErrchk(cudaMemsetAsync(d_gathered_du_dx_, 0, N * 3 * sizeof(*d_gathered_du_dx_), stream))
+        gpuErrchk(cudaMemsetAsync(d_gathered_du_dx_, 0, K_ * 3 * sizeof(*d_gathered_du_dx_), stream))
     }
     if (d_du_dp) {
-        gpuErrchk(cudaMemsetAsync(d_gathered_du_dp_, 0, N * 3 * sizeof(*d_gathered_du_dp_), stream))
+        gpuErrchk(cudaMemsetAsync(d_gathered_du_dp_, 0, K_ * 3 * sizeof(*d_gathered_du_dp_), stream))
     }
 
     // update new w coordinates
     // (tbd): cache lambda value for equilibrium calculations
-    CUresult result = compute_w_coords_instance_.configure(B, tpb, 0, stream)
+    CUresult result = compute_w_coords_instance_.configure(ceil_divide(N_, tpb), tpb, 0, stream)
                           .launch(N, lambda, cutoff_, d_lambda_plane_idxs_, d_lambda_offset_idxs_, d_w_, d_dw_dl_);
     if (result != 0) {
         throw std::runtime_error("Driver call to k_compute_w_coords");
     }
 
     gpuErrchk(cudaPeekAtLastError());
-    k_gather_2x<<<B, tpb, 0, stream>>>(N, d_sorted_atom_idxs_, d_w_, d_dw_dl_, d_gathered_w_, d_gathered_dw_dl_);
+    k_gather_2x<<<ceil_divide(K_, tpb), tpb, 0, stream>>>(
+        K_, d_sorted_atom_idxs_, d_w_, d_dw_dl_, d_gathered_w_, d_gathered_dw_dl_);
     gpuErrchk(cudaPeekAtLastError());
 
     // look up which kernel we need for this computation
@@ -373,7 +385,7 @@ void NonbondedAllPairs<RealType, Interpolated>::execute_device(
     kernel_idx |= d_u ? 1 << 3 : 0;
 
     kernel_ptrs_[kernel_idx]<<<p_ixn_count_[0], tpb, 0, stream>>>(
-        N,
+        K_,
         0,
         d_gathered_x_,
         d_gathered_p_,
@@ -395,26 +407,31 @@ void NonbondedAllPairs<RealType, Interpolated>::execute_device(
 
     // coords are N,3
     if (d_du_dx) {
-        k_scatter_accum<<<dimGrid, tpb, 0, stream>>>(N, d_sorted_atom_idxs_, d_gathered_du_dx_, d_du_dx);
+        k_scatter_accum<<<dim3(ceil_divide(K_, tpb), 3, 1), tpb, 0, stream>>>(
+            K_, d_sorted_atom_idxs_, d_gathered_du_dx_, d_du_dx);
         gpuErrchk(cudaPeekAtLastError());
     }
 
     // params are N,3
     // this needs to be an accumulated permute
     if (d_du_dp) {
-        k_scatter_assign<<<dimGrid, tpb, 0, stream>>>(N, d_sorted_atom_idxs_, d_gathered_du_dp_, d_du_dp_buffer_);
+        // scattered assignment updates K_ <= N_ elements; the rest should be 0
+        gpuErrchk(cudaMemset(d_du_dp_buffer_, 0, N_ * 3 * sizeof(*d_du_dp_buffer_)));
+        k_scatter_assign<<<dim3(ceil_divide(K_, tpb), 3, 1), tpb, 0, stream>>>(
+            K_, d_sorted_atom_idxs_, d_gathered_du_dp_, d_du_dp_buffer_);
         gpuErrchk(cudaPeekAtLastError());
     }
 
     if (d_du_dp) {
         if (Interpolated) {
-            CUresult result = compute_add_du_dp_interpolated_.configure(dimGrid, tpb, 0, stream)
-                                  .launch(lambda, N, d_du_dp_buffer_, d_du_dp);
+            CUresult result =
+                compute_add_du_dp_interpolated_.configure(dim3(ceil_divide(N_, tpb), 3, 1), tpb, 0, stream)
+                    .launch(lambda, N, d_du_dp_buffer_, d_du_dp);
             if (result != 0) {
                 throw std::runtime_error("Driver call to k_add_du_dp_interpolated failed");
             }
         } else {
-            k_add_ull_to_ull<<<dimGrid, tpb, 0, stream>>>(N, d_du_dp_buffer_, d_du_dp);
+            k_add_ull_to_ull<<<dim3(ceil_divide(N_, tpb), 3, 1), tpb, 0, stream>>>(N, d_du_dp_buffer_, d_du_dp);
         }
         gpuErrchk(cudaPeekAtLastError());
     }

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -4,6 +4,8 @@
 #include "potential.hpp"
 #include "vendored/jitify.hpp"
 #include <array>
+#include <optional>
+#include <set>
 #include <vector>
 
 namespace timemachine {
@@ -31,15 +33,19 @@ template <typename RealType, bool Interpolated> class NonbondedAllPairs : public
 private:
     std::array<k_nonbonded_fn, 16> kernel_ptrs_;
 
+    const int N_;
+    const int K_; // number of interacting atoms
+
     int *d_lambda_plane_idxs_;
     int *d_lambda_offset_idxs_;
-    int *p_ixn_count_; // pinned memory
 
     double beta_;
     double cutoff_;
-    Neighborlist<RealType> nblist_;
 
-    const int N_;
+    unsigned int *d_atom_idxs_; // [K_] indices of interacting atoms
+
+    Neighborlist<RealType> nblist_;
+    int *p_ixn_count_; // pinned memory
 
     double nblist_padding_;
     double *d_nblist_x_;    // coords which were used to compute the nblist
@@ -91,6 +97,7 @@ public:
         const std::vector<int> &lambda_offset_idxs, // N
         const double beta,
         const double cutoff,
+        const std::optional<std::set<int>> &atom_idxs,
         const std::string &kernel_src);
 
     ~NonbondedAllPairs();

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -31,8 +31,8 @@ typedef void (*k_nonbonded_fn)(
 template <typename RealType, bool Interpolated> class NonbondedAllPairs : public Potential {
 
 private:
-    const int N_;
-    const int K_; // number of interacting atoms
+    const int N_; // total number of atoms, i.e. first dimension of input coords, params
+    const int K_; // number of interacting atoms, K_ <= N_
 
     int *d_lambda_plane_idxs_;
     int *d_lambda_offset_idxs_;
@@ -54,15 +54,18 @@ private:
     double *d_w_; // 4D coordinates
     double *d_dw_dl_;
 
-    // "sorted" means
-    // - if hilbert sorting enabled, atoms are sorted according to the
-    //   hilbert curve index
-    // - otherwise, atom ordering is preserved with respect to input
+    // "gathered" arrays represent the subset of atoms specified by
+    // atom_idxs (if the latter is specified, otherwise all atoms).
+    //
+    // If hilbert sorting is enabled, "gathered" arrays are sorted by
+    // hilbert curve index; otherwise, the ordering is that specified
+    // by atom_idxs (or the input ordering, if atom_idxs is not
+    // specified)
     unsigned int *d_sorted_atom_idxs_; // [K_] indices of interacting atoms, sorted by hilbert curve index
-    double *d_gathered_x_;             // sorted coordinates
-    double *d_gathered_w_;             // sorted 4D coordinates
+    double *d_gathered_x_;             // sorted coordinates for subset of atoms
+    double *d_gathered_w_;             // sorted 4D coordinates for subset of atoms
     double *d_gathered_dw_dl_;
-    double *d_gathered_p_; // sorted parameters
+    double *d_gathered_p_; // sorted parameters for subset of atoms
     double *d_gathered_dp_dl_;
     unsigned long long *d_gathered_du_dx_;
     unsigned long long *d_gathered_du_dp_;

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -47,8 +47,6 @@ private:
     int *d_rebuild_nblist_; // whether or not we have to rebuild the nblist
     int *p_rebuild_nblist_; // pinned
 
-    unsigned int *d_perm_; // hilbert curve permutation
-
     double *d_w_; // 4D coordinates
     double *d_dw_dl_;
 
@@ -56,13 +54,14 @@ private:
     // - if hilbert sorting enabled, atoms are sorted according to the
     //   hilbert curve index
     // - otherwise, atom ordering is preserved with respect to input
-    double *d_sorted_x_; // sorted coordinates
-    double *d_sorted_w_; // sorted 4D coordinates
-    double *d_sorted_dw_dl_;
-    double *d_sorted_p_; // sorted parameters
-    double *d_sorted_dp_dl_;
-    unsigned long long *d_sorted_du_dx_;
-    unsigned long long *d_sorted_du_dp_;
+    unsigned int *d_sorted_atom_idxs_; // [K_] indices of interacting atoms, sorted by hilbert curve index
+    double *d_gathered_x_;             // sorted coordinates
+    double *d_gathered_w_;             // sorted 4D coordinates
+    double *d_gathered_dw_dl_;
+    double *d_gathered_p_; // sorted parameters
+    double *d_gathered_dp_dl_;
+    unsigned long long *d_gathered_du_dx_;
+    unsigned long long *d_gathered_du_dp_;
     unsigned long long *d_du_dp_buffer_;
 
     // used for hilbert sorting

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -31,8 +31,6 @@ typedef void (*k_nonbonded_fn)(
 template <typename RealType, bool Interpolated> class NonbondedAllPairs : public Potential {
 
 private:
-    std::array<k_nonbonded_fn, 16> kernel_ptrs_;
-
     const int N_;
     const int K_; // number of interacting atoms
 
@@ -81,6 +79,8 @@ private:
     bool disable_hilbert_;
 
     void hilbert_sort(const double *d_x, const double *d_box, cudaStream_t stream);
+
+    std::array<k_nonbonded_fn, 16> kernel_ptrs_;
 
     jitify::JitCache kernel_cache_;
     jitify::KernelInstantiation compute_w_coords_instance_;

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -56,15 +56,11 @@ private:
     // - if hilbert sorting enabled, atoms are sorted according to the
     //   hilbert curve index
     // - otherwise, atom ordering is preserved with respect to input
-    //
-    // "unsorted" means the atom ordering is preserved with respect to input
     double *d_sorted_x_; // sorted coordinates
     double *d_sorted_w_; // sorted 4D coordinates
     double *d_sorted_dw_dl_;
-    double *d_sorted_p_;   // sorted parameters
-    double *d_unsorted_p_; // unsorted parameters
+    double *d_sorted_p_; // sorted parameters
     double *d_sorted_dp_dl_;
-    double *d_unsorted_dp_dl_;
     unsigned long long *d_sorted_du_dx_;
     unsigned long long *d_sorted_du_dp_;
     unsigned long long *d_du_dp_buffer_;

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -83,7 +83,7 @@ private:
 
     jitify::JitCache kernel_cache_;
     jitify::KernelInstantiation compute_w_coords_instance_;
-    jitify::KernelInstantiation compute_permute_interpolated_;
+    jitify::KernelInstantiation compute_gather_interpolated_;
     jitify::KernelInstantiation compute_add_du_dp_interpolated_;
 
 public:

--- a/timemachine/cpp/src/nonbonded_interaction_group.cu
+++ b/timemachine/cpp/src/nonbonded_interaction_group.cu
@@ -112,10 +112,8 @@ NonbondedInteractionGroup<RealType, Interpolated>::NonbondedInteractionGroup(
     gpuErrchk(cudaMalloc(&d_sorted_w_, N_ * sizeof(*d_sorted_w_)));
     gpuErrchk(cudaMalloc(&d_sorted_dw_dl_, N_ * sizeof(*d_sorted_dw_dl_)));
 
-    gpuErrchk(cudaMalloc(&d_unsorted_p_, N_ * 3 * sizeof(*d_unsorted_p_)));         // interpolated
-    gpuErrchk(cudaMalloc(&d_sorted_p_, N_ * 3 * sizeof(*d_sorted_p_)));             // interpolated
-    gpuErrchk(cudaMalloc(&d_unsorted_dp_dl_, N_ * 3 * sizeof(*d_unsorted_dp_dl_))); // interpolated
-    gpuErrchk(cudaMalloc(&d_sorted_dp_dl_, N_ * 3 * sizeof(*d_sorted_dp_dl_)));     // interpolated
+    gpuErrchk(cudaMalloc(&d_sorted_p_, N_ * 3 * sizeof(*d_sorted_p_)));         // interpolated
+    gpuErrchk(cudaMalloc(&d_sorted_dp_dl_, N_ * 3 * sizeof(*d_sorted_dp_dl_))); // interpolated
     gpuErrchk(cudaMalloc(&d_sorted_du_dx_, N_ * 3 * sizeof(*d_sorted_du_dx_)));
     gpuErrchk(cudaMalloc(&d_sorted_du_dp_, N_ * 3 * sizeof(*d_sorted_du_dp_)));
     gpuErrchk(cudaMalloc(&d_du_dp_buffer_, N_ * 3 * sizeof(*d_du_dp_buffer_)));
@@ -185,9 +183,7 @@ NonbondedInteractionGroup<RealType, Interpolated>::~NonbondedInteractionGroup() 
     gpuErrchk(cudaFree(d_dw_dl_));
     gpuErrchk(cudaFree(d_sorted_w_));
     gpuErrchk(cudaFree(d_sorted_dw_dl_));
-    gpuErrchk(cudaFree(d_unsorted_p_));
     gpuErrchk(cudaFree(d_sorted_p_));
-    gpuErrchk(cudaFree(d_unsorted_dp_dl_));
     gpuErrchk(cudaFree(d_sorted_dp_dl_));
     gpuErrchk(cudaFree(d_sorted_du_dx_));
     gpuErrchk(cudaFree(d_sorted_du_dp_));

--- a/timemachine/cpp/src/nonbonded_interaction_group.cu
+++ b/timemachine/cpp/src/nonbonded_interaction_group.cu
@@ -61,8 +61,8 @@ NonbondedInteractionGroup<RealType, Interpolated>::NonbondedInteractionGroup(
                     &k_nonbonded_unified<RealType, 1, 1, 1, 0>,
                     &k_nonbonded_unified<RealType, 1, 1, 1, 1>}),
       compute_w_coords_instance_(kernel_cache_.program(kernel_src.c_str()).kernel("k_compute_w_coords").instantiate()),
-      compute_permute_interpolated_(
-          kernel_cache_.program(kernel_src.c_str()).kernel("k_permute_interpolated").instantiate()),
+      compute_gather_interpolated_(
+          kernel_cache_.program(kernel_src.c_str()).kernel("k_gather_interpolated").instantiate()),
       compute_add_du_dp_interpolated_(
           kernel_cache_.program(kernel_src.c_str()).kernel("k_add_du_dp_interpolated").instantiate()) {
 
@@ -325,7 +325,7 @@ void NonbondedInteractionGroup<RealType, Interpolated>::execute_device(
         }
 
         // compute new coordinates, new lambda_idxs, new_plane_idxs
-        k_permute<<<dimGrid, tpb, 0, stream>>>(N_, d_perm_, d_x, d_sorted_x_);
+        k_gather<<<dimGrid, tpb, 0, stream>>>(N_, d_perm_, d_x, d_sorted_x_);
         gpuErrchk(cudaPeekAtLastError());
 
         nblist_.build_nblist_device(
@@ -359,7 +359,7 @@ void NonbondedInteractionGroup<RealType, Interpolated>::execute_device(
         gpuErrchk(cudaMemcpyAsync(d_nblist_x_, d_x, N * 3 * sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
         gpuErrchk(cudaMemcpyAsync(d_nblist_box_, d_box, 3 * 3 * sizeof(*d_box), cudaMemcpyDeviceToDevice, stream));
     } else {
-        k_permute<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_x, d_sorted_x_);
+        k_gather<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_x, d_sorted_x_);
         gpuErrchk(cudaPeekAtLastError());
     }
 
@@ -370,13 +370,13 @@ void NonbondedInteractionGroup<RealType, Interpolated>::execute_device(
 
     // do parameter interpolation here
     if (Interpolated) {
-        CUresult result = compute_permute_interpolated_.configure(dimGrid, tpb, 0, stream)
+        CUresult result = compute_gather_interpolated_.configure(dimGrid, tpb, 0, stream)
                               .launch(lambda, N, d_perm_, d_p, d_sorted_p_, d_sorted_dp_dl_);
         if (result != 0) {
-            throw std::runtime_error("Driver call to k_permute_interpolated failed");
+            throw std::runtime_error("Driver call to k_gather_interpolated failed");
         }
     } else {
-        k_permute<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_p, d_sorted_p_);
+        k_gather<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_p, d_sorted_p_);
         gpuErrchk(cudaPeekAtLastError());
         gpuErrchk(cudaMemsetAsync(d_sorted_dp_dl_, 0, N * 3 * sizeof(*d_sorted_dp_dl_), stream))
     }
@@ -398,7 +398,7 @@ void NonbondedInteractionGroup<RealType, Interpolated>::execute_device(
     }
 
     gpuErrchk(cudaPeekAtLastError());
-    k_permute_2x<<<B, tpb, 0, stream>>>(N, d_perm_, d_w_, d_dw_dl_, d_sorted_w_, d_sorted_dw_dl_);
+    k_gather_2x<<<B, tpb, 0, stream>>>(N, d_perm_, d_w_, d_dw_dl_, d_sorted_w_, d_sorted_dw_dl_);
     gpuErrchk(cudaPeekAtLastError());
 
     // look up which kernel we need for this computation
@@ -431,14 +431,14 @@ void NonbondedInteractionGroup<RealType, Interpolated>::execute_device(
 
     // coords are N,3
     if (d_du_dx) {
-        k_inv_permute_accum<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_sorted_du_dx_, d_du_dx);
+        k_scatter_accum<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_sorted_du_dx_, d_du_dx);
         gpuErrchk(cudaPeekAtLastError());
     }
 
     // params are N,3
     // this needs to be an accumulated permute
     if (d_du_dp) {
-        k_inv_permute_assign<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_sorted_du_dp_, d_du_dp_buffer_);
+        k_scatter_assign<<<dimGrid, tpb, 0, stream>>>(N, d_perm_, d_sorted_du_dp_, d_du_dp_buffer_);
         gpuErrchk(cudaPeekAtLastError());
     }
 

--- a/timemachine/cpp/src/nonbonded_interaction_group.cu
+++ b/timemachine/cpp/src/nonbonded_interaction_group.cu
@@ -371,7 +371,7 @@ void NonbondedInteractionGroup<RealType, Interpolated>::execute_device(
     // do parameter interpolation here
     if (Interpolated) {
         CUresult result = compute_gather_interpolated_.configure(dimGrid, tpb, 0, stream)
-                              .launch(lambda, N, d_perm_, d_p, d_sorted_p_, d_sorted_dp_dl_);
+                              .launch(lambda, N, d_perm_, d_p, d_p + N * 3, d_sorted_p_, d_sorted_dp_dl_);
         if (result != 0) {
             throw std::runtime_error("Driver call to k_gather_interpolated failed");
         }

--- a/timemachine/cpp/src/nonbonded_interaction_group.hpp
+++ b/timemachine/cpp/src/nonbonded_interaction_group.hpp
@@ -64,15 +64,11 @@ private:
     //   independently
     // - otherwise, atoms are sorted into contiguous blocks by
     //   interaction group, with arbitrary ordering within each block
-    //
-    // "unsorted" means the atom ordering is preserved with respect to input
     double *d_sorted_x_; // sorted coordinates
     double *d_sorted_w_; // sorted 4D coordinates
     double *d_sorted_dw_dl_;
-    double *d_sorted_p_;   // sorted parameters
-    double *d_unsorted_p_; // unsorted parameters
+    double *d_sorted_p_; // sorted parameters
     double *d_sorted_dp_dl_;
-    double *d_unsorted_dp_dl_;
     unsigned long long *d_sorted_du_dx_;
     unsigned long long *d_sorted_du_dp_;
     unsigned long long *d_du_dp_buffer_;

--- a/timemachine/cpp/src/nonbonded_interaction_group.hpp
+++ b/timemachine/cpp/src/nonbonded_interaction_group.hpp
@@ -97,7 +97,7 @@ private:
 
     jitify::JitCache kernel_cache_;
     jitify::KernelInstantiation compute_w_coords_instance_;
-    jitify::KernelInstantiation compute_permute_interpolated_;
+    jitify::KernelInstantiation compute_gather_interpolated_;
     jitify::KernelInstantiation compute_add_du_dp_interpolated_;
 
 public:

--- a/timemachine/cpp/src/nonbonded_pair_list.cu
+++ b/timemachine/cpp/src/nonbonded_pair_list.cu
@@ -118,7 +118,7 @@ void NonbondedPairList<RealType, Negated, Interpolated>::execute_device(
 
     if (Interpolated) {
         CUresult result = compute_gather_interpolated_.configure(dimGrid, tpb, 0, stream)
-                              .launch(lambda, N, d_perm_, d_p, d_p_interp_, d_dp_dl_);
+                              .launch(lambda, N, d_perm_, d_p, d_p + N * 3, d_p_interp_, d_dp_dl_);
         if (result != 0) {
             throw std::runtime_error("Driver call to k_gather_interpolated failed");
         }

--- a/timemachine/cpp/src/nonbonded_pair_list.hpp
+++ b/timemachine/cpp/src/nonbonded_pair_list.hpp
@@ -32,7 +32,7 @@ private:
 
     jitify::JitCache kernel_cache_;
     jitify::KernelInstantiation compute_w_coords_instance_;
-    jitify::KernelInstantiation compute_permute_interpolated_;
+    jitify::KernelInstantiation compute_gather_interpolated_;
     jitify::KernelInstantiation compute_add_du_dp_interpolated_;
 
 public:

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -332,7 +332,15 @@ class NonbondedInterpolated(Nonbonded):
 
 
 class NonbondedAllPairs(CustomOpWrapper):
-    pass
+    def __init__(self, *args, disable_hilbert_sort=False):
+        super().__init__(*args)
+        self._disable_hilbert_sort = disable_hilbert_sort
+
+    def unbound_impl(self, precision):
+        impl = super().unbound_impl(precision)
+        if self._disable_hilbert_sort:
+            impl.disable_hilbert_sort()
+        return impl
 
 
 class NonbondedAllPairsInterpolated(NonbondedAllPairs):
@@ -349,7 +357,15 @@ class NonbondedAllPairsInterpolated(NonbondedAllPairs):
 
 
 class NonbondedInteractionGroup(CustomOpWrapper):
-    pass
+    def __init__(self, *args, disable_hilbert_sort=False):
+        super().__init__(*args)
+        self._disable_hilbert_sort = disable_hilbert_sort
+
+    def unbound_impl(self, precision):
+        impl = super().unbound_impl(precision)
+        if self._disable_hilbert_sort:
+            impl.disable_hilbert_sort()
+        return impl
 
 
 class NonbondedInteractionGroupInterpolated(NonbondedInteractionGroup):

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -314,6 +314,7 @@ class NonbondedInterpolated(Nonbonded):
             self.get_lambda_offset_idxs(),
             self.get_beta(),
             self.get_cutoff(),
+            None,
             *self.args[6:],  # remaining args are lambda transformation expressions
         ).unbound_impl(precision)
 


### PR DESCRIPTION
Related: #472
- Adds a constructor argument `atom_idxs` to `NonbondedAllPairs`; this is used to select a subset of atoms for computing the all-pairs potential
- Adds consistency check comparing the result of the full `Nonbonded(exclusions, scales)` potential with the sum of
    - `NonbondedAllPairs(host)`
    - `NonbondedAllPairs(ligand)`
    - `NonbondedInteractionGroup(host, ligand)`
    - `NonbondedPairList(exclusions, scales)`
---
#### Notes for review
- Commits starting with `Rename` are purely string substitutions and should contain no other changes -- these were mainly to reflect that we're no longer just doing permutations, since the potential can be computed on a subset of atoms
- Most of the implementation changes to allow computing on a subset have been squashed into 71cc0e5