### PR TITLE
Canonicalize valence indices

### DIFF
--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -159,6 +159,17 @@ def testing_find_dummy_groups_and_multiple_anchors():
         assert jks == [(1, 2)]
 
 
+def assert_bond_idxs_are_canonical(all_idxs):
+    for idxs in all_idxs:
+        assert idxs[0] < idxs[-1]
+
+
+def assert_chiral_atom_idxs_are_canonical(all_idxs):
+    for i, j, k, l in all_idxs:
+        assert (j, k, l) < (l, j, k)
+        assert (j, k, l) < (k, l, j)
+
+
 def test_hif2a_end_state_stability(num_pairs_to_setup=25, num_pairs_to_simulate=5):
     """
     Pick some random pairs from the hif2a set and ensure that they're numerically stable at the
@@ -200,6 +211,15 @@ def test_hif2a_end_state_stability(num_pairs_to_setup=25, num_pairs_to_simulate=
         ]
 
         for system in systems:
+
+            # assert that the idxs are canonicalized.
+            assert_bond_idxs_are_canonical(system.bond.get_idxs())
+            assert_bond_idxs_are_canonical(system.angle.get_idxs())
+            assert_bond_idxs_are_canonical(system.torsion.get_idxs())
+            assert_bond_idxs_are_canonical(system.nonbonded.get_idxs())
+            assert_bond_idxs_are_canonical(system.chiral_bond.get_idxs())
+            assert_chiral_atom_idxs_are_canonical(system.chiral_atom.get_idxs())
+
             U_fn = jax.jit(system.get_U_fn())
             assert np.isfinite(U_fn(x0))
             x_min = minimize_scipy(U_fn, x0)

--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -17,6 +17,7 @@ from timemachine.fe.single_topology_v3 import (
     CoreBondChangeWarning,
     MultipleAnchorWarning,
     SingleTopologyV3,
+    canonicalize_improper_idxs,
     setup_dummy_interactions_from_ff,
 )
 from timemachine.fe.system import minimize_scipy, simulate_system
@@ -165,7 +166,7 @@ def assert_bond_idxs_are_canonical(all_idxs):
 
 
 def assert_chiral_atom_idxs_are_canonical(all_idxs):
-    for i, j, k, l in all_idxs:
+    for _, j, k, l in all_idxs:
         assert (j, k, l) < (l, j, k)
         assert (j, k, l) < (k, l, j)
 
@@ -235,3 +236,20 @@ def test_hif2a_end_state_stability(num_pairs_to_setup=25, num_pairs_to_simulate=
                 assert np.all(np.isfinite(nrgs))
                 assert np.all(np.isfinite(frames))
                 assert np.all(batch_distance_check(frames) < distance_cutoff)
+
+
+def test_canonicalize_improper_idxs():
+
+    # these are in the cw rotation set
+    improper_idxs = [(5, 0, 1, 3), (5, 1, 3, 0), (5, 3, 0, 1)]
+
+    for idxs in improper_idxs:
+        # we should do nothing here.
+        assert idxs == canonicalize_improper_idxs(*idxs)
+
+    # these are in the ccw rotation set
+    #                          1          2          0
+    # bad_improper_idxs = [(5,1,0,3), (5,3,1,0), (5,0,3,1)]
+    assert canonicalize_improper_idxs(5, 1, 0, 3) == (5, 1, 3, 0)
+    assert canonicalize_improper_idxs(5, 3, 1, 0) == (5, 3, 0, 1)
+    assert canonicalize_improper_idxs(5, 0, 3, 1) == (5, 0, 1, 3)

--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -245,11 +245,11 @@ def test_canonicalize_improper_idxs():
 
     for idxs in improper_idxs:
         # we should do nothing here.
-        assert idxs == canonicalize_improper_idxs(*idxs)
+        assert idxs == canonicalize_improper_idxs(idxs)
 
     # these are in the ccw rotation set
     #                          1          2          0
     # bad_improper_idxs = [(5,1,0,3), (5,3,1,0), (5,0,3,1)]
-    assert canonicalize_improper_idxs(5, 1, 0, 3) == (5, 1, 3, 0)
-    assert canonicalize_improper_idxs(5, 3, 1, 0) == (5, 3, 0, 1)
-    assert canonicalize_improper_idxs(5, 0, 3, 1) == (5, 0, 1, 3)
+    assert canonicalize_improper_idxs((5, 1, 0, 3)) == (5, 1, 3, 0)
+    assert canonicalize_improper_idxs((5, 3, 1, 0)) == (5, 3, 0, 1)
+    assert canonicalize_improper_idxs((5, 0, 3, 1)) == (5, 0, 1, 3)

--- a/timemachine/fe/single_topology_v3.py
+++ b/timemachine/fe/single_topology_v3.py
@@ -177,7 +177,7 @@ def setup_dummy_interactions(
     )
 
 
-def canonicalize_improper_idxs(idxs):
+def canonicalize_improper_idxs(idxs) -> Tuple[int, int, int, int]:
     """
     Canonicalize an improper_idx while being symmetry aware.
 

