### PR TITLE
Jax reference VelocityVerletIntegrator

### DIFF
--- a/tests/test_reference_velocity_verlet_integrator.py
+++ b/tests/test_reference_velocity_verlet_integrator.py
@@ -11,18 +11,23 @@ from timemachine.testsystems.relative import hif2a_ligand_pair
 
 
 def assert_reversible(x0, v0, update_fxn, atol=1e-10):
-    """Assert that
-    * I(x0, v0) != (x0, v0)
-    * F(I(F(I(x0, v0)))) == (x0, v0)"""
+    """Define a fxn involute as composition of flip_velocities and update_fxn,
+    then assert that
+    * involute is its own inverse
+    * involute is not trivial (aka not the identity function)
+    """
+
+    def involute(x, v):
+        """integrate forward in time, flip v -- expected to be its own inverse"""
+        x_next, v_next = update_fxn(x, v)
+        return x_next, -v_next
 
     close = partial(np.allclose, atol=atol)
 
-    # integrate, flip v, integrate, flip v
-    x1, v1 = update_fxn(x0, v0)
-    x0_, _v0_ = update_fxn(x1, -v1)
-    v0_ = -_v0_
+    # assert "involute" is really its own inverse
+    x1, v1 = involute(x0, x0)
+    x0_, v0_ = involute(x1, v1)
 
-    # assert we got back where we started
     assert close(x0_, x0), f"max(abs(x0 - x0_)) = {np.max(np.abs(x0 - x0_))}"
     assert close(v0_, v0), f"max(abs(v0 - v0_)) = {np.max(np.abs(v0 - v0_))}"
 

--- a/tests/test_reference_velocity_verlet_integrator.py
+++ b/tests/test_reference_velocity_verlet_integrator.py
@@ -1,30 +1,67 @@
+from functools import partial
+
 import numpy as np
 from jax import config, grad, jit
 from jax import numpy as jnp
 
 config.update("jax_enable_x64", True)
 
-
 from timemachine.integrator import VelocityVerletIntegrator
+from timemachine.testsystems.relative import hif2a_ligand_pair
 
 
-def assert_reversible(x0, v0, update_fxn):
+def assert_reversible(x0, v0, update_fxn, atol=1e-8):
+    """assert that
+    * F(I(x0, v0))      != (x0, v0)
+    * F(I(F(I(x0, v0))) == (x0, v0)"""
+    close = partial(np.allclose, atol=atol)
+
+    # integrate, flip v, integrate, flip v
     x1, v1 = update_fxn(x0, v0)
-    x0_, v0_ = update_fxn(x1, -v1)
+    x0_, _v0_ = update_fxn(x1, -v1)
+    v0_ = -_v0_
 
-    assert np.isclose(x0_, x0).all()
-    assert np.isclose(-v0_, v0).all()
+    # assert we got back where we started
+    assert close(x0_, x0), f"max(abs(x0 - x0_)) = {np.max(np.abs(x0 - x0_))}"
+    assert close(v0_, v0), f"max(abs(v0 - v0_)) = {np.max(np.abs(v0 - v0_))}"
 
     # also assert this is not a no-op
-    assert not np.isclose(x1, x0).all()
+    assert (not close(x1, x0)) and (not close(v1, v0)), "update_fxn didn't do anything!"
+
+
+def assert_reversibility_using_step_implementations(intg, x0, v0, n_steps=1000, atol=1e-8):
+    """assert reversibility .step and .multiple_steps implementations"""
+
+    # check step implementation
+    def step_update(x, v):
+        for t in range(n_steps):
+            x, v = intg.step(x, v)
+        return x, v
+
+    assert_reversible(x0, v0, step_update, atol=atol)
+
+    # check multiple_steps implementation
+    def multiple_steps_update(x, v):
+        xs, vs = intg.multiple_steps(x, v, n_steps)
+        return xs[-1], vs[-1]
+
+    assert_reversible(x0, v0, multiple_steps_update, atol=atol)
 
 
 def test_reversibility_with_jax_potentials():
+    """on a simple jax-transformable potential (quartic oscillators)
+    with randomized parameters and initial conditions
+    (n oscillators, masses, dt, x0, v0)
+    assert all 3 update functions
+    (public: .step and .multiple_steps, private: ._update_via_fori_loop)
+    are reversible"""
+
     np.random.seed(2022)
 
     def U(x):
         return jnp.sum(x ** 4)
 
