### PR TITLE
Fix incorrect argument to `gpuErrchkCudaMallocAndCopy`

### DIFF
--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -66,8 +66,8 @@ void Neighborlist<RealType>::compute_block_bounds_host(
     double *h_bb_ctrs,
     double *h_bb_exts) {
 
-    double *d_coords = gpuErrchkCudaMallocAndCopy(h_coords, NC * 3 * sizeof(double));
-    double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3 * 3 * sizeof(double));
+    double *d_coords = gpuErrchkCudaMallocAndCopy(h_coords, NC * 3);
+    double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3 * 3);
 
     this->compute_block_bounds_device(NC, 0, D, d_coords, nullptr, d_box, static_cast<cudaStream_t>(0));
     gpuErrchk(cudaDeviceSynchronize());
@@ -101,12 +101,12 @@ std::vector<std::vector<int>> Neighborlist<RealType>::get_nblist_host(
     } else if (h_row_coords == nullptr && NR != 0) {
         throw std::runtime_error("No row coords provided, but NR != 0");
     }
-    double *d_col_coords = gpuErrchkCudaMallocAndCopy(h_column_coords, NC * 3 * sizeof(double));
+    double *d_col_coords = gpuErrchkCudaMallocAndCopy(h_column_coords, NC * 3);
 
     double *d_row_coords =
-        this->compute_full_matrix() ? gpuErrchkCudaMallocAndCopy(h_row_coords, NR * 3 * sizeof(double)) : nullptr;
+        this->compute_full_matrix() ? gpuErrchkCudaMallocAndCopy(h_row_coords, NR * 3) : nullptr;
 
-    double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3 * 3 * sizeof(double));
+    double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3 * 3);
 
     this->build_nblist_device(NC, NR, d_col_coords, d_row_coords, d_box, cutoff, static_cast<cudaStream_t>(0));
 

--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -103,8 +103,7 @@ std::vector<std::vector<int>> Neighborlist<RealType>::get_nblist_host(
     }
     double *d_col_coords = gpuErrchkCudaMallocAndCopy(h_column_coords, NC * 3);
 
-    double *d_row_coords =
-        this->compute_full_matrix() ? gpuErrchkCudaMallocAndCopy(h_row_coords, NR * 3) : nullptr;
+    double *d_row_coords = this->compute_full_matrix() ? gpuErrchkCudaMallocAndCopy(h_row_coords, NR * 3) : nullptr;
 
     double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3 * 3);
 


### PR DESCRIPTION
Partially addresses #663.

Fixes incorrect arguments passed to `gpuErrchkCudaMallocAndCopy` in neighborlist code, which was causing nondeterministic segfaults ([example reproduction](https://gist.github.com/mcwitt/9c62a38bff4ad373ca7044cd18661941)).

The implementation of `gpuErrchkCudaMallocAndCopy` already multiplies the argument by `sizeof(*buffer)`, so we were previously multiplying by the element size twice in the buffer size computation.