### PR TITLE
Add flat-bottom bond potential

### DIFF
--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -70,6 +70,7 @@ pybind11_add_module(${LIBRARY_NAME} SHARED NO_EXTRAS
   src/nonbonded_interaction_group.cu
   src/neighborlist.cu
   src/harmonic_bond.cu
+  src/flat_bottom_bond.cu
   src/harmonic_angle.cu
   src/periodic_torsion.cu
   src/integrator.cu

--- a/timemachine/cpp/src/flat_bottom_bond.cu
+++ b/timemachine/cpp/src/flat_bottom_bond.cu
@@ -1,0 +1,73 @@
+#include "gpu_utils.cuh"
+#include "flat_bottom_bond.hpp"
+#include "k_flat_bottom_bond.cuh"
+#include "kernel_utils.cuh"
+#include "math_utils.cuh"
+#include <vector>
+
+namespace timemachine {
+
+template <typename RealType>
+FlatBottomBond<RealType>::FlatBottomBond(const std::vector<int> &bond_idxs)
+    : B_(bond_idxs.size() / 2) {
+    
+    // validate bond_idxs: even length, all idxs non-negative, and no self-edges
+    if (bond_idxs.size() % 2 != 0) {
+        throw std::runtime_error("bond_idxs.size() must be exactly 2*k!");
+    }
+
+    for (int b = 0; b < B_; b++) {
+        auto src = bond_idxs[b * 2 + 0];
+        auto dst = bond_idxs[b * 2 + 1];
+        if (src == dst) {
+            throw std::runtime_error("src == dst");
+        }
+
+        if ((src < 0) or (dst < 0)) {
+            throw std::runtime_error("idxs must be non-negative");
+        }
+    }
+
+    // copy idxs to device
+    gpuErrchk(cudaMalloc(&d_bond_idxs_, B_ * 2 * sizeof(*d_bond_idxs_)));
+    gpuErrchk(cudaMemcpy(d_bond_idxs_, &bond_idxs[0], B_ * 2 * sizeof(*d_bond_idxs_), cudaMemcpyHostToDevice));
+};
+
+template <typename RealType> FlatBottomBond<RealType>::~FlatBottomBond() {
+    gpuErrchk(cudaFree(d_bond_idxs_));
+};
+
+template <typename RealType>
+void FlatBottomBond<RealType>::execute_device(
+    const int N,
+    const int P,
+    const double *d_x,
+    const double *d_p,
+    const double *d_box,
+    const double lambda,
+    unsigned long long *d_du_dx,
+    unsigned long long *d_du_dp,
+    unsigned long long *d_du_dl,
+    unsigned long long *d_u,
+    cudaStream_t stream) {
+
+    const int num_params_per_bond = 3;
+    int expected_P = num_params_per_bond * B_;
+
+    if (P != expected_P) {
+        throw std::runtime_error("FlatBottomBond::execute_device(): expected P == " + std::to_string(expected_P) + ", got P=" + std::to_string(P));
+    }
+
+    if (B_ > 0) {
+        const int tpb = warp_size;
+        const int blocks = ceil_divide(B_, tpb);
+
+        k_flat_bottom_bond<RealType><<<blocks, tpb, 0, stream>>>(B_, d_x, d_p, d_bond_idxs_, d_du_dx, d_du_dp, d_u);
+        gpuErrchk(cudaPeekAtLastError());
+    }
+};
+
+template class FlatBottomBond<double>;
+template class FlatBottomBond<float>;
+
+} // namespace timemachine

--- a/timemachine/cpp/src/flat_bottom_bond.hpp
+++ b/timemachine/cpp/src/flat_bottom_bond.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "potential.hpp"
+#include <vector>
+
+namespace timemachine {
+
+template <typename RealType> class FlatBottomBond : public Potential {
+
+private:
+    int *d_bond_idxs_;
+
+    const int B_;
+
+public:
+    int num_bonds() const { return B_; }
+
+    FlatBottomBond(const std::vector<int> &bond_idxs);    // [B, 2]
+
+    ~FlatBottomBond();
+
+    virtual void execute_device(
+        const int N,
+        const int P,
+        const double *d_x,
+        const double *d_p,
+        const double *d_box,
+        const double lambda,
+        unsigned long long *d_du_dx,
+        unsigned long long *d_du_dp,
+        unsigned long long *d_du_dl,
+        unsigned long long *d_u,
+        cudaStream_t stream) override;
+};
+
+} // namespace timemachine

--- a/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
@@ -1,0 +1,98 @@
+#include "../fixed_point.hpp"
+#include "k_fixed_point.cuh"
+
+template <typename RealType>
+void __global__ k_flat_bottom_bond(
+    const int B, // number of bonds
+    const double *__restrict__ coords,
+    const double *__restrict__ params, // [P, 3]
+    const int *__restrict__ bond_idxs, // [B, 2]
+    unsigned long long *__restrict__ du_dx,
+    unsigned long long *__restrict__ du_dp,
+    unsigned long long *__restrict__ u) {
+
+    // which bond
+    const auto b_idx = blockDim.x * blockIdx.x + threadIdx.x;
+    if (b_idx >= B) {
+        return;
+    }
+
+    // which atoms
+    const int num_atoms = 2;
+    int atoms_idx = b_idx * num_atoms;
+    int src_idx = bond_idxs[atoms_idx + 0];
+    int dst_idx = bond_idxs[atoms_idx + 1];
+
+    // look up params
+    const int num_params = 3;
+    int params_idx = b_idx * num_params;
+    int k_idx = params_idx + 0;
+    int rmin_idx = params_idx + 1;
+    int rmax_idx = params_idx + 2;
+
+    RealType k = params[k_idx];
+    RealType rmin = params[rmin_idx];
+    RealType rmax = params[rmax_idx];
+
+    // compute common subexpressions involving distance, displacements
+    RealType dx[3];
+    RealType r2 = 0;
+    for (int d = 0; d < 3; d++) {
+        RealType delta = coords[src_idx * 3 + d] - coords[dst_idx * 3 + d];
+        dx[d] = delta;
+        r2 += delta * delta;
+    }
+    RealType r = sqrt(r2);
+
+    // branches -> masks
+    RealType r_gt_rmax = static_cast<RealType>(r > rmax);
+    RealType r_lt_rmin = static_cast<RealType>(r < rmin);
+
+    if (u) {
+        // branchless implementation of piecewise function
+        RealType u_real = (k/4) * (r_lt_rmin * (pow(r - rmin, 4)) + r_gt_rmax * (pow(r - rmax, 4)));
+
+        // cast float -> fixed
+        auto sum_u = FLOAT_TO_FIXED_BONDED<RealType>(u_real);
+        
+        // atomic add to u array
+        atomicAdd(u + src_idx, sum_u);
+    }
+
+    if (du_dp) {
+        // compute parameter derivatives
+        RealType du_dk_real =
+            (r_gt_rmax * (pow(r - rmax, 4) / 4)) +
+            (r_lt_rmin * (pow(r - rmin, 4) / 4));
+        RealType du_drmin_real = r_lt_rmin * (-k * pow(r - rmin, 3));
+        RealType du_drmax_real = r_gt_rmax * (-k * pow(r - rmax, 3));
+        
+        // cast float -> fixed
+        auto du_dk = FLOAT_TO_FIXED_BONDED<RealType>(du_dk_real);
+        auto du_drmin = FLOAT_TO_FIXED_BONDED<RealType>(du_drmin_real);
+        auto du_drmax = FLOAT_TO_FIXED_BONDED<RealType>(du_drmax_real);
+
+        // increment du_dp array
+        atomicAdd(du_dp + k_idx, du_dk);
+        atomicAdd(du_dp + rmin_idx, du_drmin);
+        atomicAdd(du_dp + rmax_idx, du_drmax);
+    }
+
+    if (du_dx) {
+        RealType du_dr = k * ((r_gt_rmax * pow(r - rmax, 3)) + (r_lt_rmin * pow(r - rmin, 3)));
+        
+        for (int d = 0; d < 3; d++) {
+            // compute du/dcoords
+            RealType du_dsrc_real = du_dr * dx[d] / r;
+            RealType du_ddst_real = - du_dsrc_real;
+
+            // cast float -> fixed
+            auto du_dsrc = FLOAT_TO_FIXED_BONDED<RealType>(du_dsrc_real);
+            auto du_ddst = FLOAT_TO_FIXED_BONDED<RealType>(du_ddst_real);
+
+            // increment du_dx array
+            atomicAdd(du_dx + src_idx * 3 + d, du_dsrc);
+            atomicAdd(du_dx + dst_idx * 3 + d, du_ddst);
+        }
+    }
+}

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -12,6 +12,7 @@
 #include "fixed_point.hpp"
 #include "harmonic_angle.hpp"
 #include "harmonic_bond.hpp"
+#include "flat_bottom_bond.hpp"
 #include "integrator.hpp"
 #include "neighborlist.hpp"
 #include "nonbonded_all_pairs.hpp"
@@ -580,6 +581,21 @@ template <typename RealType> void declare_harmonic_bond(py::module &m, const cha
             py::arg("lamb_offset") = py::none());
 }
 
