### PR TITLE
Utilities for find_chiral_atoms and find_chiral_bonds

### DIFF
--- a/tests/test_chiral_utils.py
+++ b/tests/test_chiral_utils.py
@@ -1,0 +1,134 @@
+import numpy as np
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+from timemachine.fe import chiral_utils, utils
+from timemachine.potentials.chiral_restraints import U_chiral_atom_batch, U_chiral_bond_batch
+
+
+def test_setup_chiral_atom_restraints():
+    """On a methane conformer, assert that permuting coordinates or permuting restr_idxs
+    both independently toggle the chiral restraint"""
+    mol = Chem.MolFromMolBlock(
+        """
+  Mrv2202 06072215563D
+
+  5  4  0  0  0  0            999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3633   -0.5138    0.8900 H   0  0  0  0  0  0  0  0  0  0  0  0
+    1.0900    0.0000    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3633    1.0277    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3633   -0.5138   -0.8900 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  1  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+  1  5  1  0  0  0  0
+M  END
+$$$$""",
+        removeHs=False,
+    )
+
+    # needs to be batched in order for jax to play nicely
+    x0 = utils.get_romol_conf(mol)
+    normal_restr_idxs = chiral_utils.setup_chiral_atom_restraints(mol, x0, 0)
+
+    x0_inverted = x0[[0, 2, 1, 3, 4]]  # swap two atoms
+    inverted_restr_idxs = chiral_utils.setup_chiral_atom_restraints(mol, x0_inverted, 0)
+
+    # check the sign of the resulting idxs
+    k = 1000.0
+    assert np.all(np.asarray(U_chiral_atom_batch(x0, normal_restr_idxs, k)) == 0)
+    assert np.all(np.asarray(U_chiral_atom_batch(x0, inverted_restr_idxs, k)) > 0)
+    assert np.all(np.asarray(U_chiral_atom_batch(x0_inverted, normal_restr_idxs, k)) > 0)
+    assert np.all(np.asarray(U_chiral_atom_batch(x0_inverted, inverted_restr_idxs, k)) == 0)
+
+
+def test_setup_chiral_bond_restraints():
+    """On a 'Cl/C(F)=N/F' conformer, assert that flipping a dihedral angle or permuting restr_idxs
+    both independently toggle the chiral bond restraint"""
+
+    mol_cis = Chem.MolFromSmiles(r"Cl\C(F)=N/F")
+    mol_trans = Chem.MolFromSmiles(r"Cl\C(F)=N\F")
+
+    AllChem.EmbedMolecule(mol_cis)
+    AllChem.EmbedMolecule(mol_trans)
+
+    # needs to be batched in order for jax to play nicely
+    x0_cis = utils.get_romol_conf(mol_cis)
+    x0_trans = utils.get_romol_conf(mol_trans)
+    src_atom = 1
+    dst_atom = 3
+    normal_restr_idxs, signs = chiral_utils.setup_chiral_bond_restraints(mol_cis, x0_cis, src_atom, dst_atom)
+
+    inverted_restr_idxs, inverted_signs = chiral_utils.setup_chiral_bond_restraints(
+        mol_trans, x0_trans, src_atom, dst_atom
+    )
+    k = 1000.0
+
+    assert np.all(np.asarray(U_chiral_bond_batch(x0_cis, normal_restr_idxs, k, signs)) == 0)
+    assert np.all(np.asarray(U_chiral_bond_batch(x0_cis, inverted_restr_idxs, k, inverted_signs)) > 0)
+    assert np.all(np.asarray(U_chiral_bond_batch(x0_trans, normal_restr_idxs, k, signs)) > 0)
+    assert np.all(np.asarray(U_chiral_bond_batch(x0_trans, inverted_restr_idxs, k, inverted_signs)) == 0)
+
+
+def test_find_chiral_atoms():
+    # test that we can identify chiral atoms ub a couple of tetrahedral and pyramidal
+    # molecules.
+
+    mol = Chem.MolFromSmiles(r"FC(Cl)Br")
+    res = chiral_utils.find_chiral_atoms(mol)
+    assert res == set([1])
+
+    mol = Chem.MolFromSmiles(r"FN(Cl)Br")
+    res = chiral_utils.find_chiral_atoms(mol)
+    assert res == set([])
+
+    mol = Chem.MolFromSmiles(r"FS(Cl)Br")
+    res = chiral_utils.find_chiral_atoms(mol)
+    assert res == set([1])
+
+    mol = Chem.MolFromSmiles(r"FP(Cl)Br")
+    res = chiral_utils.find_chiral_atoms(mol)
+    assert res == set([1])
+
+    mol = Chem.AddHs(Chem.MolFromSmiles(r"C1CC2CCC3CCC1N23"))
+    res = chiral_utils.find_chiral_atoms(mol)
+    assert res == set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+    mol = Chem.AddHs(Chem.MolFromSmiles(r"n1ccccc1"))
+    res = chiral_utils.find_chiral_atoms(mol)
+    assert res == set()
+
+
+def test_find_chiral_bonds():
+    # test that we can identify chiral bonds in a couple of simple systems
+    # involving double bonds and amides
+
+    mol = Chem.MolFromSmiles(r"FOOF")
+    res = chiral_utils.find_chiral_bonds(mol)
+    assert res == set([])
+
+    mol = Chem.MolFromSmiles(r"FN=NF")
+    res = chiral_utils.find_chiral_bonds(mol)
+    assert res == set([(1, 2)])
+
+    mol = Chem.AddHs(Chem.MolFromSmiles(r"c1cocc1"))
+    res = chiral_utils.find_chiral_bonds(mol)
+    assert res == set()
+
+    mol = Chem.AddHs(Chem.MolFromSmiles(r"C1=CCC=CO1"))
+    res = chiral_utils.find_chiral_bonds(mol)
+    assert res == set([(0, 1), (3, 4)])
+
+    mol = Chem.AddHs(Chem.MolFromSmiles(r"FNC=O"))
+    res = chiral_utils.find_chiral_bonds(mol)
+    assert res == set([(1, 2)])
+
+    # tautomer of the above
+    mol = Chem.AddHs(Chem.MolFromSmiles(r"O\C=N\F"))
+    res = chiral_utils.find_chiral_bonds(mol)
+    assert res == set([(1, 2)])
+
+    mol = Chem.AddHs(Chem.MolFromSmiles(r"N(C)C(C)=O"))
+    res = chiral_utils.find_chiral_bonds(mol)
+    assert res == set([(0, 2)])

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -1,6 +1,7 @@
 import itertools
 
 import numpy as np
