### PR TITLE
Remove dependency on `bootstrapped`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-bootstrapped==0.0.2
 grpcio==1.30.0
 protobuf==3.15.0
 numpy==1.21.4

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,6 @@ setup(
     packages=find_packages(),
     python_requires=">=3.7",
     install_requires=[
-        "bootstrapped",
         "grpcio",
         "importlib-resources",
         "jax",


### PR DESCRIPTION
This is [unmaintained](https://github.com/facebookarchive/bootstrapped) and unused except in attic code (`attic/training/bootstrap.py`)