### PR TITLE
Chiral restraints

### DIFF
--- a/tests/test_chiral_restraints.py
+++ b/tests/test_chiral_restraints.py
@@ -1,0 +1,522 @@
+import multiprocessing
+import os
+
+os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=" + str(multiprocessing.cpu_count())
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import scipy
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+from timemachine.fe import chiral_utils, topology, utils
+from timemachine.ff import Forcefield
+from timemachine.integrator import simulate
+from timemachine.potentials.chiral_restraints import (
+    U_chiral_atom,
+    U_chiral_atom_batch,
+    U_chiral_bond,
+    U_chiral_bond_batch,
+    pyramidal_volume,
+    torsion_volume,
+)
+
+
+def minimize_scipy(x0, U_fn):
+    shape = x0.shape
+
+    def U_flat(x_flat):
+        x_full = x_flat.reshape(*shape)
+        return U_fn(x_full)
+
+    grad_bfgs_fn = jax.grad(U_flat)
+    res = scipy.optimize.minimize(U_flat, x0.reshape(-1), jac=grad_bfgs_fn)
+    xi = res.x.reshape(*shape)
+    return xi
+
+
+def simulate_system(U_fn, x0, num_samples=20000):
+    num_atoms = x0.shape[0]
+    x_min = minimize_scipy(x0, U_fn)
+    seed = 2023
+
+    num_workers = multiprocessing.cpu_count()
+    samples_per_worker = int(np.ceil(num_samples / num_workers))
+
+    # batches_per_worker = num_samples // num_workers
+    burn_in_batches = 2000
+    frames, _ = simulate(
+        x_min, U_fn, 300.0, np.ones(num_atoms) * 4.0, 500, samples_per_worker + burn_in_batches, num_workers, seed=seed
+    )
+    # (ytz): discard burn in batches
+    frames = frames[:, burn_in_batches:, :, :]
+    # collect over all workers
+    frames = frames.reshape(-1, num_atoms, 3)[:num_samples]
+    # sanity check that we didn't undersample
+    assert len(frames) == num_samples
+    return frames
+
+
+def test_setup_chiral_atom_restraints():
+    """On a methane conformer, assert that permuting coordinates or permuting restr_idxs
+    both independently toggle the chiral restraint"""
+    mol = Chem.MolFromMolBlock(
+        """
+  Mrv2202 06072215563D
+
+  5  4  0  0  0  0            999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3633   -0.5138    0.8900 H   0  0  0  0  0  0  0  0  0  0  0  0
+    1.0900    0.0000    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3633    1.0277    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3633   -0.5138   -0.8900 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  1  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+  1  5  1  0  0  0  0
+M  END
+$$$$""",
+        removeHs=False,
+    )
+
+    # needs to be batched in order for jax to play nicely
+    x0 = utils.get_romol_conf(mol)
+    normal_restr_idxs = chiral_utils.setup_chiral_atom_restraints(mol, x0, 0)
+
+    x0_inverted = x0[[0, 2, 1, 3, 4]]  # swap two atoms
+    inverted_restr_idxs = chiral_utils.setup_chiral_atom_restraints(mol, x0_inverted, 0)
+
+    # check the sign of the resulting idxs
+    k = 1000.0
+    assert np.all(np.asarray(U_chiral_atom_batch(x0, normal_restr_idxs, k)) == 0)
+    assert np.all(np.asarray(U_chiral_atom_batch(x0, inverted_restr_idxs, k)) > 0)
+    assert np.all(np.asarray(U_chiral_atom_batch(x0_inverted, normal_restr_idxs, k)) > 0)
+    assert np.all(np.asarray(U_chiral_atom_batch(x0_inverted, inverted_restr_idxs, k)) == 0)
+
+
+def test_setup_chiral_bond_restraints():
+    """On a 'Cl/C(F)=N/F' conformer, assert that flipping a dihedral angle or permuting restr_idxs
+    both independently toggle the chiral bond restraint"""
+
+    mol_cis = Chem.MolFromSmiles(r"Cl\C(F)=N/F")
+    mol_trans = Chem.MolFromSmiles(r"Cl\C(F)=N\F")
+
+    AllChem.EmbedMolecule(mol_cis)
+    AllChem.EmbedMolecule(mol_trans)
+
+    # needs to be batched in order for jax to play nicely
+    x0_cis = utils.get_romol_conf(mol_cis)
+    x0_trans = utils.get_romol_conf(mol_trans)
+    src_atom = 1
+    dst_atom = 3
+    normal_restr_idxs, signs = chiral_utils.setup_chiral_bond_restraints(mol_cis, x0_cis, src_atom, dst_atom)
+
+    inverted_restr_idxs, inverted_signs = chiral_utils.setup_chiral_bond_restraints(
+        mol_trans, x0_trans, src_atom, dst_atom
+    )
+    k = 1000.0
+
+    assert np.all(np.asarray(U_chiral_bond_batch(x0_cis, normal_restr_idxs, k, signs)) == 0)
+    assert np.all(np.asarray(U_chiral_bond_batch(x0_cis, inverted_restr_idxs, k, inverted_signs)) > 0)
+    assert np.all(np.asarray(U_chiral_bond_batch(x0_trans, normal_restr_idxs, k, signs)) > 0)
+    assert np.all(np.asarray(U_chiral_bond_batch(x0_trans, inverted_restr_idxs, k, inverted_signs)) == 0)
+
+
+def test_chiral_restraints_pyramidal():
+    """For ammonium, assert that:
+    * without chiral restraints, up and down states are ~ equally sampled
+    * with chiral restraints, ~ only the specified state is sampled"""
+    mol = Chem.MolFromMolBlock(
+        """
+  Mrv2202 05192218063D
+
+  4  3  0  0  0  0            999 V2000
+   -0.0541    0.5427   -0.3433 N   0  0  0  0  0  0  0  0  0  0  0  0
+    0.4368    0.0213    0.3859 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.9636    0.0925   -0.4646 H   0  0  0  0  0  0  0  0  0  0  0  0
+    0.4652    0.3942   -1.2109 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  1  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+M  END
+$$$$""",
+        removeHs=False,
+    )
+
+    ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
+    s_top = topology.BaseTopology(mol, ff)
+    x0 = utils.get_romol_conf(mol)
+
+    # check initial chirality
+    restr_idxs = np.array([0, 1, 2, 3])
+    vol = pyramidal_volume(*x0[restr_idxs])
+    assert vol > 0.5
+    system = s_top.setup_end_state()
+    U_fn = system.get_U_fn()
+    vols_orig = []
+    frames = simulate_system(U_fn, x0)
+    for f in frames:
+        vol = pyramidal_volume(*f[restr_idxs])
+        vols_orig.append(vol)
+
+    def U_total(x):
+        return U_fn(x) + U_chiral_atom(x, restr_idxs, 1000.0)
+
+    vols_chiral = []
+    frames = simulate_system(U_total, x0)
+    for f in frames:
+        vol = pyramidal_volume(*f[restr_idxs])
+        vols_chiral.append(vol)
+
+    vols_orig = np.array(vols_orig)
+    vols_chiral = np.array(vols_chiral)
+
+    # should be within 5% of 50/50 for the original distribution, the <0 case
+    # is implied
+    assert np.abs(np.mean(vols_orig < 0) - 0.5) < 0.05
+    assert np.abs(np.mean(vols_chiral < 0) - 0.95) < 0.05
+
+    ref_dist = [x for x in vols_orig if x < 0]
+    test_dist = [x for x in vols_chiral if x < 0]
+
+    # should be indistinguishable under KS-test
+    ks, pv = scipy.stats.ks_2samp(ref_dist, test_dist)
+    assert ks < 0.05
+    assert pv > 0.10
+
+    # # useful plotting diagnostics, do not remove.
+    # # compare original distributions
+    # plt.hist(vols_orig, bins=np.linspace(-1, 1, 80), alpha=0.5, label="no_chiral_restr", density=True)
+    # plt.hist(vols_chiral, bins=np.linspace(-1, 1, 80), alpha=0.5, label="with_chiral_restr", density=True)
+    # plt.legend()
+    # plt.title("pyramidal chirality")
+    # plt.xlabel("chiral volume")
+    # plt.ylabel("samples")
+    # plt.title("raw")
+    # plt.show()
+
+    # # time series
+    # plt.plot(vols_chiral, label="with_chiral_restraint")
+    # plt.show()
+
+    # # compare filtered distributions
+    # plt.hist([x for x in vols_orig if x < 0], bins=np.linspace(-1, 1, 80), alpha=0.5, label="no_chiral_restr", density=True)
+    # plt.hist([x for x in vols_chiral if x < 0], bins=np.linspace(-1, 1, 80), alpha=0.5, label="with_chiral_restr", density=True)
+    # plt.legend()
+    # plt.title("pyramidal chirality")
+    # plt.xlabel("chiral volume")
+    # plt.ylabel("samples")
+    # plt.title("normalized")
+    # plt.show()
+
+
+class BaseTopologyRescaledCharges(topology.BaseTopology):
+    def __init__(self, scale, *args, **kwargs):
+        self.scale = scale
+        super().__init__(*args, **kwargs)
+
+    def parameterize_nonbonded(self, ff_q_params, ff_lj_params):
+        params, nb = topology.BaseTopology.parameterize_nonbonded(self, ff_q_params, ff_lj_params)
+        charge_indices = jnp.index_exp[:, 0]
+        new_params = jnp.asarray(params).at[charge_indices].multiply(self.scale)
+        return new_params, nb
+
+    def parameterize_nonbonded_pairlist(self, ff_q_params, ff_lj_params):
+        params, nb = topology.BaseTopology.parameterize_nonbonded_pairlist(self, ff_q_params, ff_lj_params)
+        charge_indices = jnp.index_exp[:, 0]
+        new_params = jnp.asarray(params).at[charge_indices].multiply(self.scale)
+        return new_params, nb
+
+
+def test_chiral_restraints_torsion():
+    """For a charge-scaled version of hydrogen peroxide, assert that:
+    * without chiral bond restraints, cis/trans states are sampled ~ 30%/70%
+    * with chiral bond restraints, ~ only specified state is sampled"""
+    mol = Chem.MolFromMolBlock(
+        """
+  Mrv2202 06062222163D
+
+  4  3  0  0  0  0            999 V2000
+   -0.1757   -0.7570    0.3351 H   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0031   -0.0645   -0.3351 O   0  0  0  0  0  0  0  0  0  0  0  0
+    1.3069    0.0645   -0.3351 O   0  0  0  0  0  0  0  0  0  0  0  0
+    1.4857    0.7570    0.3351 H   0  0  0  0  0  0  0  0  0  0  0  0
+  2  3  1  0  0  0  0
+  1  2  1  0  0  0  0
+  3  4  1  0  0  0  0
+M  END
+$$$$""",
+        removeHs=False,
+    )
+
+    ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
+    scale = 0.4
+    s_top = BaseTopologyRescaledCharges(scale, mol, ff)
+    x0 = utils.get_romol_conf(mol)
+
+    # check initial chirality
+    torsion_idxs = np.array([0, 1, 2, 3])
+    vol = torsion_volume(*x0[torsion_idxs])
+
+    assert abs(vol - 0.0) < 0.05
+    system = s_top.setup_end_state()
+    U_fn = system.get_U_fn()
+
+    vols_orig = []
+    frames = simulate_system(U_fn, x0)
+    for f in frames:
+        vols_orig.append(torsion_volume(*f[torsion_idxs]))
+    vols_orig = np.array(vols_orig)
+
+    # the 30/70 ratio is dependent on the scale defined above, which affects the repulsive
+    # strength of the hydrogens.
+    assert np.abs(np.mean(vols_orig > 0) - 0.3) < 0.05
+
+    all_signs = [1, -1]  # [trans, cis]
+    for sign in all_signs:
+
+        def U_total(x):
+            return U_fn(x) + U_chiral_bond(x, torsion_idxs, 1000.0, sign)
+
+        vols_chiral = []
+        frames = simulate_system(U_total, x0)
+        for f in frames:
+            vols_chiral.append(torsion_volume(*f[torsion_idxs]))
+        vols_chiral = np.array(vols_chiral)
+
+        # # useful for plotting
+        # import matplotlib.pyplot as plt
+        # plt.hist(vols_orig, bins=np.linspace(-1, 1, 80), alpha=0.5, label="no_chiral_restr", density=True)
+        # plt.hist(vols_chiral, bins=np.linspace(-1, 1, 80), alpha=0.5, label="with_chiral_restr", density=True)
+        # plt.legend()
+        # plt.title("torsion chirality")
+        # plt.xlabel("chiral volume")
+        # plt.ylabel("samples")
+        # plt.title("raw")
+        # plt.show()
+
+        # plt.hist([x for x in vols_orig if sign*x < 0], bins=np.linspace(-1, 1, 80), alpha=0.5, label="no_chiral_restr", density=True)
+        # plt.hist([x for x in vols_chiral if sign*x < 0], bins=np.linspace(-1, 1, 80), alpha=0.5, label="with_chiral_restr", density=True)
+        # plt.legend()
+        # plt.title("torsion chirality")
+        # plt.xlabel("chiral volume")
+        # plt.ylabel("samples")
+        # plt.title("normalized")
+        # plt.show()
+
+        # we should predominantly sample the correct chiral state
+        # (95% of the samples)
+        if sign == 1:
+            assert np.abs(np.mean(vols_chiral < 0) - 0.95) < 0.05
+        else:
+            assert np.abs(np.mean(vols_chiral > 0) - 0.95) < 0.05
+
+        ref_dist = [x for x in vols_orig if sign * x < 0]
+        test_dist = [x for x in vols_chiral if sign * x < 0]
+        # should be indistinguishable under KS-test
+        ks, pv = scipy.stats.ks_2samp(ref_dist, test_dist)
+        assert ks < 0.05
+        assert pv > 0.10
+
+
+def test_chiral_restraints_tetrahedral():
+    # test that we can restrain the chirality of a tetrahedral molecule
+    # to its inverted state
+    mol = Chem.MolFromMolBlock(
+        """
+  Mrv2202 06072204223D
+
+  5  4  0  0  0  0            999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3633   -0.5138    0.8900 H   0  0  0  0  0  0  0  0  0  0  0  0
+    1.0900    0.0000    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3633    1.0277    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3633   -0.5138   -0.8900 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  1  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+  1  5  1  0  0  0  0
+M  END
+$$$$""",
+        removeHs=False,
+    )
+
+    ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
+    s_top = topology.BaseTopology(mol, ff)
+    x0 = utils.get_romol_conf(mol)
+
+    perms = [
+        [0, 1, 2, 3],
+        [0, 1, 4, 2],
+        [0, 1, 3, 4],
+        [0, 2, 4, 3],
+    ]
+
+    perms = np.array(perms)
+
+    # check initial chirality, all positive values initially
+    for p in perms:
+        vol = pyramidal_volume(*x0[p])
+        assert vol > 0
+
+    system = s_top.setup_end_state()
+    U_fn = system.get_U_fn()
+
+    vols_orig = []
+    frames = simulate_system(U_fn, x0)
+    for f in frames:
+        vols_orig.append([pyramidal_volume(*f[p]) for p in perms])
+
+    def U_total(x):
+        return U_fn(x) + jnp.sum(U_chiral_atom_batch(x, perms, 1000.0))
+
+    vols_chiral = []
+    frames = simulate_system(U_total, x0)
+    for f in frames:
+        vols_chiral.append([pyramidal_volume(*f[p]) for p in perms])
+
+    vols_orig = np.array(vols_orig).reshape(-1)
+    vols_chiral = np.array(vols_chiral).reshape(-1)
+
+    # ref_dist samples predominantly positive chiral volumes, and test_dist
+    # pre-dominantly samples the negative chiral volumes, and the distribution
+    # is symmetric about vol=0.
+    ref_dist = np.array([x for x in vols_orig if x > 0])
+    test_dist = np.array([x for x in vols_chiral if x < 0])
+    # should be indistinguishable under KS-test
+    ks, pv = scipy.stats.ks_2samp(-ref_dist, test_dist)
+    assert ks < 0.05
+    assert pv > 0.10
+
+    # debugging plots
+    # plt.hist(vols_orig, bins=np.linspace(-1, 1, 80), alpha=0.5, label="no_chiral_restr", density=True)
+    # plt.hist(vols_chiral, bins=np.linspace(-1, 1, 80), alpha=0.5, label="with_chiral_restr", density=True)
+    # plt.legend()
+    # plt.title("tetrahedral chirality")
+    # plt.xlabel("chiral volume")
+    # plt.ylabel("samples")
+    # plt.title("raw")
+    # plt.show()
+
+
+def test_chiral_spiro_cyclopentane():
+    # fused spiro cyclopentane
+    mol = Chem.MolFromMolBlock(
+        """
+  Mrv2202 06082219093D
+
+ 23 24  0  0  0  0            999 V2000
+    0.0153    0.8682   -1.0264 C   0  0  2  0  0  0  0  0  0  0  0  0
+   -1.1793    1.2423   -0.1275 C   0  0  1  0  0  0  0  0  0  0  0  0
+   -1.0368    0.3687    1.1395 C   0  0  2  0  0  0  0  0  0  0  0  0
+    0.3652   -0.2781    1.0734 C   0  0  2  0  0  0  0  0  0  0  0  0
+    1.1394    0.4765   -0.0405 C   0  0  2  0  0  0  0  0  0  0  0  0
+    1.7303    1.6686    0.5168 O   0  0  0  0  0  0  0  0  0  0  0  0
+    3.1536    1.5004    0.5804 C   0  0  2  0  0  0  0  0  0  0  0  0
+    3.4838    0.0421    0.2203 C   0  0  2  0  0  0  0  0  0  0  0  0
+    2.3003   -0.3326   -0.6729 C   0  0  2  0  0  0  0  0  0  0  0  0
+    0.3073    1.7040   -1.6701 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.2513    0.0142   -1.6581 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.1233    2.3026    0.1405 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.1297    1.0640   -0.6358 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.8062   -0.4074    1.1604 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.1399    0.9807    2.0397 H   0  0  0  0  0  0  0  0  0  0  0  0
+    0.2589   -1.3347    0.8092 H   0  0  0  0  0  0  0  0  0  0  0  0
+    0.8797   -0.2178    2.0368 H   0  0  0  0  0  0  0  0  0  0  0  0
+    3.5126    1.7577    1.5808 H   0  0  0  0  0  0  0  0  0  0  0  0
+    3.6133    2.1778   -0.1451 H   0  0  0  0  0  0  0  0  0  0  0  0
+    3.4983   -0.5783    1.1212 H   0  0  0  0  0  0  0  0  0  0  0  0
+    4.4407   -0.0475   -0.3004 H   0  0  0  0  0  0  0  0  0  0  0  0
+    2.4929    0.0029   -1.6968 H   0  0  0  0  0  0  0  0  0  0  0  0
+    2.1250   -1.4110   -0.6825 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  1  5  1  0  0  0  0
+  2  3  1  0  0  0  0
+  3  4  1  0  0  0  0
+  4  5  1  0  0  0  0
+  7  8  1  0  0  0  0
+  5  9  1  0  0  0  0
+  9  8  1  0  0  0  0
+  5  6  1  0  0  0  0
+  6  7  1  0  0  0  0
+  1 10  1  0  0  0  0
+  1 11  1  0  0  0  0
+  2 12  1  0  0  0  0
+  2 13  1  0  0  0  0
+  3 14  1  0  0  0  0
+  3 15  1  0  0  0  0
+  4 16  1  0  0  0  0
+  4 17  1  0  0  0  0
+  7 18  1  0  0  0  0
+  7 19  1  0  0  0  0
+  8 20  1  0  0  0  0
+  8 21  1  0  0  0  0
+  9 22  1  0  0  0  0
+  9 23  1  0  0  0  0
+M  END
+$$$$""",
+        removeHs=False,
+    )
+
+    x0 = utils.get_romol_conf(mol)
+    # chiral center is a_idx == 4
+    normal_restr_idxs = np.array([[4, 0, 3, 8], [4, 3, 0, 5], [4, 0, 8, 5], [4, 8, 3, 5]])
+
+    inverted_restr_idxs = np.array([[4, 3, 0, 8], [4, 0, 3, 5], [4, 8, 0, 5], [4, 3, 8, 5]])
+
+    ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
+    s_top = topology.BaseTopology(mol, ff)
+
+    kc = 1000.0
+
+    assert np.all(np.asarray(U_chiral_atom_batch(x0, normal_restr_idxs, kc)) == 0)
+    assert np.all(np.asarray(U_chiral_atom_batch(x0, inverted_restr_idxs, kc)) > 0)
+
+    system = s_top.setup_end_state()
+    U_fn = system.get_U_fn()
+
+    vols_orig = []
+    frames = simulate_system(U_fn, x0)
+    for f in frames:
+        vol_list = []
+        for p in normal_restr_idxs:
+            vol_list.append(pyramidal_volume(*f[p]))
+        vols_orig.append(vol_list)
+
+    def U_total(x):
+        nrgs = [U_fn(x)]
+        # use inverted restr_idxs
+        for p in inverted_restr_idxs:
+            nrgs.append(U_chiral_atom(x, p, kc))
+        return jnp.sum(jnp.array(nrgs))
+
+    vols_chiral = []
+    frames = simulate_system(U_total, x0)
+    for f in frames:
+        vol_list = []
+        for p in normal_restr_idxs:
+            vol_list.append(pyramidal_volume(*f[p]))
+        vols_chiral.append(vol_list)
+
+    vols_orig = np.array(vols_orig).reshape(-1)
+    vols_chiral = np.array(vols_chiral).reshape(-1)
+
+    # debugging plots
+    # import matplotlib.pyplot as plt
+    # plt.hist(vols_orig, bins=np.linspace(-1, 1, 80), alpha=0.5, label="no_chiral_restr", density=True)
+    # plt.hist(vols_chiral, bins=np.linspace(-1, 1, 80), alpha=0.5, label="with_chiral_restr", density=True)
+    # plt.legend()
+    # plt.title("tetrahedral chirality")
+    # plt.xlabel("chiral volume")
+    # plt.ylabel("samples")
+    # plt.title("raw")
+    # plt.show()
+
+    # this should generate a symmetric distribution
+    ref_dist = np.array([x for x in vols_orig if x < 0])
+    test_dist = np.array([x for x in vols_chiral if x > 0])
+    # should be indistinguishable under KS-test
+    ks, pv = scipy.stats.ks_2samp(-ref_dist, test_dist)
+    assert ks < 0.05
+    assert pv > 0.10

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -1,0 +1,57 @@
+import itertools
+
+import numpy as np
+
+from timemachine.potentials.chiral_restraints import pyramidal_volume, torsion_volume
+
+
+def setup_chiral_atom_restraints(mol, conf, a_idx):
+    """
+    Setup chiral atom restraints for the molecule at a_idx by inspecting the
+    given geometry.
+    """
+    nbs = mol.GetAtomWithIdx(a_idx).GetNeighbors()
+    restr_idxs = []
+    for a_i, a_j, a_k in itertools.combinations(nbs, 3):
+        i, j, k = a_i.GetIdx(), a_j.GetIdx(), a_k.GetIdx()
+        vol = pyramidal_volume(conf[a_idx], conf[i], conf[j], conf[k])
+        # vol may be >0 or <0, our chiral restraint always enforces vol < 0.
+        if vol < 0:
+            restr_idxs.append([a_idx, i, j, k])
+        else:
+            restr_idxs.append([a_idx, j, i, k])
+
+    return np.array(restr_idxs)
+
+
+def setup_chiral_bond_restraints(mol, conf, src_idx, dst_idx):
+    """
+    Setup chiral bond restraints for the molecule at a_idx by inspecting the
+    given geometry
+    """
+    src_nbs = [a.GetIdx() for a in mol.GetAtomWithIdx(src_idx).GetNeighbors()]
+    dst_nbs = [a.GetIdx() for a in mol.GetAtomWithIdx(dst_idx).GetNeighbors()]
+
+    assert src_idx in dst_nbs
+    assert dst_idx in src_nbs
+
+    src_nbs.remove(dst_idx)
+    dst_nbs.remove(src_idx)
+
+    # build chiral restraints
+    restr_idxs = []
+    signs = []
+    for a in src_nbs:
+        for b in dst_nbs:
+            # set up torsion i,j,k,l
+            i, j, k, l = a, src_idx, dst_idx, b
+            vol = torsion_volume(conf[i], conf[j], conf[k], conf[l])
+            restr_idxs.append([i, j, k, l])
+            if vol < 0:
+                # (jkaus): the restraints are turned on when the volume is positive
+                # so use the opposite sign here
+                signs.append(1)
+            else:
+                signs.append(-1)
+
+    return np.array(restr_idxs), np.array(signs)

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -1,0 +1,59 @@
+import functools
+
+import jax.numpy as jnp
+import numpy as np
+
+from timemachine.potentials import bonded, nonbonded
+
+
+class VacuumSystem:
+
+    # utility system container
+
+    def __init__(self, bond, angle, torsion, nonbonded):
+        self.bond = bond
+        self.angle = angle
+        self.torsion = torsion
+        self.nonbonded = nonbonded
+
+    def get_U_fn(self):
+        """
+        Return a jax function that evaluates the potential energy of a set of coordinates.
+        """
+        bond_U = functools.partial(
+            bonded.harmonic_bond,
+            params=np.array(self.bond.params),
+            box=None,
+            lamb=0.0,
+            bond_idxs=np.array(self.bond.get_idxs()),
+        )
+        angle_U = functools.partial(
+            bonded.harmonic_angle,
+            params=np.array(self.angle.params),
+            box=None,
+            lamb=0.0,
+            angle_idxs=np.array(self.angle.get_idxs()),
+        )
+        torsion_U = functools.partial(
+            bonded.periodic_torsion,
+            params=np.array(self.torsion.params),
+            box=None,
+            lamb=0.0,
+            torsion_idxs=np.array(self.torsion.get_idxs()),
+        )
+
+        nbpl_U = functools.partial(
+            nonbonded.nonbonded_v3_on_specific_pairs,
+            pairs=np.array(self.nonbonded.get_idxs()),
+            params=np.array(self.nonbonded.params),
+            box=None,
+            beta=self.nonbonded.get_beta(),
+            cutoff=self.nonbonded.get_cutoff(),
+            rescale_mask=np.array(self.nonbonded.get_rescale_mask()),
+        )
+
+        def U_fn(x):
+            Us_vdw, Us_coulomb = nbpl_U(x)
+            return bond_U(x) + angle_U(x) + torsion_U(x) + jnp.sum(Us_vdw) + jnp.sum(Us_coulomb)
+
+        return U_fn

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -405,7 +405,17 @@ class NonbondedInteractionGroupInterpolated(NonbondedInteractionGroup):
 
 
 class NonbondedPairList(NonbondedCustomOpWrapper):
