### PR TITLE
Trigger verify-typing-stubs hook only on changes to wrapper code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,7 @@ repos:
 
         language: system
         pass_filenames: false
+        files: '^timemachine/cpp/src/'
 
 exclude: >
   (?x)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
 
         language: system
         pass_filenames: false
-        files: '^timemachine/cpp/src/'
+        files: '^timemachine/cpp/src/wrap_kernels.cpp$'
 
 exclude: >
   (?x)

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -849,7 +849,7 @@ void declare_summed_potential(py::module &m) {
                     return new timemachine::SummedPotential(potentials, params_sizes);
                 }),
 
-            py::arg("potentialz"),
+            py::arg("potentials"),
             py::arg("params_sizes"))
         .def("get_potentials", &timemachine::SummedPotential::get_potentials);
 }

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -849,7 +849,7 @@ void declare_summed_potential(py::module &m) {
                     return new timemachine::SummedPotential(potentials, params_sizes);
                 }),
 
-            py::arg("potentials"),
+            py::arg("potentialz"),
             py::arg("params_sizes"))
         .def("get_potentials", &timemachine::SummedPotential::get_potentials);
 }


### PR DESCRIPTION
This avoids unnecessary compilation at commit time, e.g. for Python-only changes.

Verified that the hook runs as expected locally, and continues to work in CI (example failure in 82b78a3)