### PR TITLE
Add overlap summary fields, plot to RBFE simulation results

### DIFF
--- a/examples/relative_free_energy.py
+++ b/examples/relative_free_energy.py
@@ -39,7 +39,7 @@ def run_pair(mol_a, mol_b, core, forcefield, n_frames, protein_path, seed):
     )
 
     with open("solvent_overlap.png", "wb") as fh:
-        fh.write(solvent_res.plot_png)
+        fh.write(solvent_res.overlap_detail_png)
 
     # this st is only needed to deal with visualization jank
     write_trajectory_as_pdb(mol_a, mol_b, core, solvent_res.frames, solvent_top, "solvent_traj")
@@ -53,7 +53,7 @@ def run_pair(mol_a, mol_b, core, forcefield, n_frames, protein_path, seed):
         mol_a, mol_b, core, forcefield, complex_host_config, seed + 1, n_frames=n_frames, prefix="complex"
     )
     with open("complex_overlap.png", "wb") as fh:
-        fh.write(complex_res.plot_png)
+        fh.write(complex_res.overlap_detail_png)
     write_trajectory_as_pdb(mol_a, mol_b, core, complex_res.frames, complex_top, "complex_traj")
 
     print(f"complex dG: {np.sum(solvent_res.all_dGs):.3f} +- {np.linalg.norm(solvent_res.all_errs):.3f} kJ/mol")

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -77,8 +77,8 @@ def run_pair(mol_a, mol_b, core, forcefield, n_frames, protein_path):
 
     def check_overlaps(result: SimulationResult):
         assert result.overlaps_by_lambda.shape == (len(lambda_schedule) - 1,)
-        assert result.overlaps_by_term_lambda.shape[1] == len(lambda_schedule) - 1
-        for overlaps in [result.overlaps_by_lambda, result.overlaps_by_term_lambda]:
+        assert result.overlaps_by_lambda_by_component.shape[1] == len(lambda_schedule) - 1
+        for overlaps in [result.overlaps_by_lambda, result.overlaps_by_lambda_by_component]:
             assert (0.0 < overlaps).all()
             assert (overlaps < 0.5).all()
 

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -64,6 +64,7 @@ def run_pair(mol_a, mol_b, core, forcefield, n_frames, protein_path):
         lambda_schedule=lambda_schedule,
     )
 
+    assert solvent_res.overlap_summary_png is not None
     assert solvent_res.overlap_detail_png is not None
     assert abs(np.sum(solvent_res.all_dGs)) < 10.0
     assert np.linalg.norm(solvent_res.all_dGs) < 10.0
@@ -90,6 +91,7 @@ def run_pair(mol_a, mol_b, core, forcefield, n_frames, protein_path):
         lambda_schedule=lambda_schedule,
     )
 
+    assert solvent_res.overlap_summary_png is not None
     assert complex_res.overlap_detail_png is not None
     assert abs(np.sum(complex_res.all_dGs)) < 10.0
     assert np.linalg.norm(complex_res.all_dGs) < 10.0

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -64,7 +64,7 @@ def run_pair(mol_a, mol_b, core, forcefield, n_frames, protein_path):
         lambda_schedule=lambda_schedule,
     )
 
-    assert solvent_res.plot_png is not None
+    assert solvent_res.overlap_detail_png is not None
     assert abs(np.sum(solvent_res.all_dGs)) < 10.0
     assert np.linalg.norm(solvent_res.all_dGs) < 10.0
     assert len(solvent_res.frames[0] == n_frames)
@@ -90,7 +90,7 @@ def run_pair(mol_a, mol_b, core, forcefield, n_frames, protein_path):
         lambda_schedule=lambda_schedule,
     )
 
-    assert complex_res.plot_png is not None
+    assert complex_res.overlap_detail_png is not None
     assert abs(np.sum(complex_res.all_dGs)) < 10.0
     assert np.linalg.norm(complex_res.all_dGs) < 10.0
     assert len(complex_res.frames[0]) == n_frames

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -151,7 +151,7 @@ class InitialState:
 class SimulationResult:
     all_dGs: List[np.ndarray]
     all_errs: List[float]
-    plot_png: bytes
+    overlap_detail_png: bytes
     frames: List[np.ndarray]
     boxes: List[np.ndarray]
     initial_states: List[InitialState]
