### PR TITLE
Bootstrap BAR uncertainty

### DIFF
--- a/tests/test_bar.py
+++ b/tests/test_bar.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pymbar
+from pymbar.testsystems import gaussian_work_example
+
+from timemachine.fe.bar import bar_with_bootstrapped_uncertainty, bootstrap_bar
+
+
+def test_bootstrap_bar():
+    np.random.seed(0)
+    n_bootstrap = 1000
+
+    for sigma_F in [0.1, 1, 10]:
+        # default rbfe instance size, varying difficulty
+        w_F, w_R = gaussian_work_example(2000, 2000, sigma_F=sigma_F, seed=0)
+
+        # estimate 3 times
+        df_ref, ddf_ref = pymbar.BAR(w_F, w_R)
+        df_0, bootstrap_samples = bootstrap_bar(w_F, w_R, n_bootstrap=n_bootstrap)
+        df_1, bootstrap_sigma = bar_with_bootstrapped_uncertainty(w_F, w_R)
+
+        # assert estimates identical, uncertainties comparable
+        print(f"stddev(w_F) = {sigma_F}, bootstrap uncertainty = {bootstrap_sigma}, pymbar.BAR uncertainty = {ddf_ref}")
+        assert df_0 == df_ref
+        assert df_1 == df_ref
+        assert len(bootstrap_samples) == n_bootstrap, "timed out on default problem size!"
+        np.testing.assert_approx_equal(bootstrap_sigma, ddf_ref, significant=1)

--- a/timemachine/fe/bar.py
+++ b/timemachine/fe/bar.py
@@ -107,7 +107,7 @@ def bootstrap_bar(w_F, w_R, n_bootstrap=1000, timeout=10):
     w_R : array
         reverse works
     n_bootstrap : int
-        # boostrap samples
+        # bootstrap samples
     timeout : int
         in seconds
 

--- a/timemachine/fe/bar.py
+++ b/timemachine/fe/bar.py
@@ -1,7 +1,14 @@
+import logging
+from time import time
+
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pymbar
 from jax.scipy.special import logsumexp
+from scipy.stats import normaltest
+
+logger = logging.getLogger(__name__)
 
 
 def EXP(w_raw):
@@ -88,3 +95,76 @@ def dG_dw(w):
     dBAR_dA = jax.grad(BARzero, argnums=(1,))
     dG_dw = -dBAR_dw(w, dG)[0] / dBAR_dA(w, dG)[0]
     return dG_dw
+
+
+def bootstrap_bar(w_F, w_R, n_bootstrap=1000, timeout=10):
+    """Subsample w_F, w_R with replacement and re-run BAR many times
+
+    Parameters
+    ----------
+    w_F : array
+        forward works
+    w_R : array
+        reverse works
+    n_bootstrap : int
+        # boostrap samples
+    timeout : int
+        in seconds
+
+    Returns
+    -------
+    best_estimate : float
+        BAR(w_F, w_R, computeUncertainty=False)
+    bootstrap_samples: array
+        length <= n_bootstrap
+        (length < n_bootstrap if timed out)
+
+    Notes
+    -----
+    * TODO[deboggle] -- upgrade from pymbar3 to pymbar4 and remove this
+    * TODO[performance] -- multiprocessing, if needed?
+    """
+    full_bar_result = pymbar.BAR(w_F, w_R, compute_uncertainty=False)
+
+    n_F, n_R = len(w_F), len(w_R)
+
+    bootstrap_samples = []
+
+    t0 = time()
+
+    for _ in range(n_bootstrap):
+        elapsed_time = time() - t0
+        if elapsed_time > timeout:
+            break
+
+        inds_F = np.random.randint(0, n_F, n_F)
+        inds_R = np.random.randint(0, n_R, n_R)
+
+        bar_result = pymbar.BAR(
+            w_F=w_F[inds_F],
+            w_R=w_R[inds_R],
+            DeltaF=full_bar_result,  # warm start
+            compute_uncertainty=False,
+            relative_tolerance=1e-6,  # reduce cost
+        )
+
+        bootstrap_samples.append(bar_result)
+
+    return full_bar_result, np.array(bootstrap_samples)
+
+
+def bar_with_bootstrapped_uncertainty(w_F, w_R, n_bootstrap=1000, timeout=10):
+    """Drop-in replacement for pymbar.BAR(w_F, w_R) -> (df, ddf)
+    where first return is forwarded from pymbar.BAR but second return is computed by bootstrapping"""
+
+    df, bootstrap_dfs = bootstrap_bar(w_F, w_R, n_bootstrap=n_bootstrap, timeout=timeout)
+
+    # warn if bootstrap distribution deviates significantly from normality
+    normaltest_result = normaltest(bootstrap_dfs)
+    pvalue_threshold = 1e-3  # arbitrary, small
+    if normaltest_result.pvalue < pvalue_threshold:
+        logger.warning(f"bootstrapped errors non-normal: {normaltest_result}")
+
+    # regardless, summarize as if normal
+    ddf = np.std(bootstrap_dfs)
+    return df, ddf

