### PR TITLE
Improve self-consistency among Verlet stepper methods

### DIFF
--- a/timemachine/integrator.py
+++ b/timemachine/integrator.py
@@ -104,55 +104,37 @@ class VelocityVerletIntegrator(Integrator):
         return x, v
 
     def multiple_steps(self, x, v, n_steps=1000):
-        # note: intermediate timesteps are staggered
-        #    xs[0], vs[0] = x_0, v_0
-        #    xs[1], vs[1] = x_2, v_{1.5}
-        #    xs[2], vs[2] = x_3, v_{2.5}
-        #    ...
-        #    xs[T-1], vs[T-1] = x_T, v_{T-0.5}
-        #    xs[T],   vs[T]   = x_T, v_T
-
-        # note: reorders loop slightly to avoid ~n_steps extraneous calls to force_fxn
 
         zs = [(x, v)]
 
-        # initialize traj
-        v = v + (0.5 * self.dt / self.masses) * self.force_fxn(x)
-        x = x + self.dt * v
+        f = self.force_fxn(x)
 
-        # run n_steps-1 steps
-        for t in range(n_steps - 1):
-            v = v + (self.dt / self.masses) * self.force_fxn(x)
+        for t in range(n_steps):
+            v = v + (0.5 * self.dt / self.masses) * f
             x = x + self.dt * v
+            f = self.force_fxn(x)
+            v = v + (0.5 * self.dt / self.masses) * f
 
             zs.append((x, v))
 
-        # finalize traj
-        v = v + (0.5 * self.dt / self.masses) * self.force_fxn(x)
-
-        zs.append((x, v))
-
         xs = np.array([x for (x, _) in zs])
         vs = np.array([v for (_, v) in zs])
+
         return xs, vs
 
     def _update_via_fori_loop(self, x, v, n_steps=1000):
-        # initialize
-        v = v + (0.5 * self.dt / self.masses) * self.force_fxn(x)
-        x = x + self.dt * v
-
         def velocity_verlet_loop_body(_, val):
-            x_prev, v_prev = val
+            x_prev, v_prev, f_prev = val
 
-            v = v_prev + (self.dt / self.masses) * self.force_fxn(x_prev)
-            x = x_prev + self.dt * v
-            return x, v
+            v_mid = v_prev + 0.5 * (self.dt / self.masses) * f_prev
+            x = x_prev + self.dt * v_mid
+            f = self.force_fxn(x)
+            v = v_mid + 0.5 * (self.dt / self.masses) * f
 
-        # run n_steps - 1 steps
-        x, v = jax.lax.fori_loop(0, n_steps - 1, velocity_verlet_loop_body, (x, v))
+            return x, v, f
 
-        # finalize
-        v = v + (0.5 * self.dt / self.masses) * self.force_fxn(x)
+        f = self.force_fxn(x)
+        x, v, _ = jax.lax.fori_loop(0, n_steps, velocity_verlet_loop_body, (x, v, f))
 
         return x, v
 


### PR DESCRIPTION
Addresses https://github.com/proteneer/timemachine/pull/776#discussion_r932660565 by simplifying `.multiple_steps` to return both positions and velocities "on-step", so that it is now consistent with `.step`.

This may be helpful if we wish to use the trajectory returned by `multiple_steps` for an application that requires `U(xs[t]) + KE(vs[t]) == U(x_t) + KE(v_t)` for intermediate values of `t`. One such application is windowed acceptance HMC, described in sec. 5.4 of https://arxiv.org/abs/1206.1901 .

-----

(However, based on a discussion with @proteneer Tuesday, rearranging the loop in this way would introduce a different inconvenience if translated to a timemachine C++/CUDA integrator, as it would require evaluating `force(x)` once "within a timestep" rather than once "between timesteps" -- [`step_fwd` and `update_forward`](https://github.com/proteneer/timemachine/blob/8fc9b108435f313d0f604ede2500c23526975bd3/timemachine/cpp/src/integrator.cu#L71) reference a buffer of forces computed on previous `x`, rather than a force function. The previous implementation in https://github.com/proteneer/timemachine/pull/776 was intended to be consistent with the current signatures of `step_fwd` and `update_forward`.)