### PR TITLE
Require pymbar<4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         "jaxlib>0.3.13",
         "networkx",
         "numpy",
-        "pymbar>3.0.4",
+        "pymbar>3.0.4,<4",
         "pyyaml",
         "scipy",
         "typing-extensions",


### PR DESCRIPTION
Pymbar 4 introduced [breaking API changes](https://pymbar.readthedocs.io/en/master/moving_from_pymbar3.html) that we don't yet support (related #830)