### PR TITLE
add name to future object

### DIFF
--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -45,11 +45,15 @@ class TestProcessPool(unittest.TestCase):
 
         test_res = []
         test_ids = []
+        test_names = []
         for f in futures:
             test_res.append(f.result())
             test_ids.append(f.id)
+            test_names.append(f.name)
 
-        assert test_ids == ["0", "1", "2", "3", "4"]
+        expected_ids = ["0", "1", "2", "3", "4"]
+        assert test_ids == expected_ids
+        assert test_names == expected_ids
 
         np.testing.assert_array_equal(test_res, arr * arr)
 
@@ -106,11 +110,15 @@ class TestCUDAPoolClient(unittest.TestCase):
 
         test_res = []
         test_ids = []
+        test_names = []
         for f in futures:
             test_res.append(f.result())
             test_ids.append(f.id)
+            test_names.append(f.name)
 
-        assert test_ids == ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+        expected_ids = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+        assert test_ids == expected_ids
+        assert test_names == expected_ids
 
         expected = [str(i % self.max_workers) for i in range(operations)]
 
@@ -216,11 +224,15 @@ class TestGRPCClient(unittest.TestCase):
 
         test_res = []
         test_ids = []
+        test_names = []
         for f in futures:
             test_res.append(f.result())
             test_ids.append(f.id)
+            test_names.append(f.name)
 
-        assert test_ids == ["0", "1", "2", "3", "4"]
+        expected_ids = ["0", "1", "2", "3", "4"]
+        assert test_ids == expected_ids
+        assert test_names == expected_ids
 
         np.testing.assert_array_equal(test_res, xs * ys)
 
@@ -234,11 +246,15 @@ class TestGRPCClient(unittest.TestCase):
 
         test_res = []
         test_ids = []
+        test_names = []
         for f in futures:
             test_res.append(f.result())
             test_ids.append(f.id)
+            test_names.append(f.name)
 
-        assert test_ids == ["0", "1", "2", "3", "4"]
+        expected_ids = ["0", "1", "2", "3", "4"]
+        assert test_ids == expected_ids
+        assert test_names == expected_ids
 
         np.testing.assert_array_equal(test_res, xs * xs)
 

--- a/timemachine/parallel/client.py
+++ b/timemachine/parallel/client.py
@@ -84,6 +84,13 @@ class _MockFuture:
         """
         return "1"
 
+    @property
+    def name(self) -> str:
+        """
+        Return the name as a str for this subjob
+        """
+        return "1"
+
 
 class WrappedFuture:
     def __init__(self, future, job_id: str):
@@ -99,6 +106,10 @@ class WrappedFuture:
     @property
     def id(self):
         return self._id
+
+    @property
+    def name(self):
+        return str(self._id)
 
 
 class SerialClient(AbstractClient):
@@ -204,6 +215,10 @@ class BinaryFutureWrapper:
     @property
     def id(self):
         return self._id
+
+    @property
+    def name(self):
+        return str(self._id)
 
 
 class GRPCClient(AbstractClient):


### PR DESCRIPTION
- Add .name property to future objects
- Currently just set to str(job_id) but may be different in the future