### PR TITLE
Modify Charge Conversion to be more consistent with Separated Topologies

### DIFF
--- a/examples/validate_relative_binding.py
+++ b/examples/validate_relative_binding.py
@@ -275,22 +275,10 @@ if __name__ == "__main__":
         seed=seed,
     )
 
-    complex_conversion_schedule = construct_conversion_lambda_schedule(cmd_args.num_complex_conv_windows)
-    # complex models
-    binding_model_complex_conversion = model_rabfe.AbsoluteConversionModel(
-        client,
-        forcefield,
-        complex_system,
-        complex_conversion_schedule,
-        complex_topology,
-        temperature,
-        pressure,
-        dt,
-        cmd_args.num_complex_equil_steps,
-        cmd_args.num_complex_prod_steps,
-        frame_filter=frame_filter,
-    )
+    # force constant for the harmonic core-restraints
+    k_core = 30.0
 
+    # complex models
     binding_model_complex_decouple = model_rabfe.RelativeBindingModel(
         client,
         forcefield,
@@ -303,6 +291,23 @@ if __name__ == "__main__":
         cmd_args.num_complex_equil_steps,
         cmd_args.num_complex_prod_steps,
         frame_filter=frame_filter,
+        k_core=k_core,
+    )
+
+    complex_conversion_schedule = construct_conversion_lambda_schedule(cmd_args.num_complex_conv_windows)
+    binding_model_complex_conversion = model_rabfe.RelativeConversionModel(
+        client,
+        forcefield,
+        complex_system,
+        complex_absolute_schedule,
+        complex_topology,
+        temperature,
+        pressure,
+        dt,
+        cmd_args.num_complex_equil_steps,
+        cmd_args.num_complex_prod_steps,
+        frame_filter=frame_filter,
+        k_core=k_core,
     )
 
     # solvent models.
@@ -377,16 +382,6 @@ if __name__ == "__main__":
         complex_decouple_x0 = np.concatenate([complex_decouple_x0, aligned_mol_coords, ref_coords])
 
         # compute the free energy of conversion in complex
-        complex_conversion_x0 = minimizer.minimize_host_4d(
-            [mol],
-            complex_system,
-            complex_host_coords,
-            forcefield,
-            complex_box0,
-            [aligned_mol_coords],
-        )
-        complex_conversion_x0 = np.concatenate([complex_conversion_x0, aligned_mol_coords])
-
         min_solvent_coords = minimizer.minimize_host_4d(
             [mol], solvent_system, solvent_host_coords, forcefield, solvent_box0
         )
