### PR TITLE
Require setuptools < 64.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ follow_imports = "silent"
 requires = [
   "cmake==3.22.1",
   "mypy==0.942",
-  "setuptools>=43.0.0",
+  "setuptools >= 43.0.0, < 64.0.0",
   "wheel",
   "versioneer-518"
 ]


### PR DESCRIPTION
Temporary workaround for incompatibility with https://peps.python.org/pep-0660/

On setuptools [v64.0.0](https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400), `pip install .` fails with

```
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmplzftnbox.build-lib/timemachine/_version.py'
```

A possible workaround is to set `SETUPTOOLS_ENABLE_FEATURES="legacy-editable"`