### PR TITLE
Fix nightly test after jax update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG MINICONDA_VERSION=4.6.14
 ARG MAKE_VERSION=4.2.1-1.2
 ARG GIT_VERSION=1:2.25.1-*
 ARG WGET_VERSION=1.20.3-1ubuntu2
-RUN apt-get update && apt-get install --no-install-recommends -y wget=${WGET_VERSION} git=${GIT_VERSION} make=${MAKE_VERSION} \
+RUN apt-get update && apt-get install --no-install-recommends -y wget=${WGET_VERSION} git=${GIT_VERSION} make=${MAKE_VERSION} vim \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -O ~/miniconda.sh && \

--- a/tests/test_mtm_condensed.py
+++ b/tests/test_mtm_condensed.py
@@ -44,12 +44,11 @@ def test_condensed_phase_mtm():
     state = enhanced.VacuumState(mol, ff)
 
     proposal_U = state.U_decharged
-    seed = 2021
 
     cache_path = "mtm_condensed_cache.pkl"
     if not os.path.exists(cache_path):
         print("Generating cache")
-        num_batches = 30000
+        num_batches = 40000
         vacuum_samples, vacuum_log_weights = enhanced.generate_log_weighted_samples(
             mol, temperature, state.U_easy, proposal_U, num_batches=num_batches, seed=seed
         )


### PR DESCRIPTION
- jax lib update caused random samples generated for test_condensed_phase_mtm to differ
- increasing number of generated samples allows test to pass
- difference was 0.151 vs cut-off of 0.15 (see line https://github.com/proteneer/timemachine/compare/fix_nightly_pt2?expand=1#diff-fabbc33e091fae869ad3a2f33a9da400a6af122eda1fc1abe989dc34d83d3385L109)
- Now getting 0.11 for this value
