### PR TITLE
Detect non-trainable parameters in AM1CCCHandler

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -946,14 +946,20 @@ def test_spurious_param_idxs():
     """Assert that get_spurious_param_idxs
     * returns arrays with length sometimes > 0
     * only ever returns indices of symmetric bond types"""
-    mols = fetch_freesolv()[50:55]  # expect three of these to trigger
+
+    mols = fetch_freesolv()
+    mol_dict = {mol.GetProp("_Name"): mol for mol in mols}
+
+    # expect three of these to trigger
+    names = ["mobley_1743409", "mobley_1755375", "mobley_1760914", "mobley_1770205", "mobley_1781152"]
+    select_mols = [mol_dict[name] for name in names]
 
     ff = Forcefield.load_from_file(DEFAULT_FF)
     q_handle = ff.q_handle
     sym_idxs = set(np.where(q_handle.symmetric_pattern_mask)[0])
 
     n_params_detected_per_mol = []
-    for mol in mols:
+    for mol in select_mols:
         spurious_idxs = get_spurious_param_idxs(mol, q_handle)
         assert set(spurious_idxs).issubset(sym_idxs)
 

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -506,7 +506,7 @@ class AM1CCCHandler(SerializableMixIn):
         return self.partial_parameterize(self.params, mol)
 
     @staticmethod
-    def static_parameterize(params, smirks, mol):
+    def static_parameterize(params, smirks, mol, validate=True):
         """
         Parameters
         ----------
@@ -516,9 +516,12 @@ class AM1CCCHandler(SerializableMixIn):
             SMIRKS patterns matching bonds, to be parsed using OpenEye Toolkits
         mol: Chem.ROMol
             molecule to be parameterized.
-
+        validate: bool
+            check params, smirks
         """
-        AM1CCCHandler.static_validate(params, smirks)
+        if validate:
+            AM1CCCHandler.static_validate(params, smirks)
+
         am1_charges = compute_or_load_am1_charges(mol)
         bond_idxs, type_idxs = compute_or_load_bond_smirks_matches(mol, smirks)
 

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -2,16 +2,19 @@ import base64
 import pickle
 from collections import Counter
 
+import jax
 import jax.numpy as jnp
 import networkx as nx
 import numpy as np
+from jax import grad
+from numpy.typing import NDArray
 from rdkit import Chem
 
 from timemachine import constants
 from timemachine.ff.handlers.bcc_aromaticity import AromaticityModel
 from timemachine.ff.handlers.bcc_aromaticity import match_smirks as oe_match_smirks
 from timemachine.ff.handlers.serialize import SerializableMixIn
-from timemachine.ff.handlers.utils import canonicalize_bond
+from timemachine.ff.handlers.utils import canonicalize_bond, get_symmetry_classes
 from timemachine.ff.handlers.utils import match_smirks as rd_match_smirks
 from timemachine.graph_utils import convert_to_nx
 
@@ -545,3 +548,43 @@ class AM1CCCHandler(SerializableMixIn):
         assert q_params.shape[0] == mol.GetNumAtoms()  # check that return shape is consistent with input mol
 
         return q_params
+
+
+def get_spurious_param_idxs(mol, handle: AM1CCCHandler) -> NDArray:
+    """Find all indices i such that adjusting handle.params[i] can
+    result in distinct parameters being assigned to indistinguishable atoms in mol.
+
+    Optimizing the parameters associated with these indices should be avoided.
+    """
+
+    symmetry_classes = get_symmetry_classes(mol)
+
+    def assign_params(ff_params):
+        return handle.partial_parameterize(ff_params, mol)
+
+    def compute_spuriosity(ff_params):
+        # apply parameters
+        sys_params = assign_params(ff_params)
+
+        # compute the mean per symmetry class
+        class_sums = jax.ops.segment_sum(sys_params, symmetry_classes)
+        class_means = class_sums / np.bincount(symmetry_classes)
+
+        # expect no atom can be adjusted independently of others in its symmetry class
+        expected_constant_within_class = class_means[symmetry_classes]
+        assert expected_constant_within_class.shape == sys_params.shape
+        deviation_from_class_means = sys_params - expected_constant_within_class
+        spuriosity = jnp.sum(deviation_from_class_means ** 2)
+
+        return spuriosity
+
+    # TODO: may also want to try several points in the parameter space,
+    #   randomly or systematically flipping signs...
+    trial_params = np.ones(len(handle.params))
+
+    # get idxs where component of gradient w.r.t. trial_params is != 0
+    thresh = 1e-6
+    g = grad(compute_spuriosity)(trial_params)
+    spurious_idxs = np.where(np.abs(g) > thresh)[0]
+
+    return spurious_idxs

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -268,7 +268,7 @@ def apply_bond_charge_corrections(initial_charges, bond_idxs, deltas):
 
     net_charge = jnp.sum(initial_charges)
     final_net_charge = jnp.sum(final_charges)
