### PR TITLE
Fixes dependence on atom ordering for get_core_with_alignment

### DIFF
--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -150,6 +150,7 @@ def test_align_mols_by_core():
     assert len(core) == mol_a.GetNumAtoms()
 
 
+@pytest.mark.nogpu
 def test_align_core_different_size_mols():
     """Verifies that this works as expected if the size of the molecules aren't the same."""
     mol_a = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1"))  # benzene
@@ -180,10 +181,23 @@ def test_align_core_different_size_mols():
     assert len(core) == mol_a.GetNumAtoms() - 1
 
 
+@pytest.mark.nogpu
 def test_get_core_with_alignment():
-
+    np.random.seed(2022)
     mol_a, mol_b = get_cyclohexanes_different_confs()
 
     core, _ = get_core_with_alignment(mol_a, mol_b)
+    assert len(core) == mol_a.GetNumAtoms()
+    assert len(core) == mol_b.GetNumAtoms()
+
+    new_idxs = list(range(mol_a.GetNumAtoms()))
+    # Shuffle the indices so that not all of the hydrogens are at the end of the mol
+    np.random.shuffle(new_idxs)
+
+    mol_a_shuffled = Chem.RenumberAtoms(mol_a, new_idxs)
+    np.random.shuffle(new_idxs)
+    mol_b_shuffled = Chem.RenumberAtoms(mol_b, new_idxs)
+
+    shuffled_core, _ = get_core_with_alignment(mol_a_shuffled, mol_b_shuffled)
     assert len(core) == mol_a.GetNumAtoms()
     assert len(core) == mol_b.GetNumAtoms()

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -8,7 +8,12 @@ from timemachine.testsystems.relative import hif2a_ligand_pair
 def test_mcs():
     mcs_result = mcs(hif2a_ligand_pair.mol_a, hif2a_ligand_pair.mol_b, threshold=0.5)
     assert mcs_result.queryMol is not None
-    assert mcs_result.numAtoms > 1
+    assert mcs_result.numAtoms == 30
+
+    # Match but without any hydrogens, should expect fewer matches
+    mcs_result = mcs(hif2a_ligand_pair.mol_a, hif2a_ligand_pair.mol_b, threshold=0.5, match_hydrogens=False)
+    assert mcs_result.queryMol is not None
+    assert mcs_result.numAtoms == 23
 
 
 def test_get_core_by_mcs():

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -70,7 +70,7 @@ def mcs(
     # try on given mols
     result = rdFMCS.FindMCS([a, b], params)
 
-    # optional fallbackmcs
+    # optional fallback
     def is_trivial(mcs_result) -> bool:
         return mcs_result.numBonds < 2
 

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -14,7 +14,16 @@ from timemachine.ff import Forcefield
 from timemachine.md.align import align_mols_by_core
 
 
-def mcs(a, b, threshold: float = 2.0, timeout: int = 5, smarts: Optional[str] = None, conformer_aware=True, retry=True):
+def mcs(
+    a,
+    b,
+    threshold: float = 2.0,
+    timeout: int = 5,
+    smarts: Optional[str] = None,
+    conformer_aware: bool = True,
+    retry: bool = True,
+    match_hydrogens: bool = True,
+):
     """Find maximum common substructure between mols a and b
     using reasonable settings for single topology:
     * disallow partial ring matches
@@ -24,6 +33,8 @@ def mcs(a, b, threshold: float = 2.0, timeout: int = 5, smarts: Optional[str] = 
         (assumes conformers are aligned)
 
     if retry=True, then reseed with result of easier MCS(RemoveHs(a), RemoveHs(b)) in case of failure
+
+    if match_hydrogens=False, then do not match using hydrogens. Will not retry
     """
     params = rdFMCS.MCSParameters()
 
@@ -40,23 +51,33 @@ def mcs(a, b, threshold: float = 2.0, timeout: int = 5, smarts: Optional[str] = 
     if conformer_aware:
         params.AtomCompareParameters.MaxDistance = threshold
     params.AtomTyper = rdFMCS.AtomCompare.CompareAny
-
     # globals
     params.Timeout = timeout
     if smarts is not None:
         params.InitialSeed = smarts
 
+    def strip_hydrogens(mol):
+        """Strip hydrogens with deepcopy to be extra safe"""
+        return Chem.RemoveHs(deepcopy(mol))
+
+    if not match_hydrogens:
+        # Setting CompareAnyHeavyAtom doesn't handle this correctly, strip hydrogens explicitly
+        a = strip_hydrogens(a)
+        b = strip_hydrogens(b)
+        # Disable retrying, as it will compare original a and b
+        retry = False
+
     # try on given mols
     result = rdFMCS.FindMCS([a, b], params)
 
-    # optional fallback
+    # optional fallbackmcs
     def is_trivial(mcs_result) -> bool:
         return mcs_result.numBonds < 2
 
     if retry and is_trivial(result) and smarts is None:
         # try again, but seed with MCS computed without explicit hydrogens
-        a_without_hs = Chem.RemoveHs(deepcopy(a))
-        b_without_hs = Chem.RemoveHs(deepcopy(b))
+        a_without_hs = strip_hydrogens(a)
+        b_without_hs = strip_hydrogens(b)
 
         heavy_atom_result = rdFMCS.FindMCS([a_without_hs, b_without_hs], params)
         params.InitialSeed = heavy_atom_result.smartsString
@@ -186,21 +207,17 @@ def get_core_with_alignment(
     if ff is None:
         ff = Forcefield.load_from_file(DEFAULT_FF)
 
-    # Remove hydrogens
-    a_without_hs = Chem.RemoveHs(deepcopy(a_copy))
-    b_without_hs = Chem.RemoveHs(deepcopy(b_copy))
-
-    def setup_core(mol_a, mol_b):
-        result = mcs(mol_a, mol_b, threshold=threshold)
+    def setup_core(mol_a, mol_b, match_hydrogens):
+        result = mcs(mol_a, mol_b, threshold=threshold, match_hydrogens=match_hydrogens)
         query_mol = Chem.MolFromSmarts(result.smartsString)
         core = get_core_by_mcs(mol_a, mol_b, query_mol, threshold=threshold)
         return core, result.smartsString
 
-    heavy_atom_core, _ = setup_core(a_without_hs, b_without_hs)
+    heavy_atom_core, _ = setup_core(a_copy, b_copy, False)
 
     conf_a, conf_b = align_mols_by_core(mol_a, mol_b, heavy_atom_core, ff, n_steps=n_steps, k=k)
     set_romol_conf(a_copy, conf_a)
     set_romol_conf(b_copy, conf_b)
 
-    core, smarts = setup_core(a_copy, b_copy)
+    core, smarts = setup_core(a_copy, b_copy, True)
     return core, smarts


### PR DESCRIPTION
* Adds match_hydrogens flag to timemachine.fe.atom_mapping::mcs

### Problem
In `get_core_with_alignment` the mols would have their hydrogens removed then build a core using the hydrogen free mols. It assumed that all of the hydrogens were at the end of the molecules so that the core would be valid. This is not always true though, result in an unstable core for use during alignment which caused fewer atoms to be mapped.

### Solution
In `mcs` adds a flag `match_hydrogens` that if it is set to False, will generate the match query using the hydrogen less mols which works since it uses smarts rather than indexs. 
