### PR TITLE
Run vacuum leg

### DIFF
--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -514,7 +514,7 @@ def estimate_relative_free_energy(
         Forcefield to be used for the system
 
     host_config: HostConfig or None
-        Configuration for the host system.
+        Configuration for the host system. If None, then the vacuum leg is run.
 
     n_frames: int
         number of samples to generate for each lambda windows, where each sample is 1000 steps of MD.

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -585,7 +585,7 @@ def run_pair(mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_eq_steps
     )
 
     # vacuum error should be below a threshold, otherwise this edge is likely problematic
-    assert np.linalg.norm(vacuum_res.all_dGs) < 1.0
+    assert np.linalg.norm(vacuum_res.all_errs) < 1.0
 
     box_width = 4.0
     solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(box_width)

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -570,23 +570,6 @@ def estimate_relative_free_energy(
 
 def run_pair(mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_eq_steps=10000):
 
-    # vacuum leg
-    vacuum_host_config = None
-    vacuum_res = estimate_relative_free_energy(
-        mol_a,
-        mol_b,
-        core,
-        forcefield,
-        vacuum_host_config,
-        seed,
-        n_frames=n_frames,
-        prefix="vacuum",
-        n_eq_steps=n_eq_steps,
-    )
-
-    # vacuum error should be below a threshold, otherwise this edge is likely problematic
-    assert np.linalg.norm(vacuum_res.all_errs) < 1.0
-
     box_width = 4.0
     solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(box_width)
     solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes, deboggle later
@@ -618,4 +601,4 @@ def run_pair(mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_eq_steps
         n_eq_steps=n_eq_steps,
     )
 
-    return vacuum_res, solvent_res, solvent_top, complex_res, complex_top
+    return solvent_res, solvent_top, complex_res, complex_top

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -163,6 +163,15 @@ class VacuumSystem:
 
         return U_fn
 
+    def get_U_fns(self):
+
+        return [
+            self.bond,
+            self.angle,
+            self.torsion,
+            self.nonbonded,
+        ]
+
 
 class HostGuestSystem:
 


### PR DESCRIPTION
This PR adds a vacuum leg to allow for quick failure. If the BAR error of the vacuum leg is `>1kJ/mol` then the simulation is aborted. Note that we currently don't save any statistics, and only assert, since saving the results would break the `run_pair` API (since it would return an extra `vacuum_res`)