### PR TITLE
Remove unused atom-mapping code

### DIFF
--- a/attic/atom_mapping/mcs_atom_compare.py
+++ b/attic/atom_mapping/mcs_atom_compare.py
@@ -1,0 +1,20 @@
+import numpy as np
+from rdkit.Chem import rdFMCS
+
+
+class CompareDist(rdFMCS.MCSAtomCompare):
+    """Custom atom comparison: use positions within generated conformer"""
+
+    def __init__(self, threshold=0.5, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.threshold = threshold
+
+    def compare(self, p, mol1, atom1, mol2, atom2):
+        """Atoms match if within 0.5 Å
+
+        Signature from super method:
+        (MCSAtomCompareParameters)parameters, (Mol)mol1, (int)atom1, (Mol)mol2, (int)atom2) -> bool
+        """
+        x_i = mol1.GetConformer(0).GetPositions()[atom1]
+        x_j = mol2.GetConformer(0).GetPositions()[atom2]
+        return bool(np.linalg.norm(x_i - x_j) <= self.threshold)  # must convert from np.bool_ to Python bool!

--- a/attic/readme.md
+++ b/attic/readme.md
@@ -1,6 +1,7 @@
 Code, documentation, experiments we want to retain for reference, but that we're not currently maintaining.
 
 ### Contents
+* `atom_mapping/` -- distance-based atom comparison for rdFMCS
 * `docs/` -- write-up of initial vision for `timemachine`, involving efficient backpropagation through MD trajectories
 * `docking/` -- Docking module that docks uses non-equilibrium switching
 * `jax_tricks` -- misc. Jax functions

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -1,16 +1,4 @@
-# TODO: test mcs atom mapping
-# TODO: move run-time distance check here?
-
-# TODO: test distance atom mapping
-
-from timemachine.fe.atom_mapping import (
-    compute_all_pairs_mcs,
-    compute_transformation_size_matrix,
-    get_core_by_geometry,
-    get_core_by_mcs,
-    mcs_map,
-    transformation_size,
-)
+from timemachine.fe.atom_mapping import get_core_by_geometry, get_core_by_mcs, mcs_map
 from timemachine.testsystems.relative import hif2a_ligand_pair
 
 
@@ -18,27 +6,6 @@ def test_mcs_map():
     mcs_result = mcs_map(hif2a_ligand_pair.mol_a, hif2a_ligand_pair.mol_b, threshold=0.5)
     assert mcs_result.queryMol is not None
     assert mcs_result.numAtoms > 1
-
-
-def test_transformation_size():
-    assert transformation_size(n_A=5, n_B=5, n_MCS=5) == 0
-    assert transformation_size(n_A=5, n_B=5, n_MCS=0) > 0
-
-
-def test_compute_all_pairs_mcs():
-    mols = hif2a_ligand_pair.mol_a, hif2a_ligand_pair.mol_b
-    mcs_s = compute_all_pairs_mcs(mols)
-    assert mcs_s.shape == (len(mols), len(mols))
-
-
-def test_compute_transformation_size_matrix():
-    mols = hif2a_ligand_pair.mol_a, hif2a_ligand_pair.mol_b
-    mcs_s = compute_all_pairs_mcs(mols)
-
-    transformation_sizes = compute_transformation_size_matrix(mols, mcs_s)
-
-    assert (transformation_sizes >= 0).all()
-    assert transformation_sizes.shape == (len(mols), len(mols))
 
 
 def test_get_core_by_mcs():

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -1,4 +1,4 @@
-from timemachine.fe.atom_mapping import get_core_by_geometry, get_core_by_mcs, mcs_map
+from timemachine.fe.atom_mapping import get_core_by_mcs, mcs_map
 from timemachine.testsystems.relative import hif2a_ligand_pair
 
 
@@ -12,10 +12,4 @@ def test_get_core_by_mcs():
     mol_a, mol_b = hif2a_ligand_pair.mol_a, hif2a_ligand_pair.mol_b
     query = mcs_map(mol_a, mol_b).queryMol
     core = get_core_by_mcs(mol_a, mol_b, query)
-    assert core.shape[1] == 2
-
-
-def test_get_core_by_geometry():
-    mol_a, mol_b = hif2a_ligand_pair.mol_a, hif2a_ligand_pair.mol_b
-    core = get_core_by_geometry(mol_a, mol_b)
     assert core.shape[1] == 2

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -7,24 +7,6 @@ from rdkit.Chem import rdFMCS
 from timemachine.fe.topology import AtomMappingError
 
 
-class CompareDist(rdFMCS.MCSAtomCompare):
-    """Custom atom comparison: use positions within generated conformer"""
-
-    def __init__(self, threshold=0.5, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.threshold = threshold
-
-    def compare(self, p, mol1, atom1, mol2, atom2):
-        """Atoms match if within 0.5 Å
-
-        Signature from super method:
-        (MCSAtomCompareParameters)parameters, (Mol)mol1, (int)atom1, (Mol)mol2, (int)atom2) -> bool
-        """
-        x_i = mol1.GetConformer(0).GetPositions()[atom1]
-        x_j = mol2.GetConformer(0).GetPositions()[atom2]
-        return bool(np.linalg.norm(x_i - x_j) <= self.threshold)  # must convert from np.bool_ to Python bool!
-
-
 class CompareDistNonterminal(rdFMCS.MCSAtomCompare):
     """
     Custom comparator used in the FMCS code.

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -29,7 +29,7 @@ class CompareDistNonterminal(rdFMCS.MCSAtomCompare):
         x_j = mol2.GetConformer(0).GetPositions()[atom2]
 
         threshold = 1.0  # angstroms
-        return np.linalg.norm(x_i - x_j) <= threshold
+        return bool(np.linalg.norm(x_i - x_j) <= threshold)
 
 
 def mcs_map(a, b, threshold: float = 2.0, timeout: int = 5, smarts: Optional[str] = None):

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -27,10 +27,9 @@ class CompareDistNonterminal(rdFMCS.MCSAtomCompare):
 
         x_i = mol1.GetConformer(0).GetPositions()[atom1]
         x_j = mol2.GetConformer(0).GetPositions()[atom2]
-        if np.linalg.norm(x_i - x_j) > 1.0:  # angstroms
-            return False
-        else:
-            return True
+
+        threshold = 1.0  # angstroms
+        return np.linalg.norm(x_i - x_j) <= threshold
 
 
 def mcs_map(a, b, threshold: float = 2.0, timeout: int = 5, smarts: Optional[str] = None):

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -5,7 +5,7 @@ from rdkit import Chem
 from rdkit.Chem import rdFMCS
 
 from timemachine.fe.topology import AtomMappingError
-from timemachine.fe.utils import core_from_distances, simple_geometry_mapping
+from timemachine.fe.utils import simple_geometry_mapping
 
 
 class CompareDist(rdFMCS.MCSAtomCompare):
@@ -85,67 +85,6 @@ def mcs_map_graph_only_complete_rings(a, b, timeout: int = 3600, smarts: Optiona
         atomCompare=Chem.rdFMCS.AtomCompare.CompareAny,
         bondCompare=Chem.rdFMCS.BondCompare.CompareAny,
     )
-
-
-def transformation_size(n_A, n_B, n_MCS):
-    """Heuristic size of transformation in terms of
-        the number of atoms in A, B, and MCS(A, B)
-
-    Notes
-    -----
-    * YTZ suggests (2021/01/26)
-        (n_A + n_B) - n_MCS
-        which is size-extensive
-
-    * JF modified (2021/01/27)
-        (n_A - n_MCS) + (n_B - n_MCS)
-        which is 0 when A = B
-
-    * Alternatives considered but not tried:
-        * min(n_A, n_B) - n_MCS
-        * max(n_A, n_B) - n_MCS
-        * 1.0 - (n_MCS / min(n_A, n_B))
-    """
-    return (n_A + n_B) - 2 * n_MCS
-
-
-def compute_all_pairs_mcs(mols, threshold: float = 0.5):
-    """Generate square matrix of MCS(mols[i], mols[j]) for all pairs i,j
-
-    Parameters
-    ----------
-    mols : iterable of RDKit Mols
-
-    Returns
-    -------
-    mcs_s : numpy.ndarray of rdkit.Chem.rdFMCS.MCSResult's, of shape (len(mols), len(mols))
-
-    Notes
-    -----
-    TODO: mcs_map should be symmetric, so only have to do the upper triangle of this matrix
-    """
-    mcs_s = np.zeros((len(mols), len(mols)), dtype=object)
-
-    for i in range(len(mols)):
-        for j in range(i, len(mols)):
-            mapped = mcs_map(mols[i], mols[j], threshold=threshold)
-            mcs_s[i, j] = mapped
-            mcs_s[j, i] = mapped
-    return mcs_s
-
-
-def compute_transformation_size_matrix(mols, mcs_s):
-    N = len(mols)
-    transformation_sizes = np.zeros((N, N))
-    for i in range(N):
-        for j in range(i, N):
-            n_i = mols[i].GetNumAtoms()
-            n_j = mols[j].GetNumAtoms()
-            n_mcs = mcs_s[i, j].numAtoms
-            transforms = transformation_size(n_i, n_j, n_mcs)
-            transformation_sizes[i, j] = transforms
-            transformation_sizes[j, i] = transforms
-    return transformation_sizes
 
 
 # 4. Construct and serialize the relative transformations
@@ -230,17 +169,6 @@ def _assert_core_reasonableness(mol_a, mol_b, core):
     assert len(set(core[:, 1])) == len(core)
 
 
-def get_core_by_matching(mol_a, mol_b, threshold=1.0):
-    """Only allow to map a pair of atoms together if their conformer coordinates are within threshold.
-
-    Of the allowable core mappings, return the maximum-weight matching of maximal-cardinality,
-        where weight(i,j) = threshold - distance(mol_a[i], mol_b[j])
-    """
-    core = core_from_distances(mol_a, mol_b, threshold)
-    _assert_core_reasonableness(mol_a, mol_b, core)
-    return core
-
-
 def get_core_by_geometry(mol_a, mol_b, threshold=0.5):
     """Only allow to map a pair of atoms together if their conformer coordinates are within threshold.
 
@@ -250,36 +178,3 @@ def get_core_by_geometry(mol_a, mol_b, threshold=0.5):
     core = simple_geometry_mapping(mol_a, mol_b, threshold)
     _assert_core_reasonableness(mol_a, mol_b, core)
     return core
-
-
-def _get_unique_match(mol, core):
-    matches = mol.GetSubstructMatches(core)
-    assert len(matches) == 1
-    return matches[0]
-
-
-def get_core_by_smarts(mol_a, mol_b, core_smarts):
-    """no atom mapping errors with this one, but the core size is smaller"""
-    query = Chem.MolFromSmarts(core_smarts)
-    return np.array([_get_unique_match(mol_a, query), _get_unique_match(mol_b, query)]).T
-
-
-# 3.1. Define a custom maximum common substructure search method
-
-
-def _identify_hub(transformation_sizes):
-    return int(np.argmin(transformation_sizes.sum(0)))
-
-
-def get_star_map(mols, threshold: float = 0.5):
-    mcs_s = compute_all_pairs_mcs(mols, threshold=threshold)
-    transformation_sizes = compute_transformation_size_matrix(mols, mcs_s)
-
-    hub_index = _identify_hub(transformation_sizes)
-    hub = mols[hub_index]
-
-    # for each "spoke" in the star map, construct serializable transformation "hub -> spoke"
-    others = list(mols)
-    others.pop(hub_index)
-
-    return hub, others

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -86,7 +86,6 @@ def mcs_map_graph_only_complete_rings(a, b, timeout: int = 3600, smarts: Optiona
     )
 
 
-# 4. Construct and serialize the relative transformations
 def _check_core_map_distances(mol_a, mol_b, core, threshold=0.5) -> bool:
     """compute vector of distances[i] = distance(conf_a[core_a[i]], conf_b[core_b[i]]),
     check whether distances[i] <= threshold for all i"""
@@ -140,11 +139,6 @@ def get_core_by_mcs(mol_a, mol_b, query, threshold=0.5):
 
     # find (i,j) = argmin cost
     min_i, min_j = np.unravel_index(np.argmin(cost, axis=None), cost.shape)
-    # print(f'argmin of {n_a} x {n_b} cost matrix: {(min_i, min_j)} ')
-    # TODO: maybe also print the difference between min(cost) and cost[0,0],
-    #   to see how big of a difference it made to pick the default
-
-    # TODO: is there a way to use the matching from MCS directly?
 
     # concatenate into (n_atoms, 2) array
     inds_a, inds_b = matches_a[min_i], matches_b[min_j]

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -1,11 +1,12 @@
 from typing import Optional
 
+import networkx as nx
 import numpy as np
 from rdkit import Chem
 from rdkit.Chem import rdFMCS
+from scipy.spatial.distance import cdist
 
 from timemachine.fe.topology import AtomMappingError
-from timemachine.fe.utils import simple_geometry_mapping
 
 
 class CompareDist(rdFMCS.MCSAtomCompare):
@@ -177,4 +178,87 @@ def get_core_by_geometry(mol_a, mol_b, threshold=0.5):
     """
     core = simple_geometry_mapping(mol_a, mol_b, threshold)
     _assert_core_reasonableness(mol_a, mol_b, core)
+    return core
+
+
+def _weighted_adjacency_graph(conf_a, conf_b, threshold=1.0):
+    """construct a networkx graph with
+    nodes for atoms in conf_a, conf_b, and
+    weighted edges connecting (conf_a[i], conf_b[j])
+        if distance(conf_a[i], conf_b[j]) <= threshold,
+        with weight = threshold - distance(conf_a[i], conf_b[j])
+    """
+    distances = cdist(conf_a, conf_b)
+    within_threshold = distances <= threshold
+
+    g = nx.Graph()
+    for i in range(len(within_threshold)):
+        neighbors_of_i = np.where(within_threshold[i])[0]
+        for j in neighbors_of_i:
+            g.add_edge(f"conf_a[{i}]", f"conf_b[{j}]", weight=threshold - distances[i, j])
+    return g
+
+
+def _core_from_matching(matching):
+    """matching is a set of pairs of node names"""
+
+    # 'conf_b[9]' -> 9
+    ind_from_node_name = lambda name: int(name.split("[")[1].split("]")[0])
+
+    match_list = list(matching)
+
+    inds_a = [ind_from_node_name(u) for (u, _) in match_list]
+    inds_b = [ind_from_node_name(v) for (_, v) in match_list]
+
+    return np.array([inds_a, inds_b]).T
+
+
+def core_from_distances(mol_a, mol_b, threshold=1.0):
+    """
+    TODO: docstring
+    TODO: test
+    """
+    # fetch conformer, assumed aligned
+    conf_a = mol_a.GetConformer(0).GetPositions()
+    conf_b = mol_b.GetConformer(0).GetPositions()
+
+    g = _weighted_adjacency_graph(conf_a, conf_b, threshold)
+
+    matching = nx.algorithms.matching.max_weight_matching(g, maxcardinality=True)
+
+    return _core_from_matching(matching)
+
+
+def simple_geometry_mapping(mol_a, mol_b, threshold=0.5):
+    """For each atom i in conf_a, if there is exactly one atom j in conf_b
+    such that distance(i, j) <= threshold, add (i,j) to atom mapping
+
+    Notes
+    -----
+    * Warning! There are many situations where a pair of atoms that shouldn't be mapped together
+        could appear within distance threshold of each other in their respective conformers
+    """
+
+    # fetch conformer, assumed aligned
+    conf_a = mol_a.GetConformer(0).GetPositions()
+    conf_b = mol_b.GetConformer(0).GetPositions()
+    # TODO: perform initial alignment
+
+    within_threshold = cdist(conf_a, conf_b) <= threshold
+    num_neighbors = within_threshold.sum(1)
+    num_mappings_possible = np.prod(num_neighbors[num_neighbors > 0])
+
+    if max(num_neighbors) > 1:
+        print(
+            f"Warning! Multiple (~ {num_mappings_possible}) atom-mappings would be possible at threshold={threshold}Å."
+        )
+        print(f"Only mapping atoms that have exactly one neighbor within {threshold}Å.")
+        # TODO: print more information about difference between size of set returned and set possible
+        # TODO: also assert that only pairs of the same element will be mapped together
+
+    inds = []
+    for i in range(len(conf_a)):
+        if num_neighbors[i] == 1:
+            inds.append((i, np.argmax(within_threshold[i])))
+    core = np.array(inds)
     return core

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -1,10 +1,8 @@
 from typing import Optional
 
-import networkx as nx
 import numpy as np
 from rdkit import Chem
 from rdkit.Chem import rdFMCS
-from scipy.spatial.distance import cdist
 
 from timemachine.fe.topology import AtomMappingError
 
@@ -155,110 +153,4 @@ def get_core_by_mcs(mol_a, mol_b, query, threshold=0.5):
     if not _check_core_map_distances(mol_a, mol_b, core, threshold):
         raise AtomMappingError(f"not all mapped atoms are within {threshold:.3f}Å of each other")
 
-    return core
-
-
-def _assert_core_reasonableness(mol_a, mol_b, core):
-    # TODO move any useful run-time assertions from this script into tests/
-
-    # bounds
-    assert max(core[:, 0]) < mol_a.GetNumAtoms()
-    assert max(core[:, 1]) < mol_b.GetNumAtoms()
-
-    # uniqueness
-    assert len(set(core[:, 0])) == len(core)
-    assert len(set(core[:, 1])) == len(core)
-
-
-def get_core_by_geometry(mol_a, mol_b, threshold=0.5):
-    """Only allow to map a pair of atoms together if their conformer coordinates are within threshold.
-
-    Of the allowable core mappings, return the one that contains only atom pairs (i, j)
-    where i in mol_a has exactly one neighbor j in mol_b within threshold
-    """
-    core = simple_geometry_mapping(mol_a, mol_b, threshold)
-    _assert_core_reasonableness(mol_a, mol_b, core)
-    return core
-
-
-def _weighted_adjacency_graph(conf_a, conf_b, threshold=1.0):
-    """construct a networkx graph with
-    nodes for atoms in conf_a, conf_b, and
-    weighted edges connecting (conf_a[i], conf_b[j])
-        if distance(conf_a[i], conf_b[j]) <= threshold,
-        with weight = threshold - distance(conf_a[i], conf_b[j])
-    """
-    distances = cdist(conf_a, conf_b)
-    within_threshold = distances <= threshold
-
-    g = nx.Graph()
-    for i in range(len(within_threshold)):
-        neighbors_of_i = np.where(within_threshold[i])[0]
-        for j in neighbors_of_i:
-            g.add_edge(f"conf_a[{i}]", f"conf_b[{j}]", weight=threshold - distances[i, j])
-    return g
-
-
-def _core_from_matching(matching):
-    """matching is a set of pairs of node names"""
-
-    # 'conf_b[9]' -> 9
-    ind_from_node_name = lambda name: int(name.split("[")[1].split("]")[0])
-
-    match_list = list(matching)
-
-    inds_a = [ind_from_node_name(u) for (u, _) in match_list]
-    inds_b = [ind_from_node_name(v) for (_, v) in match_list]
-
-    return np.array([inds_a, inds_b]).T
-
-
-def core_from_distances(mol_a, mol_b, threshold=1.0):
-    """
-    TODO: docstring
-    TODO: test
-    """
-    # fetch conformer, assumed aligned
-    conf_a = mol_a.GetConformer(0).GetPositions()
-    conf_b = mol_b.GetConformer(0).GetPositions()
-
-    g = _weighted_adjacency_graph(conf_a, conf_b, threshold)
-
-    matching = nx.algorithms.matching.max_weight_matching(g, maxcardinality=True)
-
-    return _core_from_matching(matching)
-
-
-def simple_geometry_mapping(mol_a, mol_b, threshold=0.5):
-    """For each atom i in conf_a, if there is exactly one atom j in conf_b
-    such that distance(i, j) <= threshold, add (i,j) to atom mapping
-
-    Notes
-    -----
-    * Warning! There are many situations where a pair of atoms that shouldn't be mapped together
-        could appear within distance threshold of each other in their respective conformers
-    """
-
-    # fetch conformer, assumed aligned
-    conf_a = mol_a.GetConformer(0).GetPositions()
-    conf_b = mol_b.GetConformer(0).GetPositions()
-    # TODO: perform initial alignment
-
-    within_threshold = cdist(conf_a, conf_b) <= threshold
-    num_neighbors = within_threshold.sum(1)
-    num_mappings_possible = np.prod(num_neighbors[num_neighbors > 0])
-
-    if max(num_neighbors) > 1:
-        print(
-            f"Warning! Multiple (~ {num_mappings_possible}) atom-mappings would be possible at threshold={threshold}Å."
-        )
-        print(f"Only mapping atoms that have exactly one neighbor within {threshold}Å.")
-        # TODO: print more information about difference between size of set returned and set possible
-        # TODO: also assert that only pairs of the same element will be mapped together
-
-    inds = []
-    for i in range(len(conf_a)):
-        if num_neighbors[i] == 1:
-            inds.append((i, np.argmax(within_threshold[i])))
-    core = np.array(inds)
     return core

--- a/timemachine/fe/utils.py
+++ b/timemachine/fe/utils.py
@@ -1,4 +1,3 @@
-import networkx as nx
 import numpy as np
 import simtk.unit
 from rdkit import Chem
@@ -66,92 +65,6 @@ def convert_uM_to_kJ_per_mole(amount_in_uM):
 
     """
     return 0.593 * np.log(amount_in_uM * 1e-6) * 4.18
-
-
-from scipy.spatial.distance import cdist
-
-
-def _weighted_adjacency_graph(conf_a, conf_b, threshold=1.0):
-    """construct a networkx graph with
-    nodes for atoms in conf_a, conf_b, and
-    weighted edges connecting (conf_a[i], conf_b[j])
-        if distance(conf_a[i], conf_b[j]) <= threshold,
-        with weight = threshold - distance(conf_a[i], conf_b[j])
-    """
-    distances = cdist(conf_a, conf_b)
-    within_threshold = distances <= threshold
-
-    g = nx.Graph()
-    for i in range(len(within_threshold)):
-        neighbors_of_i = np.where(within_threshold[i])[0]
-        for j in neighbors_of_i:
-            g.add_edge(f"conf_a[{i}]", f"conf_b[{j}]", weight=threshold - distances[i, j])
-    return g
-
-
-def _core_from_matching(matching):
-    """matching is a set of pairs of node names"""
-
-    # 'conf_b[9]' -> 9
-    ind_from_node_name = lambda name: int(name.split("[")[1].split("]")[0])
-
-    match_list = list(matching)
-
-    inds_a = [ind_from_node_name(u) for (u, _) in match_list]
-    inds_b = [ind_from_node_name(v) for (_, v) in match_list]
-
-    return np.array([inds_a, inds_b]).T
-
-
-def core_from_distances(mol_a, mol_b, threshold=1.0):
-    """
-    TODO: docstring
-    TODO: test
-    """
-    # fetch conformer, assumed aligned
-    conf_a = mol_a.GetConformer(0).GetPositions()
-    conf_b = mol_b.GetConformer(0).GetPositions()
-
-    g = _weighted_adjacency_graph(conf_a, conf_b, threshold)
-
-    matching = nx.algorithms.matching.max_weight_matching(g, maxcardinality=True)
-
-    return _core_from_matching(matching)
-
-
-def simple_geometry_mapping(mol_a, mol_b, threshold=0.5):
-    """For each atom i in conf_a, if there is exactly one atom j in conf_b
-    such that distance(i, j) <= threshold, add (i,j) to atom mapping
-
-    Notes
-    -----
-    * Warning! There are many situations where a pair of atoms that shouldn't be mapped together
-        could appear within distance threshold of each other in their respective conformers
-    """
-
-    # fetch conformer, assumed aligned
-    conf_a = mol_a.GetConformer(0).GetPositions()
-    conf_b = mol_b.GetConformer(0).GetPositions()
-    # TODO: perform initial alignment
-
-    within_threshold = cdist(conf_a, conf_b) <= threshold
-    num_neighbors = within_threshold.sum(1)
-    num_mappings_possible = np.prod(num_neighbors[num_neighbors > 0])
-
-    if max(num_neighbors) > 1:
-        print(
-            f"Warning! Multiple (~ {num_mappings_possible}) atom-mappings would be possible at threshold={threshold}Å."
-        )
-        print(f"Only mapping atoms that have exactly one neighbor within {threshold}Å.")
-        # TODO: print more information about difference between size of set returned and set possible
-        # TODO: also assert that only pairs of the same element will be mapped together
-
-    inds = []
-    for i in range(len(conf_a)):
-        if num_neighbors[i] == 1:
-            inds.append((i, np.argmax(within_threshold[i])))
-    core = np.array(inds)
-    return core
 
 
 # TODO: add a module for atom-mapping, with RDKit MCS based and other approaches

--- a/timemachine/fe/utils.py
+++ b/timemachine/fe/utils.py
@@ -1,5 +1,3 @@
-from typing import Any, List, Tuple
-
 import networkx as nx
 import numpy as np
 import simtk.unit
@@ -218,81 +216,6 @@ def plot_atom_mapping_grid(mol_a, mol_b, core, show_idxs=False):
         legends=[mol_a.GetProp("_Name"), mol_b.GetProp("_Name")],
         useSVG=True,
     )
-
-
-def get_connected_components(nodes, relative_inds, absolute_inds) -> List[List[Any]]:
-    """Construct a graph containing (len(nodes) + 1) nodes -- one for each original node, plus a new "reference" node.*
-
-    Add edges
-    * (i, j) in relative_inds,
-    * (i, "reference") for i in absolute_inds
-
-    And then return the connected components of this graph (omitting the "reference" node we added).*
-
-    * Unless "nodes" already contained something named "reference"!
-    """
-    g = nx.Graph()
-    g.add_nodes_from(nodes)
-
-    if "reference" not in nodes:
-        g.add_node("reference")
-
-    for (i, j) in relative_inds:
-        g.add_edge(i, j)
-
-    if len(absolute_inds) == 0:
-        absolute_inds = [0]
-
-    for i in absolute_inds:
-        g.add_edge(i, "reference")
-
-    # return list of lists of elements of the nodes
-    # we will remove the "reference" node we added
-    # however, if the user actually had a node named "reference", don't remove it
-
-    components: List[List[Any]] = list(map(list, list(nx.connected_components(g))))
-
-    if "reference" in nodes:
-        return components
-    else:
-        filtered_components = []
-
-        for component in components:
-            if "reference" in component:
-                component.remove("reference")
-            filtered_components.append(component)
-        return filtered_components
-
-
-def validate_map(n_nodes: int, relative_inds: List[Tuple[int, int]], absolute_inds: List[int]) -> bool:
-    """Construct a graph containing (n_nodes + 1) nodes -- one for each original node, plus a new "reference" node.
-
-    Add edges
-    * (i, j) in relative_inds,
-    * (i, "reference") for i in absolute_inds
-
-    And then return whether this graph is connected.
-
-    If no absolute_inds provided, treat node 0 as "reference".
-
-    Examples
-    --------
-
-    >>> validate_map(4, relative_inds=[[0,1], [2,3]], absolute_inds=[0])
-    False
-
-    >>> validate_map(4, relative_inds=[[0,1], [1,2], [2,3]], absolute_inds=[0])
-    True
-
-    >>> validate_map(4, relative_inds=[[0,1], [2,3]], absolute_inds=[0,2])
-    True
-    """
-
-    if len(absolute_inds) == 0:
-        absolute_inds = [0]
-
-    components = get_connected_components(list(range(n_nodes)), relative_inds, absolute_inds)
-    return len(components) == 1
 
 
 def get_romol_bonds(mol):


### PR DESCRIPTION
A variety of heuristics were suggested, implemented, and superseded, leaving clutter in `fe/atom_mapping.py` and `fe/utils.py`. Due to near name-collisions, this increases misdirection when debugging atom-mapping failures.

This PR removes several unused atom-mapping functions + their helper functions, and retains a custom atom comparison in `attic` which may be interesting for future reference.