+from rdkit import Chem
 
 from timemachine.potentials.chiral_restraints import pyramidal_volume, torsion_volume
 
@@ -9,6 +10,24 @@ def setup_chiral_atom_restraints(mol, conf, a_idx):
     """
     Setup chiral atom restraints for the molecule at a_idx by inspecting the
     given geometry.
+
+    Parameters
+    ----------
+    mol: Chem.Mol
+        input molecule
+
+    conf: np.ndarray (N,3)
+        conformation of the molecule
+
+    a_idx: int
+        Which atom to setup restraints for
+
+    Returns
+    -------
+    list of 4-tuple
+        Has length N choose 3, where N is the number of neighbors
+        (c0, i0, j0, k0), (c0, i1, j1, k1), ...
+
     """
     nbs = mol.GetAtomWithIdx(a_idx).GetNeighbors()
     restr_idxs = []
@@ -27,7 +46,29 @@ def setup_chiral_atom_restraints(mol, conf, a_idx):
 def setup_chiral_bond_restraints(mol, conf, src_idx, dst_idx):
     """
     Setup chiral bond restraints for the molecule at a_idx by inspecting the
-    given geometry
+    given geometry.
+
+    Parameters
+    ----------
+    mol: Chem.Mol
+        input molecule
+
+    conf: np.ndarray (N,3)
+        conformation of the molecule
+
+    src_idx: int
+        Which starting atom of the bond to setup restraints for
+
+    dst_idx: int
+        Which ending atom of the bond to setup restraints for
+
+    Returns
+    -------
+    List of 4-tuple
+        Returns up to 4 chiral volumes based on the torsion of the form:
+        (i_0, src_idx, dst_idx, l_0), (i_1, src_idx, dst_idx, l_1), ...
+
+        Note that i_j may not be necessarily less than l_j
     """
     src_nbs = [a.GetIdx() for a in mol.GetAtomWithIdx(src_idx).GetNeighbors()]
     dst_nbs = [a.GetIdx() for a in mol.GetAtomWithIdx(dst_idx).GetNeighbors()]