-    pass
+    def get_idxs(self):
+        return self.args[0]
+
+    def get_rescale_mask(self):
+        return self.args[1]
+
+    def get_beta(self):
+        return self.args[2]
+
+    def get_cutoff(self):
+        return self.args[3]
 
 
 class NonbondedPairListNegated(NonbondedCustomOpWrapper):

--- a/timemachine/potentials/chiral_restraints.py
+++ b/timemachine/potentials/chiral_restraints.py
@@ -1,0 +1,128 @@
+import jax
+import jax.numpy as jnp
+
+
+def pyramidal_volume(xc, x1, x2, x3):
+    """
+    Compute the normalized pyramidal volume given four points. This is implemented
+    as a triple product with x0 at the center.
+
+    Parameters
+    ----------
+    xc: np.array (3,)
+        Center point
+
+    x1: np.array: (3,)
+        First point
+
+    x2: np.array: (3,)
+        Second point
+
+    x3: np.array: (3,)
+        Third point
+
+    Returns
+    -------
+    float
+        A number between -1.0 < x < 1.0 denoting the normalized chirality
+
+    """
+    # compute vectors
+    v0 = x1 - xc
+    v1 = x2 - xc
+    v2 = x3 - xc
+
+    v0 = v0 / jnp.linalg.norm(v0)
+    v1 = v1 / jnp.linalg.norm(v1)
+    v2 = v2 / jnp.linalg.norm(v2)
+
+    # triple product
+    return jnp.dot(jnp.cross(v0, v1), v2)
+
+
+def torsion_volume(ci, cj, ck, cl):
+    """
+    Compute normalized torsional volume given four points. This is implemented
+    as the dot product of cross products spanned by atoms (i,j,k), and atoms (j,k,l).
+
+    Parameters
+    ----------
+    np.array: (3,)
+        First point
+
+    np.array: (3,)
+        Second point
+
+    np.array: (3,)
+        Third point
+
+    np.array: (3,)
+        Fourth point
+
+    Returns
+    -------
+    float
+        A number between -1.0 < x < 1.0 denoting the normalized chirality
+
+    """
+    rij = cj - ci
+    rkj = cj - ck
+    rkl = cl - ck
+
+    rij = rij / jnp.linalg.norm(rij)
+    rkj = rkj / jnp.linalg.norm(rkj)
+    rkl = rkl / jnp.linalg.norm(rkl)
+
+    n1 = jnp.cross(rij, rkj)
+    n2 = jnp.cross(rkj, rkl)
+
+    return jnp.dot(n1, n2)
+
+
+def U_chiral_atom(x, idxs, kc):
+    """
+    Flat bottom chiral restraint, penalizing positive volumes. ie.
+    If chiral volume > 0, the U = kc*volume^2, else 0.
+    """
+    # guard against numpy/raw lists
+    x = jnp.array(x)
+    assert len(idxs) == 4
+    x0, x1, x2, x3 = x[idxs]
+    v = pyramidal_volume(x0, x1, x2, x3)
+    return jnp.where(v > 0, kc * v ** 2, 0.0)
+
+
+def U_chiral_bond(x, idxs, kc, s):
+    """
+    For torsions, the ordering of the atoms i,j,k,l is fixed (and symmetrized)
+    so we can't simply swap two idxs to get the sign.
+
+    Flat bottom chiral restraint, penalizing positive volumes. ie.
+    If chiral volume > 0, the U = kc*volume^2, else 0.
+    """
+    x = jnp.array(x)
+    assert len(idxs) == 4
+    i, j, k, l = idxs
+    # assert s == 1 or s == -1, can't be used during vmap/tracing
+    x0, x1, x2, x3 = x[i], x[j], x[k], x[l]
+    v = s * torsion_volume(x0, x1, x2, x3)
+    return jnp.where(v > 0, kc * v ** 2, 0.0)
+
+
+# allow batching over multiple_idxs
+U_chiral_atom_batch = jax.vmap(U_chiral_atom, (None, 0, None), 0)
+U_chiral_bond_batch = jax.vmap(U_chiral_bond, (None, 0, None, 0), 0)
+
+
+def chiral_atom_restraint(conf, params, box, lamb, idxs, kc):
+    """
+    Flat-bottom chiral atom restraint
+    """
+    return jnp.sum(U_chiral_atom_batch(conf, idxs, kc))
+
+
+def chiral_bond_restraint(conf, params, box, lamb, idxs, kc, signs):
+    """
+    Flat-bottom chiral bond restraint
+    """
+    return jnp.sum(U_chiral_bond_batch(conf, idxs, kc, signs))