+    @jit
     def force(x):
         return -grad(U)(x)
 
@@ -37,24 +74,48 @@ def test_reversibility_with_jax_potentials():
 
         intg = VelocityVerletIntegrator(force, masses, dt)
 
-        # check jax.lax.fori_loop implementation
+        # check "public" .step and .multiple_steps implementations
+        assert_reversibility_using_step_implementations(intg, x0, v0, n_steps)
+
+        # also check "private" jax.lax.fori_loop implementation
         @jit
         def jax_update(x, v):
             return intg._update_via_fori_loop(x, v, n_steps)
 
-        assert_reversible(x0, v0, jax_update)
+        assert_reversible(x0, v0, jax_update, atol=1e-8)
 
-        # check step implementation
-        def step_update(x, v):
-            for t in range(n_steps):
-                x, v = intg.step(x, v)
-            return x, v
 
-        assert_reversible(x0, v0, step_update)
+def test_reversibility_with_custom_ops_potentials():
+    """Check reversibility of "public" .step and .multiple_steps implementations when `force_fxn`
+    is a custom_op potential"""
+    np.random.seed(2022)
 
-        # check multiple_steps implementation
-        def multiple_steps_update(x, v):
-            xs, vs = intg.multiple_steps(x, v, n_steps)
-            return xs[-1], vs[-1]
+    # define a Python force fxn that calls custom_ops
+    rfe = hif2a_ligand_pair
+    unbound_potentials, sys_params, masses = rfe.prepare_vacuum_edge(rfe.ff.get_ordered_params())
+    coords = rfe.prepare_combined_coords()
+    bound_potentials = [
+        ubp.bind(params).bound_impl(np.float32) for (ubp, params) in zip(unbound_potentials, sys_params)
+    ]
+    box = 100 * np.eye(3)
 
-        assert_reversible(x0, v0, multiple_steps_update)
+    def force(coords):
+        du_dxs = np.array([bp.execute(coords, box, 0.5)[0] for bp in bound_potentials])
+        return -np.sum(du_dxs, 0)
+
+    dt = 1.5e-3
+    intg = VelocityVerletIntegrator(force, masses, dt)
+
+    x0 = np.array(coords)
+
+    for n_steps in [1, 10, 100, 500, 1000]:  # , 10000]:
+        v0 = np.random.randn(*coords.shape)
+
+        # check "public" .step and .multiple_steps implementations
+        assert_reversibility_using_step_implementations(intg, x0, v0, n_steps, atol=1e-10)
+
+    # TODO: possibly investigate why n_steps=10000 fails
+    # assert_reversibility_using_step_implementations(intg, x0, v0, n_steps=10000, atol=0.1)
+    # * also fails with reduced dt = 1.0e-3
+    # * passes with greatly reduced dt = 1.0e-4
+    # TODO: possibly replace with SummedPotential?

--- a/tests/test_reference_velocity_verlet_integrator.py
+++ b/tests/test_reference_velocity_verlet_integrator.py
@@ -1,0 +1,44 @@
+import numpy as np
+from jax import config, grad, jit
+from jax import numpy as jnp
+
+config.update("jax_enable_x64", True)
+
+from functools import partial
+
+from timemachine.integrator import VelocityVerletIntegrator
+
+
+def assert_reversible(x0, v0, update_fxn):
+    x1, v1 = update_fxn(x0, v0)
+    x0_, v0_ = update_fxn(x1, -v1)
+
+    assert np.isclose(x0_, x0).all()
+    assert np.isclose(-v0_, v0).all()
+
+    # also assert this is not a no-op
+    assert not np.isclose(x1, x0).all()
+
+
+def test_reversibility_on_quartic_potential():
+    def U(x):
+        return jnp.sum(x ** 4)
+
+    def force(x):
+        return -grad(U)(x)
+
+    for n_steps in [1, 10, 100, 1000, 10000]:
+        n = np.random.randint(10, 10000)  # Unif[10, 10000]
+        masses = np.random.rand(n) + 1  # Unif[1, 2]
+        dt = 0.09 * np.random.rand() + 0.01  # Unif[0.01, 0.1]
+        x0 = np.random.randn(n, 3)
+        v0 = np.random.randn(n, 3)
+
+        intg = VelocityVerletIntegrator(force, masses, dt)
+
+        @jit
+        def update(x, v, n_steps=1000):
+            return intg._update_via_fori_loop(x, v, n_steps)
+
+        update_fxn = partial(update, n_steps=n_steps)
+        assert_reversible(x0, v0, update_fxn)

