### PR TITLE
Make result of generic.Nonbonded.to_reference jax-transformable

### DIFF
--- a/tests/nonbonded/test_generic_nonbonded.py
+++ b/tests/nonbonded/test_generic_nonbonded.py
@@ -1,0 +1,29 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from timemachine.potentials import generic
+
+
+def test_generic_nonbonded_jittable(rng: np.random.Generator):
+
+    N = 30
+
+    potential = generic.Nonbonded(
+        exclusion_idxs=jnp.zeros((0,)),
+        scale_factors=jnp.zeros((0, 1)),
+        lambda_plane_idxs=jnp.zeros(N),
+        lambda_offset_idxs=jnp.zeros(N),
+        beta=1.0,
+        cutoff=0.1,
+    )
+
+    U_ref = potential.to_reference()
+    U_ref_jit = jax.jit(U_ref)
+
+    _ = U_ref_jit(
+        conf=rng.uniform(0, 1, size=(N, 3)),
+        params=rng.uniform(0, 1, size=(N, 3)),
+        box=10.0 * np.eye(3),
+        lam=0.1,
+    )

--- a/timemachine/potentials/generic.py
+++ b/timemachine/potentials/generic.py
@@ -220,7 +220,6 @@ class Nonbonded:
                 self.cutoff,
                 self.lambda_plane_idxs,
                 self.lambda_offset_idxs,
-                runtime_validate=False,  # needed for this to be JAX-transformable
             )
 
         return U

--- a/timemachine/potentials/generic.py
+++ b/timemachine/potentials/generic.py
@@ -220,6 +220,7 @@ class Nonbonded:
                 self.cutoff,
                 self.lambda_plane_idxs,
                 self.lambda_offset_idxs,
+                runtime_validate=False,  # needed for this to be JAX-transformable
             )
 
         return U


### PR DESCRIPTION
Currently the following will fail with a `ConcretizationTypeError` from JAX:

```python
# …
nonbonded: timemachine.potentials.generic.Nonbonded

nonbonded_ref = nonbonded.to_reference()
nonbonded_ref(conf, params, box, lam) # OK
nonbonded_ref_jit = jit(nonbonded_ref)
nonbonded_ref_jit(conf, params, box, lam) # Fails with `ConcretizationTypeError`
```

JAX fails to trace through the assertions in `timemachine.potentials.nonbonded.nonbonded_v3`. This can be fixed by passing `runtime_validate=False`; this PR applies the fix.