### PR TITLE
Parameter Interpolatio

### DIFF
--- a/attic/scripts/generate_gradients.py
+++ b/attic/scripts/generate_gradients.py
@@ -232,5 +232,48 @@ def torsion_grads():
             print(out_str, ccode, ");")
 
 
+def pyramidal_volume_grads():
+
+    v0x = x1-x0
+    v0y = y1-y0
+    v0z = z1-z0
+
+    v1x = x2-x0
+    v1y = y2-y0
+    v1z = z2-z0
+
+    v2x = x3-x0
+    v2y = y3-y0
+    v2z = z3-z0
+    
+    n0 = norm(v0x,v0y,v0z)
+    n1 = norm(v1x,v1y,v1z)
+    n2 = norm(v2x,v2y,v2z)
+    
+    u0x = v0x/n0
+    u0y = v0y/n0
+    u0z = v0z/n0
+
+    u1x = v1x/n1
+    u1y = v1y/n1
+    u1z = v1z/n1
+
+    u2x = v2x/n2
+    u2y = v2y/n2
+    u2z = v2z/n2
+
+    cx, cy, cz = cross_product(u0x, u0y, u0z, u1x, u1y, u1z)
+    vol = dot_product(cx, cy, cz, u2x, u2y, u2z)
+
+    dvol_dx0 = sp.ccode(sp.simplify(sp.diff(vol, x0)))
+    dvol_dy0 = sp.ccode(sp.simplify(sp.diff(vol, y0)))
+    dvol_dz0 = sp.ccode(sp.simplify(sp.diff(vol, z0)))
+
+
+    print(dvol_dx0)
+    # print(dvol_dy0)
+    # print(dvol_dz0)
+
 # torsion_grads()
