### PR TITLE
Replace print statement in U_easy with logging

### DIFF
--- a/timemachine/md/enhanced.py
+++ b/timemachine/md/enhanced.py
@@ -2,6 +2,7 @@
 
 # This file contains utility functions to generate samples in the gas-phase.
 
+import logging
 import multiprocessing
 import os
 
@@ -24,6 +25,8 @@ from timemachine.md import builders, minimizer, moves
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.md.states import CoordsVelBox
 from timemachine.potentials import bonded, nonbonded, rmsd
+
+logger = logging.getLogger(__name__)
 
 
 def identify_rotatable_bonds(mol):
@@ -173,7 +176,7 @@ class VacuumState:
         for idxs, params in zip(self.pt_potential.get_idxs(), self.proper_torsion_params):
             _, j, k, _ = idxs
             if (j, k) in rotatable_bonds:
-                print("turning off torsion", idxs)
+                logger.debug(f"turning off torsion %s", idxs)
                 continue
             else:
                 easy_proper_torsion_idxs.append(idxs)

--- a/timemachine/md/enhanced.py
+++ b/timemachine/md/enhanced.py
@@ -176,7 +176,7 @@ class VacuumState:
         for idxs, params in zip(self.pt_potential.get_idxs(), self.proper_torsion_params):
             _, j, k, _ = idxs
             if (j, k) in rotatable_bonds:
-                logger.debug(f"turning off torsion %s", idxs)
+                logger.debug("turning off torsion %s", idxs)
                 continue
             else:
                 easy_proper_torsion_idxs.append(idxs)


### PR DESCRIPTION
`VacuumState.U_easy` currently prints a list of disabled torsions every time it is called, which can lead to a lot of noise in scripts and notebooks.

There is a workaround when running from IPython (e.g. in a Jupyter notebook):

```python
with IPython.utils.io.capture_output(stdout=True, stderr=False):
    # code calling U_easy
```

This PR changes the `print` statement to a `DEBUG`-level log message, so that `turning off torsion` messages will not be printed to stdout unless the logging level is set to `DEBUG` or lower (e.g. with `logging.basicConfig(level=logging.DEBUG)` in application code). 