### PR DESCRIPTION
This PR implements chiral restraints (which will be later used in SingleTopology, and probably in DualTopology as well) in a controlled way. Suppose the domain of the probability distribution is separated into R and S regions. Suppose we intend to efficiently sample only the R region, using a sampler like MD. These restraints have the following properties:

1) If we sample into the S region, the restraining term turns on, and tries to force the geometry back into R.
2) If we sample into the R region, the restraint is a "flat-bottom", and does not affect the probability distribution within R. 

The two supported types of restraints are chiral pyramidal restraints, and chiral torsion restraints. Both are defined over 4 atoms but with a different convention for computing the chiral volume. The pyramidal restraint is implemented as the triple product of 4 points, and the torsion restraint is implemented as dot product between two cross products. The restraint is also normalized such that its volume is strictly between -1 and 1 (so as to make the strength of the restraint independent of the bond lengths). Tetrahedral restraints are implemented as 4-fold pyramidal restraints arising from 4 choose 3 choices of neighbors.

These restraints will greatly simplify the single topology code, as they're fairly robust against multiple "normal" behaviors (implemented as tests):

1) Inversion of pyramidal centers
2) Inversion of tetrahedral centers
3) Inversion of cis/trans bonds
4) Inversion of even things like spiro centers.

Note that they are not bullet proof, and do require parameterization of a force constant. There are certain pathologies (eg. enforcing trans on a ring bond that should be cis, which would require stretching bonds). In addition, if there are large vdw barriers (eg. nonbonded clashes from either the environment or intramolecular clashes), these probably wouldn't work (but we can detect this cases easily by re-weighting into the +inf potential, or by simply inspecting the geometries themselves to see if we achieve the desired state).

In otherwise, the chiral restraints are strong enough to overcome most angle and torsion terms, but may not be enough to overcome bonded or lennard jones interactions. However, needing to overcome a bond terms is usually indicative of a ring problem, and most tetrahedral centers have 1-2, 1-3, and weaken'd 1-4 exclusions to allow for easier local conversion.