@@ -418,7 +413,9 @@ if __name__ == "__main__":
             "complex_conversion": binding_model_complex_conversion.simulate_futures(
                 ordered_params,
                 mol,
-                complex_conversion_x0,
+                blocker_mol,
+                core_idxs,
+                complex_decouple_x0,
                 complex_box0,
                 prefix="complex_conversion_" + suffix,
                 seed=seed,
@@ -455,6 +452,7 @@ if __name__ == "__main__":
         dG_complex_conversion, dG_complex_conversion_error = binding_model_complex_conversion.predict_from_futures(
             results["complex_conversion"][0],
             results["mol"],
+            results["blocker"],
             results["complex_conversion"][1],
             results["complex_conversion"][2],
         )

--- a/tests/test_rabfe.py
+++ b/tests/test_rabfe.py
@@ -12,7 +12,12 @@ from timemachine.fe.free_energy_rabfe import (
     get_romol_conf,
     setup_relative_restraints_by_distance,
 )
-from timemachine.fe.model_rabfe import AbsoluteConversionModel, AbsoluteStandardHydrationModel, RelativeBindingModel
+from timemachine.fe.model_rabfe import (
+    AbsoluteConversionModel,
+    AbsoluteStandardHydrationModel,
+    RelativeBindingModel,
+    RelativeConversionModel,
+)
 from timemachine.ff import Forcefield
 from timemachine.lib.potentials import Nonbonded, NonbondedInterpolated
 from timemachine.md import builders, minimizer
@@ -27,11 +32,16 @@ NUM_GPUS = get_gpu_count()
 
 class TestRABFEModels(TestCase):
     def test_endpoint_parameters_match_decoupling_and_conversion_complex(self):
-        """Verifies that the parameters at the endpoint of conversion match with the starting parameters of
-        the decoupling. Done on a complex model, as the hydration models differ
+        r"""Verifies that the parameters are consistent for the following thermodynamic cycle:
 
-        Conv: P_start -> P_independent
-        Decouple: P_independent -> P_arbitrary
+        B                              A
+        |                              |
+        --\   X  ----\   Y   ----\  Z  --\
+        A*|  --> B-A*|  -->  B*-A| --> B*|
+        --/      ----/       ----/     --/
+
+        X,Z are the decoupling stages
+        Y is the conversion stages.
 
         """
         host_system, host_coords, host_box, host_topology = builders.build_water_system(4.0)
@@ -60,17 +70,23 @@ class TestRABFEModels(TestCase):
             frame_filter=all_frames,
         )
 
-        blocker = hif2a_ligand_pair.mol_a
-        ligand = hif2a_ligand_pair.mol_b
+        mol_a = hif2a_ligand_pair.mol_a
+        mol_b = hif2a_ligand_pair.mol_b
 
-        decouple_topo = decouple_model.setup_topology(blocker, ligand)
-        decouple_ref = RelativeFreeEnergy(decouple_topo)
-
-        decouple_unbound_potentials, decouple_sys_params, _ = decouple_ref.prepare_host_edge(
+        # b is decoupled, a stays put
+        decouple_ref_ab = RelativeFreeEnergy(decouple_model.setup_topology(mol_a, mol_b))
+        decouple_unbound_potentials_ab, decouple_sys_params_ab, _ = decouple_ref_ab.prepare_host_edge(
             ff_params, decouple_model.host_system
         )
 
-        conv_model = AbsoluteConversionModel(
+        # a is decoupled, b stays put
+        decouple_ref_ba = RelativeFreeEnergy(decouple_model.setup_topology(mol_b, mol_a))
+        decouple_unbound_potentials_ba, decouple_sys_params_ba, _ = decouple_ref_ba.prepare_host_edge(
+            ff_params, decouple_model.host_system
+        )
+
+        # convert a charges into b charges
+        conv_model_ab = RelativeConversionModel(
             client,
             hif2a_ligand_pair.ff,
             host_system,
@@ -84,43 +100,50 @@ class TestRABFEModels(TestCase):
             frame_filter=all_frames,
         )
 
-        conv_topo = conv_model.setup_topology(ligand)
-        conv_ref = AbsoluteFreeEnergy(ligand, conv_topo)
+        conv_ref = RelativeFreeEnergy(conv_model_ab.setup_topology(mol_a, mol_b))
+        conv_unbound_potentials, conv_sys_params, _ = conv_ref.prepare_host_edge(ff_params, conv_model_ab.host_system)
 
-        conv_unbound_potentials, conv_sys_params, _ = conv_ref.prepare_host_edge(ff_params, conv_model.host_system)
+        assert len(conv_sys_params) == len(decouple_sys_params_ab)
+        assert len(conv_sys_params) == len(decouple_sys_params_ba)
 
-        assert len(conv_sys_params) == len(decouple_sys_params)
         seen_nonbonded = False
-        for i, decouple_pot in enumerate(decouple_unbound_potentials):
-            if not isinstance(decouple_pot, NonbondedInterpolated):
+        for i, (decouple_pot_ab, decouple_pot_ba) in enumerate(
+            zip(decouple_unbound_potentials_ab, decouple_unbound_potentials_ba)
+        ):
+
+            if not isinstance(decouple_pot_ab, Nonbonded):
                 continue
+
             seen_nonbonded = True
 
             conv_pot = conv_unbound_potentials[i]
             assert isinstance(conv_pot, NonbondedInterpolated)
 
             conv_nonbonded_params = conv_sys_params[i]
-            decouple_nonbonded_params = decouple_sys_params[i]
+            decouple_nonbonded_params_ab = decouple_sys_params_ab[i]
+            decouple_nonbonded_params_ba = decouple_sys_params_ba[i]
 
-            # Shapes of parameters
-            # Conversion Leg [src_ligand, dest_ligand]
-            # Decouple Leg [dest_blocker, dest_ligand, blocker_halved, ligand_halved]
+            # decouple_ab params matches conv src
+            # decouple_ba params matches conv dst
+            conv_nonbonded_params_src = conv_nonbonded_params[: len(conv_nonbonded_params) // 2]
+            conv_nonbonded_params_dst = conv_nonbonded_params[len(conv_nonbonded_params) // 2 :]
 
-            # Should have the same number of parameters besides the blocker. Since params are interpolated, multiply by 2
-            assert conv_nonbonded_params.shape[0] == decouple_nonbonded_params.shape[0] - blocker.GetNumAtoms() * 2
-            # Should both share the same number of parameters types
-            assert conv_nonbonded_params.shape[1] == decouple_nonbonded_params.shape[1]
+            # decouple_nonbonded_params_ba [host, mol_a, mol_b]
+            np.testing.assert_array_equal(conv_nonbonded_params_src, decouple_nonbonded_params_ab)
 
-            conv_params = conv_nonbonded_params[num_host_atoms * 2 :]
-            decouple_params = decouple_nonbonded_params[num_host_atoms * 2 :]
+            # re-order the parameters
+            # conv_nonbonded_params_src [host, mol_a, mol_b]
+            # decouple_nonbonded_params_ba [host, mol_b, mol_a]
+            H = num_host_atoms
+            B = mol_b.GetNumAtoms()
 
-            assert conv_params.shape[0] == decouple_params.shape[0] - blocker.GetNumAtoms() * 2
+            nb_h = decouple_nonbonded_params_ba[:H]
+            nb_b = decouple_nonbonded_params_ba[H : H + B]
+            nb_a = decouple_nonbonded_params_ba[H + B :]
 
-            # Verify the dest params of conv match the src params of decouple
-            np.testing.assert_array_equal(
-                conv_params[len(conv_params) // 2 :],
-                decouple_params[len(decouple_params) // 2 + blocker.GetNumAtoms() :],
-            )
+            expected_params = np.concatenate([nb_h, nb_a, nb_b])
+
+            np.testing.assert_array_equal(conv_nonbonded_params_dst, expected_params)
 
         assert seen_nonbonded, "Found no NonbondedInterpolated potential"
 
@@ -278,7 +301,7 @@ class TestRABFEModels(TestCase):
                 ordered_params, mol_a, mol_b, core_idxs, solvent_x0, solvent_box, "prefix", seed=2022
             )
             # Since this is FF independent no issues around AM1BCC charge differences on OS/Conf
-            np.testing.assert_almost_equal(dG, -0.57731, decimal=5)
+            np.testing.assert_almost_equal(dG, -0.480238, decimal=5)
             np.testing.assert_almost_equal(dG_err, float(np.nan))
             created_files = os.listdir(temp_dir)
             # 3 npz, 1 pdb and 1 npy per mol due to a->b and b->a
@@ -286,6 +309,77 @@ class TestRABFEModels(TestCase):
             self.assertEqual(len([x for x in created_files if x.endswith(".pdb")]), 2)
             self.assertEqual(len([x for x in created_files if x.endswith(".npy")]), 2)
             self.assertEqual(len([x for x in created_files if x.endswith(".npz")]), 6)
+
+    def test_predict_relative_conversion_model(self):
+        """
+        Verify that we can handle the most basic decoupling RABFE prediction.
+
+        In particular, we check that RelativeConversionModel's predict function runs,
+        is deterministic, and creates the expected number of pdb, npy, npz files
+        """
+        # Use the Simple Charges to verify determinism of model. Needed as one endpoint uses the ff definition
+        forcefield = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
+        # build the water system
+        solvent_system, solvent_coords, solvent_box, solvent_topology = builders.build_water_system(4.0)
+
+        temperature = 300.0
+        pressure = 1.0
+        dt = 2.5e-3
+
+        client = CUDAPoolClient(NUM_GPUS)
+
+        model = RelativeConversionModel(
+            client,
+            forcefield,
+            solvent_system,
+            construct_lambda_schedule(2),
+            solvent_topology,
+            temperature,
+            pressure,
+            dt,
+            10,
+            50,
+            frame_filter=all_frames,
+        )
+        mol_a = hif2a_ligand_pair.mol_a
+        mol_b = hif2a_ligand_pair.mol_b
+
+        core_idxs = setup_relative_restraints_by_distance(mol_a, mol_b)
+
+        ref_coords = get_romol_conf(mol_a)
+        mol_coords = get_romol_conf(mol_b)  # original coords
+
+        # Align using core_idxs
+        R, t = rmsd.get_optimal_rotation_and_translation(
+            x1=ref_coords[core_idxs[:, 1]],  # reference core atoms
+            x2=mol_coords[core_idxs[:, 0]],  # mol core atoms
+        )
+
+        aligned_mol_coords = rmsd.apply_rotation_and_translation(mol_coords, R, t)
+        solvent_coords = minimizer.minimize_host_4d(
+            [mol_a, mol_b],
+            solvent_system,
+            solvent_coords,
+            forcefield,
+            solvent_box,
+            [ref_coords, aligned_mol_coords],
+        )
+        solvent_x0 = np.concatenate([solvent_coords, ref_coords, aligned_mol_coords])
+
+        ordered_params = forcefield.get_ordered_params()
+        with temporary_working_dir() as temp_dir:
+            dG, dG_err = model.predict(
+                ordered_params, mol_a, mol_b, core_idxs, solvent_x0, solvent_box, "prefix", seed=2022
+            )
+            # Since this is FF independent no issues around AM1BCC charge differences on OS/Conf
+            np.testing.assert_almost_equal(dG, -25.86479, decimal=5)
+            np.testing.assert_almost_equal(dG_err, 0.0)
+            created_files = os.listdir(temp_dir)
+
+            self.assertEqual(len(created_files), 4)
+            self.assertEqual(len([x for x in created_files if x.endswith(".pdb")]), 1)
+            self.assertEqual(len([x for x in created_files if x.endswith(".npy")]), 1)
+            self.assertEqual(len([x for x in created_files if x.endswith(".npz")]), 2)
 
     def test_predict_absolute_conversion(self):
         """Just to verify that we can handle the most basic conversion RABFE prediction"""
@@ -339,8 +433,8 @@ class TestRABFEModels(TestCase):
             dG, dG_err = model.predict(
                 ordered_params, mol_b, solvent_x0, solvent_box, "prefix", core_idxs=core_idxs[:, 0], seed=2022
             )
-            np.testing.assert_almost_equal(dG, 42.949970, decimal=5)
-            np.testing.assert_equal(dG_err, 0.0)
+            np.testing.assert_almost_equal(dG, 41.447823, decimal=5)
+            np.testing.assert_almost_equal(dG_err, 0.0)
             created_files = os.listdir(temp_dir)
             # 2 npz, 1 pdb and 1 npy per mol due to a->b and b->a
             self.assertEqual(len(created_files), 4)

--- a/timemachine/fe/free_energy_rabfe.py
+++ b/timemachine/fe/free_energy_rabfe.py
@@ -99,7 +99,8 @@ class RABFEResult:
     @property
     def dG_complex(self):
         """effective free energy of removing from complex"""
-        return self.dG_complex_conversion + self.dG_complex_decouple
+        # return self.dG_complex_conversion + self.dG_complex_decouple
+        return -self.dG_complex_conversion + self.dG_complex_decouple
 
     @property
     def dG_solvent(self):

--- a/timemachine/fe/model_rabfe.py
+++ b/timemachine/fe/model_rabfe.py
@@ -236,6 +236,7 @@ class RelativeModel(ABC):
         equil_steps: int,
         prod_steps: int,
         frame_filter: Optional[callable] = None,
+        k_core: float = 30.0,
     ):
 
         self.host_system = host_system
@@ -251,6 +252,7 @@ class RelativeModel(ABC):
         if frame_filter is None:
             frame_filter = endpoint_frames_only
         self.frame_filter = frame_filter
+        self.k_core = k_core
 
     def setup_topology(self, mol_a, mol_b):
         raise NotImplementedError()
@@ -268,7 +270,7 @@ class RelativeModel(ABC):
 
         unbound_potentials, sys_params, masses = rfe.prepare_host_edge(ff_params, self.host_system)
 
-        k_core = 30.0
+        k_core = self.k_core
 
         core_params = np.zeros_like(combined_core_idxs).astype(np.float64)
         core_params[:, 0] = k_core
@@ -376,6 +378,8 @@ class RelativeModel(ABC):
     def simulate_futures(
         self, ff_params, mol_a, mol_b, core, x0, box0, prefix, seed=0
     ) -> Tuple[List[Any], List[estimator_abfe.FreeEnergyModel], List[List[Any]]]:
+        """Compute the delta G of morphing mol_a into mol_b according to the
+        protocol described by the topology object."""
 
         num_host_atoms = x0.shape[0] - mol_a.GetNumAtoms() - mol_b.GetNumAtoms()
         host_coords = x0[:num_host_atoms]
@@ -420,8 +424,8 @@ class RelativeModel(ABC):
         combined_coords = np.concatenate([host_coords, mol_b_coords, mol_a_coords])
         sys_params, model, futures = self._futures_a_to_b(
             ff_params,
-            mol_b,
-            mol_a,
+            mol_b,  # BLOCKER
+            mol_a,  # ACTUAL MOL
             combined_core_idxs,
             combined_coords,
             box0,
@@ -580,5 +584,290 @@ class AbsoluteStandardHydrationModel(AbsoluteModel):
 
 class RelativeBindingModel(RelativeModel):
     def setup_topology(self, mol_a, mol_b):
-        top = topology.DualTopologyStandardDecoupling(mol_a, mol_b, self.ff)
+        top = topology.DualTopologyDecoupling(mol_a, mol_b, self.ff)
         return top
+
+
+class RelativeConversionModel:
+    """
+    Estimate the free energy of decharging molecule A and charging molecule B
+    while both molecules are in the binding pocket.
+    """
+
+    def __init__(
+        self,
+        client: Optional[AbstractClient],
+        ff: Forcefield,
+        host_system: openmm.System,
+        host_schedule: np.ndarray,
+        host_topology: openmm.app.Topology,
+        temperature: float,
+        pressure: float,
+        dt: float,
+        equil_steps: int,
+        prod_steps: int,
+        frame_filter: Optional[callable] = None,
+        k_core: float = 30.0,
+    ):
+
+        self.host_system = host_system
+        self.temperature = temperature
+        self.pressure = pressure
+        self.dt = dt
+        self.host_schedule = host_schedule
+        self.host_topology = host_topology
+        self.client = client
+        self.ff = ff
+        self.equil_steps = equil_steps
+        self.prod_steps = prod_steps
+        if frame_filter is None:
+            frame_filter = endpoint_frames_only
+        self.frame_filter = frame_filter
+        self.k_core = k_core
+
+    def setup_topology(self, mol_a, mol_b):
+        top = topology.DualTopologyChargeConversion(mol_a, mol_b, self.ff)
+        return top
+
+    def _futures_a_to_b(self, ff_params, mol_a, mol_b, combined_core_idxs, x0, box0, prefix, seed):
+
+        num_host_atoms = x0.shape[0] - mol_a.GetNumAtoms() - mol_b.GetNumAtoms()
+
+        # (ytz): super ugly, undo combined_core_idxs to get back original idxs
+        core_idxs = combined_core_idxs - num_host_atoms
+        core_idxs[:, 1] -= mol_a.GetNumAtoms()
+
+        dual_topology = self.setup_topology(mol_a, mol_b)
+        rfe = free_energy_rabfe.RelativeFreeEnergy(dual_topology)
+
+        unbound_potentials, sys_params, masses = rfe.prepare_host_edge(ff_params, self.host_system)
+
+        # this should be consistent between the decoupling and conversion stages.
+        k_core = self.k_core
+
+        core_params = np.zeros_like(combined_core_idxs).astype(np.float64)
+        core_params[:, 0] = k_core
+
+        restraint_potential = potentials.HarmonicBond(
+            combined_core_idxs,
+        )
+
+        unbound_potentials.append(restraint_potential)
+        sys_params.append(core_params)
+
+        # tbd sample from boltzmann distribution later
+        v0 = np.zeros_like(x0)
+
+        beta = 1 / (constants.BOLTZ * self.temperature)
+
+        bond_list = np.concatenate([unbound_potentials[0].get_idxs(), core_idxs])
+        masses = model_utils.apply_hmr(masses, bond_list)
+
+        friction = 1.0
+        integrator = LangevinIntegrator(self.temperature, self.dt, friction, masses, seed)
+        bond_list = list(map(tuple, bond_list))
+        group_indices = get_group_indices(bond_list)
+        barostat_interval = 5
+
+        barostat = MonteCarloBarostat(
+            x0.shape[0], self.pressure, self.temperature, group_indices, barostat_interval, seed
+        )
+
+        endpoint_correct = False
+        model = estimator_abfe.FreeEnergyModel(
+            unbound_potentials,
+            endpoint_correct,
+            self.client,
+            box0,  # important, use equilibrated box.
+            x0,
+            v0,
+            integrator,
+            barostat,
+            self.host_schedule,
+            self.equil_steps,
+            self.prod_steps,
+            beta,
+            prefix,
+        )
+
+        bound_potentials = []
+        for params, unbound_pot in zip(sys_params, model.unbound_potentials):
+            bp = unbound_pot.bind(np.asarray(params))
+            bound_potentials.append(bp)
+
+        all_args = []
+        for lamb_idx, lamb in enumerate(model.lambda_schedule):
+
+            subsample_interval = 1000
+
+            all_args.append(
+                (
+                    lamb,
+                    model.box,
+                    model.x0,
+                    model.v0,
+                    bound_potentials,
+                    model.integrator,
+                    model.barostat,
+                    model.equil_steps,
+                    model.prod_steps,
+                    subsample_interval,
+                    subsample_interval,
+                    model.lambda_schedule,
+                )
+            )
+
+        futures = []
+        if self.client is None:
+            for args in all_args:
+                futures.append(_MockFuture(estimator_abfe.simulate(*args)))
+        else:
+            for args in all_args:
+                futures.append(self.client.submit(estimator_abfe.simulate, *args))
+
+        return sys_params, model, futures
+
+    def simulate_futures(
+        self, ff_params, mol_a, mol_b, core, x0, box0, prefix, seed=0
+    ) -> Tuple[List[Any], List[estimator_abfe.FreeEnergyModel], List[List[Any]]]:
+        """Compute the delta G of decharging mol_a while simultaneously charging mol_b"""
+
+        num_host_atoms = x0.shape[0] - mol_a.GetNumAtoms() - mol_b.GetNumAtoms()
+        host_coords = x0[:num_host_atoms]
+        mol_a_coords = x0[num_host_atoms : num_host_atoms + mol_a.GetNumAtoms()]
+        mol_b_coords = x0[num_host_atoms + mol_a.GetNumAtoms() :]
+
+        # pull out mol_b from combined state
+        combined_core_idxs = np.copy(core)
+        combined_core_idxs[:, 0] += num_host_atoms
+        combined_core_idxs[:, 1] += num_host_atoms + mol_a.GetNumAtoms()
+        # this is redundant, but thought it best to be explicit about ordering here..
+        combined_coords = np.concatenate([host_coords, mol_a_coords, mol_b_coords])
+
+        if seed == 0:
+            seed = np.random.randint(np.iinfo(np.int32).max)
+
+        all_sys = []
+        models = []
+        all_futures = []
+        sys_params, model, futures = self._futures_a_to_b(
+            ff_params,
+            mol_a,
+            mol_b,
+            combined_core_idxs,
+            combined_coords,
+            box0,
+            prefix + "_ref_to_mol",
+            seed,
+        )
+
+        all_sys.append(sys_params)
+        models.append(model)
+        all_futures.append(futures)
+
+        return all_sys, models, all_futures
+
+    def predict_from_futures(
+        self, sys_params, mol_a, mol_b, models: List[estimator_abfe.FreeEnergyModel], futures: List[List[Any]]
+    ):
+        assert len(futures) == 1
+        assert len(models) == 1
+        assert len(sys_params) == 1
+
+        model = models[0]
+        params = sys_params[0]
+        sub_futures = futures[0]
+
+        results = [fut.result() for fut in sub_futures]
+        dG, dG_err, results = estimator_abfe.deltaG_from_results(model, results, params)
+
+        # Save out the pdb
+        model_utils.generate_openmm_topology(
+            [self.host_topology, mol_a, mol_b], model.x0, box=model.box, out_filename=f"initial_{model.prefix}.pdb"
+        )
+
+        for lambda_idx, res in self.frame_filter(results):
+            np.savez(
+                f"initial_{model.prefix}_lambda_idx_{lambda_idx}.npz",
+                xs=res.xs,
+                boxes=res.boxes,
+                lambda_us=res.lambda_us,
+            )
+
+        return dG, dG_err
+
+    def predict(
+        self,
+        ff_params: list,
+        mol_a: Chem.Mol,
+        mol_b: Chem.Mol,
+        core_idxs: np.array,
+        x0: np.array,
+        box0: np.array,
+        prefix: str,
+        seed: int = 0,
+    ):
+        """
+        Compute the free of energy of turning off the charges of mol_a while simultaneously
+        turning on the charges of mol_b. Both molecules are interacting with the environment, but
+        not with each other.
+
+        Parameters
+        ----------
+
+        ff_params: list of np.ndarray
+            This should match the ordered params returned by the forcefield
+
+        mol_a: Chem.Mol
+            Starting molecule
+
+        mol_b: Chem.Mol
+            Resulting molecule
+
+        core_idxs: np.array (Nx2), dtype int32
+            Atom mapping defining the core, mapping atoms from mol_a to atoms in mol_b.
+
+        x0: np.ndarray
+            Initial coordinates of the combined system.
+
+        box0: np.ndarray
+            Initial box vectors.
+
+        prefix: str
+            Auxiliary string to prepend print-outs
+
+        seed: int
+            Seed to run the simulation using, defaults to generating a seed randomly
+        Returns
+        -------
+        float
+            delta delta G in kJ/mol of morphing mol_a into mol_b
+
+        float
+            BAR error in the delta delta G in kJ/mol
+
+        Note that the error estimate is likely to be biased for two reasons: we don't
+            know the true decorrelation time, and by re-using intermediate windows
+            to compute delta_Us, the BAR estimates themselves become correlated.
+
+        """
+
+        sys_params, models, futures = self.simulate_futures(
+            ff_params,
+            mol_a,
+            mol_b,
+            core_idxs,
+            x0,
+            box0,
+            prefix,
+            seed=seed,
+        )
+        dG, dG_err = self.predict_from_futures(
+            sys_params,
+            mol_b,
+            mol_a,
+            models,
+            futures,
+        )
+
+        return dG, dG_err


### PR DESCRIPTION
This PR makes two important changes:

1) Remove the ff conversion stage, our new re-weighting protocol no longer relies on this.
2) Better support for charged compounds (note: changing charges is still not supported) using a thermodynamic cycle more consistent with separated topologies. In particular, we now do a charge conversion stage in between the decoupling stages where the charges are swapped.

We need to do a little bit more validation on some test systems before this can be merged. I will remove the `standard_qlj_typer` in a separate PR during deboggling week.