### PR TITLE
Freeze random seed in `bootstrap_bar`

### DIFF
--- a/timemachine/fe/bar.py
+++ b/timemachine/fe/bar.py
@@ -140,12 +140,12 @@ def bootstrap_bar(w_F, w_R, n_bootstrap=1000, timeout=10):
         if elapsed_time > timeout:
             break
 
-        w_F_sample = rng.choice(w_F, replace=True)
-        w_R_sample = rng.choice(w_R, replace=True)
+        w_F_sample = rng.choice(w_F, size=(n_F,), replace=True)
+        w_R_sample = rng.choice(w_R, size=(n_R,), replace=True)
 
         bar_result = pymbar.BAR(
-            w_F=w_F[inds_F],
-            w_R=w_R[inds_R],
+            w_F=w_F_sample,
+            w_R=w_R_sample,
             DeltaF=full_bar_result,  # warm start
             compute_uncertainty=False,
             relative_tolerance=1e-6,  # reduce cost

--- a/timemachine/fe/bar.py
+++ b/timemachine/fe/bar.py
@@ -132,13 +132,16 @@ def bootstrap_bar(w_F, w_R, n_bootstrap=1000, timeout=10):
 
     t0 = time()
 
+    seed = 2022
+    rng = np.random.RandomState(seed)
+
     for _ in range(n_bootstrap):
         elapsed_time = time() - t0
         if elapsed_time > timeout:
             break
 
-        inds_F = np.random.randint(0, n_F, n_F)
-        inds_R = np.random.randint(0, n_R, n_R)
+        inds_F = rng.randint(0, n_F, n_F)
+        inds_R = rng.randint(0, n_R, n_R)
 
         bar_result = pymbar.BAR(
             w_F=w_F[inds_F],

--- a/timemachine/fe/bar.py
+++ b/timemachine/fe/bar.py
@@ -140,8 +140,8 @@ def bootstrap_bar(w_F, w_R, n_bootstrap=1000, timeout=10):
         if elapsed_time > timeout:
             break
 
-        inds_F = rng.randint(0, n_F, n_F)
-        inds_R = rng.randint(0, n_R, n_R)
+        w_F_sample = rng.choice(w_F, replace=True)
+        w_R_sample = rng.choice(w_R, replace=True)
 
         bar_result = pymbar.BAR(
             w_F=w_F[inds_F],

--- a/timemachine/fe/bar.py
+++ b/timemachine/fe/bar.py
@@ -133,7 +133,7 @@ def bootstrap_bar(w_F, w_R, n_bootstrap=1000, timeout=10):
     t0 = time()
 
     seed = 2022
-    rng = np.random.RandomState(seed)
+    rng = np.random.default_rng(seed)
 
     for _ in range(n_bootstrap):
         elapsed_time = time() - t0


### PR DESCRIPTION
Makes `bootstrap_bar` deterministic aside from possible `timeout`.

Later, can modify to allow passing an optional random seed / RNG state, but the current PR just hard-codes the random seed, to avoid changing the signature in any way.