@@ -55,3 +96,70 @@ def setup_chiral_bond_restraints(mol, conf, src_idx, dst_idx):
                 signs.append(-1)
 
     return np.array(restr_idxs), np.array(signs)
+
+
+def find_chiral_atoms(mol):
+    """
+    Find chiral atoms in a molecule. Note that an atom is chiral if it has an non-invertible
+    energy barrier. Even a center like methane is considered chiral.
+
+    Parameters
+    ----------
+    mol: Chem.Mol
+        input molecule
+
+    Returns
+    -------
+    set of int
+        Chiral atoms
+
+    """
+    # these should be mutually exclusive, but if any pattern is hit then the results
+    # are accumulated to a set
+    chiral_patterns = [
+        "[X4:1]",  # any tetrahedral atom
+        "[#16X3,#15X3:1]",  # trivalent sulfur, phosphorous are assumed to be non-invertible
+        "[#7X3:1](~[R])(~[R])~[R]",  # nitrogen directly bonded to three ring atoms
+    ]
+
+    chiral_atoms = set()
+    for patt in chiral_patterns:
+        query_mol = Chem.MolFromSmarts(patt)
+        assert query_mol is not None
+        for match in mol.GetSubstructMatches(query_mol):
+            chiral_atoms.add(match[0])
+
+    return chiral_atoms
+
+
+def find_chiral_bonds(mol):
+    """
+    Find chiral bonds in a molecule. Current limited to double bonds and amides. Similarly,
+    a bond is considered chiral if it has an extremely high rotational barrier that would
+    be typically kinetically inaccessible.
+
+    Parameters
+    ----------
+    mol: Chem.Mol
+        input molecule
+
+    Returns
+    -------
+    set of 2-tuple
+        Chiral bonds
+
+    """
+
+    chiral_patterns = [
+        "[X2,X3:1]=[X2,X3:2]",  # all double bonds with two or three neighbors,
+        "[NX3,NX2:1][CX3:2](=[OX1])",  # amide bond
+    ]
+
+    chiral_bonds = set()
+    for patt in chiral_patterns:
+        query_mol = Chem.MolFromSmarts(patt)
+        assert query_mol is not None
+        for match in mol.GetSubstructMatches(query_mol):
+            chiral_bonds.add(tuple(sorted([match[0], match[1]])))
+
+    return chiral_bonds


### PR DESCRIPTION
This PR implements a SMARTS based way to identify chiral atoms and bonds, it's mostly a simplification of a small [comment](https://github.com/proteneer/timemachine/pull/746#discussion_r894019109) that @maxentile made yesterday. Note that chiral here simply means that there's an extremely high inversion barrier, so even a symmetric atom like CH4 would be considered "chiral", since one can't arbitrary swap the two hydrogens without overcoming an extremely high energy barrier (high enough to be deemed kinetically inaccessible in an experiment).

For any given pyramidal structure, eg. NH3, the following permutations would be okay, let (1,2,3) denote the hydrogen barriers:

(1,2,3)
(2,3,1)
(3,1,2)

But pair swaps would be illlegal:

(2,1,3)
(1,3,2)
(3,2,1)

Note that we can't simply inspect force constants, because most classical forcefields are generally not well parameterized with respect to the barrier heights (they only get the curvature of the minimas correct, not the height of the maximas). So we just use a couple of simple heuristics to catch cases like amides, ring bonds, sulfurs, phosphor, etc. 