-    net_charge_is_unchanged = jnp.isclose(final_net_charge, net_charge, atol=1e-5)
+    net_charge_is_unchanged = jnp.isclose(final_net_charge, net_charge, atol=1e-4)
 
     assert net_charge_is_unchanged
 

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -5,13 +5,12 @@ from collections import Counter
 import jax.numpy as jnp
 import networkx as nx
 import numpy as np
-from rdkit import Chem
 
 from timemachine import constants
 from timemachine.ff.handlers.bcc_aromaticity import AromaticityModel
 from timemachine.ff.handlers.bcc_aromaticity import match_smirks as oe_match_smirks
 from timemachine.ff.handlers.serialize import SerializableMixIn
-from timemachine.ff.handlers.utils import canonicalize_bond
+from timemachine.ff.handlers.utils import canonicalize_bond, convert_to_oe
 from timemachine.ff.handlers.utils import match_smirks as rd_match_smirks
 from timemachine.graph_utils import convert_to_nx
 
@@ -24,23 +23,6 @@ AM1ELF10 = "AM1ELF10"
 AM1BCC = "AM1BCC"
 AM1BCCELF10 = "AM1BCCELF10"
 ELF10_MODELS = (AM1ELF10, AM1BCCELF10)
-
-
-def convert_to_oe(mol):
-    """Convert an ROMol into an OEMol"""
-
-    # imported here for optional dependency
-    from openeye import oechem
-
-    mb = Chem.MolToMolBlock(mol)
-    ims = oechem.oemolistream()
-    ims.SetFormat(oechem.OEFormat_SDF)
-    ims.openstring(mb)
-
-    for buf_mol in ims.GetOEMols():
-        oemol = oechem.OEMol(buf_mol)
-    ims.close()
-    return oemol
 
 
 def oe_generate_conformations(oemol, sample_hydrogens=True):

--- a/timemachine/ff/handlers/utils.py
+++ b/timemachine/ff/handlers/utils.py
@@ -126,10 +126,6 @@ def check_bond_smarts_symmetric(bond_smarts: str) -> bool:
         #  (false negatives possible -- but are also possible in the other branch...)
         return False
 
-    assert type(match) is re.Match, "unrecognized bond smarts"
-    assert match.span() == (0, len(bond_smarts)), "leftovers"
-    return match.group("atom1") == match.group("atom2")
-
 
 def get_symmetry_classes(rdmol: Chem.Mol) -> NDArray:
     """[atom.GetSymmetryClass() for atom in mol],
@@ -185,7 +181,7 @@ def get_spurious_param_idxs(mol, handle) -> NDArray:
     assert trial_params.shape == handle.params.shape
 
     # get idxs where component of gradient w.r.t. trial_params is != 0
-    thresh = 1e-6
+    thresh = 1e-4
     g = grad(compute_spuriosity)(trial_params)
     spurious_idxs = np.where(np.abs(g) > thresh)[0]
 

--- a/timemachine/ff/handlers/utils.py
+++ b/timemachine/ff/handlers/utils.py
@@ -105,16 +105,26 @@ def check_bond_smarts_symmetric(bond_smarts: str) -> bool:
         for example
         check_bond_smarts_symmetric("[#6,#7:1]~[#7,#6:2]")
         will be a false negative
-    * Does not match all possible bond smarts
+    * Does not handle all possible bond smarts
         for example
-        "[#6,#7:1]~[#7,#6:2]~[#1]"
+        "[#6:1]~[#6:2]~[#1]"
         or
         "[#6:1](~[#8])(~[#16:2])"
-        would throw an error
+        will not be matched, will return False by default.
+        However, for the bond smarts subset used by the AM1CCC model, this covers most cases
     """
 
     pattern = re.compile(r"\[(?P<atom1>.*)\:1\].\[(?P<atom2>.*)\:2\]")
     match = pattern.match(bond_smarts)