-bond_grads()
+# bond_grads()
+pyramidal_volume_grads()

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -1,0 +1,223 @@
+from jax.config import config
+
+config.update("jax_enable_x64", True)
+
+from importlib import resources
+
+import numpy as np
+from rdkit import Chem
+
+from timemachine.fe import atom_mapping, interpolate, single_topology_v3
+from timemachine.fe.utils import get_romol_conf
+from timemachine.ff import Forcefield
+
+
+def test_align_harmonic_bond():
+    """
+    Test that we can align idxs and parameters correctly for harmonic bonds.
+    We expect that decoupled terms have their force constants turned set to zero,
+    while maintaining the same equilibrium bond lengths.
+    """
+    a, b, c, d, e, f, g, h, i, j = np.random.rand(10)
+
+    # tbd: what do we do if there are repeats?
+    # merge repeats into a single term first?
+    src_idxs = [(4, 9), (3, 4)]
+    src_params = [(a, b), (c, d)]
+
+    dst_idxs = [(3, 4), (5, 9), (2, 3)]
+    dst_params = [(e, f), (g, h), (i, j)]
+
+    test_kv = interpolate.align_harmonic_bond_idxs_and_params(src_idxs, src_params, dst_idxs, dst_params)
+
+    ref_kv = {
+        ((4, 9), (a, b), (0, b)),
+        ((3, 4), (c, d), (e, f)),
+        ((5, 9), (0, h), (g, h)),
+        ((2, 3), (0, j), (i, j)),
+    }
+
+    assert test_kv == ref_kv
+
+
+def test_align_harmonic_angle():
+    """
+    Test that we can align idxs and parameters correctly for harmonic angles.
+    We expect that decoupled terms have their force constants turned set to zero,
+    while maintaining the same equilibrium angles.
+    """
+    a, b, c, d, e, f, g, h, i, j = np.random.rand(10)
+
+    # tbd: what do we do if there are repeats?
+    # merge repeats into a single term first?
+    src_idxs = [(4, 9, 5), (3, 4, 6)]
+    src_params = [(a, b), (c, d)]
+
+    dst_idxs = [(3, 4, 6), (4, 5, 9), (2, 3, 4)]
+    dst_params = [(e, f), (g, h), (i, j)]
+
+    test_kv = interpolate.align_harmonic_bond_idxs_and_params(src_idxs, src_params, dst_idxs, dst_params)
+
+    ref_kv = {
+        ((4, 9, 5), (a, b), (0, b)),
+        ((3, 4, 6), (c, d), (e, f)),
+        ((4, 5, 9), (0, h), (g, h)),
+        ((2, 3, 4), (0, j), (i, j)),
+    }
+
+    assert test_kv == ref_kv
+
+
+def test_align_torsion():
+    """
+    Test that we can align idxs and parameters correctly for periodic torsions.
+    Periodic torsions differ from bonds and angles in that their uniqueness is
+    also determined by the "period", which is currently encoded as one of the parameters.
+
+    We expect that decoupled terms have their force constants turned set to zero,
+    while maintaining the same equilibrium angles for the *same* period.
+    """
+    a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p = np.random.rand(16)
+
+    # tbd: what do we do if there are repeats?
+    # merge repeats into a single term first?
+    src_idxs = [(2, 3, 9, 4), (2, 1, 4, 3), (0, 1, 4, 2), (0, 1, 4, 2)]
+    src_params = [(a, b, 2), (c, d, 1), (e, f, 3), (g, h, 1)]
+
+    dst_idxs = [(2, 3, 9, 4), (2, 3, 9, 4), (0, 1, 4, 2), (3, 0, 2, 6)]
+    dst_params = [(i, j, 2), (k, l, 1), (m, n, 3), (o, p, 4)]
+
+    test_kv = interpolate.align_torsion_idxs_and_params(src_idxs, src_params, dst_idxs, dst_params)
+
+    ref_kv = {
+        ((2, 3, 9, 4), (a, b, 2), (i, j, 2)),
+        ((2, 1, 4, 3), (c, d, 1), (0, d, 1)),
+        ((0, 1, 4, 2), (e, f, 3), (m, n, 3)),
+        ((0, 1, 4, 2), (g, h, 1), (0, h, 1)),
+        ((2, 3, 9, 4), (0, l, 1), (k, l, 1)),
+        ((3, 0, 2, 6), (0, p, 4), (o, p, 4)),
+    }
+
+    assert test_kv == ref_kv
+
+
+def test_align_nonbonded():
+    """
+    Test that we can align idxs and parameters for nonbonded forces. For decoupled
+    nonbonded interactions, we should set q_ij, s_ij, and e_ij all to zero.
+    """
+    a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r = np.random.rand(18)
+
+    src_idxs = [(0, 3), (0, 2), (2, 3), (2, 4)]
+    src_params = [(a, b, c), (d, e, f), (g, h, i), (j, k, l)]
+    dst_idxs = [(0, 2), (4, 5)]
+    dst_params = [(m, n, o), (p, q, r)]
+
+    test_kv = interpolate.align_nonbonded_idxs_and_params(src_idxs, src_params, dst_idxs, dst_params)
+
+    ref_kv = {
+        ((0, 3), (a, b, c), (0, 0, 0)),
+        ((0, 2), (d, e, f), (m, n, o)),
+        ((2, 3), (g, h, i), (0, 0, 0)),
+        ((2, 4), (j, k, l), (0, 0, 0)),
+        ((4, 5), (0, 0, 0), (p, q, r)),
+    }
+
+    assert test_kv == ref_kv
+
+
+def test_align_chiral_atoms():
+    """
+    Test that we can align idxs and parameters for chiral atom restraints. We should
+    expect that force constants are set to zero.
+    """
+    a, b, c, d, e = np.random.rand(5)
+
+    src_idxs = [(0, 3, 4, 5), (0, 4, 3, 5), (4, 3, 5, 6)]
+    src_params = [a, b, c]
+    dst_idxs = [(0, 4, 3, 5), (4, 3, 5, 7)]
+    dst_params = [d, e]
+
+    test_kv = interpolate.align_chiral_atom_idxs_and_params(src_idxs, src_params, dst_idxs, dst_params)
+
+    ref_kv = {
+        ((0, 3, 4, 5), a, 0),
+        ((0, 4, 3, 5), b, d),
+        ((4, 3, 5, 6), c, 0),
+        ((4, 3, 5, 7), 0, e),
+    }
+
+    assert test_kv == ref_kv
+
+
+def test_align_chiral_bonds():
+
+    a, b, c, d, e, f, g = np.random.rand(7)
+
+    src_idxs = [(0, 3, 4, 5), (0, 3, 4, 5), (0, 4, 3, 5), (4, 3, 5, 6)]
+    src_params = [a, b, c, d]
+    src_signs = [1, -1, 1, 1]
+    dst_idxs = [(4, 3, 5, 7), (0, 3, 4, 5), (4, 3, 5, 6)]
+    dst_params = [e, f, g]
+    dst_signs = [1, -1, -1]
+
+    test_kv = interpolate.align_chiral_bond_idxs_and_params(
+        src_idxs, src_params, src_signs, dst_idxs, dst_params, dst_signs
+    )
+
+    ref_kv = {
+        ((0, 3, 4, 5), 1, a, 0),
+        ((0, 3, 4, 5), -1, b, f),
+        ((0, 4, 3, 5), 1, c, 0),
+        ((4, 3, 5, 6), 1, d, 0),
+        ((4, 3, 5, 6), -1, 0, g),
+        ((4, 3, 5, 7), 1, 0, e),
+    }
+
+    assert test_kv == ref_kv
+
+
+def test_intermediate_states(num_pairs_to_setup=10):
+    """
+    Test that intermediate states evaluated at lambda=0 and lambda=1 have the same energy
+    as the src and dst end-states.
+    """
+
+    with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
+        suppl = Chem.SDMolSupplier(str(path_to_ligand), removeHs=False)
+        mols = [m for m in suppl]
+
+    pairs = [(mol_a, mol_b) for mol_a in mols for mol_b in mols]
+    np.random.seed(2023)
+    np.random.shuffle(pairs)
+    ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
+
+    for mol_a, mol_b in pairs[:num_pairs_to_setup]:
+
+        print("Checking", mol_a.GetProp("_Name"), "->", mol_b.GetProp("_Name"))
+        mcs_threshold = 0.75  # distance threshold, in nanometers
+        res = atom_mapping.mcs_map(mol_a, mol_b, mcs_threshold)
+        query = Chem.MolFromSmarts(res.smartsString)
+        core_pairs = atom_mapping.get_core_by_mcs(mol_a, mol_b, query, mcs_threshold)
+
+        top = single_topology_v3.SingleTopologyV3(mol_a, mol_b, core_pairs, ff)
+        x0 = top.combine_confs(get_romol_conf(mol_a), get_romol_conf(mol_b))
+
+        # test end-states and check to see if the forces are the same
+        system_src = top.setup_end_state_src()
+        system_lambda_0 = top.setup_intermediate_state(0)
+
+        U_ref = system_src.get_U_fn()
+        U_test = system_lambda_0.get_U_fn()
+
+        # these are not guaranteed to be bitwise identical
+        # since the permuting the order of idxs will affect
+        # the order of operations
+        np.testing.assert_almost_equal(U_ref(x0), U_test(x0))
+
+        system_dst = top.setup_end_state_dst()
+        system_lambda_1 = top.setup_intermediate_state(1)
+        U_ref = system_dst.get_U_fn()
+        U_test = system_lambda_1.get_U_fn()
+
+        np.testing.assert_almost_equal(U_ref(x0), U_test(x0))

