### PR TITLE
Fix overlap summary plot

### DIFF
--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -408,9 +408,10 @@ def estimate_free_energy_given_initial_states(initial_states, protocol, temperat
     ukln_by_lambda_by_component = np.array(ukln_by_component_by_lambda).swapaxes(0, 1)
 
     def pair_overlap(u_kln):
-        assert u_kln.shape[:2] == (2, 2)
-        u_kn = np.concatenate(u_kln, axis=1)
-        N_k = u_kln.shape[2] * np.ones(u_kn.shape[0])
+        k, l, n = u_kln.shape
+        assert k == l == 2
+        u_kn = u_kln.reshape(k, -1)  # (k, l * n)
+        N_k = n * np.ones(l)
         return pymbar.MBAR(u_kn, N_k).computeOverlap()["matrix"][0, 1]  # type: ignore
 
     lambdas = [s.lamb for s in initial_states]

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -279,6 +279,7 @@ def plot_overlap_summary(ax, components, lambdas, overlaps):
     ax.set_xlabel(r"$\lambda_i$")
     ax.set_ylabel(r"pair BAR overlap ($\lambda_i$, $\lambda_{i+1}$)")
     ax.legend()
+    ax.ticklabel_format(useOffset=False)
 
 
 def estimate_free_energy_given_initial_states(initial_states, protocol, temperature, prefix, keep_idxs):

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -410,7 +410,8 @@ def estimate_free_energy_given_initial_states(initial_states, protocol, temperat
     def pair_overlap(u_kln):
         k, l, n = u_kln.shape
         assert k == l == 2
-        u_kn = u_kln.reshape(k, -1)  # (k, l * n)
+        u_kn = u_kln.reshape(k, -1)
+        assert u_kn.shape == (k, l * n)
         N_k = n * np.ones(l)
         return pymbar.MBAR(u_kn, N_k).computeOverlap()["matrix"][0, 1]  # type: ignore
 


### PR DESCRIPTION
Fixes a bug that resulted in incorrect overlap values in the RBFE overlap summary plots.

```python
u_kn = np.concatenate(u_kln, axis=1)  # (k, l, n) -> (l, k*n) INCORRECT
u_kn = u_kln.reshape(k, -1)           # (k, l, n) -> (k, l*n)
```