### PR TITLE
Local Geometry Helper Functions

### DIFF
--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,534 @@
+# This file tests geometry classification for a wide variety of molecules,
+# selected from common drugs and baran's heterocyclic chemistry
+
+from rdkit import Chem
+
+from timemachine.fe import geometry
+from timemachine.fe.geometry import LocalGeometry as LG
+
+
+def test_assign_aspirin():
+    mol = Chem.AddHs(Chem.MolFromSmiles("CC(=O)OC1=CC=CC=C1C(=O)O"))
+    atom_types = geometry.classify_geometry(mol)
+
+    expected_types = [
+        LG.G4_TETRAHEDRAL,
+        LG.G3_PLANAR,
+        LG.G1_TERMINAL,
+        LG.G2_KINK,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G1_TERMINAL,
+        LG.G2_KINK,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_assign_nitrogens():
+    """Test assignment with weird SP and SP2 nitrogens."""
+
+    mol = Chem.AddHs(Chem.MolFromSmiles("CC1C(N)C2=C(C=NC(=C2)C#N)C1=O"))
+    atom_types = geometry.classify_geometry(mol)
+
+    expected_types = [
+        LG.G4_TETRAHEDRAL,
+        LG.G4_TETRAHEDRAL,
+        LG.G4_TETRAHEDRAL,
+        LG.G3_PYRAMIDAL,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G2_KINK,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G2_LINEAR,
+        LG.G1_TERMINAL,
+        LG.G3_PLANAR,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_assign_truncated_sildenafil():
+    # useful for having a mixture of sulfur groups, and common heterocycles
+    mol = Chem.AddHs(Chem.MolFromSmiles("CCOC1=C(C=C(C=C1)S(=O)(=O)N1CCN(C)CC1)C1=NC=CC(=O)N1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G4_TETRAHEDRAL,
+        LG.G4_TETRAHEDRAL,
+        LG.G2_KINK,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G4_TETRAHEDRAL,  # S
+        LG.G1_TERMINAL,  # O-S
+        LG.G1_TERMINAL,  # O-S
+        LG.G3_PYRAMIDAL,  # N
+        LG.G4_TETRAHEDRAL,  # C
+        LG.G4_TETRAHEDRAL,  # C
+        LG.G3_PYRAMIDAL,  # N
+        LG.G4_TETRAHEDRAL,  # C-N
+        LG.G4_TETRAHEDRAL,  # C
+        LG.G4_TETRAHEDRAL,  # C
+        LG.G3_PLANAR,
+        LG.G2_KINK,  # N
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G1_TERMINAL,  # C=O
+        LG.G3_PLANAR,  # N
+        LG.G1_TERMINAL,  # Hydrogens below
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_hif2a_set():
+    # test that we can successfully assign all of the hif2a set without assertions
+    suppl = Chem.SDMolSupplier("timemachine/testsystems/data/ligands_40.sdf", removeHs=False)
+    for mol in suppl:
+        geometry.classify_geometry(mol)
+
+
+def test_baran_pyrrole():
+    mol = Chem.AddHs(Chem.MolFromSmiles("c1ccc[nH]1"))
+    atom_types = geometry.classify_geometry(mol)
+
+    expected_types = [
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_pyrrolidine():
+    mol = Chem.AddHs(Chem.MolFromSmiles("C1CCCN1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G4_TETRAHEDRAL,
+        LG.G4_TETRAHEDRAL,
+        LG.G4_TETRAHEDRAL,
+        LG.G4_TETRAHEDRAL,
+        LG.G3_PYRAMIDAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_isoindole():
+    mol = Chem.AddHs(Chem.MolFromSmiles("c1cccc2c1c[nH]c2"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_carbazole():
+    mol = Chem.AddHs(Chem.MolFromSmiles("c1ccc2c(c1)c3ccccc3[nH]2"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_furan():
+    mol = Chem.AddHs(Chem.MolFromSmiles("c1ccco1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G2_KINK,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_thiophene():
+    mol = Chem.AddHs(Chem.MolFromSmiles("c1cccs1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G2_KINK,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_2h_pyran():
+    mol = Chem.AddHs(Chem.MolFromSmiles("C1C=CC=CO1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G4_TETRAHEDRAL,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G2_KINK,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_pyridine():
+    mol = Chem.AddHs(Chem.MolFromSmiles("c1ccccn1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G2_KINK,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_quinoline():
+    mol = Chem.AddHs(Chem.MolFromSmiles("C1=CC=C2C(=C1)C=CC=N2"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G2_KINK,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_oxazole():
+    mol = Chem.AddHs(Chem.MolFromSmiles("o1cncc1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G2_KINK,
+        LG.G3_PLANAR,
+        LG.G2_KINK,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_thiazole():
+    mol = Chem.AddHs(Chem.MolFromSmiles("s1cncc1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G2_KINK,
+        LG.G3_PLANAR,
+        LG.G2_KINK,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_imidazole():
+    mol = Chem.AddHs(Chem.MolFromSmiles("[nH]1cncc1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G2_KINK,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_triazole():
+    mol = Chem.AddHs(Chem.MolFromSmiles("[nH]1nncc1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G3_PLANAR,
+        LG.G2_KINK,
+        LG.G2_KINK,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_morpholine():
+    mol = Chem.AddHs(Chem.MolFromSmiles("O1CC[NH]CC1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G2_KINK,
+        LG.G4_TETRAHEDRAL,
+        LG.G4_TETRAHEDRAL,
+        LG.G3_PYRAMIDAL,
+        LG.G4_TETRAHEDRAL,
+        LG.G4_TETRAHEDRAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_piperazine():
+    mol = Chem.AddHs(Chem.MolFromSmiles("[nH]1CC[nH]CC1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G3_PYRAMIDAL,
+        LG.G4_TETRAHEDRAL,
+        LG.G4_TETRAHEDRAL,
+        LG.G3_PYRAMIDAL,
+        LG.G4_TETRAHEDRAL,
+        LG.G4_TETRAHEDRAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_pyrazine():
+    mol = Chem.AddHs(Chem.MolFromSmiles("n1ccncc1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G2_KINK,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G2_KINK,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_baran_tetrazole():
+    mol = Chem.AddHs(Chem.MolFromSmiles("[nH]1nnnc1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G3_PLANAR,
+        LG.G2_KINK,
+        LG.G2_KINK,
+        LG.G2_KINK,
+        LG.G3_PLANAR,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+# test baran examples with reasonable titratable sites
+def test_protonated_pyridine():
+    mol = Chem.AddHs(Chem.MolFromSmiles("c1cccc[nH+]1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types
+
+
+def test_protonated_imidazole():
+    mol = Chem.AddHs(Chem.MolFromSmiles("[nH]1c[nH+]cc1"))
+    atom_types = geometry.classify_geometry(mol)
+    expected_types = [
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G3_PLANAR,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+        LG.G1_TERMINAL,
+    ]
+
+    assert atom_types == expected_types

--- a/timemachine/fe/geometry.py
+++ b/timemachine/fe/geometry.py
@@ -1,0 +1,78 @@
+# Utility functions to help assign and identify local geometry points
+
+from enum import Enum
+from typing import List
+
+from rdkit import Chem
+from rdkit.Chem import HybridizationType
+
+
+class LocalGeometry(Enum):
+    G1_TERMINAL = 0  # R-X
+    G2_KINK = 1  # R-X-H
+    G2_LINEAR = 2  # R-X#N
+    G3_PLANAR = 3  # R-X(=O)O
+    G3_PYRAMIDAL = 4  # R-X(-H)H
+    G4_TETRAHEDRAL = 5  # R-X(-H)(-H)H
+
+
+def assign_atom_geometry(atom):
+    """
+    Heuristic using hybridization information to assign local description
+    of geometry.
+    """
+    nbrs = list(atom.GetNeighbors())
+    hybridization = atom.GetHybridization()
+    if len(nbrs) == 0:
+        assert 0, "Ion not supported"
+    elif len(nbrs) == 1:
+        return LocalGeometry.G1_TERMINAL
+    elif len(nbrs) == 2:
+        if hybridization == HybridizationType.SP3:
+            return LocalGeometry.G2_KINK
+        elif hybridization == HybridizationType.SP2:
+            return LocalGeometry.G2_KINK
+        elif hybridization == HybridizationType.SP:
+            return LocalGeometry.G2_LINEAR
+        else:
+            assert 0, "Unknown 2-nbr geometry!"
+    elif len(nbrs) == 3:
+        if hybridization == HybridizationType.SP3:
+            return LocalGeometry.G3_PYRAMIDAL
+        elif hybridization == HybridizationType.SP2:
+            return LocalGeometry.G3_PLANAR
+        else:
+            assert 0, "Unknown 3-nbr geometry"
+    elif len(nbrs) == 4:
+        if hybridization == HybridizationType.SP3:
+            return LocalGeometry.G4_TETRAHEDRAL
+        else:
+            assert 0, "Unknown 4-nbr geometry"
+    else:
+        assert 0, "Too many neighbors"
+
+
+def classify_geometry(mol: Chem.Mol) -> List[LocalGeometry]:
+    """
+    Identify the local geometry of the molecule. This current uses a heuristic but we
+    should really be generating this from gas-phase simulations of the real forcefield.
+
+    Currently, 3D coordinates are not required, but this may change in the future.
+
+    Parameters
+    ----------
+    mol: Chem.Mol
+        Input molecule.
+
+    Returns
+    -------
+    List[LocalGeometry]
+        List of per atom geometries
+
+    """
+
+    geometry_types = []
+    for a in mol.GetAtoms():
+        geometry_types.append(assign_atom_geometry(a))
+
+    return geometry_types


### PR DESCRIPTION
This PR is part of a much more involved branch dealing with restraints in single topology methods. In particular, this PR introduces a heuristic for identifying the local geometry of a given atom. This will be used later on to setup specialized, factorizable, restraints for each local geometry combination.

The local geometry classification is as follows:

```
class LocalGeometry(Enum):
    G1_TERMINAL = 0  # R-X
    G2_KINK = 1  # R-X-H
    G2_LINEAR = 2  # R-X#N
    G3_PLANAR = 3  # R-X(=O)O
    G3_PYRAMIDAL = 4  # R-X(-H)H
    G4_TETRAHEDRAL = 5  # R-X(-H)(-H)H
```

A function `assign_atom_geometry` is introduced that uses simple hybridization and connectivity rules to determine the local geometry of each atom within a molecule. It does not care for rings, nor does it currently require structural information! The tests cover three categories:

1) drug-like molecules (aspirin, etc.)
2) common neutral heterocycles from Baran I
3) some examples of 2) that have reasonable titratable sites (though I'm looking for more examples of this in general). 