+
+    if type(match) is re.Match:
+        complete = match.span() == (0, len(bond_smarts))
+        symmetric = match.group("atom1") == match.group("atom2")
+        return complete and symmetric
+    else:
+        # TODO: possibly warn in this branch?
+        #  (false negatives possible -- but are also possible in the other branch...)
+        return False
 
     assert type(match) is re.Match, "unrecognized bond smarts"
     assert match.span() == (0, len(bond_smarts)), "leftovers"

--- a/timemachine/ff/handlers/utils.py
+++ b/timemachine/ff/handlers/utils.py
@@ -86,7 +86,8 @@ def check_bond_smarts_symmetric(bond_smarts: str) -> bool:
     * Does not match all possible bond smarts
         for example
         "[#6,#7:1]~[#7,#6:2]~[#1]"
-        will throw an error
+        should throw an error
+        TODO: detect this case
     """
 
     pattern = re.compile(r"\[(?P<atom1>.*)\:1\].\[(?P<atom2>.*)\:2\]")

--- a/timemachine/ff/handlers/utils.py
+++ b/timemachine/ff/handlers/utils.py
@@ -1,3 +1,5 @@
+import re
+
 from rdkit import Chem
 
 
@@ -67,3 +69,27 @@ def match_smirks(mol, smirks):
         matches.append(tuple(mas))
 
     return matches
+
+
+def check_bond_smarts_symmetric(bond_smarts: str) -> bool:
+    """Match [<atom1>:1]*[<atom2>:2],
+    and return whether atom1 and atom2 are identical strings
+
+    Notes
+    -----
+    * The AM1CCC model contains symmetric patterns that must be assigned 0 parameters
+        (Otherwise, behavior when symmetric bond matches in an arbitrary direction)
+    * Only checks string equivalence!
+        for example
+        check_bond_smarts_symmetric("[#6,#7:1]~[#7,#6:2]")
+        will be a false negative
+    * Does not match all possible bond smarts
+        for example
+        "[#6,#7:1]~[#7,#6:2]~[#1]"
+        will throw an error
+    """
+
+    pattern = re.compile(r"\[(?P<atom1>.*)\:1\].\[(?P<atom2>.*)\:2\]")
+    match = pattern.match(bond_smarts)
+    assert type(match) is re.Match, "unrecognized bond smarts"
+    return match.group("atom1") == match.group("atom2")

--- a/timemachine/ff/handlers/utils.py
+++ b/timemachine/ff/handlers/utils.py
@@ -86,7 +86,7 @@ def check_bond_smarts_symmetric(bond_smarts: str) -> bool:
     Notes
     -----
     * The AM1CCC model contains symmetric patterns that must be assigned 0 parameters
-        (Otherwise, behavior when symmetric bond matches in an arbitrary direction)
+        (Otherwise, undefined behavior when symmetric bond matches in an arbitrary direction)
     * Only checks string equivalence!
         for example
         check_bond_smarts_symmetric("[#6,#7:1]~[#7,#6:2]")
@@ -95,7 +95,7 @@ def check_bond_smarts_symmetric(bond_smarts: str) -> bool:
         for example
         "[#6,#7:1]~[#7,#6:2]~[#1]"
         or
-        ""[#6:1](~[#8])(~[#16:2])"
+        "[#6:1](~[#8])(~[#16:2])"
         would throw an error
     """
 

--- a/timemachine/ff/handlers/utils.py
+++ b/timemachine/ff/handlers/utils.py
@@ -5,10 +5,24 @@ import numpy as np
 from jax import grad
 from jax import numpy as jnp
 from numpy.typing import NDArray
-from openeye import oechem
 from rdkit import Chem
 
-from timemachine.ff.handlers.nonbonded import convert_to_oe
+
+def convert_to_oe(mol):
+    """Convert an ROMol into an OEMol"""
+
+    # imported here for optional dependency
+    from openeye import oechem
+
+    mb = Chem.MolToMolBlock(mol)
+    ims = oechem.oemolistream()
+    ims.SetFormat(oechem.OEFormat_SDF)
+    ims.openstring(mb)
+
+    for buf_mol in ims.GetOEMols():
+        oemol = oechem.OEMol(buf_mol)
+    ims.close()
+    return oemol
 
 
 def canonicalize_bond(arr):