--- a/tests/test_interpolate_fe.py
+++ b/tests/test_interpolate_fe.py
@@ -1,0 +1,104 @@
+# test that we can estimate free energies reliably using pair bar.
+import multiprocessing
+import os
+from importlib import resources
+
+import jax
+import numpy as np
+import pymbar
+from rdkit import Chem
+
+from timemachine.constants import BOLTZ
+from timemachine.fe import single_topology_v3
+from timemachine.fe.system import simulate_system
+from timemachine.fe.utils import get_romol_conf
+from timemachine.ff import Forcefield
+
+os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=" + str(multiprocessing.cpu_count())
+
+
+def test_hif2a_free_energy_estimates():
+    # Test that we can estimate the free energy differences for some simple transformations
+
+    forcefield = Forcefield.load_from_file("smirnoff_1_1_0_ccc.py")
+
+    with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
+        suppl = Chem.SDMolSupplier(str(path_to_ligand), removeHs=False)
+
+    all_mols = [x for x in suppl]
+    mol_a = all_mols[1]
+    mol_b = all_mols[4]
+
+    core = np.array(
+        [
+            [0, 0],
+            [2, 2],
+            [1, 1],
+            [6, 6],
+            [5, 5],
+            [4, 4],
+            [3, 3],
+            [15, 16],
+            [16, 17],
+            [17, 18],
+            [18, 19],
+            [19, 20],
+            [20, 21],
+            [32, 30],
+            [26, 25],
+            [27, 26],
+            [7, 7],
+            [8, 8],
+            [9, 9],
+            [10, 10],
+            [29, 11],
+            [11, 12],
+            [12, 13],
+            [14, 15],
+            [31, 29],
+            [13, 14],
+            [23, 24],
+            [30, 28],
+            [28, 27],
+            [21, 22],
+        ]
+    )
+
+    st = single_topology_v3.SingleTopologyV3(mol_a, mol_b, core, forcefield)
+
+    # lambda_schedule = np.linspace(0.0, 1.0, 5)
+    lambda_schedule = np.linspace(0.0, 0.1, 10)
+    systems = [st.setup_intermediate_state(lamb) for lamb in lambda_schedule]
+    U_fns = [sys.get_U_fn() for sys in systems]
+
+    batch_U_fns = [jax.vmap(x) for x in U_fns]
+
+    all_frames = []
+
+    x0 = st.combine_confs(get_romol_conf(mol_a), get_romol_conf(mol_b))
+
+    kT = BOLTZ * 300.0
+    beta = 1 / kT
+
+    for lambda_idx, U_fn in enumerate(U_fns):
+
+        all_frames.append(simulate_system(U_fn, x0, num_samples=1000))
+
+        if lambda_idx > 0:
+
+            prev_frames = all_frames[lambda_idx - 1]
+            cur_frames = all_frames[lambda_idx]
+
+            prev_U_fn = batch_U_fns[lambda_idx - 1]
+            cur_U_fn = batch_U_fns[lambda_idx]
+
+            fwd_delta_u = beta * (cur_U_fn(prev_frames) - prev_U_fn(prev_frames))
+            rev_delta_u = beta * (prev_U_fn(cur_frames) - cur_U_fn(cur_frames))
+
+            dG_exact, exact_bar_err = pymbar.BAR(fwd_delta_u, rev_delta_u)
+            dG_exact /= beta
+            exact_bar_err /= beta
+
+            print(
+                f"BAR: lambda {lambda_schedule[lambda_idx-1]:.3f} -> {lambda_schedule[lambda_idx]:.3f} dG: {dG_exact:.3f} dG_err: {exact_bar_err:.3f}"
+            )

