### PR TITLE
Local minimization

### DIFF
--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -57,11 +57,7 @@ def test_local_minimize_water_box():
     bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     box0 += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes at the boundary
 
-    impls = []
-    for bp in bps:
-        impls.append(bp.bound_impl(np.float32))
-
-    val_and_grad_fn = minimizer.get_val_and_grad_fn(impls, box0, lamb)
+    val_and_grad_fn = minimizer.get_val_and_grad_fn(bps, box0, lamb)
 
     free_idxs = [0, 2, 3, 6, 7, 9, 15, 16]
     frozen_idxs = set(range(len(x0))).difference(set(free_idxs))

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -49,8 +49,6 @@ def test_equilibrate_host():
 def test_local_minimize_water_box():
     """
     Test that we can locally relax a box of water by selecting some random indices.
-
-    Furthermore, assert that we can
     """
 
     system, x0, box0, _ = builders.build_water_system(4.0)

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -109,8 +109,7 @@ def sample(initial_state, protocol):
 
     val_and_grad_fn = minimizer.get_val_and_grad_fn(bound_impls, initial_state.box0, initial_state.lamb)
 
-    # note, can't use np.any(np.isnan(initial_state.x0)) is False since np.any returns a bool type
-    assert not np.any(np.isnan(initial_state.x0)), "Initial coordinates contain nan"
+    assert np.all(np.isfinite(initial_state.x0)), "Initial coordinates contain nan or inf"
 
     x0_min = minimizer.local_minimize(initial_state.x0, val_and_grad_fn, free_idxs)
 

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -107,7 +107,7 @@ def sample(initial_state, protocol):
     # if any atom is within any of the ligand's atom's ixn radius, flag it for minimization
     free_idxs = np.where(np.any(d_ij < cutoff, axis=0))[0].tolist()
 
-    val_and_grad_fn = minimizer.get_val_and_grad_fn(bound_impls, initial_state.box0, initial_state.lamb)
+    val_and_grad_fn = minimizer.get_val_and_grad_fn(initial_state.potentials, initial_state.box0, initial_state.lamb)
 
     assert np.all(np.isfinite(initial_state.x0)), "Initial coordinates contain nan or inf"
 

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -108,7 +108,6 @@ def sample(initial_state, protocol):
     free_idxs = np.where(np.any(d_ij < cutoff, axis=0))[0].tolist()
 
     val_and_grad_fn = minimizer.get_val_and_grad_fn(bound_impls, initial_state.box0, initial_state.lamb)
-
     x0_min = minimizer.local_minimize(initial_state.x0, val_and_grad_fn, free_idxs)
 
     # (ytz): re-use the initial states' v0?

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -10,6 +10,7 @@ import numpy as np
 import pymbar
 from rdkit import Chem
 from rdkit.Chem import AllChem, Draw
+from scipy.spatial.distance import cdist
 
 from timemachine.constants import BOLTZ, DEFAULT_TEMP
 from timemachine.fe import model_utils
@@ -98,7 +99,20 @@ def sample(initial_state, protocol):
     intg_impl = initial_state.integrator.impl()
     baro_impl = initial_state.barostat.impl(bound_impls)
 
-    ctxt = custom_ops.Context(initial_state.x0, initial_state.v0, initial_state.box0, intg_impl, bound_impls, baro_impl)
+    # minimize the local region, removing clashes and unstretching some bonds
+    cutoff = 1.0  # in nanometers
+    # local minimize region around ligand
+    ligand_coords = initial_state.x0[initial_state.ligand_idxs]
+    d_ij = cdist(ligand_coords, initial_state.x0)
+    # if any atom is within any of the ligand's atom's ixn radius, flag it for minimization
+    free_idxs = np.where(np.any(d_ij < cutoff, axis=0))[0].tolist()
+
+    val_and_grad_fn = minimizer.get_val_and_grad_fn(bound_impls, initial_state.box0, initial_state.lamb)
+
+    x0_min = minimizer.local_minimize(initial_state.x0, val_and_grad_fn, free_idxs)
+
+    # (ytz): re-use the initial states' v0?
+    ctxt = custom_ops.Context(x0_min, initial_state.v0, initial_state.box0, intg_impl, bound_impls, baro_impl)
 
     # burn-in
     ctxt.multiple_steps_U(
@@ -147,6 +161,7 @@ class InitialState:
     v0: np.ndarray
     box0: np.ndarray
     lamb: float
+    ligand_idxs: np.ndarray
 
 
 @dataclass
@@ -213,7 +228,11 @@ def setup_initial_states(st, host_config, temperature, lambda_schedule, seed):
         ligand_conf = st.combine_confs(mol_a_conf, mol_b_conf)
         combined_conf = np.concatenate([host_conf, ligand_conf])
         x0 = combined_conf
-        v0 = np.zeros_like(x0)
+        v0 = np.zeros_like(x0)  # tbd resample from Maxwell-boltzman?
+        num_ligand_atoms = len(ligand_conf)
+        num_total_atoms = len(x0)
+        ligand_idxs = list(range(num_total_atoms - num_ligand_atoms, num_total_atoms))
+
         box0 = host_config.box
         group_idxs = get_group_indices(get_bond_list(hgs.bond))
         run_seed = seed + lamb_idx
@@ -222,7 +241,8 @@ def setup_initial_states(st, host_config, temperature, lambda_schedule, seed):
         friction = 1.0
         intg = LangevinIntegrator(temperature, dt, friction, hmr_masses, run_seed)
         baro = MonteCarloBarostat(len(hmr_masses), 1.0, temperature, group_idxs, 15, run_seed + 1)
-        state = InitialState(potentials, intg, baro, x0, v0, box0, lamb)
+
+        state = InitialState(potentials, intg, baro, x0, v0, box0, lamb, ligand_idxs)
         initial_states.append(state)
 
     return initial_states

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -306,9 +306,6 @@ def local_minimize(x0, val_and_grad_fn, local_idxs):
     x0: np.array (N,3)
         Coordinates
 
-    box0: np.array (3,3)
-        Frozen box
-
     val_and_grad_fn: f: R^(Nx3,3x3) -> (R^1, R^Nx3)
         Energy function
 

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -333,7 +333,8 @@ def local_minimize(x0, val_and_grad_fn, local_idxs):
         x_prime = x0.copy()
         x_prime[local_idxs] = x_local
         u_full, grad_full = val_and_grad_fn(x_prime)
-        # we minimized the energy too much, likely an overflow
+        # avoid being trapped when overflows spuriously appear as large negative numbers
+        # remove after resolution of https://github.com/proteneer/timemachine/issues/481
         if u_0 - u_full > guard_threshold:
             u_full = np.inf
             grad_full = np.nan * grad_full

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -317,7 +317,7 @@ def local_minimize(x0, val_and_grad_fn, local_idxs):
 
     Returns
     -------
-    Optimized set of coordinates.
+    Optimized set of coordinates (N,3)
 
     """
 


### PR DESCRIPTION
This PR adds a local minimization step where a local region (defined by any atom near any ligand atom, including itself) is minimized using BFGS. This is used to deal with bad initial states containing dummy atoms that are stretched due to poor core geometries. The BFGS routine also adds a sanity guard to deal with the fixed point overflow, however, unlike:

https://github.com/proteneer/timemachine/blob/cd360eb4d26894eedcee10e126cbc9cc13ddd109/timemachine/md/ensembles.py#L40-L41

Which uses a fixed abs on a size-extensive energy, this instead looks at the energy *difference* relative to the start geometry (which is still size extensive, but less so). 
