### PR TITLE
Configure warnings for nvcc

### DIFF
--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -16,6 +16,8 @@ string(APPEND CMAKE_CUDA_FLAGS
   " -Werror all-warnings"
   " -Wall"
   " -Wno-sign-compare"
+  " -Wextra"
+  " -Wno-unused-parameter"
 )
 message(${CMAKE_CUDA_FLAGS})
 

--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -12,6 +12,11 @@ find_package(PythonLibs 3.7 REQUIRED)
 string(APPEND CMAKE_CXX_FLAGS "-Werror -Wall -Wextra")
 
 string(APPEND CMAKE_CUDA_FLAGS "-O3 -lineinfo")
+string(APPEND CMAKE_CUDA_FLAGS
+  " -Werror all-warnings"
+  " -Wall"
+  " -Wno-sign-compare"
+)
 message(${CMAKE_CUDA_FLAGS})
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -18,6 +18,7 @@ string(APPEND CMAKE_CUDA_FLAGS
   " -Wno-sign-compare"
   " -Wextra"
   " -Wno-unused-parameter"
+  " -Wreorder"
 )
 message(${CMAKE_CUDA_FLAGS})
 

--- a/timemachine/cpp/src/barostat.cu
+++ b/timemachine/cpp/src/barostat.cu
@@ -21,8 +21,8 @@ MonteCarloBarostat::MonteCarloBarostat(
     const int interval,
     const std::vector<BoundPotential *> bps,
     const int seed)
