### PR TITLE
Add deterministic interface to reference LangevinIntegrator, XLA-accelerated `multiple_steps`

### DIFF
--- a/tests/test_reference_langevin_integrator.py
+++ b/tests/test_reference_langevin_integrator.py
@@ -58,28 +58,52 @@ def test_reference_langevin_integrator(threshold=1e-4):
 
 def test_reference_langevin_integrator_deterministic():
     """
-    Asserts that trajectories produced by `_deterministic` methods
-    are reproducible, and that the implementation in terms of the XLA
-    scan primitive gives a consistent result to that of the
-    implementation as a Python for-loop
+    Asserts that trajectories produced by `_deterministic` methods are deterministic
     """
     force_fxn = lambda x: -4 * x ** 3
     langevin = LangevinIntegrator(force_fxn, masses=1.0, temperature=300.0, dt=0.1, friction=1.0)
     x0, v0 = 0.1 * jax.random.uniform(jax.random.PRNGKey(1), shape=(2, 5))
+    key, key_ = jax.random.split(jax.random.PRNGKey(1))
 
-    xs1, vs1 = langevin.multiple_steps_deterministic(jax.random.PRNGKey(1), x0, v0)
+    def assert_deterministic(method):
+        xs1, vs1 = method(key, x0, v0)
 
-    # implementation based on jax.lax.scan should give identical result
-    xs2, vs2 = langevin.multiple_steps_deterministic_lax(jax.random.PRNGKey(1), x0, v0)
+        # same key should give same result
+        xs2, vs2 = method(key, x0, v0)
+        np.testing.assert_array_equal(xs1, xs2)
+        np.testing.assert_array_equal(vs1, vs2)
 
+        # different key should give different result
+        xs3, vs3 = method(key_, x0, v0)
+        assert not np.allclose(xs2, xs3)
+        assert not np.allclose(vs2, vs3)
+
+    assert_deterministic(langevin.multiple_steps_deterministic)
+    assert_deterministic(langevin.multiple_steps_deterministic_lax)
+
+
+def test_reference_langevin_integrator_consistent():
+    """
+    Asserts that the implementation in terms of jax.lax primitives
+    gives a consistent result to that of the implementation as a
+    Python for-loop
+    """
+    force_fxn = lambda x: -4 * x ** 3
+    langevin = LangevinIntegrator(force_fxn, masses=1.0, temperature=300.0, dt=0.1, friction=1.0)
+    x0, v0 = 0.1 * jax.random.uniform(jax.random.PRNGKey(1), shape=(2, 5))
+    key = jax.random.PRNGKey(1)
+
+    xs1, vs1 = langevin.multiple_steps_deterministic(key, x0, v0)
+
+    # should be consistent with the jax.lax implementation
+    xs2, vs2 = langevin.multiple_steps_deterministic_lax(key, x0, v0)
+
+    # NOTE: result of the jax.lax implementation is NOT bitwise
+    # equivalent to the pure Python implementation. This might be due
+    # to loop-unrolling and reassociation optimizations performed by
+    # XLA
     np.testing.assert_allclose(xs1, xs2)
     np.testing.assert_allclose(vs1, vs2)
-
-    # different seed; should give a different result
-    xs3, vs3 = langevin.multiple_steps_deterministic_lax(jax.random.PRNGKey(2), x0, v0)
-
-    assert not np.allclose(xs1, xs3)
-    assert not np.allclose(vs1, vs3)
 
 
 def test_reference_langevin_integrator_with_custom_ops():

--- a/tests/test_reference_langevin_integrator.py
+++ b/tests/test_reference_langevin_integrator.py
@@ -1,6 +1,9 @@
 from itertools import product
 
 import jax
+
+jax.config.update("jax_enable_x64", True)
+
 import numpy as np
 from jax import grad, jit
 from jax import numpy as jnp

--- a/tests/test_reference_langevin_integrator.py
+++ b/tests/test_reference_langevin_integrator.py
@@ -72,8 +72,8 @@ def test_reference_langevin_integrator_deterministic():
     # implementation based on jax.lax.scan should give identical result
     xs2, vs2 = langevin.multiple_steps_deterministic_lax(jax.random.PRNGKey(1), x0, v0)
 