+
+template <typename RealType> void declare_flat_bottom_bond(py::module &m, const char *typestr) {
+
+    using Class = timemachine::FlatBottomBond<RealType>;
+    std::string pyclass_name = std::string("FlatBottomBond_") + typestr;
+    py::class_<Class, std::shared_ptr<Class>, timemachine::Potential>(
+        m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+        .def(
+            py::init([](const py::array_t<int, py::array::c_style> &bond_idxs) {
+                std::vector<int> vec_bond_idxs(bond_idxs.data(), bond_idxs.data() + bond_idxs.size());
+                return new Class(vec_bond_idxs);
+            }),
+            py::arg("bond_idxs"));
+}
+
 template <typename RealType> void declare_harmonic_angle(py::module &m, const char *typestr) {
 
     using Class = timemachine::HarmonicAngle<RealType>;
@@ -957,6 +973,9 @@ PYBIND11_MODULE(custom_ops, m) {
 
     declare_harmonic_bond<double>(m, "f64");
     declare_harmonic_bond<float>(m, "f32");
+
+    declare_flat_bottom_bond<double>(m, "f64");
+    declare_flat_bottom_bond<float>(m, "f32");
 
     declare_harmonic_angle<double>(m, "f64");
     declare_harmonic_angle<float>(m, "f32");

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -174,6 +174,15 @@ class HarmonicBond(BondedWrapper):
     pass
 
 
+
+class FlatBottomBond(CustomOpWrapper):
+    def get_idxs(self):
+        return self.args[0]
+
+    def set_idxs(self, new_idxs):
+        self.args[0] = new_idxs
+
+
 # this is an alias to make type checking easier
 class CoreRestraint(HarmonicBond):
     def unbound_impl(self, precision):


### PR DESCRIPTION
Intended usage:
* Generating samples where a bond length is nearly uniform between r_min, r_max, e.g. as a proposal for reweighting to a variety of equilibrium bond-lengths

Design notes:
* uses r^4 instead of r^2 so that the function is C^2 continuous

Implementation notes:
* Signature is simplified relative to harmonic bond (does not reference `lamb_mult`, `lamb_offset` vectors or expose a dependence on lambda)
* `test_flat_bottom_bond` introduces code duplication with `test_harmonic_bond` -- if we add more `*BondPotential` variants, may be worthwhile to factor out common parts of the test