@@ -110,6 +124,9 @@ def check_bond_smarts_symmetric(bond_smarts: str) -> bool:
 def get_symmetry_classes(rdmol: Chem.Mol) -> NDArray:
     """[atom.GetSymmetryClass() for atom in mol],
     just renumbered for convenience"""
+
+    # imported here for optional dependency
+    from openeye import oechem
 
     oemol = convert_to_oe(rdmol)
     oechem.OEPerceiveSymmetry(oemol)

--- a/timemachine/ff/handlers/utils.py
+++ b/timemachine/ff/handlers/utils.py
@@ -155,9 +155,10 @@ def get_spurious_param_idxs(mol, handle) -> NDArray:
     """
 
     symmetry_classes = get_symmetry_classes(mol)
+    smirks = handle.smirks
 
     def assign_params(ff_params):
-        return handle.partial_parameterize(ff_params, mol)
+        return handle.static_parameterize(ff_params, smirks, mol, validate=False)
 
     def compute_spuriosity(ff_params):
         # apply parameters


### PR DESCRIPTION
Problem:

I observed that it is currently possible for AM1CCCHandler to assign distinct parameters to indistinguishable atoms.

Based on discussion with @proteneer , we found that this behavior can be triggered when a symmetric bond pattern in AM1CCCHandler such as 
https://github.com/proteneer/timemachine/blob/fd14908113315ca07c8983e7ecd4dd92178d03a8/timemachine/ff/params/smirnoff_1_1_0_ccc.py#L363
is assigned a non-zero parameter. When a BCC like `('[#6X4:1]-[#6X4:2]', +1.0)` can match a pair of atoms in either direction, an arbitrary direction is selected, leading to undefined behavior in general. When applied to a symmetric molecule like cyclohexane, this can even result in different charges being applied to indistinguishable atoms.

In the initial, untrained force field file, BCCs defined by symmetric bond SMARTS all have parameter values of 0.0, so the undefined match direction has no effect on the assigned charges. However, gradients of realistic training objectives w.r.t. these parameters can be non-zero, so numerical optimization can readily exploit this undefined behavior, which is undesirable.

------------
Possible workarounds:

* Manually identify symmetric patterns, and set their parameter values to nan in the forcefield .py file, so that gradients w.r.t. these parameters would be nan-poisoned. (However, this would also have the effect of nan-poisoning the assigned charges themselves...)
* Detect symmetric SMARTS patterns in the forcefield by string manipulation
* Detect symmetric SMARTS patterns in the force field by inspection of the resulting query mols
* Detect symmetric patterns at runtime by seeing if they match in both directions on a given molecule
* Detect where initial parameter == 0.0. (However, there are some safely asymmetric patterns, such as https://github.com/proteneer/timemachine/blob/fd14908113315ca07c8983e7ecd4dd92178d03a8/timemachine/ff/params/smirnoff_1_1_0_ccc.py#L430 , where the initial parameter is 0.0.)
* Modify definition of AM1CCCHandler so that it's safe for arbitrary SMARTS patterns to have arbitrary parameter values (e.g. by matching both directions rather than an arbitrary direction)

--------

Current PR:

This draft PR adds two heuristic ways to detect parameter indices that currently should not be trained in AM1CCCHandler:

* `check_bond_smarts_symmetric` -- string manipulation heuristic -- regex match `"[<atom1>:1]*[<atom2>:2]"` and return whether atom1 and atom2 are identical strings... If applied to https://github.com/proteneer/timemachine/blob/fd14908113315ca07c8983e7ecd4dd92178d03a8/timemachine/ff/params/smirnoff_1_1_0_ccc.py#L343 , will flag 25 patterns as symmetric.

* `get_spurious_param_idxs` -- intended to be similar to the use case of gradient-based force field optimization (defines an objective function that can only be increased if spuriously distinct parameters are assigned to indistinguishable atoms, takes gradient w.r.t. params, reports indices of any non-zero components of this gradient). This was how I initially detected the problem, and in principle it could be useful for validating any model that assigns parameters to atoms.

------

TBD:

Not sure exactly where best to use this information yet.
* Add a "trainable" vs. "non-trainable" mask to the `AM1CCCHandler` object? (This seems most natural to me, since training script already makes a selection of which parameters to train -- want to use this information to narrow the selection of trainable parameters.)
* Throw an exception due to undefined behavior in `AM1CCCHandler.static_parameterize` when parameters associated with symmetric bond SMARTS are != 0?