-    assert np.allclose(xs1, xs2)
-    assert np.allclose(vs1, vs2)
+    np.testing.assert_allclose(xs1, xs2)
+    np.testing.assert_allclose(vs1, vs2)
 
     # different seed; should give a different result
     xs3, vs3 = langevin.multiple_steps_deterministic_lax(jax.random.PRNGKey(2), x0, v0)

--- a/tests/test_reference_langevin_integrator.py
+++ b/tests/test_reference_langevin_integrator.py
@@ -65,13 +65,13 @@ def test_reference_langevin_integrator_deterministic():
     x0, v0 = 0.1 * np.ones((2, 5))
 
     # private "reference" implementation (not using XLA primitives)
-    xs1, vs1 = langevin._multiple_steps_deterministic(jax.random.PRNGKey(1), x0, v0)
+    xs1, vs1 = langevin.multiple_steps_deterministic(jax.random.PRNGKey(1), x0, v0)
 
     # should give the same result using XLA primitives
-    xs2, vs2 = langevin.multiple_steps_deterministic(jax.random.PRNGKey(1), x0, v0)
+    xs2, vs2 = langevin.multiple_steps_deterministic_lax(jax.random.PRNGKey(1), x0, v0)
 
     # different seed; should give a different result
-    xs3, vs3 = langevin.multiple_steps_deterministic(jax.random.PRNGKey(2), x0, v0)
+    xs3, vs3 = langevin.multiple_steps_deterministic_lax(jax.random.PRNGKey(2), x0, v0)
 
     assert np.allclose(xs1, xs2)
     assert np.allclose(vs1, vs2)

--- a/tests/test_reference_langevin_integrator.py
+++ b/tests/test_reference_langevin_integrator.py
@@ -62,7 +62,7 @@ def test_reference_langevin_integrator_deterministic():
     """
     force_fxn = lambda x: -4 * x ** 3
     langevin = LangevinIntegrator(force_fxn, masses=1.0, temperature=300.0, dt=0.1, friction=1.0)
-    x0, v0 = 0.1 * np.ones((2, 5))
+    x0, v0 = 0.1 * jax.random.uniform(jax.random.PRNGKey(1), shape=(2, 5))
 
     xs1, vs1 = langevin.multiple_steps_deterministic(jax.random.PRNGKey(1), x0, v0)
 

--- a/tests/test_reference_langevin_integrator.py
+++ b/tests/test_reference_langevin_integrator.py
@@ -1,3 +1,4 @@
+from functools import partial
 from itertools import product
 
 import jax
@@ -57,46 +58,52 @@ def test_reference_langevin_integrator(threshold=1e-4):
 
 
 def test_reference_langevin_integrator_deterministic():
-    """
-    Asserts that trajectories produced by `_deterministic` methods are deterministic
-    """
+    """Asserts that trajectories are deterministic given a seed value"""
     force_fxn = lambda x: -4 * x ** 3
     langevin = LangevinIntegrator(force_fxn, masses=1.0, temperature=300.0, dt=0.1, friction=1.0)
     x0, v0 = 0.1 * jax.random.uniform(jax.random.PRNGKey(1), shape=(2, 5))
-    key, key_ = jax.random.split(jax.random.PRNGKey(1))
 
-    def assert_deterministic(method):
-        xs1, vs1 = method(key, x0, v0)
+    def assert_deterministic(f):
+        xs1, vs1 = f(1)
 
-        # same key should give same result
-        xs2, vs2 = method(key, x0, v0)
+        # same seed should yield same result
+        xs2, vs2 = f(1)
         np.testing.assert_array_equal(xs1, xs2)
         np.testing.assert_array_equal(vs1, vs2)
 
-        # different key should give different result
-        xs3, vs3 = method(key_, x0, v0)
+        # different seed should give different result
+        xs3, vs3 = f(2)
         assert not np.allclose(xs2, xs3)
         assert not np.allclose(vs2, vs3)
 
-    assert_deterministic(langevin.multiple_steps_deterministic)
-    assert_deterministic(langevin.multiple_steps_deterministic_lax)
+    assert_deterministic(lambda seed: langevin.multiple_steps(x0, v0, rng=np.random.default_rng(seed)))
+    assert_deterministic(lambda seed: langevin.multiple_steps_lax(jax.random.PRNGKey(seed), x0, v0))
 
 
 def test_reference_langevin_integrator_consistent():
     """