--- a/tests/test_reference_velocity_verlet_integrator.py
+++ b/tests/test_reference_velocity_verlet_integrator.py
@@ -26,7 +26,7 @@ def assert_reversible(x0, v0, update_fxn, atol=1e-10):
     close = partial(np.allclose, atol=atol)
 
     # assert "self_inverse" is really its own inverse
-    x1, v1 = self_inverse(x0, x0)
+    x1, v1 = self_inverse(x0, v0)
     x0_, v0_ = self_inverse(x1, v1)
 
     assert close(x0_, x0), f"max(abs(x0 - x0_)) = {np.max(np.abs(x0 - x0_))}"

--- a/tests/test_reference_velocity_verlet_integrator.py
+++ b/tests/test_reference_velocity_verlet_integrator.py
@@ -11,22 +11,23 @@ from timemachine.testsystems.relative import hif2a_ligand_pair
 
 
 def assert_reversible(x0, v0, update_fxn, atol=1e-10):
-    """Define a fxn involute as composition of flip_velocities and update_fxn,
+    """Define a fxn self_inverse as composition of flip_velocities and update_fxn,
     then assert that
-    * involute is its own inverse
-    * involute is not trivial (aka not the identity function)
+    * self_inverse is its own inverse
+    * self_inverse is not trivial (aka not the identity function)
     """
 
-    def involute(x, v):
-        """integrate forward in time, flip v -- expected to be its own inverse"""
+    def self_inverse(x, v):
+        """integrate forward in time, flip v
+        (expected to be an "involution" i.e. its own inverse)"""
         x_next, v_next = update_fxn(x, v)
         return x_next, -v_next
 
     close = partial(np.allclose, atol=atol)
 
-    # assert "involute" is really its own inverse
-    x1, v1 = involute(x0, x0)
-    x0_, v0_ = involute(x1, v1)
+    # assert "self_inverse" is really its own inverse
+    x1, v1 = self_inverse(x0, x0)
+    x0_, v0_ = self_inverse(x1, v1)
 
     assert close(x0_, x0), f"max(abs(x0 - x0_)) = {np.max(np.abs(x0 - x0_))}"
     assert close(v0_, v0), f"max(abs(v0 - v0_)) = {np.max(np.abs(v0 - v0_))}"

--- a/timemachine/integrator.py
+++ b/timemachine/integrator.py
@@ -90,12 +90,13 @@ class LangevinIntegrator(Integrator):
 
 class VelocityVerletIntegrator(Integrator):
     def __init__(self, force_fxn, masses, dt):
+        """WARNING: `.step` makes 2x more calls to force_fxn per timestep than `.multiple_steps`"""
         self.dt = dt
         self.masses = masses[:, np.newaxis]  # TODO: cleaner way to handle (n_atoms,) vs. (n_atoms, 3) mismatch?
         self.force_fxn = force_fxn
 
     def step(self, x, v):
-        # note: 2 calls to force_fxn per timestep
+        """WARNING: makes 2 calls to force_fxn per timestep -- prefer `.multiple_steps` in most cases"""
         v_mid = v + (0.5 * self.dt / self.masses) * self.force_fxn(x)
         x = x + self.dt * v_mid
         v = v_mid + (0.5 * self.dt / self.masses) * self.force_fxn(x)


### PR DESCRIPTION
- [x] Add `VelocityVerletIntegrator` to `integrator.py`, with 3 methods of updating state (following what is present for `LangevinIntegrator`):
  - 2 "public" methods `.step` and `.multiple_steps` (only requiring a callable `force_fxn`), and
  - 1 "private" method `._update_via_fori_loop` (using accelerated jax.lax loop when `force_fxn` is jax-transformable)
- [x] Test reversibility up to numerical precision (key property for some applications, e.g. as a proposal in HMC)