### PR TITLE
Setup chiral restraints in topology

### DIFF
--- a/tests/test_chiral_utils.py
+++ b/tests/test_chiral_utils.py
@@ -30,10 +30,10 @@ $$$$""",
 
     # needs to be batched in order for jax to play nicely
     x0 = utils.get_romol_conf(mol)
-    normal_restr_idxs = chiral_utils.setup_chiral_atom_restraints(mol, x0, 0)
+    normal_restr_idxs = np.array(chiral_utils.setup_chiral_atom_restraints(mol, x0, 0))
 
     x0_inverted = x0[[0, 2, 1, 3, 4]]  # swap two atoms
-    inverted_restr_idxs = chiral_utils.setup_chiral_atom_restraints(mol, x0_inverted, 0)
+    inverted_restr_idxs = np.array(chiral_utils.setup_chiral_atom_restraints(mol, x0_inverted, 0))
 
     # check the sign of the resulting idxs
     k = 1000.0
@@ -59,10 +59,13 @@ def test_setup_chiral_bond_restraints():
     src_atom = 1
     dst_atom = 3
     normal_restr_idxs, signs = chiral_utils.setup_chiral_bond_restraints(mol_cis, x0_cis, src_atom, dst_atom)
-
+    normal_restr_idxs = np.array(normal_restr_idxs)
+    signs = np.array(signs)
     inverted_restr_idxs, inverted_signs = chiral_utils.setup_chiral_bond_restraints(
         mol_trans, x0_trans, src_atom, dst_atom
     )
+    inverted_restr_idxs = np.array(inverted_restr_idxs)
+    inverted_signs = np.array(inverted_signs)
     k = 1000.0
 
     assert np.all(np.asarray(U_chiral_bond_batch(x0_cis, normal_restr_idxs, k, signs)) == 0)

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -1,6 +1,5 @@
 import itertools
 
-import numpy as np
 from rdkit import Chem
 
 from timemachine.potentials.chiral_restraints import pyramidal_volume, torsion_volume
@@ -36,11 +35,11 @@ def setup_chiral_atom_restraints(mol, conf, a_idx):
         vol = pyramidal_volume(conf[a_idx], conf[i], conf[j], conf[k])
         # vol may be >0 or <0, our chiral restraint always enforces vol < 0.
         if vol < 0:
-            restr_idxs.append([a_idx, i, j, k])
+            restr_idxs.append((a_idx, i, j, k))
         else:
-            restr_idxs.append([a_idx, j, i, k])
+            restr_idxs.append((a_idx, j, i, k))
 
-    return np.array(restr_idxs)
+    return restr_idxs
 
 
 def setup_chiral_bond_restraints(mol, conf, src_idx, dst_idx):
@@ -87,7 +86,7 @@ def setup_chiral_bond_restraints(mol, conf, src_idx, dst_idx):
             # set up torsion i,j,k,l
             i, j, k, l = a, src_idx, dst_idx, b
             vol = torsion_volume(conf[i], conf[j], conf[k], conf[l])
-            restr_idxs.append([i, j, k, l])
+            restr_idxs.append((i, j, k, l))
             if vol < 0:
                 # (jkaus): the restraints are turned on when the volume is positive
                 # so use the opposite sign here
@@ -95,7 +94,7 @@ def setup_chiral_bond_restraints(mol, conf, src_idx, dst_idx):
             else:
                 signs.append(-1)
 
-    return np.array(restr_idxs), np.array(signs)
+    return restr_idxs, signs
 
 
 def find_chiral_atoms(mol):

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -1,20 +1,80 @@
 import functools
+import multiprocessing
 
+import jax
 import jax.numpy as jnp
 import numpy as np
+import scipy
 
-from timemachine.potentials import bonded, nonbonded
+from timemachine.integrator import simulate
+from timemachine.potentials import bonded, chiral_restraints, nonbonded
+
+
+def minimize_scipy(U_fn, x0, return_traj=False):
+    shape = x0.shape
+
+    def U_flat(x_flat):
+        x_full = x_flat.reshape(*shape)
+        return U_fn(x_full)
+
+    grad_bfgs_fn = jax.jit(jax.grad(U_flat))
+
+    traj = []
+
+    def callback_fn(x):
+        traj.append(x.reshape(*shape))
+
+    res = scipy.optimize.minimize(U_flat, x0.reshape(-1), jac=grad_bfgs_fn, callback=callback_fn)
+    xi = res.x.reshape(*shape)
+
+    if return_traj:
+        return traj
+    else:
+        return xi
+
+
+def simulate_system(U_fn, x0, num_samples=20000, steps_per_batch=500, num_workers=None, minimize=True):
+    num_atoms = x0.shape[0]
+    if minimize:
+        x_min = minimize_scipy(U_fn, x0)
+    else:
+        x_min = x0
+    seed = 2023
+
+    num_workers = num_workers or multiprocessing.cpu_count()
+    samples_per_worker = int(np.ceil(num_samples / num_workers))
+
+    burn_in_batches = num_samples // 10
+    frames, _ = simulate(
+        x_min,
+        U_fn,
+        300.0,
+        np.ones(num_atoms) * 4.0,
+        steps_per_batch,
+        samples_per_worker + burn_in_batches,
+        num_workers,
+        seed=seed,
+    )
+    # (ytz): discard burn in batches
+    frames = frames[:, burn_in_batches:, :, :]
+    # collect over all workers
+    frames = frames.reshape(-1, num_atoms, 3)[:num_samples]
+    # sanity check that we didn't undersample
+    assert len(frames) == num_samples
+    return frames
 
 
 class VacuumSystem:
 
     # utility system container
 
-    def __init__(self, bond, angle, torsion, nonbonded):
+    def __init__(self, bond, angle, torsion, nonbonded, chiral_atom, chiral_bond):
         self.bond = bond
         self.angle = angle
         self.torsion = torsion
         self.nonbonded = nonbonded
+        self.chiral_atom = chiral_atom
+        self.chiral_bond = chiral_bond
 
     def get_U_fn(self):
         """
