### PR TITLE
Print warning and fall back to default arch if nvidia-smi command fails

### DIFF
--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -113,7 +113,7 @@ if (NOT CUDA_ARCH)
     if (STATUS AND NOT STATUS EQUAL 0)
       message("Warning: failed to determine CUDA_ARCH automatically: ${SMI_OUTPUT}")
     else()
-      STRING(REPLACE "." "" SMI_OUTPUT ${CUDA_ARCH})
+      STRING(REPLACE "." "" CUDA_ARCH ${SMI_OUTPUT})
       # Verify that only one compute capability was returned
       STRING(REGEX MATCHALL "\n" NEW_LINES "${CUDA_ARCH}")
       # NUM_COMPUTE_CAPS is off by one, as there will be one less newline than there are compute capabilities

--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -102,20 +102,26 @@ if (NOT CUDA_ARCH)
     execute_process(
       COMMAND
       bash
+      "-o"
+      "pipefail"
       "-c"
       "nvidia-smi --query-gpu=compute_cap --format=csv | grep -v compute_cap | uniq"
-      OUTPUT_VARIABLE CUDA_ARCH
+      OUTPUT_VARIABLE SMI_OUTPUT
       OUTPUT_STRIP_TRAILING_WHITESPACE
+      RESULT_VARIABLE STATUS
     )
-
-    STRING(REPLACE "." "" CUDA_ARCH ${CUDA_ARCH})
-    # Verify that only one compute capability was returned
-    STRING(REGEX MATCHALL "\n" NEW_LINES "${CUDA_ARCH}")
-    # NUM_COMPUTE_CAPS is off by one, as there will be one less newline than there are compute capabilities
-    list(LENGTH NEW_LINES NUM_COMPUTE_CAPS)
-    # If there are multiple compute capabilities, unset the CUDA_ARCH, fall back to the default below.
-    if(NUM_COMPUTE_CAPS GREATER_EQUAL 1)
-      unset(CUDA_ARCH)
+    if (STATUS AND NOT STATUS EQUAL 0)
+      message("Warning: failed to determine CUDA_ARCH automatically: ${SMI_OUTPUT}")
+    else()
+      STRING(REPLACE "." "" SMI_OUTPUT ${CUDA_ARCH})
+      # Verify that only one compute capability was returned
+      STRING(REGEX MATCHALL "\n" NEW_LINES "${CUDA_ARCH}")
+      # NUM_COMPUTE_CAPS is off by one, as there will be one less newline than there are compute capabilities
+      list(LENGTH NEW_LINES NUM_COMPUTE_CAPS)
+      # If there are multiple compute capabilities, unset the CUDA_ARCH, fall back to the default below.
+      if(NUM_COMPUTE_CAPS GREATER_EQUAL 1)
+        unset(CUDA_ARCH)
+      endif()
     endif()
   endif()
 endif()


### PR DESCRIPTION
Small quality of life improvement. Previously, if `nvidia-smi` returned an error, `CUDA_ARCH` would be set to the failure message, resulting in failures further on in the build.

This adds a check for the exit code of the `nvidia-smi` command. If the code indicates an error, we print a warning including the output and fall back to the default `CUDA_ARCH` (as we do if `nvidia-smi` is not found).