### PR TITLE
Add functions to use SMC to compute dG_parameters in solvent/vacuum legs

### DIFF
--- a/tests/test_absolute_hydration.py
+++ b/tests/test_absolute_hydration.py
@@ -1,0 +1,166 @@
+import functools
+from typing import Tuple
+
+import numpy as np
+import pymbar
+import pytest
+
+from timemachine import testsystems
+from timemachine.constants import BOLTZ, DEFAULT_FF
+from timemachine.fe import absolute_hydration
+from timemachine.fe.functional import construct_differentiable_interface_fast
+from timemachine.fe.reweighting import one_sided_exp
+from timemachine.ff import Forcefield
+from timemachine.md import enhanced, moves, smc
+from timemachine.md.states import CoordsVelBox
+
+
+def get_ff_am1ccc():
+    return Forcefield.load_from_file(DEFAULT_FF)
+
+
+def test_smc_parameter_change_vacuum():
+    """
+    Tests correctness of using SMC to switch between parameters.
+    The SMC predicted dg ff0 -> ff1 should match results from
+    BAR using independent sampling.
+
+    """
+    seed = 2022
+    np.random.seed(seed)
+
+    # Reduce these so the test is faster
+    num_batches = 10
+    n_md_steps = 10
+    temperature = 300.0
+    kBT = BOLTZ * temperature
+
+    mol, _ = testsystems.ligands.get_biphenyl()
+    ff0 = get_ff_am1ccc()
+
+    # shift the ff parameters
+    # should be small enough so that 1-EXP is still valid
+    ff1 = get_ff_am1ccc()
+    ff1.q_handle.params += 0.2
+    box = np.eye(3) * 1000.0
+
+    # generate vacuum samples for each ff
+    def generate_samples(mol, ff) -> Tuple[enhanced.VacuumState, smc.Samples]:
+        state = enhanced.VacuumState(mol, ff)
+        _vacuum_xv_samples, vacuum_log_weights = enhanced.generate_log_weighted_samples(
+            mol,
+            temperature,
+            state.U_easy,
+            state.U_full,
+            seed,
+            num_batches=num_batches,
+            num_workers=1,
+            steps_per_batch=n_md_steps,
+        )
+
+        # discard velocities: (x, v) -> x
+        vacuum_samples = _vacuum_xv_samples[:, 0, :]
+        vacuum_vels = _vacuum_xv_samples[:, 1, :]
+        idxs = smc.multinomial_resample(vacuum_log_weights)[0]
+        vacuum_samples = [CoordsVelBox(coords=vacuum_samples[i], velocities=vacuum_vels[i], box=box) for i in idxs]
+        return state, vacuum_samples
+
+    state0, vacuum_samples0 = generate_samples(mol, ff0)
+    state1, vacuum_samples1 = generate_samples(mol, ff1)
+
+    # set up a system for sampling the new parameters using SMC
+    samples, lambdas, propagate, log_prob, resample = absolute_hydration.set_up_ahfe_system_for_smc_parameter_changes(
+        mol,
+        n_walkers=num_batches,
+        n_md_steps=n_md_steps,
+        resample_thresh=0.6,
+        initial_samples=vacuum_samples0,
+        ff0=ff0,
+        ff1=ff1,
+        is_vacuum=True,
+        n_windows=10,
+    )
+
+    smc_result = smc.sequential_monte_carlo(samples, lambdas, propagate, log_prob, resample)
+    smc_dg = one_sided_exp(-smc_result["log_weights_traj"][-1])
+
+    # BAR from independent runs
+    def batched_u_fxn(samples, state):
+        # Only compute vacuum energies
+        return np.array([state.U_full(x.coords) for x in samples]) / kBT
+
+    u_fwd = batched_u_fxn(vacuum_samples0, state1) - batched_u_fxn(vacuum_samples0, state0)
+    u_rev = batched_u_fxn(vacuum_samples1, state0) - batched_u_fxn(vacuum_samples1, state1)
+    bar_dg = pymbar.BAR(u_fwd, u_rev, compute_uncertainty=False)
+    assert smc_dg == pytest.approx(bar_dg, abs=1e-1)
+
+
+def test_smc_parameter_change_solvent():
+    """
+    Tests correctness of using SMC to switch between parameters.
+    The SMC predicted dg ff0 -> ff1 should match results from
+    BAR using independent sampling.
+
+    """
+    seed = 2022
+    np.random.seed(seed)
+
+    # Reduce these so the test is faster
+    num_batches = 20
+    n_md_steps = 100
+    temperature = 300.0
+    pressure = 1.0
+    n_eq_steps = 1000
+    kBT = BOLTZ * temperature
+
+    mol, _ = testsystems.ligands.get_biphenyl()
+    ff0 = get_ff_am1ccc()
+
+    # shift the ff parameters
+    # should be small enough so that 1-EXP is still valid
+    ff1 = get_ff_am1ccc()
+    ff1.q_handle.params += 0.2
+
+    def generate_samples(mol, ff):  # -> Tuple[Ene_fxn, smc.Samples]:
+        ubps, params, masses, coords, box = enhanced.get_solvent_phase_system(mol, ff, minimize_energy=True)
+        xvb0 = enhanced.equilibrate_solvent_phase(
+            ubps, params, masses, coords, box, temperature, pressure, n_eq_steps, seed
+        )
+        lam = 0.0
+        npt_mover = moves.NPTMove(ubps, lam, masses, temperature, pressure, n_steps=n_md_steps, seed=seed)
+        xvbs = [xvb0]
+        for _ in range(num_batches):
+            xvbs.append(npt_mover.move(xvbs[-1]))
+
+        U_fn = construct_differentiable_interface_fast(ubps, params)
+        U_fn = functools.partial(U_fn, params=params)
+        return U_fn, xvbs
+
+    U_fn0, solvent_samples0 = generate_samples(mol, ff0)
+    U_fn1, solvent_samples1 = generate_samples(mol, ff1)
+
+    # set up a system for sampling the new parameters using SMC
+    samples, lambdas, propagate, log_prob, resample = absolute_hydration.set_up_ahfe_system_for_smc_parameter_changes(
+        mol,
+        n_walkers=num_batches,
+        n_md_steps=n_md_steps,
+        resample_thresh=0.6,
+        initial_samples=solvent_samples0,
+        ff0=ff0,
+        ff1=ff1,
+        is_vacuum=False,
+        n_windows=10,
+    )
+
+    smc_result = smc.sequential_monte_carlo(samples, lambdas, propagate, log_prob, resample)
+    smc_dg = one_sided_exp(-smc_result["log_weights_traj"][-1])
+
+    # BAR from independent runs
+    def batched_u_fxn(samples, U_fn):
+        # Only compute vacuum energies
+        return np.array([U_fn(x.coords, box=x.box, lam=0.0) for x in samples]) / kBT
+
+    u_fwd = batched_u_fxn(solvent_samples0, U_fn1) - batched_u_fxn(solvent_samples0, U_fn0)
+    u_rev = batched_u_fxn(solvent_samples1, U_fn0) - batched_u_fxn(solvent_samples1, U_fn1)
+    bar_dg = pymbar.BAR(u_fwd, u_rev, compute_uncertainty=False)
+    assert smc_dg == pytest.approx(bar_dg, abs=1e-1)