--- a/timemachine/fe/interpolate.py
+++ b/timemachine/fe/interpolate.py
@@ -1,0 +1,217 @@
+import numpy as np
+
+
+def _add_dst_to_src_bond_or_angle(src_idxs, src_params, dst_idxs, dst_params):
+    """
+    eg:
+    src_idxs: [[4,9], [3,4]]
+    src_params: [[a, b], [c, d]]
+
+    dst_idxs: [[3,4], [9,5]]
+    dst_params: [[e, f], [g, h]]
+
+    zero_flags: [True, False]
+
+    Generate end-state key value pairs
+
+    src_idxs: [[4,9], [3,4], [9,5]]
+    src_params: [[a,b], [c,d], [0,h]
+
+    """
+    # used for:
+    # bonds, angles, and nonbonded terms. do not use this for torsions since the periods
+    # are unstable. note that *missing* terms are the result of core-hopping, or chiral
+    # inversions on core atoms. dummy atom interactions (bonds/angles) are fully maintained
+    # at the end-state.
+    assert len(set((src_idxs))) == len(src_idxs)
+    assert len(set((dst_idxs))) == len(dst_idxs)
+
+    src_kv = dict(zip(src_idxs, src_params))
+    for idxs, params in zip(dst_idxs, dst_params):
+        assert idxs[0] < idxs[-1]
+        if idxs not in src_kv:
+            # new_params = []
+            _, bond_or_angle = params
+            src_kv[idxs] = (0, bond_or_angle)
+
+    return src_kv
+
+
+def align_harmonic_bond_or_angle_idxs_and_params(src_idxs, src_params, dst_idxs, dst_params):
+
+    # sanitize
+    src_idxs = [tuple(p) for p in src_idxs]
+    src_params = [tuple(p) for p in src_params]
+    dst_idxs = [tuple(p) for p in dst_idxs]
+    dst_params = [tuple(p) for p in dst_params]
+
+    src_kv = _add_dst_to_src_bond_or_angle(src_idxs, src_params, dst_idxs, dst_params)
+    dst_kv = _add_dst_to_src_bond_or_angle(dst_idxs, dst_params, src_idxs, src_params)
+    assert src_kv.keys() == dst_kv.keys()
+
+    res = set()
+
+    for k in src_kv.keys():
+        res.add((tuple(k), src_kv[k], dst_kv[k]))
+
+    return res
+
+
+align_harmonic_bond_idxs_and_params = align_harmonic_bond_or_angle_idxs_and_params
+align_harmonic_angle_idxs_and_params = align_harmonic_bond_or_angle_idxs_and_params
+
+# special case for torsions
+def _add_dst_to_src_torsion(src_idxs, src_params, dst_idxs, dst_params):
+
+    src_kv = dict()
+
+    for idxs, params in zip(src_idxs, src_params):
+        assert idxs[0] < idxs[-1]
+        k, phase, period = params
+        key = (idxs, period)
+        src_kv[key] = (k, phase)
+
+    for idxs, params in zip(dst_idxs, dst_params):
+        assert idxs[0] < idxs[-1]
+        k, phase, period = params
+        key = (idxs, period)
+        if key not in src_kv:
+            src_kv[key] = (0, phase)
+
+    return src_kv
+
+
+def align_torsion_idxs_and_params(src_idxs, src_params, dst_idxs, dst_params):
+
+    # sanitize
+    src_idxs = [tuple(p) for p in src_idxs]
+    src_params = [tuple(p) for p in src_params]
+    dst_idxs = [tuple(p) for p in dst_idxs]
+    dst_params = [tuple(p) for p in dst_params]
+
+    src_kv = _add_dst_to_src_torsion(src_idxs, src_params, dst_idxs, dst_params)
+    dst_kv = _add_dst_to_src_torsion(dst_idxs, dst_params, src_idxs, src_params)
+
+    assert src_kv.keys() == dst_kv.keys()
+
+    res = set()
+
+    for key in src_kv.keys():
+        idxs, period = key
+        assert idxs[0] < idxs[-1]
+        src_k, src_phase = src_kv[key]
+        dst_k, dst_phase = dst_kv[key]
+        res.add((idxs, (src_k, src_phase, period), (dst_k, dst_phase, period)))
+
+    return res
+
+
+def _add_dst_to_src_nonbonded(src_idxs, src_params, dst_idxs):
+    assert len(set((src_idxs))) == len(src_idxs)
+    assert len(set((dst_idxs))) == len(dst_idxs)
+
+    src_kv = dict(zip(src_idxs, src_params))
+    for idxs in dst_idxs:
+        assert idxs[0] < idxs[-1]
+        if idxs not in src_kv:
+            src_kv[idxs] = (0, 0, 0)
+
+    return src_kv
+
+
+def align_nonbonded_idxs_and_params(src_idxs, src_params, dst_idxs, dst_params):
+
+    # sanitize
+    src_idxs = [tuple(p) for p in src_idxs]
+    src_params = [tuple(p) for p in src_params]
+    dst_idxs = [tuple(p) for p in dst_idxs]
+    dst_params = [tuple(p) for p in dst_params]
+
+    src_kv = _add_dst_to_src_nonbonded(src_idxs, src_params, dst_idxs)
+    dst_kv = _add_dst_to_src_nonbonded(dst_idxs, dst_params, src_idxs)
+    assert src_kv.keys() == dst_kv.keys()
+
+    res = set()
+
+    for k in src_kv.keys():
+        res.add((tuple(k), src_kv[k], dst_kv[k]))
+
+    return res
+
+
+# special case for torsions
+def _add_dst_to_src_chiral_atom(src_idxs, src_params, dst_idxs):
+    src_kv = dict()
+
+    for idxs, k in zip(src_idxs, src_params):
+        src_kv[idxs] = k
+
+    for idxs in dst_idxs:
+        if idxs not in src_kv:
+            src_kv[idxs] = 0
+
+    return src_kv
+
+
+def align_chiral_atom_idxs_and_params(src_idxs, src_params, dst_idxs, dst_params):
+
+    # sanitize
+    src_idxs = [tuple(p) for p in src_idxs]
+    dst_idxs = [tuple(p) for p in dst_idxs]
+
+    src_kv = _add_dst_to_src_chiral_atom(src_idxs, src_params, dst_idxs)
+    dst_kv = _add_dst_to_src_chiral_atom(dst_idxs, dst_params, src_idxs)
+    assert src_kv.keys() == dst_kv.keys()
+
+    res = set()
+
+    for k in src_kv.keys():
+        res.add((tuple(k), src_kv[k], dst_kv[k]))
+
+    return res
+
+
+def _add_dst_to_src_chiral_bond(src_idxs, src_params, src_signs, dst_idxs, dst_params, dst_signs):
+    src_kv = dict()
+
+    for idxs, k, sign in zip(src_idxs, src_params, src_signs):
+        assert idxs[0] < idxs[-1]
+        key = (idxs, sign)
+        src_kv[key] = k
+
+    for idxs, k, sign in zip(dst_idxs, dst_params, dst_signs):
+        assert idxs[0] < idxs[-1]
+        key = (idxs, sign)
+        if key not in src_kv:
+            src_kv[key] = 0
+
+    return src_kv
+
+
+def align_chiral_bond_idxs_and_params(src_idxs, src_params, src_signs, dst_idxs, dst_params, dst_signs):
+
+    # sanitize
+    src_idxs = [tuple(p) for p in src_idxs]
+    dst_idxs = [tuple(p) for p in dst_idxs]
+
+    src_kv = _add_dst_to_src_chiral_bond(src_idxs, src_params, src_signs, dst_idxs, dst_params, dst_signs)
+    dst_kv = _add_dst_to_src_chiral_bond(dst_idxs, dst_params, dst_signs, src_idxs, src_params, src_signs)
+
+    assert src_kv.keys() == dst_kv.keys()
+
+    res = set()
+
+    for key in src_kv.keys():
+        idxs, sign = key
+        src_k = src_kv[key]
+        dst_k = dst_kv[key]
+        res.add((idxs, sign, src_k, dst_k))
+
+    return res
+
+
+def linear_interpolation(src_params, dst_params, lamb):
+    """
+    Linearly interpolate between src and dst params
+    """
+    return (1 - lamb) * np.array(src_params) + lamb * np.array(dst_params)