-    Asserts that the implementation in terms of jax.lax primitives
-    gives a consistent result to that of the implementation as a
-    Python for-loop
+    Asserts that the result of the implementation based on jax.lax
+    primitives is consistent with a simple for-loop implementation
     """
     force_fxn = lambda x: -4 * x ** 3
     langevin = LangevinIntegrator(force_fxn, masses=1.0, temperature=300.0, dt=0.1, friction=1.0)
     x0, v0 = 0.1 * jax.random.uniform(jax.random.PRNGKey(1), shape=(2, 5))
     key = jax.random.PRNGKey(1)
 
-    xs1, vs1 = langevin.multiple_steps_deterministic(key, x0, v0)
+    def multiple_steps_reference(key, x, v, n_steps=1000):
+        keys = jax.random.split(key, n_steps)
+        xs, vs = [x], [v]
 
-    # should be consistent with the jax.lax implementation
-    xs2, vs2 = langevin.multiple_steps_deterministic_lax(key, x0, v0)
+        for key in keys:
+            new_x, new_v = langevin.step_lax(key, xs[-1], vs[-1])
+
+            xs.append(new_x)
+            vs.append(new_v)
+
+        return np.array(xs), np.array(vs)
+
+    xs1, vs1 = multiple_steps_reference(key, x0, v0)
+    xs2, vs2 = langevin.multiple_steps_lax(key, x0, v0)
 
     # NOTE: result of the jax.lax implementation is NOT bitwise
     # equivalent to the pure Python implementation. This might be due

--- a/tests/test_reference_langevin_integrator.py
+++ b/tests/test_reference_langevin_integrator.py
@@ -64,17 +64,17 @@ def test_reference_langevin_integrator_deterministic():
     langevin = LangevinIntegrator(force_fxn, masses=1.0, temperature=300.0, dt=0.1, friction=1.0)
     x0, v0 = 0.1 * np.ones((2, 5))
 
-    # private "reference" implementation (not using XLA primitives)
     xs1, vs1 = langevin.multiple_steps_deterministic(jax.random.PRNGKey(1), x0, v0)
 
-    # should give the same result using XLA primitives
+    # implementation based on jax.lax.scan should give identical result
     xs2, vs2 = langevin.multiple_steps_deterministic_lax(jax.random.PRNGKey(1), x0, v0)
+
+    assert np.allclose(xs1, xs2)
+    assert np.allclose(vs1, vs2)
 
     # different seed; should give a different result
     xs3, vs3 = langevin.multiple_steps_deterministic_lax(jax.random.PRNGKey(2), x0, v0)
 
-    assert np.allclose(xs1, xs2)
-    assert np.allclose(vs1, vs2)
     assert not np.allclose(xs1, xs3)
     assert not np.allclose(vs1, vs3)
 

--- a/tests/test_reference_langevin_integrator.py
+++ b/tests/test_reference_langevin_integrator.py
@@ -1,4 +1,3 @@
-from functools import partial
 from itertools import product
 
 import jax

--- a/timemachine/integrator.py
+++ b/timemachine/integrator.py
@@ -100,10 +100,8 @@ class LangevinIntegrator(Integrator):
         Return trajectories of x and v, advanced by n_steps. Accepts a
         PRNGKey for determinism.
 
-        NOTE: if `force_fxn` is jax-transformable,
-        `multiple_steps_deterministic_lax` should be preferred in most
-        situations. The latter is expressed in terms of XLA
-        primitives, allowing jax.jit to produce efficient code.
+        Note: if force_fxn is jax-transformable,
+        multiple_steps_deterministic_lax should be preferred
         """
         keys = jax.random.split(key, n_steps + 1)
         xs, vs = [x], [v]