--- a/tests/test_absolute_hydration.py
+++ b/tests/test_absolute_hydration.py
@@ -19,7 +19,8 @@ def get_ff_am1ccc():
     return Forcefield.load_from_file(DEFAULT_FF)
 
 
-def test_smc_parameter_change_vacuum():
+@pytest.mark.parametrize("reverse", [False, True])
+def test_smc_parameter_change_vacuum(reverse):
     """
     Tests correctness of using SMC to switch between parameters.
     The SMC predicted dg ff0 -> ff1 should match results from
@@ -43,6 +44,9 @@ def test_smc_parameter_change_vacuum():
     ff1 = get_ff_am1ccc()
     ff1.q_handle.params += 0.2
     box = np.eye(3) * 1000.0
+
+    if reverse:
+        ff0, ff1 = ff1, ff0
 
     # generate vacuum samples for each ff
     def generate_samples(mol, ff) -> Tuple[enhanced.VacuumState, smc.Samples]:

--- a/tests/test_absolute_hydration.py
+++ b/tests/test_absolute_hydration.py
@@ -6,13 +6,17 @@ import pymbar
 import pytest
 
 from timemachine import testsystems
-from timemachine.constants import BOLTZ
+from timemachine.constants import BOLTZ, DEFAULT_FF
 from timemachine.fe import absolute_hydration
 from timemachine.fe.functional import construct_differentiable_interface_fast
 from timemachine.fe.reweighting import one_sided_exp
+from timemachine.ff import Forcefield
 from timemachine.md import enhanced, moves, smc
 from timemachine.md.states import CoordsVelBox
-from timemachine.utils import get_ff_am1ccc
+
+
+def get_ff_am1ccc():
+    return Forcefield.load_from_file(DEFAULT_FF)
 
 
 def test_smc_parameter_change_vacuum():

--- a/tests/test_absolute_hydration.py
+++ b/tests/test_absolute_hydration.py
@@ -6,17 +6,13 @@ import pymbar
 import pytest
 
 from timemachine import testsystems
-from timemachine.constants import BOLTZ, DEFAULT_FF
+from timemachine.constants import BOLTZ
 from timemachine.fe import absolute_hydration
 from timemachine.fe.functional import construct_differentiable_interface_fast
 from timemachine.fe.reweighting import one_sided_exp
-from timemachine.ff import Forcefield
 from timemachine.md import enhanced, moves, smc
 from timemachine.md.states import CoordsVelBox
-
-
-def get_ff_am1ccc():
-    return Forcefield.load_from_file(DEFAULT_FF)
+from timemachine.utils import get_ff_am1ccc
 
 
 def test_smc_parameter_change_vacuum():

--- a/tests/test_enhanced.py
+++ b/tests/test_enhanced.py
@@ -8,7 +8,6 @@ from timemachine.datasets import fetch_freesolv
 from timemachine.fe import utils
 from timemachine.fe.functional import construct_differentiable_interface_fast
 from timemachine.ff import Forcefield
-from timemachine.ff.handlers import AM1CCCHandler
 from timemachine.md import enhanced
 from timemachine.md.enhanced import identify_rotatable_bonds
 

--- a/tests/test_enhanced.py
+++ b/tests/test_enhanced.py
@@ -27,9 +27,7 @@ def ff_pair():
     ff1 = Forcefield.load_from_file(DEFAULT_FF)
 
     # Modify the charge parameters for ff1
-    for h, p in zip(ff1.get_ordered_handles(), ff1.get_ordered_params()):
-        if isinstance(h, AM1CCCHandler):
-            p += 1.0
+    ff1.q_handle.params += 1.0
     return ff0, ff1
 
 

--- a/tests/test_enhanced.py
+++ b/tests/test_enhanced.py
@@ -1,4 +1,15 @@
+import functools
+
+import numpy as np
+import pytest
+
+from timemachine.constants import DEFAULT_FF
 from timemachine.datasets import fetch_freesolv
+from timemachine.fe import utils
+from timemachine.fe.functional import construct_differentiable_interface_fast
+from timemachine.ff import Forcefield
+from timemachine.ff.handlers import AM1CCCHandler
+from timemachine.md import enhanced
 from timemachine.md.enhanced import identify_rotatable_bonds
 
 
@@ -8,3 +19,83 @@ def test_identify_rotatable_bonds_runs_on_freesolv():
 
     for mol in mols:
         _ = identify_rotatable_bonds(mol)
+
+
+@pytest.fixture
+def ff_pair():
+    ff0 = Forcefield.load_from_file(DEFAULT_FF)
+    ff1 = Forcefield.load_from_file(DEFAULT_FF)
+
+    # Modify the charge parameters for ff1
+    for h, p in zip(ff1.get_ordered_handles(), ff1.get_ordered_params()):
+        if isinstance(h, AM1CCCHandler):
+            p += 1.0
+    return ff0, ff1
+
+
+def test_get_solvent_phase_system_parameter_changes(ff_pair):
+    ff0, ff1 = ff_pair
+    mol = fetch_freesolv()[0]
+
+    ubps, params, m, coords, box = enhanced.get_solvent_phase_system_parameter_changes(
+        mol, ff0=ff0, ff1=ff1, minimize_energy=False
+    )
+    U_ff = construct_differentiable_interface_fast(ubps, params)
+
+    ubps0, params0, m0, coords0, box0 = enhanced.get_solvent_phase_system(mol, ff0, minimize_energy=False)
+    U0 = construct_differentiable_interface_fast(ubps0, params0)
+
+    ubps1, params1, m1, coords1, box1 = enhanced.get_solvent_phase_system(mol, ff1, minimize_energy=False)
+    U1 = construct_differentiable_interface_fast(ubps1, params1)
+
+    u_ff0 = U_ff(coords, params, box, lam=0)
+    u_ff1 = U_ff(coords, params, box, lam=1)
+
+    u0 = U0(coords0, params0, box0, lam=0)
+    u1 = U1(coords1, params1, box1, lam=0)
+
+    # Check that the endstate energies are consistent
+    assert pytest.approx(u_ff0) == u0
+    assert pytest.approx(u_ff1) == u1
+
+    # Check that the masses are consistent
+    assert pytest.approx(m) == m0
+    assert pytest.approx(m) == m1
+
+    # Check that the box is consistent
+    assert pytest.approx(box) == box0
+    assert pytest.approx(box) == box1
+
+    # Check that the coords is consistent
+    assert pytest.approx(coords) == coords0
+    assert pytest.approx(coords) == coords1
+
+
+def test_get_vacuum_phase_system_parameter_changes(ff_pair):
+    ff0, ff1 = ff_pair
+    get_system_fxn = functools.partial(enhanced.get_vacuum_phase_system_parameter_changes, ff0=ff0, ff1=ff1)
+
+    mol = fetch_freesolv()[0]
+
+    ubps, params, m, coords = get_system_fxn(mol)
+    U_ff = construct_differentiable_interface_fast(ubps, params)
+
+    U0 = enhanced.VacuumState(mol, ff0).U_full
+    U1 = enhanced.VacuumState(mol, ff1).U_full
+
+    box = np.eye(3) * 1000.0
+    u_ff0 = U_ff(coords, params, box, lam=0)
+    u_ff1 = U_ff(coords, params, box, lam=1)
+
+    u0 = U0(coords)
+    u1 = U1(coords)
+
+    # Check that the endstate energies are consistent
+    assert pytest.approx(u_ff0) == u0
+    assert pytest.approx(u_ff1) == u1
+
+    # Check that the masses are consistent
+    assert pytest.approx(m) == utils.get_mol_masses(mol)
+
+    # Check that the coords is consistent
+    assert pytest.approx(coords) == utils.get_romol_conf(mol)

--- a/tests/test_enhanced.py
+++ b/tests/test_enhanced.py
@@ -34,9 +34,7 @@ def test_get_solvent_phase_system_parameter_changes(ff_pair):
     ff0, ff1 = ff_pair
     mol = fetch_freesolv()[0]
 
-    ubps, params, m, coords, box = enhanced.get_solvent_phase_system_parameter_changes(
-        mol, ff0=ff0, ff1=ff1, minimize_energy=False
-    )
+    ubps, params, m, coords, box = enhanced.get_solvent_phase_system_parameter_changes(mol, ff0=ff0, ff1=ff1)
     U_ff = construct_differentiable_interface_fast(ubps, params)
 
     ubps0, params0, m0, coords0, box0 = enhanced.get_solvent_phase_system(mol, ff0, minimize_energy=False)

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -15,7 +15,7 @@ from timemachine.constants import DEFAULT_FF
 from timemachine.fe import topology
 from timemachine.fe.utils import get_romol_conf
 from timemachine.ff import Forcefield, combine_ordered_params
-from timemachine.ff.handlers import AM1CCCHandler, openmm_deserializer
+from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md import builders
 from timemachine.testsystems.relative import hif2a_ligand_pair
 
@@ -381,9 +381,7 @@ def test_relative_free_energy_forcefield():
     ff1 = Forcefield.load_from_file(DEFAULT_FF)
 
     # Modify the charge parameters for ff1
-    for h, p in zip(ff1.get_ordered_handles(), ff1.get_ordered_params()):
-        if isinstance(h, AM1CCCHandler):
-            p += 1.0
+    ff1.q_handle.params += 1.0
 
     fftop = topology.RelativeFreeEnergyForcefield(mol, ff0, ff1)
     bt0 = topology.BaseTopology(mol, ff0)

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -373,7 +373,6 @@ def test_component_idxs():
 
 
 def test_relative_free_energy_forcefield():
-    BOND, ANGLE, PROPER, IMPROPER, CHARGE, LJ = 0, 1, 2, 3, 4, 5
 
     with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
         mol = next(Chem.SDMolSupplier(str(path_to_ligand), removeHs=False))
@@ -390,10 +389,22 @@ def test_relative_free_energy_forcefield():
     bt0 = topology.BaseTopology(mol, ff0)
     bt1 = topology.BaseTopology(mol, ff1)
 
+    ordered_handles = ff0.get_ordered_handles()
+    bond_idx = ordered_handles.index(ff0.hb_handle)
+    angle_idx = ordered_handles.index(ff0.ha_handle)
+    proper_idx = ordered_handles.index(ff0.pt_handle)
+    improper_idx = ordered_handles.index(ff0.it_handle)
+    charge_idx = ordered_handles.index(ff0.q_handle)
+    lj_idx = ordered_handles.index(ff0.lj_handle)
+    ff0_params = ff0.get_ordered_params()
+    ff1_params = ff1.get_ordered_params()
+
     combined_params = combine_ordered_params(ff0, ff1)
-    combined_qlj_params, combined_ubp = fftop.parameterize_nonbonded(combined_params[CHARGE], combined_params[LJ])
-    qlj0_params, ubp0 = bt0.parameterize_nonbonded(ff0.get_ordered_params()[CHARGE], ff0.get_ordered_params()[LJ])
-    qlj1_params, ubp1 = bt1.parameterize_nonbonded(ff1.get_ordered_params()[CHARGE], ff1.get_ordered_params()[LJ])
+    combined_qlj_params, combined_ubp = fftop.parameterize_nonbonded(
+        combined_params[charge_idx], combined_params[lj_idx]
+    )
+    qlj0_params, ubp0 = bt0.parameterize_nonbonded(ff0_params[charge_idx], ff0_params[lj_idx])
+    qlj1_params, ubp1 = bt1.parameterize_nonbonded(ff1_params[charge_idx], ff1_params[lj_idx])
 
     coords = get_romol_conf(mol)
     box = np.identity(3) * 99.0
@@ -413,20 +424,20 @@ def test_relative_free_energy_forcefield():
     assert pytest.approx(u1_combined) == u1
 
     # Check that other terms can not be changed
-    fftop.parameterize_harmonic_bond(combined_params[BOND])
-    invalid = [combined_params[BOND][0], combined_params[BOND][0] + 1.0]
+    fftop.parameterize_harmonic_bond(combined_params[bond_idx])
+    invalid = [combined_params[bond_idx][0], combined_params[bond_idx][0] + 1.0]
     with pytest.raises(AssertionError, match="changing harmonic bond"):
         fftop.parameterize_harmonic_bond(invalid)
 
-    fftop.parameterize_harmonic_angle(combined_params[ANGLE])
-    invalid = [combined_params[ANGLE][0], combined_params[ANGLE][0] + 1.0]
+    fftop.parameterize_harmonic_angle(combined_params[angle_idx])
+    invalid = [combined_params[angle_idx][0], combined_params[angle_idx][0] + 1.0]
     with pytest.raises(AssertionError, match="changing harmonic angle"):
         fftop.parameterize_harmonic_angle(invalid)
 
-    fftop.parameterize_periodic_torsion(combined_params[PROPER], combined_params[IMPROPER])
-    invalid = [combined_params[PROPER][0], combined_params[PROPER][0] + 1.0]
+    fftop.parameterize_periodic_torsion(combined_params[proper_idx], combined_params[improper_idx])
+    invalid = [combined_params[proper_idx][0], combined_params[proper_idx][0] + 1.0]
     with pytest.raises(AssertionError, match="changing proper"):
-        fftop.parameterize_periodic_torsion(invalid, combined_params[IMPROPER])
-    invalid = [combined_params[IMPROPER][0], combined_params[IMPROPER][0] + 1.0]
+        fftop.parameterize_periodic_torsion(invalid, combined_params[improper_idx])
+    invalid = [combined_params[improper_idx][0], combined_params[improper_idx][0] + 1.0]
     with pytest.raises(AssertionError, match="changing improper"):
-        fftop.parameterize_periodic_torsion(combined_params[PROPER], invalid)
+        fftop.parameterize_periodic_torsion(combined_params[proper_idx], invalid)

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -158,7 +158,7 @@ def set_up_ahfe_system_for_smc(
     return samples, lambdas, propagate, log_prob, resample
 
 
-def set_up_ahfe_for_smc_parameter_changes(
+def set_up_smc_parameter_changes_at_endstates(
     mol,
     temperature=300.0,
     pressure=1.0,
@@ -181,8 +181,7 @@ def set_up_ahfe_for_smc_parameter_changes(
     Returns
     -------
     * reduced_potential_fxn
-    * mover at lam=0
-    * mover at lam=1
+    * mover with lamb=None. The mover.lamb attribute must be set before use.
     """
     if type(seed) != int:
         seed = np.random.randint(1000)
