### PR TITLE
Default to parallel setuptools build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 Adapted from https://github.com/pypa/sampleproject/blob/main/setup.py
 """
 
+import multiprocessing
 import os
 import pathlib
 import subprocess
@@ -44,8 +45,8 @@ class CMakeBuild(build_ext):
         build_args += ["--config", cfg]
 
         if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
-            if hasattr(self, "parallel") and self.parallel:
-                build_args += [f"-j{self.parallel}"]
+            nprocs = self.parallel if hasattr(self, "parallel") and self.parallel else multiprocessing.cpu_count()
+            build_args += [f"-j{nprocs}"]
 
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,6 @@ class CMakeBuild(build_ext):
         if not extdir.endswith(os.path.sep):
             extdir += os.path.sep
 
-        debug = int(os.environ.get("DEBUG", 0)) if self.debug is None else self.debug
-        cfg = "Debug" if debug else "Release"
-
         cmake_args = [
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}",
             f"-DPYTHON_EXECUTABLE={sys.executable}",
@@ -42,11 +39,8 @@ class CMakeBuild(build_ext):
         if "CMAKE_ARGS" in os.environ:
             cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") if item]
 
-        build_args += ["--config", cfg]
-
         if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
-            nprocs = self.parallel if hasattr(self, "parallel") and self.parallel else multiprocessing.cpu_count()
-            build_args += [f"-j{nprocs}"]
+            build_args += [f"-j{multiprocessing.cpu_count()}"]
 
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)


### PR DESCRIPTION
Currently `pip install .` will build the C++ extension using only a single process. It's possible to use an incantation like `CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) pip install .` to enable build parallelism, but this is hard to remember.

This PR changes the default build parallelism to `multiprocessing.cpu_count()` (it can still be overriden with `CMAKE_BUILD_PARALLEL_LEVEL`).

This also cleans up some unused CMake-related configuration in `setup.py` that was carried over from the example this was originally adapted from.