### PR TITLE
Local minimization (#821)

### DIFF
--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -99,9 +99,9 @@ def sample(initial_state, protocol):
     intg_impl = initial_state.integrator.impl()
     baro_impl = initial_state.barostat.impl(bound_impls)
 
-    # minimize the local region, removing clashes and unstretching some bonds
-    cutoff = 1.0  # in nanometers
-    # local minimize region around ligand
+    cutoff = 0.5  # in nanometers
+    # local minimize region around ligand, should result in ~300 atoms
+
     ligand_coords = initial_state.x0[initial_state.ligand_idxs]
     d_ij = cdist(ligand_coords, initial_state.x0)
     # if any atom is within any of the ligand's atom's ixn radius, flag it for minimization

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -326,8 +326,8 @@ def local_minimize(x0, val_and_grad_fn, local_idxs):
     x_local_shape = (len(local_idxs), 3)
     u_0, _ = val_and_grad_fn(x0)
 
-    # deal with overflow
-    guard_threshold = 1e6
+    # deal with overflow, empirically obtained by testing on some real systems.
+    guard_threshold = 5e4
 
     def val_and_grad_fn_local(x_local):
         x_prime = x0.copy()
@@ -349,7 +349,7 @@ def local_minimize(x0, val_and_grad_fn, local_idxs):
     x_local_0 = x0[local_idxs]
     x_local_0_flat = x_local_0.reshape(-1)
 
-    res = scipy.optimize.minimize(val_and_grad_fn_bfgs, x_local_0_flat, jac=True, options={"disp": True})
+    res = scipy.optimize.minimize(val_and_grad_fn_bfgs, x_local_0_flat, method="BFGS", jac=True, options={"disp": True})
 
     x_final = x0.copy()
     x_final[local_idxs] = res.x.reshape(x_local_shape)


### PR DESCRIPTION
This PR:

-Reduces search radius of BFGS from 1nm to 0.5nm (reducing number of atoms from 1200 to 300)
-Improve the guard threshold from `1e6` to `5e4`, improving the overflow behavior since we're operating on delta Us