@@ -257,7 +256,7 @@ def set_up_ahfe_system_for_smc_parameter_changes(
         log_prob fxn
         resample fxn
     """
-    reduced_potential, mover = set_up_ahfe_for_smc_parameter_changes(
+    reduced_potential, mover = set_up_smc_parameter_changes_at_endstates(
         mol, n_steps=n_md_steps, seed=seed, ff0=ff0, ff1=ff1, is_vacuum=is_vacuum
     )
     np.random.seed(seed)

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -198,9 +198,7 @@ def set_up_smc_parameter_changes_at_endstates(
     if is_vacuum:
         potentials, params, masses, _ = enhanced.get_vacuum_phase_system_parameter_changes(mol, ff0, ff1)
     else:
-        potentials, params, masses, _, _ = enhanced.get_solvent_phase_system_parameter_changes(
-            mol, ff0, ff1, minimize_energy=False
-        )
+        potentials, params, masses, _, _ = enhanced.get_solvent_phase_system_parameter_changes(mol, ff0, ff1)
 
     U_fn = functional.construct_differentiable_interface_fast(potentials, params)
     kBT = BOLTZ * temperature

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -156,3 +156,125 @@ def set_up_ahfe_system_for_smc(
     resample = partial(conditional_multinomial_resample, thresh=resample_thresh)
 
     return samples, lambdas, propagate, log_prob, resample
+
+
+def set_up_ahfe_for_smc_parameter_changes(
+    mol,
+    temperature=300.0,
+    pressure=1.0,
+    n_steps=1000,
+    seed=2022,
+    ff0=None,
+    ff1=None,
+    is_vacuum=False,
+):
+    """
+    Prepare a system for using SMC to generate samples under
+    different forcefields at each endstate.
+
+    Parameters
+    ----------
+    is_vacuum: bool
+        Set to True to set up the vacuum leg, using NVT.
+        Set to False to set up the solvent leg, using NPT.
+
+    Returns
+    -------
+    * reduced_potential_fxn
+    * mover at lam=0
+    * mover at lam=1
+    """
+    if type(seed) != int:
+        seed = np.random.randint(1000)
+        print(f"setting seed randomly to {seed}")
+    else:
+        print(f"setting seed to {seed}")
+
+    np.random.seed(seed)
+
+    # set up potentials
+    ff0 = ff0 or Forcefield.load_from_file(DEFAULT_FF)
+    ff1 = ff1 or Forcefield.load_from_file(DEFAULT_FF)
+
+    if is_vacuum:
+        potentials, params, masses, _ = enhanced.get_vacuum_phase_system_parameter_changes(mol, ff0, ff1)
+    else:
+        potentials, params, masses, _, _ = enhanced.get_solvent_phase_system_parameter_changes(
+            mol, ff0, ff1, minimize_energy=False
+        )
+
+    U_fn = functional.construct_differentiable_interface_fast(potentials, params)
+    kBT = BOLTZ * temperature
+
+    def reduced_potential_fxn(xvb, lam):
+        return U_fn(xvb.coords, params, xvb.box, lam) / kBT
+
+    for U, p in zip(potentials, params):
+        U.bind(p)
+
+    if is_vacuum:
+        mover = moves.NVTMove(potentials, None, masses, temperature, n_steps, seed)
+    else:
+        mover = moves.NPTMove(potentials, None, masses, temperature, pressure, n_steps, seed)
+    return reduced_potential_fxn, mover
+
+
+def set_up_ahfe_system_for_smc_parameter_changes(
+    mol,
+    n_walkers,
+    n_md_steps,
+    resample_thresh,
+    initial_samples,
+    seed=2022,
+    ff0=None,
+    ff1=None,
+    n_windows=10,
+    is_vacuum=False,
+):
+    """
+    Set up an absolute hydration free energy system such that
+    the samples can be propagated using different forcefields
+    at the end states.
+
+    Parameters
+    ----------
+    initial_samples: Samples
+        Initial set of unweighted samples generated using the initial forcefield.
+    ff0: Forcefield
+        Initial forcefield (lam=0)
+    ff1: Forcefield
+        New forcefield (lam=1)
+    n_windws: int
+        Number of windows to use for parameter change.
+    is_vacuum: bool
+        True if this should be the vacuum leg or False for the solvent leg.
+
+    Returns
+    -------
+        initial samples
+        lambdas schedule
+        propagate fxn
+        log_prob fxn
+        resample fxn
+    """
+    reduced_potential, mover = set_up_ahfe_for_smc_parameter_changes(
+        mol, n_steps=n_md_steps, seed=seed, ff0=ff0, ff1=ff1, is_vacuum=is_vacuum
+    )
+    np.random.seed(seed)
+
+    sample_inds = np.random.choice(np.arange(len(initial_samples)), size=n_walkers, replace=True)
+    samples = [initial_samples[i] for i in sample_inds]
+    lambdas = np.linspace(0.0, 1.0, n_windows, endpoint=True)
+
+    def propagate(xs, lam):
+        mover.lamb = lam
+        xs_next = [mover.move(x) for x in xs]
+        return xs_next
+
+    def log_prob(xs, lam):
+        u_s = np.array([reduced_potential(x, lam) for x in xs])
+        return -u_s
+
+    resample = partial(conditional_multinomial_resample, thresh=resample_thresh)
+
+    return samples, lambdas, propagate, log_prob, resample

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -319,6 +319,66 @@ class BaseTopologyConversion(BaseTopology):
         return combined_qlj_params, interpolated_potential
 
 
+class RelativeFreeEnergyForcefield(BaseTopology):
+    """
+    Used to run the same molecule under different forcefields.
+    Currently only changing the nonbonded parameters is supported.
+
+    The parameterize_* methods should be passed a list of parameters
+    corresponding to forcefield0 and forcefield1.
+    """
+
+    def __init__(self, mol, forcefield0, forcefield1):
+        """
+        Utility for working with a single ligand.
+
+        Parameter
+        ---------
+        mol: ROMol
+            Ligand to be parameterized
+
+        forcefield0: ff.Forcefield
+            A convenience wrapper for forcefield lists.
+
+        forcefield1: ff.Forcefield
+            A convenience wrapper for forcefield lists.
+
+        """
+        self.mol = mol
+        self.ff = forcefield0
+        self.ff1 = forcefield1
+        self.bt1 = BaseTopology(mol, forcefield1)
+
+    def parameterize_nonbonded(self, ff_q_params, ff_lj_params):
+        src_qlj_params, nb_potential = super().parameterize_nonbonded(ff_q_params[0], ff_lj_params[0])
+        dst_qlj_params, _ = self.bt1.parameterize_nonbonded(ff_q_params[1], ff_lj_params[1])
+
+        combined_qlj_params = jnp.concatenate([src_qlj_params, dst_qlj_params])
+        lambda_plane_idxs = np.zeros(self.mol.GetNumAtoms(), dtype=np.int32)
+        lambda_offset_idxs = np.zeros(self.mol.GetNumAtoms(), dtype=np.int32)
+
+        interpolated_potential = nb_potential.interpolate()
+        interpolated_potential.set_lambda_plane_idxs(lambda_plane_idxs)
+        interpolated_potential.set_lambda_offset_idxs(lambda_offset_idxs)
+
+        return combined_qlj_params, interpolated_potential
+
+    def parameterize_harmonic_bond(self, ff_params):
+        assert np.allclose(ff_params[0], ff_params[1]), "changing harmonic bond parameters is not supported"
+        return super().parameterize_harmonic_bond(ff_params[0])
+
+    def parameterize_harmonic_angle(self, ff_params):
+        assert np.allclose(ff_params[0], ff_params[1]), "changing harmonic angle parameters is not supported"
+        return super().parameterize_harmonic_angle(ff_params[0])
+
+    def parameterize_periodic_torsion(self, proper_params, improper_params):
+        assert np.allclose(proper_params[0], proper_params[1]), "changing proper torsion parameters is not supported"
+        assert np.allclose(
+            improper_params[0], improper_params[1]
+        ), "changing improper torsion parameters is not supported"
+        return super().parameterize_periodic_torsion(proper_params[0], improper_params[0])
+
+
 class BaseTopologyDecoupling(BaseTopology):
     """
     Decouple a ligand from the environment. The ligand has its charges set to zero

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -350,6 +350,8 @@ class RelativeFreeEnergyForcefield(BaseTopology):
         self.bt1 = BaseTopology(mol, forcefield1)
 
     def parameterize_nonbonded(self, ff_q_params, ff_lj_params):
+        assert self.ff.lj_handle.smirks == self.ff1.lj_handle.smirks, "changing lj smirks is not supported"
+        assert self.ff.q_handle.smirks == self.ff1.q_handle.smirks, "changing charge smirks is not supported"
         src_qlj_params, nb_potential = super().parameterize_nonbonded(ff_q_params[0], ff_lj_params[0])
         dst_qlj_params, _ = self.bt1.parameterize_nonbonded(ff_q_params[1], ff_lj_params[1])
 
@@ -365,17 +367,23 @@ class RelativeFreeEnergyForcefield(BaseTopology):
 
     def parameterize_harmonic_bond(self, ff_params):
         assert np.allclose(ff_params[0], ff_params[1]), "changing harmonic bond parameters is not supported"
+        assert self.ff.hb_handle.smirks == self.ff1.hb_handle.smirks, "changing harmonic bond smirks is not supported"
         return super().parameterize_harmonic_bond(ff_params[0])
 
     def parameterize_harmonic_angle(self, ff_params):
         assert np.allclose(ff_params[0], ff_params[1]), "changing harmonic angle parameters is not supported"
+        assert self.ff.ha_handle.smirks == self.ff1.ha_handle.smirks, "changing harmonic angle smirks is not supported"
         return super().parameterize_harmonic_angle(ff_params[0])
 
     def parameterize_periodic_torsion(self, proper_params, improper_params):
         assert np.allclose(proper_params[0], proper_params[1]), "changing proper torsion parameters is not supported"
+        assert self.ff.pt_handle.smirks == self.ff1.pt_handle.smirks, "changing proper torsion smirks is not supported"
         assert np.allclose(
             improper_params[0], improper_params[1]
         ), "changing improper torsion parameters is not supported"
+        assert (
+            self.ff.it_handle.smirks == self.ff1.it_handle.smirks
+        ), "changing improper torsion smirks is not supported"
         return super().parameterize_periodic_torsion(proper_params[0], improper_params[0])
 
 

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -334,7 +334,7 @@ class RelativeFreeEnergyForcefield(BaseTopology):
 
         Parameter
         ---------
-        mol: ROMol
+        mol: Chem.Mol
             Ligand to be parameterized
 
         forcefield0: ff.Forcefield

--- a/timemachine/ff/__init__.py
+++ b/timemachine/ff/__init__.py
@@ -95,3 +95,7 @@ class Forcefield:
             Return a flat, pre-determined ordering of the handlers
         """
         return [self.hb_handle, self.ha_handle, self.pt_handle, self.it_handle, self.q_handle, self.lj_handle]
+
+
+def combine_ordered_params(ff0: Forcefield, ff1: Forcefield):
+    return list(zip(ff0.get_ordered_params(), ff1.get_ordered_params()))

--- a/timemachine/md/enhanced.py
+++ b/timemachine/md/enhanced.py
@@ -471,11 +471,11 @@ def get_solvent_phase_system(mol, ff, box_width=3.0, margin=0.5, minimize_energy
     return potentials, params, masses, coords, water_box
 
 
-def get_solvent_phase_system_parameter_changes(mol, ff0, ff1, box_width=3.0, margin=0.5, minimize_energy=True):
+def get_solvent_phase_system_parameter_changes(mol, ff0, ff1, box_width=3.0, margin=0.5):
     """
-    Given a mol and a pair of forcefields return a solvated system where the
-    solvent has (optionally) been minimized. The system is set up to determine
-    the relative free energy of changing the forcefield parameters.
+    Given a mol and a pair of forcefields return a solvated system.
+    The system is set up to determine the relative free energy of
+    changing the forcefield parameters.
 
     Parameters
     ----------
@@ -506,13 +506,9 @@ def get_solvent_phase_system_parameter_changes(mol, ff0, ff1, box_width=3.0, mar
     combined_ff_params = combine_ordered_params(ff0, ff1)
     potentials, params, masses = afe.prepare_host_edge(combined_ff_params, water_system)
 
-    # concatenate (optionally minimized) water_coords and ligand_coords
+    # concatenate water_coords and ligand_coords
     ligand_coords = get_romol_conf(mol)
-    if minimize_energy:
-        new_water_coords = minimizer.minimize_host_4d([mol], water_system, water_coords, ff0, water_box)
-        coords = np.concatenate([new_water_coords, ligand_coords])
-    else:
-        coords = np.concatenate([water_coords, ligand_coords])
+    coords = np.concatenate([water_coords, ligand_coords])
 
     return potentials, params, np.array(masses), coords, water_box
 

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -96,7 +96,7 @@ class NVTMove(MonteCarloMove):
         ctxt = custom_ops.Context(x.coords, x.velocities, x.box, self.integrator_impl, self.bound_impls)
         return self._steps(ctxt)
 
-    def _steps(self, ctxt: custom_ops.Context) -> CoordsVelBox:
+    def _steps(self, ctxt: "custom_ops.Context") -> CoordsVelBox:
         # arguments: lambda_schedule, du_dl_interval, x_interval
         _, xs, boxes = ctxt.multiple_steps(self.lamb * np.ones(self.n_steps), 0, 0)
         x_t = xs[0]

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -71,7 +71,47 @@ class CompoundMove(MonteCarloMove):
         return np.sum(self.n_proposed_by_move)
 
 
-class NPTMove(MonteCarloMove):
+class NVTMove(MonteCarloMove):
+    def __init__(
+        self,
+        ubps: List[potentials.CustomOpWrapper],
+        lamb: float,
+        masses: NDArray,
+        temperature: float,
+        n_steps: int,
+        seed: int,
+        dt: float = 1.5e-3,
+        friction: float = 1.0,
+    ):
+        intg = lib.LangevinIntegrator(temperature, dt, friction, masses, seed)
+        self.integrator_impl = intg.impl()
+        all_impls = [bp.bound_impl(np.float32) for bp in ubps]
+
+        self.bound_impls = all_impls
+        self.lamb = lamb
+        self.n_steps = n_steps
+
+    def move(self, x: CoordsVelBox) -> CoordsVelBox:
+        # note: context creation overhead here is actually very small!
+        ctxt = custom_ops.Context(x.coords, x.velocities, x.box, self.integrator_impl, self.bound_impls)
+        return self._steps(ctxt)
+
+    def _steps(self, ctxt: custom_ops.Context) -> CoordsVelBox:
+        # arguments: lambda_schedule, du_dl_interval, x_interval
+        _, xs, boxes = ctxt.multiple_steps(self.lamb * np.ones(self.n_steps), 0, 0)
+        x_t = xs[0]
+        v_t = ctxt.get_v_t()
+        box = boxes[0]
+
+        after_steps = CoordsVelBox(x_t, v_t, box)
+
+        self.n_proposed += 1
+        self.n_accepted += 1
+
+        return after_steps
+
+
+class NPTMove(NVTMove):
     def __init__(
         self,
         ubps: List[potentials.CustomOpWrapper],
@@ -85,10 +125,7 @@ class NPTMove(MonteCarloMove):
         friction: float = 1.0,
         barostat_interval: int = 5,
     ):
-
-        intg = lib.LangevinIntegrator(temperature, dt, friction, masses, seed)
-        self.integrator_impl = intg.impl()
-        all_impls = [bp.bound_impl(np.float32) for bp in ubps]
+        super().__init__(ubps, lamb, masses, temperature, n_steps, seed, dt=dt, friction=friction)
 
         assert isinstance(ubps[0], potentials.HarmonicBond), "First potential must be of type HarmonicBond"
 
@@ -96,31 +133,15 @@ class NPTMove(MonteCarloMove):
         group_idxs = get_group_indices(bond_list)
 
         barostat = lib.MonteCarloBarostat(len(masses), pressure, temperature, group_idxs, barostat_interval, seed + 1)
-        barostat_impl = barostat.impl(all_impls)
-
-        self.bound_impls = all_impls
+        barostat_impl = barostat.impl(self.bound_impls)
         self.barostat_impl = barostat_impl
-        self.lamb = lamb
-        self.n_steps = n_steps
 
     def move(self, x: CoordsVelBox) -> CoordsVelBox:
         # note: context creation overhead here is actually very small!
         ctxt = custom_ops.Context(
             x.coords, x.velocities, x.box, self.integrator_impl, self.bound_impls, self.barostat_impl
         )
-
-        # arguments: lambda_schedule, du_dl_interval, x_interval
-        _, xs, boxes = ctxt.multiple_steps(self.lamb * np.ones(self.n_steps), 0, 0)
-        x_t = xs[0]
-        v_t = ctxt.get_v_t()
-        box = boxes[0]
-
-        after_npt = CoordsVelBox(x_t, v_t, box)
-
-        self.n_proposed += 1
-        self.n_accepted += 1
-
-        return after_npt
+        return self._steps(ctxt)
 
 
 class DeterministicMTMMove(MonteCarloMove):

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -112,6 +112,11 @@ class NVTMove(MonteCarloMove):
 
 
 class NPTMove(NVTMove):
+    """
+    Functionally, NPT is implemented as NVTMove plus a MC Barostat.
+    So inherit from NVTMove here.
+    """
+
     def __init__(
         self,
         ubps: List[potentials.CustomOpWrapper],


### PR DESCRIPTION
 - Adds absolute_hydration.set_up_ahfe_system_for_smc_parameter_changes which
    can be used during refitting to generate new samples under a new set of
    charge parameters.

- Adds moves.NVTMove so NVT simulations can be run with SMC.

 - Adds topology.RelativeFreeEnergyForcefield which is used to represent
    a molecule under different parameters (controlled by lambda).