### PR TITLE
[Draft] updates to rbfe protocol

### DIFF
--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -510,7 +510,7 @@ def estimate_relative_free_energy(
     single_topology = SingleTopologyV3(mol_a, mol_b, core, ff)
 
     if lambda_schedule is None:
-        lambda_schedule = np.array([0.0, 0.01, 0.02, 0.04, 0.06, 0.08, 0.11, 0.15, 0.20, 0.32, 0.42])
+        lambda_schedule = np.array([0.0, 0.02, 0.06, 0.11, 0.15, 0.20, 0.32, 0.42])
         lambda_schedule = np.concatenate([lambda_schedule, (1 - lambda_schedule[::-1])])
     else:
         warnings.warn("Warning: setting lambda_schedule manually, this argument may be removed in a future release.")

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -455,6 +455,7 @@ def estimate_relative_free_energy(
     lambda_schedule=None,
     keep_idxs=None,
     n_eq_steps=10000,
+    steps_per_frame=400,
 ):
     """
     Estimate relative free energy between mol_a and mol_b. Molecules should be aligned to each
@@ -496,6 +497,9 @@ def estimate_relative_free_energy(
     n_eq_steps: int
         Number of equilibration steps for each window.
 
+    steps_per_frame: int
+        Number of steps per frame. Total simulation time is n_frames * steps_per_frame.
+
     Returns
     -------
     SimulationResult
@@ -513,7 +517,7 @@ def estimate_relative_free_energy(
 
     temperature = DEFAULT_TEMP
     initial_states = setup_initial_states(single_topology, host_config, temperature, lambda_schedule, seed)
-    protocol = SimulationProtocol(n_frames=n_frames, n_eq_steps=n_eq_steps, steps_per_frame=400)
+    protocol = SimulationProtocol(n_frames=n_frames, n_eq_steps=n_eq_steps, steps_per_frame=steps_per_frame)
 
     if keep_idxs is None:
         keep_idxs = [0, -1]  # keep first and last frames
@@ -529,7 +533,7 @@ def estimate_relative_free_energy(
         raise err
 
 
-def run_pair(mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_eq_steps=10000):
+def run_pair(mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_eq_steps=10000, steps_per_frame=400):
     box_width = 4.0
     solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(box_width)
     solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes, deboggle later
@@ -544,6 +548,7 @@ def run_pair(mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_eq_steps
         n_frames=n_frames,
         prefix="solvent",
         n_eq_steps=n_eq_steps,
+        steps_per_frame=steps_per_frame,
     )
 
     complex_sys, complex_conf, _, _, complex_box, complex_top = builders.build_protein_system(protein)
@@ -559,6 +564,7 @@ def run_pair(mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_eq_steps
         n_frames=n_frames,
         prefix="complex",
         n_eq_steps=n_eq_steps,
+        steps_per_frame=steps_per_frame,
     )
 
     return solvent_res, solvent_top, complex_res, complex_top


### PR DESCRIPTION
- Currently an edge with default parameters will generate trajectories that are 4 GB (complex) and 1.2 GB (solvent).
- Make option to set steps_per_frame as a kwarg, so the file size can be decreased
- Decrease # of lambdas from 21 to 16