### PR TITLE
Avoid computing BAR on energy components

### DIFF
--- a/timemachine/fe/bar.py
+++ b/timemachine/fe/bar.py
@@ -1,3 +1,4 @@
+import logging
 from time import time
 
 import jax
@@ -6,6 +7,8 @@ import numpy as np
 import pymbar
 from jax.scipy.special import logsumexp
 from scipy.stats import normaltest
+
+logger = logging.getLogger(__name__)
 
 
 def EXP(w_raw):
@@ -163,7 +166,7 @@ def bar_with_bootstrapped_uncertainty(w_F, w_R, n_bootstrap=1000, timeout=10):
     normaltest_result = normaltest(bootstrap_dfs)
     pvalue_threshold = 1e-3  # arbitrary, small
     if normaltest_result.pvalue < pvalue_threshold:
-        print(f"bootstrapped errors non-normal: {normaltest_result}")
+        logger.warning(f"bootstrapped errors non-normal: {normaltest_result}")
 
     # regardless, summarize as if normal
     ddf = np.std(bootstrap_dfs)

--- a/timemachine/fe/bar.py
+++ b/timemachine/fe/bar.py
@@ -1,4 +1,3 @@
-import logging
 from time import time
 
 import jax
@@ -7,8 +6,6 @@ import numpy as np
 import pymbar
 from jax.scipy.special import logsumexp
 from scipy.stats import normaltest
-
-logger = logging.getLogger(__name__)
 
 
 def EXP(w_raw):
@@ -166,7 +163,7 @@ def bar_with_bootstrapped_uncertainty(w_F, w_R, n_bootstrap=1000, timeout=10):
     normaltest_result = normaltest(bootstrap_dfs)
     pvalue_threshold = 1e-3  # arbitrary, small
     if normaltest_result.pvalue < pvalue_threshold:
-        logger.warning(f"bootstrapped errors non-normal: {normaltest_result}")
+        print(f"bootstrapped errors non-normal: {normaltest_result}")
 
     # regardless, summarize as if normal
     ddf = np.std(bootstrap_dfs)

--- a/timemachine/fe/bar.py
+++ b/timemachine/fe/bar.py
@@ -14,7 +14,7 @@ def EXP(w_raw):
 
     Parameters
     ----------
-    w : np.ndarray, float, (N)
+    w_raw : np.ndarray, float, (N)
         work for N frames
 
     Returns

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -264,6 +264,14 @@ def setup_initial_states(st, host_config, temperature, lambda_schedule, seed):
     return initial_states
 
 
+def plot_work(w_forward, w_reverse, axes):
+    """histograms of +forward and -reverse works"""
+    axes.hist(+w_forward, alpha=0.5, label="fwd", density=True, bins=20)
+    axes.hist(-w_reverse, alpha=0.5, label="-rev", density=True, bins=20)
+    axes.set_xlabel("work (kT)")
+    axes.legend()
+
+
 def plot_BAR(df, df_err, fwd_delta_u, rev_delta_u, title, axes):
     """
     Generate a subplot showing overlap for a particular pair of delta_us.
@@ -290,10 +298,7 @@ def plot_BAR(df, df_err, fwd_delta_u, rev_delta_u, title, axes):
 
     """
     axes.set_title(f"{title}, dg: {df:.2f} +- {df_err:.2f} kTs")
-    axes.hist(fwd_delta_u, alpha=0.5, label="fwd", density=True, bins=20)
-    axes.hist(-rev_delta_u, alpha=0.5, label="-rev", density=True, bins=20)
-    axes.set_xlabel("work (kTs)")
-    axes.legend()
+    plot_work(fwd_delta_u, rev_delta_u, axes)
 
 
 def pair_overlap_from_ukln(u_kln):

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -285,9 +285,6 @@ def plot_BAR(df, df_err, fwd_delta_u, rev_delta_u, title, axes):
     title: str
         title to use
 
-    plot_idx: triple (n_row, n_col, n_pos)
-        where to place the subplot
-
     axes: matplotlib axis
         obj used to draw the figures
 

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -406,9 +406,9 @@ def estimate_free_energy_given_initial_states(initial_states, protocol, temperat
 
                 fwd_delta_u = u_10 - u_00
                 rev_delta_u = u_01 - u_11
-                df, df_err = bar_with_bootstrapped_uncertainty(fwd_delta_u, rev_delta_u)
                 plot_axis = all_axes[lamb_idx - 1][u_idx]
-                plot_BAR(df, df_err, fwd_delta_u, rev_delta_u, U_names[u_idx], plot_axis)
+                plot_work(fwd_delta_u, rev_delta_u, plot_axis)
+                plot_axis.set_title(U_names[u_idx])
 
             # sanity check - I don't think the dG calculation commutes with its components, so we have to re-estimate
             # the dG from the sum of the delta_us as opposed to simply summing the component dGs


### PR DESCRIPTION
Based on observation from @badisa that `WARNING:timemachine.fe.bar:bootstrapped errors non-normal: NormaltestResult(statistic=2705.698965619963, pvalue=0.0)` is being repeated many times (with identical numerical values!) in logs:

~Revert from `logger.warning` -> `print`, to eliminate possibility of repeated message bug due to some unexpected interaction with `logging`. (I have not confirmed that this is the cause, because I have not reproduced the issue locally.)~ (@badisa established this is not the culprit!)

Modify inner-loop diagnostic plots -- which show histograms of w_f_component, w_r_component -- to avoid calling BAR on w_f_component, w_r_component. (I don't think it makes sense to decompose the free energy difference per potential energy component, although it is intuitively still helpful to look at work variance/overlap/etc by energy component. This retains the descriptive plots decomposed by energy component, but avoids computing two quantitative results `dg, dg_err` for each component.)