### PR TITLE
Fix failure to evaluate intermediate potential when there are no chiral restraints, disable chiral restraints in vacuum simulations

### DIFF
--- a/tests/test_chiral_restraints.py
+++ b/tests/test_chiral_restraints.py
@@ -5,6 +5,7 @@ os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=" + str(multip
 
 import jax.numpy as jnp
 import numpy as np
+import pytest
 import scipy
 from rdkit import Chem
 
@@ -417,6 +418,8 @@ $$$$""",
     assert ks < 0.05 or pv > 0.10
 
 
+# Expected to fail until chiral restraints are re-enabled for vacuum simulations
+@pytest.mark.xfail
 def test_chiral_topology():
     # test adding chiral restraints to the base topology
     # this molecule has several chiral atoms and bonds

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -8,7 +8,10 @@ import scipy
 
 from timemachine.integrator import simulate
 from timemachine.lib import potentials
-from timemachine.potentials import bonded, chiral_restraints, nonbonded
+from timemachine.potentials import bonded, nonbonded
+
+# Chiral restraints are disabled until checks are added (see GH #815)
+# from timemachine.potentials import bonded, chiral_restraints, nonbonded
 
 
 def minimize_scipy(U_fn, x0, return_traj=False):
@@ -132,34 +135,37 @@ class VacuumSystem:
             cutoff=self.nonbonded.get_cutoff(),
         )
 
-        if self.chiral_atom:
-            chiral_atom_U = functools.partial(
-                chiral_restraints.chiral_atom_restraint,
-                params=jnp.array(self.chiral_atom.params),
-                box=None,
-                idxs=np.array(self.chiral_atom.get_idxs()),
-                lamb=0.0,
-            )
-        else:
-            chiral_atom_U = lambda _: 0
+        # Chiral restraints are disabled until checks are added (see GH #815)
+        # if self.chiral_atom:
+        #     chiral_atom_U = functools.partial(
+        #         chiral_restraints.chiral_atom_restraint,
+        #         params=jnp.array(self.chiral_atom.params),
+        #         box=None,
+        #         idxs=np.array(self.chiral_atom.get_idxs()),
+        #         lamb=0.0,
+        #     )
+        # else:
+        #     chiral_atom_U = lambda _: 0
 
-        if self.chiral_bond:
-            chiral_bond_U = functools.partial(
-                chiral_restraints.chiral_bond_restraint,
-                params=jnp.array(self.chiral_bond.params),
-                box=None,
-                idxs=np.array(self.chiral_bond.get_idxs()),
-                signs=np.array(self.chiral_bond.get_signs()),
-                lamb=0.0,
-            )
-        else:
-            chiral_bond_U = lambda _: 0
+        # if self.chiral_bond:
+        #     chiral_bond_U = functools.partial(
+        #         chiral_restraints.chiral_bond_restraint,
+        #         params=jnp.array(self.chiral_bond.params),
+        #         box=None,
+        #         idxs=np.array(self.chiral_bond.get_idxs()),
+        #         signs=np.array(self.chiral_bond.get_signs()),
+        #         lamb=0.0,
+        #     )
+        # else:
+        #     chiral_bond_U = lambda _: 0
 
         def U_fn(x):
             Us_vdw, Us_coulomb = nbpl_U(x)
-            chiral_U = chiral_atom_U(x) + chiral_bond_U(x)
 
-            return bond_U(x) + angle_U(x) + torsion_U(x) + jnp.sum(Us_vdw) + jnp.sum(Us_coulomb) + chiral_U
+            # Chiral restraints are disabled until checks are added (see GH #815)
+            # chiral_U = chiral_atom_U(x) + chiral_bond_U(x)
+
+            return bond_U(x) + angle_U(x) + torsion_U(x) + jnp.sum(Us_vdw) + jnp.sum(Us_coulomb)  # + chiral_U
 
         return U_fn
 

--- a/timemachine/potentials/chiral_restraints.py
+++ b/timemachine/potentials/chiral_restraints.py
@@ -123,7 +123,7 @@ def chiral_atom_restraint(conf, params, box, lamb, idxs):
     Flat-bottom chiral atom restraint
     """
     assert len(idxs) == len(params)
-    return jnp.sum(U_chiral_atom_batch_all(conf, idxs, params))
+    return jnp.sum(U_chiral_atom_batch_all(conf, idxs, params)) if len(idxs) else 0.0
 
 
 def chiral_bond_restraint(conf, params, box, lamb, idxs, signs):
@@ -132,4 +132,4 @@ def chiral_bond_restraint(conf, params, box, lamb, idxs, signs):
     """
     assert len(idxs) == len(params)
     assert len(idxs) == len(signs)
-    return jnp.sum(U_chiral_bond_batch_all(conf, idxs, params, signs))
+    return jnp.sum(U_chiral_bond_batch_all(conf, idxs, params, signs)) if len(idxs) else 0.0


### PR DESCRIPTION
## What
- Fixes bug causing intermediate vacuum potential evaluation to fail when there are no chiral atom restraints or no chiral bond restraints
- Adds test cases
- Disables chiral restraints in vacuum simulations (similar to #815)

## Why
Currently
```python
U_fn = st.setup_intermediate_state(0.1).get_U_fn()
_ = U_fn(conf)
```
fails with `TypeError: len() of unsized object` if the intermediate does not have any chiral atom (or bond) restraints (as is the case for the benzene-iodobenzine transformation in the added test). This adds a branch that returns zero energy if `idxs` is empty.

~Should we also disable chiral restraints for vacuum simulations in this PR (as in #815 ?)~ Done.