@@ -52,8 +112,33 @@ class VacuumSystem:
             rescale_mask=np.array(self.nonbonded.get_rescale_mask()),
         )
 
+        if self.chiral_atom:
+            chiral_atom_U = functools.partial(
+                chiral_restraints.chiral_atom_restraint,
+                params=np.array(self.chiral_atom.params),
+                box=None,
+                idxs=np.array(self.chiral_atom.get_idxs()),
+                lamb=0.0,
+            )
+        else:
+            chiral_atom_U = lambda _: 0
+
+        if self.chiral_bond:
+            chiral_bond_U = functools.partial(
+                chiral_restraints.chiral_bond_restraint,
+                params=np.array(self.chiral_bond.params),
+                box=None,
+                idxs=np.array(self.chiral_bond.get_idxs()),
+                signs=np.array(self.chiral_bond.get_signs()),
+                lamb=0.0,
+            )
+        else:
+            chiral_bond_U = lambda _: 0
+
         def U_fn(x):
             Us_vdw, Us_coulomb = nbpl_U(x)
-            return bond_U(x) + angle_U(x) + torsion_U(x) + jnp.sum(Us_vdw) + jnp.sum(Us_coulomb)
+            chiral_U = chiral_atom_U(x) + chiral_bond_U(x)
+
+            return bond_U(x) + angle_U(x) + torsion_U(x) + jnp.sum(Us_vdw) + jnp.sum(Us_coulomb) + chiral_U
 
         return U_fn

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -170,6 +170,15 @@ class BondedWrapper(CustomOpWrapper):
             self.args.append(offset)
 
 
+class ChiralAtomRestraint(BondedWrapper):
+    pass
+
+
+class ChiralBondRestraint(BondedWrapper):
+    def get_signs(self):
+        return self.args[1]
+
+
 class HarmonicBond(BondedWrapper):
     pass
 

--- a/timemachine/potentials/chiral_restraints.py
+++ b/timemachine/potentials/chiral_restraints.py
@@ -109,20 +109,27 @@ def U_chiral_bond(x, idxs, kc, s):
     return jnp.where(v > 0, kc * v ** 2, 0.0)
 
 
-# allow batching over multiple_idxs
+# allow batching over multiple idxs and force constants
 U_chiral_atom_batch = jax.vmap(U_chiral_atom, (None, 0, None), 0)
 U_chiral_bond_batch = jax.vmap(U_chiral_bond, (None, 0, None, 0), 0)
 
+# allow batching over multiple idxs and force constants
+U_chiral_atom_batch_all = jax.vmap(U_chiral_atom, (None, 0, 0), 0)
+U_chiral_bond_batch_all = jax.vmap(U_chiral_bond, (None, 0, 0, 0), 0)
 
-def chiral_atom_restraint(conf, params, box, lamb, idxs, kc):
+
+def chiral_atom_restraint(conf, params, box, lamb, idxs):
     """
     Flat-bottom chiral atom restraint
     """
-    return jnp.sum(U_chiral_atom_batch(conf, idxs, kc))
+    assert len(idxs) == len(params)
+    return jnp.sum(U_chiral_atom_batch_all(conf, idxs, params))
 
 
-def chiral_bond_restraint(conf, params, box, lamb, idxs, kc, signs):
+def chiral_bond_restraint(conf, params, box, lamb, idxs, signs):
     """
     Flat-bottom chiral bond restraint
     """
-    return jnp.sum(U_chiral_bond_batch(conf, idxs, kc, signs))
+    assert len(idxs) == len(params)
+    assert len(idxs) == len(signs)
+    return jnp.sum(U_chiral_bond_batch_all(conf, idxs, params, signs))

--- a/timemachine/potentials/nonbonded.py
+++ b/timemachine/potentials/nonbonded.py
@@ -308,9 +308,9 @@ def nonbonded_v3_on_specific_pairs(
     if rescale_mask is not None:
         assert rescale_mask.shape == (len(pairs), 2)
         rescale_vdW = rescale_mask[:, 1]
-        vdW = jnp.where(rescale_vdW != 0, vdW, 0)
+        vdW = jnp.where(rescale_vdW != 0, rescale_vdW * vdW, 0)
         rescale_electrostatics = rescale_mask[:, 0]
-        electrostatics = jnp.where(rescale_electrostatics != 0, electrostatics, 0)
+        electrostatics = jnp.where(rescale_electrostatics != 0, rescale_electrostatics * electrostatics, 0)
 
     return vdW, electrostatics
 


### PR DESCRIPTION
This PR enables the `BaseTopology` to setup the `chiral_restraints` automatically.  This PR has some minor bits cherry-picked from #756 but is mostly independent. 