### PR TITLE
Validate harmonic bonds

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -932,4 +932,4 @@ def test_harmonic_bonds_complete():
 
     with pytest.raises(ValueError) as e:
         _, _ = parameterize(mol)
-    assert "number of bonds" in str(e)
+    assert "missing bonds" in str(e)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -923,21 +923,14 @@ def test_symmetric_am1ccc():
 
 def test_harmonic_bonds_complete():
     """On a test molecule containing [oxygen] ~ [halogen] bonds,
-    assert that either: (1) a ValueError is raised or (2) the number of
-    parameterized bonds equals the number of input bonds"""
+    assert that a ValueError is raised."""
 
     mol = Chem.MolFromSmiles("O(F)F")  # 0 smirks matches using current (2022-05-16) handler
 
     ff = Forcefield.load_from_file(DEFAULT_FF)
     parameterize = ff.hb_handle.parameterize
 
-    try:
-        with pytest.raises(ValueError) as e:
-            _, _ = parameterize(mol)
+    with pytest.raises(ValueError) as e:
+        _, _ = parameterize(mol)
 
-            assert "number of bonds" in e
-    except Exception:
-        expected_num_bonds = mol.GetNumBonds()
-        _, idxs = parameterize(mol)
-
-        assert len(idxs) == expected_num_bonds
+        assert "number of bonds" in e

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -932,5 +932,4 @@ def test_harmonic_bonds_complete():
 
     with pytest.raises(ValueError) as e:
         _, _ = parameterize(mol)
-
-        assert "number of bonds" in e
+    assert "number of bonds" in e

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -932,4 +932,4 @@ def test_harmonic_bonds_complete():
 
     with pytest.raises(ValueError) as e:
         _, _ = parameterize(mol)
-    assert "number of bonds" in e
+    assert "number of bonds" in str(e)

--- a/timemachine/ff/handlers/bonded.py
+++ b/timemachine/ff/handlers/bonded.py
@@ -74,12 +74,19 @@ class HarmonicBondHandler(ReversibleBondHandler):
     def static_parameterize(params, smirks, mol):
         mol_params, bond_idxs = super(HarmonicBondHandler, HarmonicBondHandler).static_parameterize(params, smirks, mol)
 
-        # validate expected number of bonds
-        expected_num_bonds = mol.GetNumBonds()
-        assigned_num_bonds = len(bond_idxs)
-        if assigned_num_bonds != expected_num_bonds:
-            message = f"""Did not assign the correct number of bonds!
-            (# assigned = {assigned_num_bonds}, but # expected = {expected_num_bonds}"""
+        # validate expected set of bonds
+        rd_bonds = set()
+        for b in mol.GetBonds():
+            rd_bonds.add(tuple(sorted([b.GetBeginAtomIdx(), b.GetEndAtomIdx()])))
+
+        ff_bonds = set()
+        for i, j in bond_idxs:
+            rd_bonds.add(tuple(sorted([i, j])))
+
+        if rd_bonds != ff_bonds:
+            message = f"""Did not preserve the bond table of input mol!
+            missing bonds (present in mol): {rd_bonds - ff_bonds}
+            new bonds (not present in mol): {ff_bonds - rd_bonds}"""
             raise ValueError(message)
 
         # handle special case of 0 bonds

--- a/timemachine/ff/handlers/bonded.py
+++ b/timemachine/ff/handlers/bonded.py
@@ -76,6 +76,14 @@ class HarmonicBondHandler(ReversibleBondHandler):
         if len(mol_params) == 0:
             mol_params = params[:0]  # empty slice with same dtype, other dimensions
             bond_idxs = np.zeros((0, 2), dtype=np.int32)
+
+            expected_num_bonds = mol.GetNumBonds()
+            assigned_num_bonds = len(bond_idxs)
+            if assigned_num_bonds != expected_num_bonds:
+                message = f"""Did not assign the correct number of bonds!
+                (# assigned = {assigned_num_bonds}, but # expected = {expected_num_bonds}"""
+                raise ValueError(message)
+
         return mol_params, bond_idxs
 
 

--- a/timemachine/ff/handlers/bonded.py
+++ b/timemachine/ff/handlers/bonded.py
@@ -81,7 +81,7 @@ class HarmonicBondHandler(ReversibleBondHandler):
 
         ff_bonds = set()
         for i, j in bond_idxs:
-            rd_bonds.add(tuple(sorted([i, j])))
+            ff_bonds.add(tuple(sorted([i, j])))
 
         if rd_bonds != ff_bonds:
             message = f"""Did not preserve the bond table of input mol!

--- a/timemachine/ff/handlers/bonded.py
+++ b/timemachine/ff/handlers/bonded.py
@@ -73,16 +73,19 @@ class HarmonicBondHandler(ReversibleBondHandler):
     @staticmethod
     def static_parameterize(params, smirks, mol):
         mol_params, bond_idxs = super(HarmonicBondHandler, HarmonicBondHandler).static_parameterize(params, smirks, mol)
+
+        # validate expected number of bonds
+        expected_num_bonds = mol.GetNumBonds()
+        assigned_num_bonds = len(bond_idxs)
+        if assigned_num_bonds != expected_num_bonds:
+            message = f"""Did not assign the correct number of bonds!
+            (# assigned = {assigned_num_bonds}, but # expected = {expected_num_bonds}"""
+            raise ValueError(message)
+
+        # handle special case of 0 bonds
         if len(mol_params) == 0:
             mol_params = params[:0]  # empty slice with same dtype, other dimensions
             bond_idxs = np.zeros((0, 2), dtype=np.int32)
-
-            expected_num_bonds = mol.GetNumBonds()
-            assigned_num_bonds = len(bond_idxs)
-            if assigned_num_bonds != expected_num_bonds:
-                message = f"""Did not assign the correct number of bonds!
-                (# assigned = {assigned_num_bonds}, but # expected = {expected_num_bonds}"""
-                raise ValueError(message)
 
         return mol_params, bond_idxs
 


### PR DESCRIPTION
Raise ValueError in `HarmonicBondHandler.static_parameterize(... mol)` if the ~number~ set of harmonic bonds is not equal to ~`mol.GetNumBonds()`~ the set contained in `mol.GetBonds()`.

Unclear how widespread the issue might be, but it seems that:
* when there are no smirks matches for a bond, the current harmonic bond handler will silently fail to assign parameters to the bond
* this occurs at least for [oxygen] ~ [halogen] bonds (e.g. the molecule `smi="O(F)F"` is assigned 0 harmonic bonds)
* the proposed change does not raise any new errors on FreeSolv