### PR TITLE
Validate harmonic angle idxs, refactor idx canonicalization

### DIFF
--- a/timemachine/ff/handlers/bonded.py
+++ b/timemachine/ff/handlers/bonded.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from timemachine.ff.handlers.serialize import SerializableMixIn
 from timemachine.ff.handlers.suffix import _SUFFIX
-from timemachine.ff.handlers.utils import canonicalize_angle, canonicalize_bond, get_all_angles, match_smirks
+from timemachine.ff.handlers.utils import canonicalize_angle, canonicalize_bonded_ixn, get_all_angles, match_smirks
 
 
 def generate_vd_idxs(mol, smirks):
@@ -17,7 +17,7 @@ def generate_vd_idxs(mol, smirks):
     for p_idx, patt in enumerate(smirks):
         matches = match_smirks(mol, patt)
         for m in matches:
-            sorted_m = canonicalize_bond(m)
+            sorted_m = canonicalize_bonded_ixn(m)
             vd[sorted_m] = p_idx
 
     bond_idxs = np.array(list(vd.keys()), dtype=np.int32)
@@ -237,7 +237,7 @@ class ImproperTorsionHandler(SerializableMixIn):
             center = atom_idxs[1]
             others = [atom_idxs[0], atom_idxs[2], atom_idxs[3]]
             for p in [(others[i], others[j], others[k]) for (i, j, k) in [(0, 1, 2), (1, 2, 0), (2, 0, 1)]]:
-                improper_idxs.append(canonicalize_bond((center, p[0], p[1], p[2])))
+                improper_idxs.append(canonicalize_bonded_ixn((center, p[0], p[1], p[2])))
                 param_idxs.append(p_idx)
 
         param_idxs = np.array(param_idxs)

--- a/timemachine/ff/handlers/bonded.py
+++ b/timemachine/ff/handlers/bonded.py
@@ -88,7 +88,7 @@ class HarmonicAngleHandler(ReversibleBondHandler):
 
         # check that an interaction is assigned to all possible angle tuples
         all_possible_angles = get_all_angles(mol)
-        parameterized_angles = set([canonicalize_angle(angle) for angle in angle_idxs])
+        parameterized_angles = set([canonicalize_angle((a, b, c)) for (a, b, c) in angle_idxs])
         missing_angles = set(all_possible_angles) - parameterized_angles
 
         if len(missing_angles) > 0:

--- a/timemachine/ff/handlers/utils.py
+++ b/timemachine/ff/handlers/utils.py
@@ -92,7 +92,7 @@ def get_improper_torsion_permutations(torsion):
 
     canonical_permutations = []
     for (i, j, k) in neighbor_permutations:
-        canonical_permutations.append(canonicalize_bonded_ixn([center, neighbors[i], neighbors[j], neighbors[k]]))
+        canonical_permutations.append(canonicalize_bonded_ixn((center, neighbors[i], neighbors[j], neighbors[k])))
 
     return canonical_permutations
 

--- a/timemachine/ff/handlers/utils.py
+++ b/timemachine/ff/handlers/utils.py
@@ -92,7 +92,13 @@ def get_improper_torsion_permutations(torsion):
 
     canonical_permutations = []
     for (i, j, k) in neighbor_permutations:
-        canonical_permutations.append(canonicalize_bonded_ixn((center, neighbors[i], neighbors[j], neighbors[k])))
+        forward = (center, neighbors[i], neighbors[j], neighbors[k])
+
+        # note: canonicalizing forward/reverse does NOT introduce any indexing-dependent change in energies, since
+        # signed_torsion_angle(a, b, c, d) == signed_torsion_angle(d, c, b, a) for any (a, b, c, d)
+        canonicalized = canonicalize_bonded_ixn(forward)
+
+        canonical_permutations.append(canonicalized)
 
     return canonical_permutations
 

--- a/timemachine/ff/handlers/utils.py
+++ b/timemachine/ff/handlers/utils.py
@@ -106,10 +106,9 @@ def get_all_angles(mol) -> Set[Angle]:
     angles = set()
     for a in range(n):
         for b in range(n):
