### PR TITLE
Fix error when importing timemachine.lib.potentials without CUDA extension

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,9 +51,7 @@ nogpu-tests:
   rules:
     - if: $CI_EXTERNAL_PULL_REQUEST_IID
   script:
-    - CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) pip install -e .[test]
-    # HACK: remove C++/CUDA library (is there a way to tell pip not to build it?)
-    - rm timemachine/lib/custom_ops.*.so
+    - SKIP_CUSTOM_OPS=1 pip install -e .[test]
     - make nogpu_tests
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-nogpu-tests"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,26 @@ lint:
   script:
     - make verify
 
+nogpu-tests:
+  stage: test
+  image: $DOCKER_TAG
+  needs: ["lint"]
+  tags:
+    - timemachine
+  rules:
+    - if: $CI_EXTERNAL_PULL_REQUEST_IID
+  script:
+    - CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) pip install -e .[test]
+    # HACK: remove C++/CUDA library (is there a way to tell pip not to build it?)
+    - rm timemachine/lib/custom_ops.*.so
+    - make nogpu_tests
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-nogpu-tests"
+    paths:
+        - coverage/
+    when: on_success
+    expire_in: 1 week
+
 memory-tests:
   stage: test
   image: $DOCKER_TAG

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ memcheck_tests:
 
 .PHONY: unit_tests
 unit_tests:
-	pytest -m 'not $(MEMCHECK_MARKER)' $(PYTEST_CI_ARGS)
+	pytest -m 'not $(NOGPU_MARKER) and not $(MEMCHECK_MARKER)' $(PYTEST_CI_ARGS)
 
 .PHONY: ci
 ci: verify memcheck_tests unit_tests

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CPP_DIR := $(MKFILE_DIR)timemachine/cpp/
 INSTALL_PREFIX := $(MKFILE_DIR)timemachine/
 PYTEST_CI_ARGS := --color=yes --cov=. --cov-report=html:coverage/ --cov-append --durations=100
 
+NOGPU_MARKER := nogpu
 MEMCHECK_MARKER := memcheck
 
 NPROCS = `nproc`
@@ -24,6 +25,10 @@ grpc:
 .PHONY: verify
 verify:
 	pre-commit run --all-files --show-diff-on-failure --color=always
+
+.PHONY: nogpu_tests
+nogpu_tests:
+	pytest -m $(NOGPU_MARKER) $(PYTEST_CI_ARGS)
 
 .PHONY: memcheck_tests
 memcheck_tests:

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ conda activate timemachine
 
 ### Install Time Machine
 
-### Linux
+#### Linux
 
 ```shell
 pip install -r requirements.txt
 pip install .
 ```
 
-### Non-Linux
+#### Non-Linux
 
 The CUDA extension module implementing custom ops is only supported on Linux, but partial functionality is still available on non-Linux OSes. To install without the extension:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We currently support the following functional forms. Parameters that can be opti
 
 If using conda the following can be used to configure your environment
 
-```
+```shell
 conda env create -f environment.yml -n timemachine
 conda install openmm=7.5.1 -c conda-forge # only if using openmm from conda
 conda activate timemachine
@@ -45,9 +45,20 @@ conda activate timemachine
 
 ### Install Time Machine
 
-```
+### Linux
+
+```shell
 pip install -r requirements.txt
 pip install .
+```
+
+### Non-Linux
+
+The CUDA extension module implementing custom ops is only supported on Linux, but partial functionality is still available on non-Linux OSes. To install without the extension:
+
+```shell
+pip install -r requirements.txt
+SKIP_CUSTOM_OPS=1 pip install .
 ```
 
 ## Developing Time Machine
@@ -63,18 +74,19 @@ Possible variants of the last step include
 
 ```shell
 pip install -e .[dev,test]                 # optionally install dev and test dependencies
-CMAKE_ARGS=-DCUDA_ARCH=86 pip install -e . # overriding CUDA_ARCH
+CMAKE_ARGS=-DCUDA_ARCH=86 pip install -e . # override CUDA_ARCH
+SKIP_CUSTOM_OPS=1 pip install -e .         # skip building CUDA extension (non-Linux)
 
 # use parallel CMake build with `nproc` threads
 CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) pip install -e .
 ```
 
 To rebuild the extension module after making changes to the C++/CUDA code, either rerun
-```
+```shell
 pip install -e .
 ```
 or
-```
+```shell
 make build
 ```
 
@@ -84,7 +96,7 @@ Note that `PYTHONPATH` must be set to include the `timemachine` repo root. To ru
 
 For example, starting from a clean environment with the openeye license file in `~/.openeye`:
 
-```
+```shell
 OE_DIR=~/.openeye PYTHONPATH=. pytest -xsv tests/
 ```
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ testpaths =
     tests/
 markers =
     memcheck: marks tests to be run with cuda memory checks, triggers cuda device reset at end of marked tests (deselect with '-m "not memcheck"')