--- a/timemachine/fe/estimator.py
+++ b/timemachine/fe/estimator.py
@@ -8,6 +8,7 @@ import pymbar
 from numpy.typing import NDArray
 
 from timemachine.fe import endpoint_correction, standard_state
+from timemachine.fe.bar import bar_with_bootstrapped_uncertainty
 from timemachine.fe.utils import extract_delta_Us_from_U_knk, sanitize_energies
 from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, custom_ops, potentials
 from timemachine.md import minimizer
@@ -344,7 +345,8 @@ def deltaG_from_results(
         fwd_delta_u = model.beta * delta_Us[lambda_idx][0]
         rev_delta_u = model.beta * delta_Us[lambda_idx][1]
 
-        dG_exact, exact_bar_err = pymbar.BAR(fwd_delta_u, rev_delta_u)
+        dG_exact, exact_bar_err = bar_with_bootstrapped_uncertainty(fwd_delta_u, rev_delta_u)
+
         bar_dG += dG_exact / model.beta
         exact_bar_overlap = endpoint_correction.overlap_from_cdf(fwd_delta_u, rev_delta_u)
 
@@ -405,7 +407,9 @@ def deltaG_from_results(
             rhs_xs=results[-1].xs,
             seed=2021,
         )
-        dG_endpoint, endpoint_err = pymbar.BAR(model.beta * lhs_du, model.beta * np.array(rhs_du))
+        dG_endpoint, endpoint_err = bar_with_bootstrapped_uncertainty(
+            model.beta * lhs_du, model.beta * np.array(rhs_du)
+        )
         dG_endpoint = dG_endpoint / model.beta
         endpoint_err = endpoint_err / model.beta
         # compute standard state corrections for translation and rotation

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -286,7 +286,7 @@ def plot_BAR(df, df_err, fwd_delta_u, rev_delta_u, title, axes):
     axes.set_title(f"{title}, dg: {df:.2f} +- {df_err:.2f} kTs")
     axes.hist(fwd_delta_u, alpha=0.5, label="fwd", density=True, bins=20)
     axes.hist(-rev_delta_u, alpha=0.5, label="-rev", density=True, bins=20)
-    axes.set_xlabel("work (kTs)")
+    axes.set_xlabel("work (kBTs)")
     axes.legend()
 
 

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -287,7 +287,7 @@ def plot_BAR(df, df_err, fwd_delta_u, rev_delta_u, title, axes):
     axes.set_title(f"{title}, dg: {df:.2f} +- {df_err:.2f} kTs")
     axes.hist(fwd_delta_u, alpha=0.5, label="fwd", density=True, bins=20)
     axes.hist(-rev_delta_u, alpha=0.5, label="-rev", density=True, bins=20)
-    axes.set_xlabel("work (kBTs)")
+    axes.set_xlabel("work (kTs)")
     axes.legend()
 
 

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -14,6 +14,7 @@ from scipy.spatial.distance import cdist
 
 from timemachine.constants import BOLTZ, DEFAULT_TEMP
 from timemachine.fe import model_utils
+from timemachine.fe.bar import bar_with_bootstrapped_uncertainty
 from timemachine.fe.single_topology_v3 import SingleTopologyV3
 from timemachine.fe.system import convert_bps_into_system
 from timemachine.fe.utils import get_mol_name, get_romol_conf
@@ -395,7 +396,7 @@ def estimate_free_energy_given_initial_states(initial_states, protocol, temperat
 
                 fwd_delta_u = u_10 - u_00
                 rev_delta_u = u_01 - u_11
-                df, df_err = pymbar.BAR(fwd_delta_u, rev_delta_u)
+                df, df_err = bar_with_bootstrapped_uncertainty(fwd_delta_u, rev_delta_u)
                 plot_axis = all_axes[lamb_idx - 1][u_idx]
                 plot_BAR(df, df_err, fwd_delta_u, rev_delta_u, U_names[u_idx], plot_axis)
 
@@ -406,7 +407,7 @@ def estimate_free_energy_given_initial_states(initial_states, protocol, temperat
             ukln_by_component = np.array(ukln_by_component, dtype=np.float64)
             total_fwd_delta_us = (ukln_by_component[:, 1, 0, :] - ukln_by_component[:, 0, 0, :]).sum(axis=0)
             total_rev_delta_us = (ukln_by_component[:, 0, 1, :] - ukln_by_component[:, 1, 1, :]).sum(axis=0)
-            total_df, total_df_err = pymbar.BAR(total_fwd_delta_us, total_rev_delta_us)
+            total_df, total_df_err = bar_with_bootstrapped_uncertainty(total_fwd_delta_us, total_rev_delta_us)
 
             plot_axis = all_axes[lamb_idx - 1][u_idx + 1]
 


### PR DESCRIPTION
Replaces pymbar3 BAR uncertainty with bootstrap in `rbfe.py` and `estimator.py`
* bootstrap samples are computed at looser relative tolerance, for speed
* a timeout is provided, in case instance size or difficulty is greater than expected
* a warning is logged if distribution of bootstrapped estimates deviates a lot from normality

Introduces a deboggling to-do: remove this code after upgrade to pymbar4, which supports bootstrapping.