### PR TITLE
Increase launch timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ verify:
 
 .PHONY: memcheck_tests
 memcheck_tests:
-	compute-sanitizer --leak-check full --error-exitcode 1 pytest -m $(MEMCHECK_MARKER) $(PYTEST_CI_ARGS)
+	compute-sanitizer --launch-timeout 1 --leak-check full --error-exitcode 1 pytest -m $(MEMCHECK_MARKER) $(PYTEST_CI_ARGS)
 
 .PHONY: unit_tests
 unit_tests:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ verify:
 
 .PHONY: memcheck_tests
 memcheck_tests:
-	compute-sanitizer --launch-timeout 1 --leak-check full --error-exitcode 1 pytest -m $(MEMCHECK_MARKER) $(PYTEST_CI_ARGS)
+	compute-sanitizer --launch-timeout 120 --leak-check full --error-exitcode 1 pytest -m $(MEMCHECK_MARKER) $(PYTEST_CI_ARGS)
 
 .PHONY: unit_tests
 unit_tests:


### PR DESCRIPTION
What I had thought was an issue with the Gitlab runner configuration turned out to be a timing issue with compute-sanitizer. If compute-sanitizer fails to attach to the process the tests hang indefinitely, so this PR increases the timeout from the default of 10 seconds to 2 minutes. This did reveal a worth while change to make to the gitlab runner though, so expect a PR for that as well. 

Examples:
Run using 14.8.2 gitlab runner that succeeded
https://gitlab.com/relaytx/physics-platform/timemachine/-/jobs/2200729882

Failure with 14.8.2 gitlab runner that logs issue about timing out, which does seem more common with new agent, but no differences in docker, nvidia configuration *container toolkit, drivers, etc).
https://gitlab.com/relaytx/physics-platform/timemachine/-/jobs/2211911855

Run from commit, cancelled with no progress after 15 minutes[ b707265](https://github.com/proteneer/timemachine/pull/668/commits/b70726534638206a6b2c2d864e585d155b2d84c5)
https://gitlab.com/relaytx/physics-platform/timemachine/-/jobs/2213005592