### PR TITLE
Add generic NonbondedPairListPrecomputed

### DIFF
--- a/tests/nonbonded/test_nonbonded_precomputed.py
+++ b/tests/nonbonded/test_nonbonded_precomputed.py
@@ -2,15 +2,12 @@ import jax
 
 jax.config.update("jax_enable_x64", True)
 
-import functools
-
-import jax.numpy as jnp
 import numpy as np
 import pytest
 from common import GradientTest
 
 from timemachine.lib.potentials import NonbondedPairListPrecomputed
-from timemachine.potentials import nonbonded, generic
+from timemachine.potentials import generic
 
 pytestmark = [pytest.mark.memcheck]
 

--- a/tests/nonbonded/test_nonbonded_precomputed.py
+++ b/tests/nonbonded/test_nonbonded_precomputed.py
@@ -10,7 +10,7 @@ import pytest
 from common import GradientTest
 
 from timemachine.lib.potentials import NonbondedPairListPrecomputed
-from timemachine.potentials import nonbonded
+from timemachine.potentials import nonbonded, generic
 
 pytestmark = [pytest.mark.memcheck]
 
@@ -69,27 +69,14 @@ def test_nonbonded_pair_list_precomputed_correctness(
         1 + rng.uniform(0, 1, size=3) * 3
     )  # box should be fully ignored tbh (just like all other bonded forces)
 
-    ref_nb = functools.partial(
-        nonbonded.nonbonded_v3_on_precomputed_pairs,
-        pairs=pair_idxs,
-        offsets=w_offsets,
-        beta=beta,
-        cutoff=cutoff,
-    )
+    potential = generic.NonbondedPairListPrecomputed(pair_idxs, w_offsets, beta, cutoff)
 
-    def ref_potential(conf, params, box, lamb):
-        a, b = ref_nb(conf, params, box)
-        return jnp.sum(a) + jnp.sum(b)
-
-    test_potential = NonbondedPairListPrecomputed(pair_idxs, w_offsets, beta, cutoff)
-
-    GradientTest().compare_forces(
+    GradientTest().compare_forces_gpu_vs_reference(
         conf,
         params,
         box,
         [0.0],
-        ref_potential,
-        test_potential,
+        potential,
         precision=precision,
         rtol=rtol,
         atol=atol,


### PR DESCRIPTION
Adds a generic interface for `NonbondedPairListPrecomputed`. This is useful for analyzing results of vacuum simulations set up with `SingleTopologyV3`.