--- a/timemachine/fe/single_topology_v3.py
+++ b/timemachine/fe/single_topology_v3.py
@@ -4,7 +4,7 @@ from typing import Tuple
 
 import numpy as np
 
-from timemachine.fe import system, topology, utils
+from timemachine.fe import interpolate, system, topology, utils
 from timemachine.fe.dummy import canonicalize_bond, identify_dummy_groups, identify_root_anchors
 from timemachine.lib import potentials
 
@@ -612,3 +612,95 @@ class SingleTopologyV3:
             return (1 - lamb) * U0_fn(x) + lamb * U1_fn(x)
 
         return U_fn
+
+    def _setup_intermediate_bonded_term(self, src_bond, dst_bond, lamb, align_fn, interpolate_fn):
+
+        src_cls_bond = type(src_bond)
+        dst_cls_bond = type(dst_bond)
+
+        assert src_cls_bond == dst_cls_bond
+
+        bond_idxs_and_params = align_fn(
+            src_bond.get_idxs(),
+            src_bond.params,
+            dst_bond.get_idxs(),
+            dst_bond.params,
+        )
+        bond_idxs = []
+        bond_params = []
+        for idxs, src_params, dst_params in bond_idxs_and_params:
+            bond_idxs.append(idxs)
+            new_params = interpolate_fn(src_params, dst_params, lamb)
+            bond_params.append(new_params)
+
+        if src_cls_bond == potentials.NonbondedPairListPrecomputed:
+            assert src_bond.get_beta() == dst_bond.get_beta()
+            assert src_bond.get_cutoff() == dst_bond.get_cutoff()
+            return src_cls_bond(np.array(bond_idxs), src_bond.get_beta(), src_bond.get_cutoff()).bind(bond_params)
+        else:
+            return src_cls_bond(np.array(bond_idxs)).bind(bond_params)
+
+    def _setup_intermediate_chiral_bond_term(self, src_bond, dst_bond, lamb, interpolate_fn):
+
+        assert type(src_bond) == potentials.ChiralBondRestraint
+        assert type(dst_bond) == potentials.ChiralBondRestraint
+
+        idxs_and_params = interpolate.align_chiral_bond_idxs_and_params(
+            src_bond.get_idxs(),
+            src_bond.params,
+            src_bond.get_signs(),
+            dst_bond.get_idxs(),
+            dst_bond.params,
+            dst_bond.get_idxs(),
+        )
+        chiral_bond_idxs = []
+        chiral_bond_params = []
+        chiral_bond_signs = []
+        for idxs, sign, src_k, dst_k in idxs_and_params:
+            chiral_bond_idxs.append(idxs)
+            new_params = interpolate_fn(src_k, dst_k, lamb)
+            chiral_bond_params.append(new_params)
+            chiral_bond_signs.append(sign)
+
+        # these should be properly sized
+        chiral_bond_idxs = np.array(chiral_bond_idxs, dtype=np.int32).reshape((-1, 4))
+
+        return potentials.ChiralBondRestraint(chiral_bond_idxs, chiral_bond_signs).bind(chiral_bond_params)
+
+    def setup_intermediate_state(self, lamb):
+        """
+        Setup intermediate states at some value of lambda.
+        """
+        src_system = self.setup_end_state_src()
+        dst_system = self.setup_end_state_dst()
+        interpolate_fn = interpolate.linear_interpolation
+
+        # tbd: use different interpolation functions later
+        bond = self._setup_intermediate_bonded_term(
+            src_system.bond, dst_system.bond, lamb, interpolate.align_harmonic_bond_idxs_and_params, interpolate_fn
+        )
+        angle = self._setup_intermediate_bonded_term(
+            src_system.angle, dst_system.angle, lamb, interpolate.align_harmonic_angle_idxs_and_params, interpolate_fn
+        )
+        torsion = self._setup_intermediate_bonded_term(
+            src_system.torsion, dst_system.torsion, lamb, interpolate.align_torsion_idxs_and_params, interpolate_fn
+        )
+        nonbonded = self._setup_intermediate_bonded_term(
+            src_system.nonbonded,
+            dst_system.nonbonded,
+            lamb,
+            interpolate.align_nonbonded_idxs_and_params,
+            interpolate_fn,
+        )
+        chiral_atom = self._setup_intermediate_bonded_term(
+            src_system.chiral_atom,
+            dst_system.chiral_atom,
+            lamb,
+            interpolate.align_chiral_atom_idxs_and_params,
+            interpolate_fn,
+        )
+        chiral_bond = self._setup_intermediate_chiral_bond_term(
+            src_system.chiral_bond, dst_system.chiral_bond, lamb, interpolate_fn
+        )
+
+        return system.VacuumSystem(bond, angle, torsion, nonbonded, chiral_atom, chiral_bond)


### PR DESCRIPTION
This PR sets up parameter interpolation for bond, angle, torsion, nonbonded, chiral_atom/bond terms. It roughly operates in two passes:

1) For a given potential, define its idxs and parameters at the end-states as `idxs0, p0` and `idxs1, p1`
2) `idxs0` and `idxs1` are aligned and deduplicated to generate a list of tuples `idxs_c, (p0, p1)`
3) A simple linear interpolation scheme `p_i(lambda)=(1-lambda)*p0 + lambda*p1` is implemented, but @mcwitt will be optimizing this extensively to be more efficient.

There were lots of tricky cases to cover:

1) for bonded terms that are being turned off,  equilibrium bond lengths, angles, and phases are *not* modified. only the force constants are scaled down.
2) for nonbonded terms that are being turned off, `q_ij`, `sig_ij`, `eps_ij` are *all* scaled down.
3) for chiral bond restraints, the deduplication uses the `sign` information in addition to the `idxs` 
4) for torsions, the deduplication uses the `period` information in addition to the `idxs`

Not done yet:

documentation on tests some of the functions - trying to figure out what level of detail I should add to them.