-    : N_(N), pressure_(pressure), temperature_(temperature), interval_(interval), bps_(bps), group_idxs_(group_idxs),
-      num_grouped_atoms_(0), d_sum_storage_(nullptr), d_sum_storage_bytes_(0), seed_(seed), step_(0) {
+    : N_(N), bps_(bps), pressure_(pressure), temperature_(temperature), interval_(interval), seed_(seed),
+      group_idxs_(group_idxs), step_(0), num_grouped_atoms_(0), d_sum_storage_(nullptr), d_sum_storage_bytes_(0) {
 
     // Trigger check that interval is valid
     this->set_interval(interval_);

--- a/timemachine/cpp/src/barostat.hpp
+++ b/timemachine/cpp/src/barostat.hpp
@@ -44,11 +44,12 @@ public:
     void set_pressure(const double pressure);
 
 private:
+    const int N_;
+
     void reset_counters();
 
     const std::vector<BoundPotential *> bps_;
 
-    const int N_;
     double pressure_;
     const double temperature_;
     int interval_;

--- a/timemachine/cpp/src/context.cu
+++ b/timemachine/cpp/src/context.cu
@@ -15,7 +15,7 @@ Context::Context(
     Integrator *intg,
     std::vector<BoundPotential *> bps,
     MonteCarloBarostat *barostat)
-    : N_(N), intg_(intg), bps_(bps), step_(0), d_sum_storage_(nullptr), d_sum_storage_bytes_(0), barostat_(barostat) {
+    : N_(N), barostat_(barostat), step_(0), d_sum_storage_(nullptr), d_sum_storage_bytes_(0), intg_(intg), bps_(bps) {
     d_x_t_ = gpuErrchkCudaMallocAndCopy(x_0, N * 3);
     d_v_t_ = gpuErrchkCudaMallocAndCopy(v_0, N * 3);
     d_box_t_ = gpuErrchkCudaMallocAndCopy(box_0, 3 * 3);

--- a/timemachine/cpp/src/context.hpp
+++ b/timemachine/cpp/src/context.hpp
@@ -45,6 +45,8 @@ public:
     void get_box(double *out_buffer) const;
 
 private:
+    int N_; // number of particles
+
     MonteCarloBarostat *barostat_;
 
     void _step(double lambda, unsigned long long *du_dl_out);
@@ -52,7 +54,6 @@ private:
     void _step_equilibrium(double lambda, unsigned long long *du_dl_out);
 
     int step_;
-    int N_; // number of particles
 
     double *d_x_t_;   // coordinates
     double *d_v_t_;   // velocities

--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -58,13 +58,7 @@ template <typename RealType> Neighborlist<RealType>::~Neighborlist() {
 
 template <typename RealType>
 void Neighborlist<RealType>::compute_block_bounds_host(
-    const int NC,
-    const int D,
-    const int block_size,
-    const double *h_coords,
-    const double *h_box,
-    double *h_bb_ctrs,
-    double *h_bb_exts) {
+    const int NC, const int D, const double *h_coords, const double *h_box, double *h_bb_ctrs, double *h_bb_exts) {
 
     double *d_coords = gpuErrchkCudaMallocAndCopy(h_coords, NC * 3);
     double *d_box = gpuErrchkCudaMallocAndCopy(h_box, 3 * 3);
@@ -113,7 +107,6 @@ std::vector<std::vector<int>> Neighborlist<RealType>::get_nblist_host(
     const int tpb = warp_size;
     const int column_blocks = this->column_blocks();
     const int row_blocks = this->B();
-    const int Y = this->Y();
 
     unsigned long long MAX_TILE_BUFFER = row_blocks * column_blocks;
     unsigned long long MAX_ATOM_BUFFER = MAX_TILE_BUFFER * tpb;
@@ -167,7 +160,6 @@ void Neighborlist<RealType>::build_nblist_device(
     this->compute_block_bounds_device(NC, NR, D, d_col_coords, d_row_coords, d_box, stream);
 
     const int tpb = warp_size;
-    const int column_blocks = this->column_blocks();
     const int row_blocks = this->B();
     const int Y = this->Y();
 
@@ -252,8 +244,6 @@ void Neighborlist<RealType>::compute_block_bounds_device(
     } else if (d_row_coords == nullptr && NR != 0) {
         throw std::runtime_error("No row coords provided, but NR != 0");
     }
-
-    const bool compute_row_bounds = this->compute_full_matrix();
 
     const int tpb = warp_size;
     const int column_blocks = this->column_blocks(); // total number of blocks we need to process

--- a/timemachine/cpp/src/neighborlist.hpp
+++ b/timemachine/cpp/src/neighborlist.hpp
@@ -53,13 +53,7 @@ public:
         cudaStream_t stream);
 
     void compute_block_bounds_host(
-        const int NC,
-        const int D,
-        const int block_size,
-        const double *h_coords,
-        const double *h_box,
-        double *h_bb_ctrs,
-        double *h_bb_exts);
+        const int NC, const int D, const double *h_coords, const double *h_box, double *h_bb_ctrs, double *h_bb_exts);
 
     unsigned int *get_ixn_atoms() { return d_ixn_atoms_; }
 

--- a/timemachine/cpp/src/nonbonded_interaction_group.cu
+++ b/timemachine/cpp/src/nonbonded_interaction_group.cu
@@ -36,8 +36,8 @@ NonbondedInteractionGroup<RealType, Interpolated>::NonbondedInteractionGroup(
     const double beta,
     const double cutoff,
     const std::string &kernel_src)
-    : N_(lambda_offset_idxs.size()), NR_(row_atom_idxs.size()), NC_(N_ - NR_), cutoff_(cutoff), nblist_(NC_, NR_),
-      beta_(beta), d_sort_storage_(nullptr), d_sort_storage_bytes_(0), nblist_padding_(0.1), disable_hilbert_(false),
+    : N_(lambda_offset_idxs.size()), NR_(row_atom_idxs.size()), NC_(N_ - NR_),
+
       kernel_ptrs_({// enumerate over every possible kernel combination
                     // U: Compute U
                     // X: Compute DU_DL
@@ -60,6 +60,10 @@ NonbondedInteractionGroup<RealType, Interpolated>::NonbondedInteractionGroup(
                     &k_nonbonded_unified<RealType, 1, 1, 0, 1>,
                     &k_nonbonded_unified<RealType, 1, 1, 1, 0>,
                     &k_nonbonded_unified<RealType, 1, 1, 1, 1>}),
+
+      beta_(beta), cutoff_(cutoff), nblist_(NC_, NR_), nblist_padding_(0.1), d_sort_storage_(nullptr),
+      d_sort_storage_bytes_(0), disable_hilbert_(false),
+
       compute_w_coords_instance_(kernel_cache_.program(kernel_src.c_str()).kernel("k_compute_w_coords").instantiate()),
       compute_gather_interpolated_(
           kernel_cache_.program(kernel_src.c_str()).kernel("k_gather_interpolated").instantiate()),

--- a/timemachine/cpp/src/nonbonded_pair_list.hpp
+++ b/timemachine/cpp/src/nonbonded_pair_list.hpp
@@ -9,6 +9,9 @@ namespace timemachine {
 template <typename RealType, bool Negated, bool Interpolated> class NonbondedPairList : public Potential {
 
 private:
+    const int N_; // number of atoms
+    const int M_; // number of pairs
+
     int *d_pair_idxs_; // [M, 2]
     double *d_scales_; // [M, 2]
     int *d_lambda_plane_idxs_;
@@ -16,9 +19,6 @@ private:
 
     double beta_;
     double cutoff_;
-
-    const int M_; // number of pairs
-    const int N_; // number of atoms
 
     double *d_w_;
     double *d_dw_dl_;

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -56,7 +56,7 @@ template <typename RealType> void declare_neighborlist(py::module &m, const char
                 py::array_t<double, py::array::c_style> py_bb_exts({B, D});
 
                 nblist.compute_block_bounds_host(
-                    N, D, block_size, coords.data(), box.data(), py_bb_ctrs.mutable_data(), py_bb_exts.mutable_data());
+                    N, D, coords.data(), box.data(), py_bb_ctrs.mutable_data(), py_bb_exts.mutable_data());
 
                 return py::make_tuple(py_bb_ctrs, py_bb_exts);
             })


### PR DESCRIPTION
Enables the following warnings for compilation of CUDA code with `nvcc`:

- `-Wall`
  - disable `-Wsign-compare`; fixing this would be a big project, probably requiring either changing the `Potential` interface to use unsigned ints for `N` and `P`, or introducing lots of `static_cast`s (which wouldn't help with safety)

- `-Wextra`
  - disable `-Wunused-parameter`; there are lots of false positives e.g. in `execute_device` subclass implementations that don't use all parameters; "fixing" these by removing the parameter names [harms readability](https://github.com/proteneer/timemachine/pull/697#discussion_r844199375)

- `-Wreorder`: ensures correct ordering of initializers to prevent undefined behavior
  - note: for plain C++ code this is already enabled by `-Wall`; however, it seems necessary to add this flag separately so it's [picked up by `nvcc`](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#generic-tool-options-Wreorder)

Also removes some unused definitions that were exposed by the (now disabled) warning `-Wunused-parameter`, but do seem correct to remove (ebb86dc)