--- a/timemachine/fe/single_topology_v3.py
+++ b/timemachine/fe/single_topology_v3.py
@@ -342,7 +342,6 @@ def setup_end_state(ff, mol_a, mol_b, core, a_to_c, b_to_c):
     torsion_potential = potentials.PeriodicTorsion(mol_c_torsion_idxs_canon).bind(mol_c_torsion_params)
 
     # dummy atoms do not have any nonbonded interactions, so we simply turn them off
-
     mol_c_nbpl_idxs_canon = [canonicalize_bond(idxs) for idxs in mol_a_nbpl_idxs]
     mol_a_nbpl.set_idxs(mol_c_nbpl_idxs_canon)
     nonbonded_potential = mol_a_nbpl.bind(mol_a_nbpl_params)

--- a/timemachine/fe/single_topology_v3.py
+++ b/timemachine/fe/single_topology_v3.py
@@ -1,5 +1,6 @@
 import warnings
 from collections.abc import Iterable
+from typing import Tuple
 
 import numpy as np
 
@@ -202,18 +203,20 @@ def canonicalize_improper_idxs(idxs) -> Tuple[int, int, int, int]:
     jj, kk, ll = sorted(key)
 
     # generate clockwise permutations
-    cw_jkl = (jj, kk, ll)
-    cw_klj = (kk, ll, jj)
-    cw_ljk = (ll, jj, kk)
+    # note: cw/ccw has nothing to do with the direction of rotation
+    # cw/ccw is related by a pair swap.
+    cw_jkl = (jj, kk, ll)  # starting idxs
+    cw_klj = (kk, ll, jj)  # rotate left
+    cw_ljk = (ll, jj, kk)  # rotate left
     cw_items = sorted([cw_jkl, cw_klj, cw_ljk])
 
     if key in cw_items:
         return (i, j, k, l)
 
     # generate counter clockwise permutations
-    ccw_kjl = (kk, jj, ll)
-    ccw_jlk = (jj, ll, kk)
-    ccw_lkj = (ll, kk, jj)
+    ccw_kjl = (kk, jj, ll)  # swap 1st and 2nd element
+    ccw_jlk = (jj, ll, kk)  # rotate left
+    ccw_lkj = (ll, kk, jj)  # rotate left
     ccw_items = sorted([ccw_kjl, ccw_jlk, ccw_lkj])
 
     assert key in ccw_items

--- a/timemachine/fe/single_topology_v3.py
+++ b/timemachine/fe/single_topology_v3.py
@@ -184,8 +184,8 @@ def canonicalize_improper_idxs(idxs):
     Given idxs (i,j,k,l), where i is the center, and (j,k,l) are neighbors:
 
     0) Canonicalize the (j,k,l) into (jj,kk,ll) by sorting
-    1) Generate clockwise rotations of (j,k,l)
-    2) Generate counter clockwise rotations of (j,k,l)
+    1) Generate clockwise rotations of (jj,kk,ll)
+    2) Generate counter clockwise rotations of (jj,kk,ll)
     3) We now can sort 1) and 2) and assign a mapping
 
     If the (j,k,l) is in the cw rotation ordered set, we're done. Otherwise it must


### PR DESCRIPTION
This PR is a sanity PR to ensure that the combined alchemical molecule has valence idxs that are properly canonicalized. Bond, angle, torsion, nonbonded, chiral_bond, are straight forward. chiral_atom has a special symmetry check added.