-            b_neighbors = g.neighbors(b)
             for c in range(n):
-                ab = a in b_neighbors
-                bc = c in b_neighbors
+                ab = a in g.neighbors(b)
+                bc = c in g.neighbors(b)
                 a_neq_c = a != c
 
                 if ab and bc and a_neq_c:

--- a/timemachine/ff/handlers/utils.py
+++ b/timemachine/ff/handlers/utils.py
@@ -1,4 +1,10 @@
+from typing import Set, Tuple
+
 from rdkit import Chem
+
+from timemachine.graph_utils import convert_to_nx
+
+Angle = Tuple[int, int, int]
 
 
 def canonicalize_bond(arr):
@@ -30,6 +36,32 @@ def canonicalize_bond(arr):
         raise ValueError("Invalid bond with first and last indices equal")
     else:
         return arr
+
+
+def canonicalize_angle(angle) -> Tuple[int, int, int]:
+    """Treat angle(a, b, c) as equivalent to angle(c, b, a) -- e.g. when assessing ff coverage"""
+    a, b, c = angle
+    return min((a, b, c), (c, b, a))
+
+
+def get_all_angles(mol) -> Set[Angle]:
+    """Get all canonical tuples (a, b, c) such that (a bonded to b), (b bonded to c) and (a != c)"""
+
+    g = convert_to_nx(mol)
+    n = mol.GetNumAtoms()
+
+    angles = set()
+    for a in range(n):
+        for b in range(n):
+            b_neighbors = g.neighbors(b)
+            for c in range(n):
+                ab = a in b_neighbors
+                bc = c in b_neighbors
+                a_neq_c = a != c
+
+                if ab and bc and a_neq_c:
+                    angles.add(canonicalize_angle((a, b, c)))
+    return angles
 
 
 def match_smirks(mol, smirks):

--- a/timemachine/ff/handlers/utils.py
+++ b/timemachine/ff/handlers/utils.py
@@ -73,6 +73,7 @@ def canonicalize_improper_torsion(torsion):
     canonicalized_1 = container_type([a, b, c, d])
 
     # approach 2: take min((b, a, c, d), (d, c, a, b)) (used for applying trefoil convention)
+    a, b, c, d = torsion
     canonicalized_2 = canonicalize_bonded_ixn([b, a, c, d])
 
     # TODO: which one?

--- a/timemachine/ff/handlers/utils.py
+++ b/timemachine/ff/handlers/utils.py
@@ -82,7 +82,7 @@ def get_improper_torsion_permutations(torsion):
 
     # see also implementations in
     # * TM ImproperTorsionHandler https://github.com/proteneer/timemachine/blob/451803e01afe6231147a0e6a3ca019d4aa5069d8/timemachine/ff/handlers/bonded.py#L225-L230
-    # * espaloma https://github.com/choderalab/espaloma/blob/68d62847d4a20d4317157441710a25883ebda0cd/espaloma/redux/symmetry.py#L81-L87
+    # * OpenFF toolkit https://github.com/openforcefield/openff-toolkit/blob/fade767977cda3c2d70399ac38644aa5428414fe/openff/toolkit/typing/engines/smirnoff/parameters.py#L3437-L3453
 
     torsion = canonicalize_improper_torsion(torsion)
 


### PR DESCRIPTION
Based on suggestion https://github.com/proteneer/timemachine/pull/742#issuecomment-1128356628 , adds a check for completeness of the `angle_idxs` returned by `HarmonicAngleHandler`. This raises an error unless angle terms are present for all canonical angle tuples `(a, b, c)`.

Side quest: Also attempted to improve naming of index canonicalization function (`canonicalize_bond((a, b, c))` -> `canonicalize_angle((a, b, c))` or `canonicalize_bonded_ixn((a, b, c))`).

Side-side quest: Ran into a hiccup while adding `canonicalize_improper_torsion` -- will need to look more carefully at the logic of the two sites I'm extracting the definition from, or skip adding this for now.