### PR TITLE
Atom mapping improvements

### DIFF
--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -83,10 +83,9 @@ def read_from_args():
             mol_b = get_mol_by_name(mols, mol_b_name)
 
             print(f"Submitting job for {mol_a_name} -> {mol_b_name}")
-            mcs_threshold = 0.75
-            mcs_result = atom_mapping.mcs_map(mol_a, mol_b, threshold=mcs_threshold)
+            mcs_result = atom_mapping.mcs_map_graph_only_complete_rings(mol_a, mol_b)
             query_mol = Chem.MolFromSmarts(mcs_result.smartsString)
-            core = atom_mapping.get_core_by_mcs(mol_a, mol_b, query_mol, threshold=mcs_threshold)
+            core = atom_mapping.get_core_by_mcs(mol_a, mol_b, query_mol, threshold=1000.0)
             fut = cpc.submit(
                 run_pair, mol_a, mol_b, core, args.forcefield, args.protein, args.seed + row_idx, args.n_frames
             )

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -85,7 +85,7 @@ def read_from_args():
             print(f"Submitting job for {mol_a_name} -> {mol_b_name}")
             mcs_result = atom_mapping.mcs_map_graph_only_complete_rings(mol_a, mol_b)
             query_mol = Chem.MolFromSmarts(mcs_result.smartsString)
-            core = atom_mapping.get_core_by_mcs(mol_a, mol_b, query_mol, threshold=1000.0)
+            core = atom_mapping.get_core_by_mcs(mol_a, mol_b, query_mol, threshold=2.0)
             fut = cpc.submit(
                 run_pair, mol_a, mol_b, core, args.forcefield, args.protein, args.seed + row_idx, args.n_frames
             )

--- a/examples/relative_free_energy.py
+++ b/examples/relative_free_energy.py
@@ -103,15 +103,14 @@ def read_from_args():
     mol_b = get_mol_by_name(mols, args.mol_b_name)  # 30 in test pair
 
     print("Searching for the maximum common substructure...")
-    mcs_threshold = 0.75
-    mcs_result = atom_mapping.mcs_map(mol_a, mol_b, threshold=mcs_threshold)
+    mcs_result = atom_mapping.mcs_map_graph_only_complete_rings(mol_a, mol_b)
     query_mol = Chem.MolFromSmarts(mcs_result.smartsString)
 
     print("mol_a SMILES:", Chem.MolToSmiles(mol_a, isomericSmiles=False))
     print("mol_b SMILES:", Chem.MolToSmiles(mol_b, isomericSmiles=False))
     print("core SMARTS:", mcs_result.smartsString)
 
-    core = atom_mapping.get_core_by_mcs(mol_a, mol_b, query_mol, threshold=mcs_threshold)
+    core = atom_mapping.get_core_by_mcs(mol_a, mol_b, query_mol, threshold=2.0)
     print("core mapping:", core.tolist())
 
     res = plot_atom_mapping_grid(mol_a, mol_b, mcs_result.smartsString, core)

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -65,6 +65,22 @@ def mcs_map(a, b, threshold: float = 0.5, timeout: int = 5, smarts: Optional[str
     return rdFMCS.FindMCS([a, b], params)
 
 
+def mcs_map_graph_only_complete_rings(a, b, timeout: int = 3600, smarts: Optional[str] = None):
+    """Find the MCS map of going from A to B, disregarding conformer information. This also ensures
+    that core-core bonds are not broken."""
+    return rdFMCS.FindMCS(
+        [a, b],
+        maximizeBonds=True,
+        timeout=timeout,
+        matchValences=False,
+        ringMatchesRingOnly=True,
+        completeRingsOnly=True,
+        matchChiralTag=False,
+        atomCompare=Chem.rdFMCS.AtomCompare.CompareAny,
+        bondCompare=Chem.rdFMCS.BondCompare.CompareAny,
+    )
+
+
 def transformation_size(n_A, n_B, n_MCS):
     """Heuristic size of transformation in terms of
         the number of atoms in A, B, and MCS(A, B)


### PR DESCRIPTION
This PR implements a slight improvement to the previous MCS protocol by removing the need for conformation alignment during the initial core smarts matching.  It also resolves a subtle issue where sometimes a single bond core is generated.

We still take the argmin of all the distance of all possible matches in a subsequent step pruning set. On the hif2a set, it reduces the average number of dummy atoms from about 14 to 7. This still doesn't check for chiral restraints (separate PR in the works). This still prevents bond breaking on the core atoms.