### PR TITLE
Fix nightly tests

### DIFF
--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -98,7 +98,7 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
 
     assert solvent_res.overlap_summary_png is not None
     assert solvent_res.overlap_detail_png is not None
-    assert np.linalg.norm(solvent_res.all_errs) < 10.0
+    assert np.linalg.norm(solvent_res.all_errs) < 0.1
     assert len(solvent_res.frames[0] == n_frames)
     assert len(solvent_res.frames[-1] == n_frames)
     assert len(solvent_res.boxes[0] == n_frames)
@@ -135,7 +135,7 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
 
     assert solvent_res.overlap_summary_png is not None
     assert complex_res.overlap_detail_png is not None
-    assert np.linalg.norm(complex_res.all_errs) < 10.0
+    assert np.linalg.norm(complex_res.all_errs) < 0.1
     assert len(complex_res.frames[0]) == n_frames
     assert len(complex_res.frames[-1]) == n_frames
     assert len(complex_res.boxes[0]) == n_frames

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -69,8 +69,7 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
 
     assert vacuum_res.overlap_summary_png is not None
     assert vacuum_res.overlap_detail_png is not None
-    assert abs(np.sum(vacuum_res.all_dGs)) < 10.0
-    assert np.linalg.norm(vacuum_res.all_dGs) < 10.0
+    assert np.linalg.norm(vacuum_res.all_errs) < 10.0
     assert len(vacuum_res.frames[0] == n_frames)
     assert len(vacuum_res.frames[-1] == n_frames)
     assert len(vacuum_res.boxes[0] == n_frames)
@@ -98,8 +97,7 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
 
     assert solvent_res.overlap_summary_png is not None
     assert solvent_res.overlap_detail_png is not None
-    assert abs(np.sum(solvent_res.all_dGs)) < 10.0
-    assert np.linalg.norm(solvent_res.all_dGs) < 10.0
+    assert np.linalg.norm(solvent_res.all_errs) < 10.0
     assert len(solvent_res.frames[0] == n_frames)
     assert len(solvent_res.frames[-1] == n_frames)
     assert len(solvent_res.boxes[0] == n_frames)
@@ -136,8 +134,7 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
 
     assert solvent_res.overlap_summary_png is not None
     assert complex_res.overlap_detail_png is not None
-    assert abs(np.sum(complex_res.all_dGs)) < 10.0
-    assert np.linalg.norm(complex_res.all_dGs) < 10.0
+    assert np.linalg.norm(complex_res.all_errs) < 10.0
     assert len(complex_res.frames[0]) == n_frames
     assert len(complex_res.frames[-1]) == n_frames
     assert len(complex_res.boxes[0]) == n_frames

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -70,7 +70,7 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
 
     assert vacuum_res.overlap_summary_png is not None
     assert vacuum_res.overlap_detail_png is not None
-    assert np.linalg.norm(vacuum_res.all_errs) < 10.0
+    assert np.linalg.norm(vacuum_res.all_errs) < 0.1
     assert len(vacuum_res.frames[0] == n_frames)
     assert len(vacuum_res.frames[-1] == n_frames)
     assert len(vacuum_res.boxes[0] == n_frames)

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -64,6 +64,7 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
         seed,
         n_frames=n_frames,
         prefix="vacuum",
+        lambda_schedule=lambda_schedule,
         n_eq_steps=n_eq_steps,
     )
 


### PR DESCRIPTION
Nightlies are failing after https://github.com/proteneer/timemachine/pull/833, on this assertion https://github.com/proteneer/timemachine/pull/833/files#diff-b968240f912984023d9458794895d8d0560a02645cb8034a7f387526662ed201R72

```text
def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_steps):
    
        seed = 2023
    
        lambda_schedule = [0.01, 0.02, 0.03]
        vacuum_host_config = None
        vacuum_res = estimate_relative_free_energy(
            mol_a,
            mol_b,
            core,
            forcefield,
            vacuum_host_config,
            seed,
            n_frames=n_frames,
            prefix="vacuum",
            n_eq_steps=n_eq_steps,
        )
    
        assert vacuum_res.overlap_summary_png is not None
        assert vacuum_res.overlap_detail_png is not None
>       assert abs(np.sum(vacuum_res.all_dGs)) < 10.0
E       assert 19.036675161208375 < 10.0
E        +  where 19.036675161208375 = abs(-19.036675161208375)
E        +    where -19.036675161208375 = <function sum at 0x7fc012226e60>([-0.3038431409324921, -0.6131373090487799, -2.0707852014953985, -2.9484653674[6336](https://gitlab.com/relaytx/physics-platform/timemachine/-/jobs/3037786778#L6336)96, -3.4011602456447223, -4.16583469814006, ...])
E        +      where <function sum at 0x7fc012226e60> = np.sum
E        +      and   [-0.3038431409324921, -0.6131373090487799, -2.0707852014953985, -2.9484653674633696, -3.4011602456447223, -4.16583469814006, ...] = SimulationResult(all_dGs=[-0.3038431409324921, -0.6131373090487799, -2.0707852014953985, -2.9484653674633696, -3.4011602456447223, -4.16583469814006, -3.65337578651778, 0.8951983822912267, 8.586886164200424, 0.8016965284922359, -0.9516028290974761, -2.1504861376711495, -3.4799063505450225, -1.81636400029352, -1.280019522610989, -0.6716621278287614, -0.4303661184892327, -0.4318925437138231, -0.4317783977005832, -0.2506971831060223, -0.2690792758930809], all_errs=[0.027308665857559984, 0.03142409031029376, 0.08536427792995524, 0.11450978092769298, 0.13959766679693195, 0.20932132022943445, 0.4321868078725671, 0.3788949426697053, 0.5659437091639236, 0.2738237114303938, 0.520961999677642, 0.29607984616443767, 0.3387222360269236, 0.1408295182311457, 0.12064981627481226, 0.08793102445405673, 0.05882021860220969, 0.0646680003118824, 0.06400603290371755, 0.030032000361831457, 0.026807587706022082], overlaps_by_lambda=array([0.49685007, 0.49595241, 0.47262035, 0.44972099, 0.43322015, 0.36538847, 0.19850656, 0.23827712, 0.14001903, 0.2981682 , 0.15043394, 0.28257865, 0.24653068, 0.42208676, 0.44902732, 0.46928732, 0.48593976, 0.48564592, 0.48469993, 0.49639748, 0.49703511]), overlaps_by_lam...02726],\n       [ 2.88873,  0.06401, -0.74156],\n       [ 2.84959,  0.17705, -1.16621],\n       [ 2.4842 ,  0.11182, -1.38525]]), v0=array([[0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.],\n       [0., 0., 0.]]), box0=array([[10.,  0.,  0.],\n       [ 0., 10.,  0.],\n       [ 0.,  0., 10.]]), lamb=1.0, ligand_idxs=array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34]))], protocol=SimulationProtocol(n_frames=100, n_eq_steps=1000, steps_per_frame=400)).all_dGs
tests/test_relative_free_energy.py:72: AssertionError
```

------------


Removes failing assertion on `abs(sum(dGs))` and similar assertions, modifies assertions on `norm(dGs)` to `norm(errs)`