@@ -120,8 +118,10 @@ class LangevinIntegrator(Integrator):
     def multiple_steps_deterministic_lax(self, key, x, v, n_steps=1000):
         """
         Return trajectories of x and v, advanced by n_steps.
-        Implemented in terms of XLA primitives to allow jax.jit to
-        produce efficient code.
+        Implemented using jax.lax.scan to allow jax.jit to produce
+        efficient code.
+
+        Note: requires that force_fxn be jax-transformable
         """
 
         def f(xv, key):

--- a/timemachine/integrator.py
+++ b/timemachine/integrator.py
@@ -80,11 +80,11 @@ class LangevinIntegrator(Integrator):
         # note: per-atom frictions allowed
         self.ca, self.cb, self.cc = np.expand_dims(ca, -1), np.expand_dims(cb, -1), np.expand_dims(cc, -1)
 
-    def _step(self, x, v, eta):
+    def _step(self, x, v, noise):
         """Intended to match https://github.com/proteneer/timemachine/blob/37e60205b3ae3358d9bb0967d03278ed184b8976/timemachine/cpp/src/integrator.cu#L71-L74"""
         v_mid = v + self.cb * self.force_fxn(x)
 
-        new_v = (self.ca * v_mid) + (self.cc * eta)
+        new_v = (self.ca * v_mid) + (self.cc * noise)
         new_x = x + 0.5 * self.dt * (v_mid + new_v)
 
         return new_x, new_v

--- a/timemachine/integrator.py
+++ b/timemachine/integrator.py
@@ -95,15 +95,15 @@ class LangevinIntegrator(Integrator):
         """Return copies x and v, updated by a single timestep. Accepts a PRNGKey for determinism."""
         return self._step(x, v, jax.random.normal(key, x.shape))
 
-    def _multiple_steps_deterministic(self, key, x, v, n_steps=1000):
+    def multiple_steps_deterministic(self, key, x, v, n_steps=1000):
         """
         Return trajectories of x and v, advanced by n_steps. Accepts a
         PRNGKey for determinism.
 
-        Note: in most situations `multiple_steps_deterministic` should
-        be preferred. The latter is expressed in terms of XLA
-        primitives, allowing jax.jit to produce efficient code. This
-        version is retained as a reference for testing.
+        NOTE: if `force_fxn` is jax-transformable,
+        `multiple_steps_deterministic_lax` should be preferred in most
+        situations. The latter is expressed in terms of XLA
+        primitives, allowing jax.jit to produce efficient code.
         """
         keys = jax.random.split(key, n_steps + 1)
         xs, vs = [x], [v]
@@ -117,7 +117,7 @@ class LangevinIntegrator(Integrator):
         return np.array(xs), np.array(vs)
 
     @partial(jax.jit, static_argnums=(0, 4))
-    def multiple_steps_deterministic(self, key, x, v, n_steps=1000):
+    def multiple_steps_deterministic_lax(self, key, x, v, n_steps=1000):
         """
         Return trajectories of x and v, advanced by n_steps.
         Implemented in terms of XLA primitives to allow jax.jit to

--- a/timemachine/integrator.py
+++ b/timemachine/integrator.py
@@ -141,7 +141,7 @@ class LangevinIntegrator(StochasticIntegrator):
         return new_x, new_v
 
     def step(self, x, v, rng):
-        return self._step(x, v, rng.normal(*x.shape))
+        return self._step(x, v, rng.normal(size=x.shape))
 
     def step_lax(self, key, x, v):
         """Return copies x and v, updated by a single timestep. Accepts a PRNGKey for determinism."""


### PR DESCRIPTION
Adds a new method, `multiple_steps_deterministic`, to `LangevinIntegrator`.

The main API difference vs. the existing `multiple_steps` is that `multiple_steps_deterministic` also accepts a RNG key instance, allowing for determinism.

The main motivation for this is a ~60% speedup ([example](https://gitlab.com/relaytx/users/mwittmann/notebooks/-/blob/main/experiments/20220801-deterministic-langevin/readme.ipynb)) gained by implementing `multiple_steps_deterministic` in terms of `jax.lax.scan` (after applying `jax.jit`). The new implementation also works with `vmap` and `pmap`.