### PR TITLE
Apply bccs both ways

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -899,3 +899,25 @@ def test_lennard_jones_handler():
     # if a parameter is > 99 then its adjoint should be zero (converse isn't necessarily true since)
     mask = np.argwhere(params > 90)
     assert np.all(adjoints[mask] == 0.0)
+
+
+def test_symmetric_am1ccc():
+    """Assert that (symmetric_bond_smarts, +1.0) has same behavior as (symmetric_bond_smarts, 0.0) on one test mol"""
+
+    cyclohexane = "C1CCCCC1"
+    mol = Chem.MolFromSmiles(cyclohexane)
+    mol = Chem.AddHs(mol)
+
+    smirks = ["[#6:1]~[#6:2]"]
+    zeros = np.zeros(len(smirks))
+    ones = np.ones(len(smirks))
+
+    ref_charges = np.array(nonbonded.AM1CCCHandler.static_parameterize(zeros, smirks, mol))
+    test_charges = np.array(nonbonded.AM1CCCHandler.static_parameterize(ones, smirks, mol))
+
+    # at https://github.com/proteneer/timemachine/tree/fd14908113315ca07c8983e7ecd4dd92178d03a8
+    # set(ref_charges) == {-1.8165082, -1.8158009, 0.90795946}
+    # set(test_charges) == {-3.815801, -1.8158009, 0.18349183, 0.90795946}
+    assert len(set(test_charges)) == len(set(ref_charges)), set(test_charges)
+
+    np.testing.assert_allclose(test_charges, ref_charges)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -918,6 +918,4 @@ def test_symmetric_am1ccc():
     # at https://github.com/proteneer/timemachine/tree/fd14908113315ca07c8983e7ecd4dd92178d03a8
     # set(ref_charges) == {-1.8165082, -1.8158009, 0.90795946}
     # set(test_charges) == {-3.815801, -1.8158009, 0.18349183, 0.90795946}
-    assert len(set(test_charges)) == len(set(ref_charges)), set(test_charges)
-
-    np.testing.assert_allclose(test_charges, ref_charges)
+    np.testing.assert_array_equal(test_charges, ref_charges)

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -243,15 +243,12 @@ def compute_or_load_bond_smirks_matches(mol, smirks_list):
         for type_idx, smirks in enumerate(smirks_list):
             matches = oe_match_smirks(smirks, oemol)
 
-            for matched_indices in matches:
-                a, b = matched_indices[0], matched_indices[1]
-                forward_matched_bond = [a, b]
-                reverse_matched_bond = [b, a]
-
-                already_assigned = forward_matched_bond in bond_idxs or reverse_matched_bond in bond_idxs
+            for match in matches:
+                bond = [match[0], match[1]]
+                already_assigned = bond in bond_idxs
 
                 if not already_assigned:
-                    bond_idxs.append(forward_matched_bond)
+                    bond_idxs.append(bond)
                     type_idxs.append(type_idx)
         mol.SetProp(BOND_SMIRK_MATCH_CACHE, base64.b64encode(pickle.dumps((bond_idxs, type_idxs))))
     else:
@@ -292,14 +289,10 @@ def apply_bond_charge_corrections(initial_charges, bond_idxs, deltas):
 
     # print some safety warnings
     directed_bonds = Counter([tuple(b) for b in bond_idxs])
-    undirected_bonds = Counter([tuple(sorted(b)) for b in bond_idxs])
 
     if max(directed_bonds.values()) > 1:
         duplicates = [bond for (bond, count) in directed_bonds.items() if count > 1]
         print(UserWarning(f"Duplicate directed bonds! {duplicates}"))
-    elif max(undirected_bonds.values()) > 1:
-        duplicates = [bond for (bond, count) in undirected_bonds.items() if count > 1]
-        print(UserWarning(f"Duplicate undirected bonds! {duplicates}"))
 
     return final_charges
 

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -243,12 +243,14 @@ def compute_or_load_bond_smirks_matches(mol, smirks_list):
         for type_idx, smirks in enumerate(smirks_list):
             matches = oe_match_smirks(smirks, oemol)
 
-            for match in matches:
-                bond = [match[0], match[1]]
-                already_assigned = bond in bond_idxs
+            for matched_indices in matches:
+                a, b = matched_indices[0], matched_indices[1]
+                forward_matched_bond = [a, b]
+
+                already_assigned = forward_matched_bond in bond_idxs
 
                 if not already_assigned:
-                    bond_idxs.append(bond)
+                    bond_idxs.append(forward_matched_bond)
                     type_idxs.append(type_idx)
         mol.SetProp(BOND_SMIRK_MATCH_CACHE, base64.b64encode(pickle.dumps((bond_idxs, type_idxs))))
     else:


### PR DESCRIPTION
Another possible workaround for the issue in https://github.com/proteneer/timemachine/pull/737 , suggested in https://github.com/proteneer/timemachine/pull/737#issue-1228477107 :
> Modify definition of AM1CCCHandler so that it's safe for arbitrary SMARTS patterns to have arbitrary parameter values (e.g. by matching both directions rather than an arbitrary direction)

This is simpler than adding special case code to detect symmetric bond smarts and avoid applying the correction in an arbitrary direction.

In the symmetric case where a smarts pattern can match the same bond both directions, charges will be incremented by `(+param) + (-param)`, effectively ignoring `param`