+    nogpu: marks tests that should run without the C++/CUDA extension module being built, e.g. tests that should run on platforms other than linux

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,9 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     keywords="molecular dynamics",
-    ext_modules=[CMakeExtension("timemachine.lib.custom_ops", "timemachine/cpp")],
+    ext_modules=[CMakeExtension("timemachine.lib.custom_ops", "timemachine/cpp")]
+    if not os.environ.get("SKIP_CUSTOM_OPS")
+    else [],
     packages=find_packages(),
     python_requires=">=3.7",
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     ],
     keywords="molecular dynamics",
     ext_modules=[CMakeExtension("timemachine.lib.custom_ops", "timemachine/cpp")]
-    if "SKIP_CUSTOM_OPS" not in os.environ
+    if not os.environ.get("SKIP_CUSTOM_OPS")
     else [],
     packages=find_packages(),
     python_requires=">=3.7",

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     ],
     keywords="molecular dynamics",
     ext_modules=[CMakeExtension("timemachine.lib.custom_ops", "timemachine/cpp")]
-    if not os.environ.get("SKIP_CUSTOM_OPS")
+    if "SKIP_CUSTOM_OPS" not in os.environ
     else [],
     packages=find_packages(),
     python_requires=">=3.7",

--- a/tests/test_import_without_custom_ops.py
+++ b/tests/test_import_without_custom_ops.py
@@ -1,0 +1,7 @@
+import pytest
+
+pytestmark = [pytest.mark.nogpu]
+
+
+def test_import_lib_potentials_without_custom_ops():
+    import timemachine.lib.potentials  # noqa: F401

--- a/timemachine/lib/custom_ops.py
+++ b/timemachine/lib/custom_ops.py
@@ -1,6 +1,14 @@
-# (ytz): this file is left intentionally blank.
-# it's a trick to allow us to do a dummy import on the client side
-# that don't have custom_ops shared objects.
+# This file contains stubs for some classes defined in the C++
+# extension module.
+#
+# The purpose is to allow importing modules with
+# unavoidable top-level references to objects defined in the extension
+# (e.g. modules containing subclasses of classes defined in the C++
+# code).
+#
+# If the extension module .so file is present, the definitions
+# in it will take precedence over the stubs defined here.
 
-# on the worker side, a custom .so file for the custom_op and will
-# have higher import priority than the .py file
+
+class FanoutSummedPotential:
+    pass

--- a/timemachine/lib/custom_ops.py
+++ b/timemachine/lib/custom_ops.py
@@ -1,14 +1,6 @@
-# This file contains stubs for some classes defined in the C++
-# extension module.
-#
-# The purpose is to allow importing modules with
-# unavoidable top-level references to objects defined in the extension
-# (e.g. modules containing subclasses of classes defined in the C++
-# code).
-#
-# If the extension module .so file is present, the definitions
-# in it will take precedence over the stubs defined here.
+# (ytz): this file is left intentionally blank.
+# it's a trick to allow us to do a dummy import on the client side
+# that don't have custom_ops shared objects.
 
-
-class FanoutSummedPotential:
-    pass
+# on the worker side, a custom .so file for the custom_op and will
+# have higher import priority than the .py file

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -218,6 +218,27 @@ class CentroidRestraint(CustomOpWrapper):
 
 
 class NonbondedImplWrapper(custom_ops.FanoutSummedPotential):
+    """Wraps custom_ops.FanoutSummedPotential, adding methods that
+    should be provided by the Nonbonded implementation according to
+    the current API spec"""
+
+    # NOTE: This extends custom_ops.FanoutSummedPotential (vs.
+    # CustomOpWrapper) because it needs to implement the C++ Potential
+    # class interface. The motivation for this is to allow the
+    # Nonbonded kernel as implemented using FanoutSummedPotential to
+    # maintain the same interface as the older monolithic kernel, in
+    # particular providing disable_hilbert_sort() and
+    # set_nblist_padding().
+    #
+    # Longer term, it might be preferable to make a breaking API
+    # change so that e.g. disable_hilbert_sort() isn't called directly
+    # on the full nonbonded potential (which is typically a sum of
+    # parts, not all of which use a neighborlist), but on the
+    # underlying NonbondedAllPairs or NonbondedInteractionGroup
+    # potentials (a helper function could be added to the Python
+    # library to make this more convenient). At that point, the
+    # wrapper class can be removed.
+
     def disable_hilbert_sort(self):
         for impl in self.get_potentials():
             if hasattr(impl, "disable_hilbert_sort"):


### PR DESCRIPTION
#661 broke the ability to import `timemachine.lib.potentials` when the extension module was not present (in particular on all non-linux machines, where the extension can't be built).

The cause was the addition of the `NonbondedImplWrapper` class, which allows the `disable_hilbert()` and `set_nblist_padding()` methods to work on custom nonbonded potentials built using `FanoutSummedPotential`. The wrapper class inherits from `custom_ops.FanoutSummedPotential`, so the declaration will fail if the `custom_ops` module is not present.

This PR:
- adds an empty stub for `FanoutSummedPotential` to `custom_ops.py`. This allows the top-level declaration of `NonbondedImplWrapper` to succeed even if the extension is not present
- adds a test that will fail if `import timemachine.lib.potentials` fails without the extension present