@@ -360,9 +360,17 @@ def estimate_free_energy_given_initial_states(initial_states, protocol, temperat
     buffer = io.BytesIO()
     plt.savefig(buffer, format="png")
     buffer.seek(0)
-    img_as_bytes = buffer.read()
+    overlap_detail_png = buffer.read()
 
-    return SimulationResult(all_dGs, all_errs, img_as_bytes, stored_frames, stored_boxes, initial_states, protocol)
+    return SimulationResult(
+        all_dGs,
+        all_errs,
+        overlap_detail_png,
+        stored_frames,
+        stored_boxes,
+        initial_states,
+        protocol,
+    )
 
 
 def estimate_relative_free_energy(

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -346,6 +346,7 @@ def estimate_free_energy_given_initial_states(initial_states, protocol, temperat
 
             # sanity check - I don't think the dG calculation commutes with its components, so we have to re-estimate
             # the dG from the sum of the delta_us as opposed to simply summing the component dGs
+            # (num components, energy fxn idx, sampled state idx, num samples)
             ukln_by_term = np.array(ukln_by_term, dtype=np.float64)
             total_fwd_delta_us = (ukln_by_term[:, 1, 0, :] - ukln_by_term[:, 0, 0, :]).sum(axis=0)
             total_rev_delta_us = (ukln_by_term[:, 0, 1, :] - ukln_by_term[:, 1, 1, :]).sum(axis=0)

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -244,8 +244,8 @@ def plot_overlap_summary(ax, terms, lambdas, overlaps):
     for term, ys in zip(terms, overlaps):
         ax.plot(lambdas[:-1], ys, marker=".", label=term)
 
-    ax.set_xlabel(r"$\lambda$")
-    ax.set_ylabel("BAR overlap")
+    ax.set_xlabel(r"$\lambda_i$")
+    ax.set_ylabel(r"pair BAR overlap ($\lambda_i$, $\lambda_{i+1}$)")
     ax.legend()
 
 
@@ -389,17 +389,17 @@ def estimate_free_energy_given_initial_states(initial_states, protocol, temperat
         N_k = u_kln.shape[-1] * np.ones(u_kn.shape[0])
         return pymbar.MBAR(u_kn, N_k).computeOverlap()["matrix"][0, 1]  # type: ignore
 
+    lambdas = [s.lamb for s in initial_states]
+
+    _, (ax_top, ax_btm) = plt.subplots(2, 1, figsize=(7, 9))
+    overlaps_by_lambda = np.array([pair_overlap(u_kln) for u_kln in ukln_by_term_lambda.sum(axis=0)])
+    plot_overlap_summary(ax_top, ["Overall"], lambdas, [overlaps_by_lambda])
+
     overlaps_by_term_lambda = np.array(
         [[pair_overlap(u_kln) for u_kln in ukln_by_lambda] for ukln_by_lambda in ukln_by_term_lambda]
     )
+    plot_overlap_summary(ax_btm, U_names, lambdas, overlaps_by_term_lambda)
 
-    plt.figure()
-    plot_overlap_summary(
-        plt.gca(),
-        terms=U_names,
-        lambdas=[s.lamb for s in initial_states],
-        overlaps=overlaps_by_term_lambda,
-    )
     buffer = io.BytesIO()
     plt.savefig(buffer, format="png")
     buffer.seek(0)

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -387,8 +387,9 @@ def estimate_free_energy_given_initial_states(initial_states, protocol, temperat
     ukln_by_term_lambda = np.array(ukln_by_lam_term).swapaxes(0, 1)  # (term, lambda, 2, 2, sample)
 
     def pair_overlap(u_kln):
+        assert u_kln.shape[:2] == (2, 2)
         u_kn = np.concatenate(u_kln, axis=1)
-        N_k = u_kln.shape[-1] * np.ones(u_kn.shape[0])
+        N_k = u_kln.shape[2] * np.ones(u_kn.shape[0])
         return pymbar.MBAR(u_kn, N_k).computeOverlap()["matrix"][0, 1]  # type: ignore
 
     lambdas = [s.lamb for s in initial_states]

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -151,6 +151,8 @@ class InitialState:
 class SimulationResult:
     all_dGs: List[np.ndarray]
     all_errs: List[float]
+    overlaps_by_lambda: np.ndarray  # (L - 1,)
+    overlaps_by_term_lambda: np.ndarray  # (len(U_names), L - 1)
     overlap_summary_png: bytes
     overlap_detail_png: bytes
     frames: List[np.ndarray]
@@ -408,6 +410,8 @@ def estimate_free_energy_given_initial_states(initial_states, protocol, temperat
     return SimulationResult(
         all_dGs,
         all_errs,
+        overlaps_by_lambda,
+        overlaps_by_term_lambda,
         overlap_summary_png,
         overlap_detail_png,
         stored_frames,

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -292,10 +292,7 @@ def estimate_free_energy_given_initial_states(initial_states, protocol, temperat
     all_dGs = []
     all_errs = []
 
-    U_names = []
-    for U_fn in initial_states[0].potentials:
-        # convert from '<timemachine.lib.potentials.Nonbonded object at 0x7f7880b900b8>' -> Nonbonded
-        U_names.append(repr(U_fn).split(".")[-1].split()[0])
+    U_names = [type(U_fn).__name__ for U_fn in initial_states[0].potentials]
 
     num_rows = len(initial_states) - 1
     num_cols = len(U_names) + 1


### PR DESCRIPTION
Adds and populates new fields of the RBFE simulation result object (`timemachine.fe.rbfe.SimulationResult`):

- **`overlaps_by_lambda`**: `(L-1,)` array of BAR overlaps between neighboring pairs of states
- **`overlaps_by_term_lambda`**: `(len(potentials), L-1)` array of BAR overlaps between neighboring pairs of states, for each potential (bond, angle, etc.)
- **`overlap_summary_png`**: plot summarizing the above data (as PNG-encoded binary buffer, similar to existing `plot_png`. Example:
   ![image](https://user-images.githubusercontent.com/319411/187542935-c2ff6da6-e244-4950-8b2c-62f42b60d550.png)


Also renames `plot_png` to `overlap_detail_png` to disambiguate with the new plot.
