### PR TITLE
Fix description of `freesolv.sdf`

### DIFF
--- a/timemachine/datasets/readme.md
+++ b/timemachine/datasets/readme.md
@@ -1,5 +1,7 @@
 ## `freesolv`
-`freesolv.sdf` contains a snapshot of v0.52 the FreeSolv database of hydration free energies curated by David Mobley, Peter Guthrie, and colleagues here: https://github.com/MobleyLab/FreeSolv/releases/tag/v0.52
+`freesolv.sdf` contains a sanitized version of v0.52 the FreeSolv database of hydration free energies curated by David Mobley, Peter Guthrie, and colleagues here: https://github.com/MobleyLab/FreeSolv/releases/tag/v0.52
+
+(Note: `freesolv.sdf` reflects a fix described in https://github.com/MobleyLab/FreeSolv/issues/48 )
 
 ## `fep-benchmark`
 Datasets in the `fep-benchmark` folder are imported from v1.0 of https://github.com/MCompChem/fep-benchmark/releases/tag/v1.0 (distributed under MIT license), created by Christina Schindler and Daniel Kuhn, Merck KGaA, Darmstadt, Germany, December 2018 , accompanying https://chemrxiv.org/articles/preprint/Large-Scale_Assessment_of_Binding_Free_Energy_Calculations_in_Active_Drug_Discovery_Projects/11364884 (Schindler et al., 2019)


### PR DESCRIPTION
Fixes a mistaken description I had added in the datasets readme

Thanks to @badisa for spotting differences between `freesolv.sdf` and the SDF files in FreeSolv v 0.52 (which @proteneer described in https://github.com/MobleyLab/FreeSolv/issues/48 )