### PR TITLE
Improve protocol for ring opening/closing transformations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 MKFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 CPP_DIR := $(MKFILE_DIR)timemachine/cpp/
 INSTALL_PREFIX := $(MKFILE_DIR)timemachine/
-PYTEST_CI_ARGS := --color=yes --cov=. --cov-report=html:coverage/ --cov-append --durations=100
+PYTEST_CI_ARGS := --color=yes --cov=. --cov-report=html:coverage/ --cov-append --durations=100 --hypothesis-profile ci
 
 NOGPU_MARKER := nogpu
 MEMCHECK_MARKER := memcheck

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
             "mypy==0.942",
             "pre-commit==2.17.0",
         ],
-        "test": ["pytest", "pytest-cov", "hilbertcurve==1.0.5", "hypothesis==6.54.6"],
+        "test": ["pytest", "pytest-cov", "hilbertcurve==1.0.5"],
     },
     package_data={
         "timemachine": [

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
             "mypy==0.942",
             "pre-commit==2.17.0",
         ],
-        "test": ["pytest", "pytest-cov", "hilbertcurve==1.0.5"],
+        "test": ["pytest", "pytest-cov", "hilbertcurve==1.0.5", "hypothesis==6.54.6"],
     },
     package_data={
         "timemachine": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,13 @@
 
 import gc
 
+import hypothesis
 import pytest
 
 from timemachine.lib import custom_ops
+
+# disable deadline in CI to avoid "Flaky" errors if the first example times out
+hypothesis.settings.register_profile("ci", deadline=None)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_chiral_restraints.py
+++ b/tests/test_chiral_restraints.py
@@ -1,6 +1,8 @@
 import multiprocessing
 import os
 
+# NOTE: To have an effect, XLA_FLAGS must be set in the environment before loading JAX (whether directly or transitively
+# through another import)
 os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=" + str(multiprocessing.cpu_count())
 
 import jax.numpy as jnp

--- a/tests/test_interpolate_fe.py
+++ b/tests/test_interpolate_fe.py
@@ -2,6 +2,8 @@
 import multiprocessing
 import os
 
+# NOTE: To have an effect, XLA_FLAGS must be set in the environment before loading JAX (whether directly or transitively
+# through another import)
 os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=" + str(multiprocessing.cpu_count())
 
 from importlib import resources

--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -455,7 +455,7 @@ def test_interpolate_harmonic_force_constant(src_k, dst_k, k_min, lambda_interva
 
     lambdas = np.arange(0.01, 1.0, 0.01)
 
-    # all interpolated values less than k_min
+    # all interpolated values >= k_min
     np.testing.assert_array_less(1.0, f(src_k, dst_k, lambdas) / k_min + 1e-9)
 
     def assert_nondecreasing(f):

--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -421,6 +421,16 @@ def test_handle_ring_opening_closing_symmetric(k, lambda_interval, lam):
     )
 
 
+@given(nonzero_force_constants, st.lists(lambdas, min_size=3, max_size=3, unique=True).map(sorted))
+@seed(2022)
+def test_handle_ring_opening_closing_pin_to_end_states(k, lambdas):
+    lam, lambda_min, lambda_max = lambdas
+    assert handle_ring_opening_closing(linear_interpolation, 0.0, k, lam, lambda_min, lambda_max) == 0.0
+
+    lambda_min, lambda_max, lam = lambdas
+    assert handle_ring_opening_closing(linear_interpolation, 0.0, k, lam, lambda_min, lambda_max) == k
+
+
 @given(
     nonzero_force_constants,
     nonzero_force_constants,
@@ -517,6 +527,16 @@ def test_cyclic_difference_inverse(a, b, period):
 @seed(2022)
 def test_cyclic_difference_antisymmetric(a, b, period):
     assert cyclic_difference(a, b, period) + cyclic_difference(b, a, period) == 0
+
+
+@given(bounded_ints, bounded_ints, bounded_ints, bounded_ints, periods)
+@seed(2022)
+def test_cyclic_difference_shift_by_n_periods(a, b, m, n, period):
+    assert_equal_cyclic(
+        cyclic_difference(a + m * period, b + n * period, period),
+        cyclic_difference(a, b, period),
+        period,
+    )
 
 
 @given(bounded_ints, bounded_ints, bounded_ints, periods)

--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -492,6 +492,16 @@ def test_cyclic_difference():
     assert cyclic_difference(0, 0, 3) == 0
     assert cyclic_difference(0, 1, 3) == 1
     assert cyclic_difference(0, 2, 3) == -1
+
+    # antisymmetric
+    assert cyclic_difference(0, 1, 3) == -cyclic_difference(1, 0, 3)
+    assert cyclic_difference(0, 2, 3) == -cyclic_difference(2, 0, 3)
+
+    # translation invariant
+    assert cyclic_difference(0, 1, 3) == cyclic_difference(-1, 0, 3)
+    assert cyclic_difference(0, 4, 8) == cyclic_difference(-2, 2, 8) == cyclic_difference(-4, 0, 8)
+
+    # jittable
     _ = jax.jit(cyclic_difference)(0, 1, 1)
 
 

--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -14,8 +14,6 @@ from importlib import resources
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from hypothesis import given
-from hypothesis.strategies import floats
 from jax import vmap
 from jax.experimental.checkify import checkify
 from rdkit import Chem
@@ -497,24 +495,6 @@ def test_cyclic_difference():
     assert cyclic_difference(0, 1, 3) == 1
     assert cyclic_difference(0, 2, 3) == -1
     _ = jax.jit(cyclic_difference)(0, 1, 1)
-
-
-finite_floats = functools.partial(floats, allow_subnormal=False, allow_nan=False, allow_infinity=False)
-
-
-@given(finite_floats(-1e6, 1e6), finite_floats(-1e6, 1e6), finite_floats(min_value=0.0, exclude_min=True))
-def test_cyclic_difference_prop(a, b, period):
-    cdiff = cyclic_difference(a, b, period)
-
-    def assert_allclose_cyclic(a, b, **kwargs):
-        def f(x):
-            x_mod = x % period
-            return np.minimum(x_mod, period - x_mod)
-
-        return np.testing.assert_allclose(f(a), f(b), **kwargs)
-
-    assert_allclose_cyclic(a + cdiff, b, atol=1e-10)
-    assert_allclose_cyclic(np.abs(cdiff), np.abs(a - b), atol=1e-12)
 
 
 def assert_linear(f, x1, x2, x3):

--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -399,10 +399,10 @@ nonzero_force_constants = finite_floats(1e-9, 1e9)
 
 lambdas = finite_floats(0.0, 1.0)
 
-open_lambda_intervals = st.lists(finite_floats(1e-9, 1.0 - 1e-9), min_size=2, max_size=2, unique=True).map(sorted)
+lambda_intervals = st.lists(finite_floats(1e-9, 1.0 - 1e-9), min_size=2, max_size=2, unique=True).map(sorted)
 
 
-@given(nonzero_force_constants, open_lambda_intervals, lambdas)
+@given(nonzero_force_constants, lambda_intervals, lambdas)
 def test_handle_ring_opening_closing_symmetry(k, lambda_interval, lam):
     lambda_min, lambda_max = lambda_interval
 
@@ -424,7 +424,7 @@ def test_handle_ring_opening_closing_symmetry(k, lambda_interval, lam):
     nonzero_force_constants,
     nonzero_force_constants,
     nonzero_force_constants,
-    open_lambda_intervals,
+    lambda_intervals,
 )
 def test_interpolate_harmonic_force_constant(src_k, dst_k, k_min, lambda_interval):
     lambda_min, lambda_max = lambda_interval

--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -522,6 +522,7 @@ bounded_ints = st.integers(-int(1e9), int(1e9))
 @seed(2022)
 def test_cyclic_difference_inverse(a, b, period):
     x = cyclic_difference(a, b, period)
+    assert np.abs(x) <= period / 2
     assert_equal_cyclic(a + x, b, period)
 
 

--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -455,6 +455,9 @@ def test_interpolate_harmonic_force_constant(src_k, dst_k, k_min, lambda_interva
 
     lambdas = np.arange(0.01, 1.0, 0.01)
 
+    # all interpolated values less than k_min
+    np.testing.assert_array_less(1.0, f(src_k, dst_k, lambdas) / k_min + 1e-9)
+
     def assert_nondecreasing(f):
         y = f(lambdas)
         np.testing.assert_array_less(y[:-1] / y[1:], 1.0 + 1e-9)

--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -14,7 +14,6 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 from jax import vmap
-from jax.experimental.checkify import checkify
 from rdkit import Chem
 from rdkit.Chem import AllChem
 
@@ -325,7 +324,7 @@ def test_jax_transform_intermediate_potential():
     def U(x, lam):
         return st.setup_intermediate_state(lam).get_U_fn()(x)
 
-    _ = jax.jit(checkify(U))(conf, 0.1)
+    _ = jax.jit(U)(conf, 0.1)
 
     confs = jnp.array([conf for _ in range(10)])
     lambdas = jnp.linspace(0, 1, 10)

--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -6,7 +6,6 @@ import jax
 
 jax.config.update("jax_enable_x64", True)
 
-# test that end-states are setup correctly in single topology calculations.
 import functools
 import os
 from importlib import resources

--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -1,6 +1,8 @@
 import multiprocessing
 import os
 
+# NOTE: To have an effect, XLA_FLAGS must be set in the environment before loading JAX (whether directly or transitively
+# through another import)
 os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=" + str(multiprocessing.cpu_count())
 import jax
 

--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -439,7 +439,7 @@ def test_interpolate_harmonic_force_constant(src_k, dst_k, k_min, lambda_interva
     assert f(src_k, dst_k, 0.0) == src_k
     assert f(src_k, dst_k, 1.0) == dst_k
 
-    lambdas = np.linspace(lambda_min, lambda_max, 10)
+    lambdas = np.arange(0.01, 1.0, 0.01)
 
     def assert_nondecreasing(f):
         y = f(lambdas)

--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -503,10 +503,3 @@ def test_cyclic_difference():
 
     # jittable
     _ = jax.jit(cyclic_difference)(0, 1, 1)
-
-
-def assert_linear(f, x1, x2, x3):
-    np.testing.assert_allclose(
-        (f(x2) - f(x1)) / (x2 - x1),
-        (f(x3) - f(x2)) / (x3 - x2),
-    )

--- a/timemachine/fe/interpolate.py
+++ b/timemachine/fe/interpolate.py
@@ -165,6 +165,10 @@ def log_linear_interpolation(src_params, dst_params, lamb, min_value):
 
 
 def pad(f, src_params, dst_params, lamb, lambda_min, lambda_max):
+    """
+    Use the specified interpolation function in the interval [lambda_min, lambda_max], otherwise pin to the end-state
+    values.
+    """
     return jnp.where(
         lamb < lambda_min,
         src_params,

--- a/timemachine/fe/interpolate.py
+++ b/timemachine/fe/interpolate.py
@@ -153,15 +153,18 @@ def linear_interpolation(src_params, dst_params, lamb):
 
 def log_linear_interpolation(src_params, dst_params, lamb, min_value):
     """
-    Linear interpolation in log space
+    Linear interpolation in log space.
+
+    Notes
+    ----
+    * f(0) = src_params, f(1) = dst_params only if src_params and dst_params are strictly positive, respectively.
     """
-    return jnp.exp(
-        linear_interpolation(
-            jnp.log(jnp.maximum(src_params, min_value)),
-            jnp.log(jnp.maximum(dst_params, min_value)),
-            lamb,
-        )
-    )
+
+    # clip to handle out-of-range end state values
+    src_params = jnp.maximum(src_params, min_value)
+    dst_params = jnp.maximum(dst_params, min_value)
+
+    return jnp.exp(linear_interpolation(jnp.log(src_params), jnp.log(dst_params), lamb))
 
 
 def pad(f, src_params, dst_params, lamb, lambda_min, lambda_max):

--- a/timemachine/fe/interpolate.py
+++ b/timemachine/fe/interpolate.py
@@ -151,8 +151,26 @@ def linear_interpolation(src_params, dst_params, lamb):
     return (1 - lamb) * jnp.asarray(src_params) + lamb * jnp.asarray(dst_params)
 
 
-def log_linear_interpolation(src_params, dst_params, lamb):
+def log_linear_interpolation(src_params, dst_params, lamb, min_value):
     """
     Linear interpolation in log space
     """
-    return jnp.exp(linear_interpolation(jnp.log(src_params), jnp.log(dst_params), lamb))
+    return jnp.exp(
+        linear_interpolation(
+            jnp.log(jnp.maximum(src_params, min_value)),
+            jnp.log(jnp.maximum(dst_params, min_value)),
+            lamb,
+        )
+    )
+
+
+def pad(f, src_params, dst_params, lamb, lambda_min, lambda_max):
+    return jnp.where(
+        lamb < lambda_min,
+        src_params,
+        jnp.where(
+            lambda_max < lamb,
+            dst_params,
+            f(src_params, dst_params, (lamb - lambda_min) / (lambda_max - lambda_min)),
+        ),
+    )

--- a/timemachine/fe/interpolate.py
+++ b/timemachine/fe/interpolate.py
@@ -1,7 +1,7 @@
 from functools import partial
 from typing import Any, Callable, Iterable, Set, Tuple
 
-import numpy as np
+import jax.numpy as jnp
 
 
 class DuplicateAlignmentKeysError(RuntimeError):
@@ -148,4 +148,11 @@ def linear_interpolation(src_params, dst_params, lamb):
     """
     Linearly interpolate between src and dst params
     """
-    return (1 - lamb) * np.array(src_params) + lamb * np.array(dst_params)
+    return (1 - lamb) * jnp.asarray(src_params) + lamb * jnp.asarray(dst_params)
+
+
+def log_linear_interpolation(src_params, dst_params, lamb):
+    """
+    Linear interpolation in log space
+    """
+    return jnp.exp(linear_interpolation(jnp.log(src_params), jnp.log(dst_params), lamb))

--- a/timemachine/fe/interpolate.py
+++ b/timemachine/fe/interpolate.py
@@ -157,7 +157,7 @@ def log_linear_interpolation(src_params, dst_params, lamb, min_value):
 
     Notes
     ----
-    * f(0) = src_params, f(1) = dst_params only if src_params and dst_params are strictly positive, respectively.
+    * f(0) = src_params, f(1) = dst_params only if src_params and dst_params are > min_value, respectively.
     """
 
     # clip to handle out-of-range end state values

--- a/timemachine/fe/single_topology_v3.py
+++ b/timemachine/fe/single_topology_v3.py
@@ -579,8 +579,12 @@ def interpolate_harmonic_bond_params(src_params, dst_params, lamb, k_min, lambda
 
 def cyclic_difference(a, b, period):
     """
-    For 0 < a, b < period, returns d such that (a + d) mod period = b and abs(d) is minimized. I.e. the minimum
-    displacement between two points, with periodic boundaries.
+    Returns the minimum difference between two points, with periodic boundaries.
+    I.e. the solution of ::
+
+        (a + d) % period = b % period
+
+    with minimum abs(d).
     """
 
     d = jnp.fmod(b - a, period)

--- a/timemachine/fe/single_topology_v3.py
+++ b/timemachine/fe/single_topology_v3.py
@@ -497,6 +497,18 @@ def handle_ring_opening_closing(
 
     In the case where src_k = 0 or dst_k = 0 (e.g. ring closing and ring opening, respectively), restrict interpolation
     to the interval [lambda_min, lambda_max], and pin to the end state values outside of this range.
+
+    Parameters
+    ----------
+    f : callable, (src_k: float, dst_k: float, lam: float) -> float
+        interpolation function; should satisfy f(0) = src_k, f(1) = dst_k
+
+    src_k, dst_k : float, k >= 0
+        force constants at lambda=0 and lambda=1, respectively
+
+    lambda_min, lambda_max : float, in 0 < lambda_min < lambda_max < 1
+        interpolate in range [lambda_min, lambda_max] (pin to end states otherwise). Note that if dst_k=0, the
+        convention is flipped so that 1 - lambda_min corresponds to f(0) and 1 - lambda_max corresponds to f(1).
     """
 
     def ring_closing(src_k, dst_k, lamb):
@@ -536,10 +548,10 @@ def interpolate_harmonic_force_constant(src_k, dst_k, lamb, k_min, lambda_min, l
         minimum force constant for interpolation
 
     lambda_min, lambda_max : float, in 0 < lambda_min < lambda_max < 1
-        values of the control parameter at which to begin and end interpolation, respectively. This is only relevant
-        when k=0 in the src or dst params. Note that if k=0 in the dst params (i.e. ring opening), the convention is
-        "flipped", i.e. interpolation "begins" at lambda = 1 - lambda_min and "ends" at 1 - lambda_max.
+        interpolate in range [lambda_min, lambda_max] (pin to end states otherwise). Note that if dst_k=0, the
+        convention is flipped so that 1 - lambda_min corresponds to f(0) and 1 - lambda_max corresponds to f(1).
     """
+
     return jnp.where(
         lamb == 0.0,
         src_k,

--- a/timemachine/fe/single_topology_v3.py
+++ b/timemachine/fe/single_topology_v3.py
@@ -638,10 +638,9 @@ def interpolate_harmonic_angle_params(src_params, dst_params, lamb, k_min, lambd
 
     k = interpolate_harmonic_force_constant(src_k, dst_k, lamb, k_min, lambda_min, lambda_max)
 
-    tau = 2 * np.pi
     phase = interpolate.linear_interpolation(
         src_phase,
-        src_phase + cyclic_difference(src_phase % tau, dst_phase % tau, tau),
+        src_phase + cyclic_difference(src_phase, dst_phase, period=2 * np.pi),
         lamb,
     )
 
@@ -679,10 +678,9 @@ def interpolate_periodic_torsion_params(src_params, dst_params, lamb, lambda_min
 
     k = handle_ring_opening_closing(interpolate.linear_interpolation, src_k, dst_k, lamb, lambda_min, lambda_max)
 
-    tau = 2 * np.pi
     phase = interpolate.linear_interpolation(
         src_phase,
-        src_phase + cyclic_difference(src_phase % tau, dst_phase % tau, tau),
+        src_phase + cyclic_difference(src_phase, dst_phase, period=2 * np.pi),
         lamb,
     )
 

--- a/timemachine/fe/single_topology_v3.py
+++ b/timemachine/fe/single_topology_v3.py
@@ -588,7 +588,7 @@ def interpolate_harmonic_bond_params(src_params, dst_params, lamb, k_min, lambda
         force constant and equilibrium length at lambda=1
 
     lamb : float
-        control parameter
+        alchemical parameter
 
     k_min, lambda_min, lambda_max : float
         see docstring of `interpolate_harmonic_force_constant` for documentation of these parameters
@@ -608,9 +608,9 @@ def cyclic_difference(a, b, period):
     Returns the minimum difference between two points, with periodic boundaries.
     I.e. the solution of ::
 
-        (a + d) % period = b % period
+        (a + x) % period = b % period
 
-    with minimum abs(d).
+    with minimum abs(x).
     """
 
     d = jnp.fmod(b - a, period)
@@ -639,7 +639,7 @@ def interpolate_harmonic_angle_params(src_params, dst_params, lamb, k_min, lambd
         force constant and equilibrium angle at lambda=1
 
     lamb : float
-        control parameter
+        alchemical parameter
 
     k_min, lambda_min, lambda_max : float
         see docstring of `interpolate_harmonic_force_constant` for documentation of these parameters
@@ -663,10 +663,10 @@ def interpolate_periodic_torsion_params(src_params, dst_params, lamb, lambda_min
     """
     Interpolate periodic torsion parameters using
 
-    1. linear interpolation for force constants (see note on ring
+    1. Linear interpolation for force constants (see note on ring
        closing in `interpolate_harmonic_bond_params` docstring)
-    2. linear interpolation for angles, using the shortest path
-    3. no interpolation for periodicity (pinned to source value)
+    2. Linear interpolation for angles, using the shortest path
+    3. No interpolation for periodicity (pinned to source value)
 
     * see note on special case when src_k=0 or dst_k=0 in the docstring of `interpolate_harmonic_force_constant`.
 
@@ -679,7 +679,7 @@ def interpolate_periodic_torsion_params(src_params, dst_params, lamb, lambda_min
         force constant and equilibrium dihedral angle, and periodicity at lambda=1
 
     lamb : float
-        control parameter
+        alchemical parameter
 
     k_min, lambda_min, lambda_max : float
         see docstring of `interpolate_harmonic_force_constant` for documentation of these parameters
@@ -996,7 +996,8 @@ class SingleTopologyV3:
         src_system = self.src_system
         dst_system = self.dst_system
 
-        # parameters controlling when angles and torsions "turn on" for ring opening/closing transformations
+        # alchemical parameter values at which angle and torsion force constants transition from zero to nonzero for
+        # ring closing transformations
         lambda_angles = 0.4  # for angles, src_k = 0 => k(lamb) = 0 when lamb < lambda_angles
         lambda_torsions = 0.7  # analogous for torsions
 

--- a/timemachine/fe/single_topology_v3.py
+++ b/timemachine/fe/single_topology_v3.py
@@ -491,7 +491,7 @@ def handle_ring_opening_closing(
     lamb: float,
     lambda_min: float,
     lambda_max: float,
-):
+) -> float:
     """
     In the typical case (src_k != 0 and dst_k != 0), use the specified interpolation function, f.
 
@@ -509,6 +509,11 @@ def handle_ring_opening_closing(
     lambda_min, lambda_max : float, in 0 < lambda_min < lambda_max < 1
         interpolate in range [lambda_min, lambda_max] (pin to end states otherwise). Note that if dst_k=0, the
         convention is flipped so that 1 - lambda_min corresponds to f(0) and 1 - lambda_max corresponds to f(1).
+
+    Returns
+    -------
+    float
+        interpolated force constant
     """
 
     def ring_closing(src_k, dst_k, lamb):
@@ -550,6 +555,11 @@ def interpolate_harmonic_force_constant(src_k, dst_k, lamb, k_min, lambda_min, l
     lambda_min, lambda_max : float, in 0 < lambda_min < lambda_max < 1
         interpolate in range [lambda_min, lambda_max] (pin to end states otherwise). Note that if dst_k=0, the
         convention is flipped so that 1 - lambda_min corresponds to f(0) and 1 - lambda_max corresponds to f(1).
+
+    Returns
+    -------
+    float
+        interpolated force constant
     """
 
     return jnp.where(
@@ -592,6 +602,11 @@ def interpolate_harmonic_bond_params(src_params, dst_params, lamb, k_min, lambda
 
     k_min, lambda_min, lambda_max : float
         see docstring of `interpolate_harmonic_force_constant` for documentation of these parameters
+
+    Returns
+    -------
+    array, float, (2,)
+        interpolated (force constant, equilibrium length)
     """
 
     src_k, src_x = src_params
@@ -643,6 +658,11 @@ def interpolate_harmonic_angle_params(src_params, dst_params, lamb, k_min, lambd
 
     k_min, lambda_min, lambda_max : float
         see docstring of `interpolate_harmonic_force_constant` for documentation of these parameters
+
+    Returns
+    -------
+    array, float, (2,)
+        interpolated (force constant, equilibrium phase)
     """
 
     src_k, src_phase = src_params
@@ -682,6 +702,11 @@ def interpolate_periodic_torsion_params(src_params, dst_params, lamb, lambda_min
 
     lambda_min, lambda_max : float
         see docstring of `interpolate_harmonic_force_constant` for documentation of these parameters
+
+    Returns
+    -------
+    array, float, (3,)
+        interpolated (force constant, equilibrium phase, periodicity)
     """
 
     src_k, src_phase, src_period = src_params

--- a/timemachine/fe/single_topology_v3.py
+++ b/timemachine/fe/single_topology_v3.py
@@ -663,8 +663,7 @@ def interpolate_periodic_torsion_params(src_params, dst_params, lamb, lambda_min
     """
     Interpolate periodic torsion parameters using
 
-    1. Linear interpolation for force constants (see note on ring
-       closing in `interpolate_harmonic_bond_params` docstring)
+    1. Linear interpolation for force constants*
     2. Linear interpolation for angles, using the shortest path
     3. No interpolation for periodicity (pinned to source value)
 
@@ -681,7 +680,7 @@ def interpolate_periodic_torsion_params(src_params, dst_params, lamb, lambda_min
     lamb : float
         alchemical parameter
 
-    k_min, lambda_min, lambda_max : float
+    lambda_min, lambda_max : float
         see docstring of `interpolate_harmonic_force_constant` for documentation of these parameters
     """
 

--- a/timemachine/fe/single_topology_v3.py
+++ b/timemachine/fe/single_topology_v3.py
@@ -485,6 +485,13 @@ def find_dummy_groups_and_anchors(mol_a, mol_b, core_a, core_b):
 
 
 def handle_ring_opening_closing(f, src_k, dst_k, lamb, lambda_min, lambda_max):
+    """
+    In the typical case (src_k != 0 and dst_k != 0), use the specified interpolation function, f.
+
+    In the case where src_k = 0 or dst_k = 0 (e.g. ring closing and ring opening, respectively), restrict interpolation
+    to the interval [lambda_min, lambda_max], and pin to the end state values outside of this range.
+    """
+
     def ring_closing(src_k, dst_k, lamb):
         return interpolate.pad(f, src_k, dst_k, lamb, lambda_min, lambda_max)
 
@@ -504,14 +511,14 @@ def handle_ring_opening_closing(f, src_k, dst_k, lamb, lambda_min, lambda_max):
 
 def interpolate_harmonic_force_constant(src_k, dst_k, lamb, k_min, lambda_min, lambda_max):
     """
-    Interpolate between harmonic force parameters using a log-linear functional form.
+    Interpolate between force constants using a log-linear functional form.
 
     In the special case when src_k=0 or dst_k=0 (e.g. ring opening or closing transformations):
 
     1. Intermediates are interpolated from k_min instead of zero (since 0 is not in the range of the interpolation
        function)
-    2. Interpolation is restricted to the domain [lambda_min, lambda_max] and pinned to the end state values outside of
-       this range
+    2. Interpolation is restricted to the interval [lambda_min, lambda_max] and pinned to the end state values outside
+       of this range
 
     Parameters
     ----------

--- a/timemachine/fe/single_topology_v3.py
+++ b/timemachine/fe/single_topology_v3.py
@@ -1,7 +1,7 @@
 import warnings
 from collections.abc import Iterable
 from functools import partial
-from typing import Tuple
+from typing import Callable, Tuple
 
 import jax.numpy as jnp
 import numpy as np
@@ -484,7 +484,14 @@ def find_dummy_groups_and_anchors(mol_a, mol_b, core_a, core_b):
     return dummy_groups_b, all_jks
 
 
-def handle_ring_opening_closing(f, src_k, dst_k, lamb, lambda_min, lambda_max):
+def handle_ring_opening_closing(
+    f: Callable[[float, float, float], float],
+    src_k: float,
+    dst_k: float,
+    lamb: float,
+    lambda_min: float,
+    lambda_max: float,
+):
     """
     In the typical case (src_k != 0 and dst_k != 0), use the specified interpolation function, f.
 

--- a/timemachine/fe/single_topology_v3.py
+++ b/timemachine/fe/single_topology_v3.py
@@ -637,7 +637,7 @@ def cyclic_difference(a, b, period):
     def f(d):
         return jnp.where(d <= period / 2, d, d - period)
 
-    return jnp.where(0 < d, f(d), -f(-d))
+    return jnp.sign(d) * f(jnp.abs(d))
 
 
 def interpolate_harmonic_angle_params(src_params, dst_params, lamb, k_min, lambda_min, lambda_max):


### PR DESCRIPTION
- Changes the functional form used for interpolation of harmonic bond and angle force constants in single topology transformations from linear to log-linear
   - This is motivated by the observation that the optimal transformation between gaussians is approximately log-linear in sigma in the limit that initial and final mu are identical ([theory reference](http://www.stat.columbia.edu/~gelman/research/published/path2.pdf), [numerical evidence (cell 75)](https://gitlab.com/relaytx/users/jfass/notebooks/-/blob/master/protocol_optimization/RingClosingTwoWays.ipynb)).

- For bonds, angles and torsions In the case where `src_k=0` or `dst_k=0` (e.g. ring opening/closing), sequences force constant transformations so that force constants "turn on" in the order (bonds, angles, torsions).
   - This is to prevent numerical instability seen when an angle with nonzero k spans a bond with near-zero k (due to potential colocation of atoms), or when a torsion with nonzero k spans an angle with near-zero k (due to potential collinearity of bonds).

### hif2a vacuum single topology test

- 32 windows
- 750 ps / window
- 80 edges (from `results_edges_20ns.csv`)

#### Before
Simultaneous linear interpolation for bonds and angle force constants
![image](https://user-images.githubusercontent.com/319411/191347921-362bf39c-4c5e-403f-85cd-c336dc3ab9be.png)

#### After
Log-linear interpolation for bond, angle force constants; sequenced (bonds, angles, torsions)
![image](https://user-images.githubusercontent.com/319411/191348043-1b0a362b-a300-4419-975b-1f9df0535698.png)


