### PR TITLE
Overlap summary improvements

### DIFF
--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -112,7 +112,7 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
         assert result.overlaps_by_lambda_by_component.shape[1] == len(lambda_schedule) - 1
         for overlaps in [result.overlaps_by_lambda, result.overlaps_by_lambda_by_component]:
             assert (0.0 < overlaps).all()
-            assert (overlaps < 0.5).all()
+            assert (overlaps < 1.0).all()
 
     check_overlaps(solvent_res)
 

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -188,10 +188,10 @@ def test_pair_overlap_from_ukln():
         return pair_overlap_from_ukln(u_kln)
 
     # identical distributions
-    np.testing.assert_allclose(gaussian_overlap((0, 1), (0, 1)), 0.5)
+    np.testing.assert_allclose(gaussian_overlap((0, 1), (0, 1)), 1.0)
 
     # non-overlapping
     assert gaussian_overlap((0, 0.01), (1, 0.01)) < 1e-10
 
     # overlapping
-    assert gaussian_overlap((0, 0.1), (0.5, 0.2)) > 0.05
+    assert gaussian_overlap((0, 0.1), (0.5, 0.2)) > 0.1

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -305,7 +305,7 @@ def pair_overlap_from_ukln(u_kln):
     u_kn = u_kln.reshape(k, -1)
     assert u_kn.shape == (k, l * n)
     N_k = n * np.ones(l)
-    return pymbar.MBAR(u_kn, N_k).computeOverlap()["matrix"][0, 1]  # type: ignore
+    return 2 * pymbar.MBAR(u_kn, N_k).computeOverlap()["matrix"][0, 1]  # type: ignore
 
 
 def plot_overlap_summary(ax, components, lambdas, overlaps):

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -312,6 +312,7 @@ def plot_overlap_summary(ax, components, lambdas, overlaps):
     for component, ys in zip(components, overlaps):
         ax.plot(lambdas[:-1], ys, marker=".", label=component)
 
+    ax.set_ylim(0, 1)
     ax.set_xlabel(r"$\lambda_i$")
     ax.set_ylabel(r"pair BAR overlap ($\lambda_i$, $\lambda_{i+1}$)")
     ax.legend()


### PR DESCRIPTION
- Scale pairwise overlap statistic by 2 so its range is [0, 1] instead of [0, 0.5]
- Set y axis limits in overlap summary plot to the allowed range of overlap values, [0, 1]