### PR TITLE
Task/reduce docker container size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,3 +22,8 @@
 
 # Licensing
 oe_license.txt
+
+Dockerfile
+
+# Files from tests
+*.svg

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,7 @@ memory-tests:
   rules:
     - if: $CI_EXTERNAL_PULL_REQUEST_IID
   script:
-    - CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) pip install .[test]
+    - pip install .[test]
     - make memcheck_tests
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-memtests"
@@ -97,7 +97,7 @@ unit-tests:
   variables:
     CMAKE_ARGS: -DCUDA_ARCH=75
   script:
-    - CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) pip install .[test]
+    - pip install .[test]
     - make unit_tests
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-tests"
@@ -117,7 +117,7 @@ nightly-tests:
   variables:
     CMAKE_ARGS: -DCUDA_ARCH=75
   script:
-    - CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) pip install .[test]
+    - pip install .[test]
     - make nightly_tests
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-nightly-tests"

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,9 +99,9 @@ ARG CUDA_ARCH=75
 ENV CMAKE_ARGS -DCUDA_ARCH=${CUDA_ARCH}
 COPY . /code/timemachine/
 WORKDIR /code/timemachine/
-RUN pip install --no-cache-dir -e .[dev,test]
+RUN pip install --no-cache-dir -e . && rm -rf ./build
 
-# Container with only cuda runtime
+# Container with only cuda runtime, half the size of dev container
 FROM nvidia/cuda:11.6.0-runtime-ubuntu20.04 as timemachine
 COPY --from=timemachine_dev /opt/ /opt/
 COPY --from=timemachine_dev /code/ /code/

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,9 +93,20 @@ RUN cd /code/timemachine && git init . && pre-commit install-hooks
 COPY ci/requirements.txt /code/timemachine/ci/requirements.txt
 RUN pip install --no-cache-dir -r timemachine/ci/requirements.txt
 
-FROM tm_base_env AS timemachine
+# Dev container that contains the cuda developer tools
+FROM tm_base_env AS timemachine_dev
 ARG CUDA_ARCH=75
 ENV CMAKE_ARGS -DCUDA_ARCH=${CUDA_ARCH}
 COPY . /code/timemachine/
 WORKDIR /code/timemachine/
-RUN CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) pip install --no-cache-dir -e .[dev,test]
+RUN pip install --no-cache-dir -e .[dev,test]
+
+# Container with only cuda runtime
+FROM nvidia/cuda:11.6.0-runtime-ubuntu20.04 as timemachine
+COPY --from=timemachine_dev /opt/ /opt/
+COPY --from=timemachine_dev /code/ /code/
+COPY --from=timemachine_dev /root/.bashrc /root/.bashrc
+RUN ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+ARG ENV_NAME=timemachine
+ENV PATH /opt/conda/envs/${ENV_NAME}/bin:$PATH
+ENV CONDA_DEFAULT_ENV ${ENV_NAME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ ARG CUDA_ARCH=75
 ENV CMAKE_ARGS -DCUDA_ARCH=${CUDA_ARCH}
 COPY . /code/timemachine/
 WORKDIR /code/timemachine/
-RUN pip install --no-cache-dir -e . && rm -rf ./build
+RUN pip install --no-cache-dir -e .[test] && rm -rf ./build
 
 # Container with only cuda runtime, half the size of dev container
 FROM nvidia/cuda:11.6.0-runtime-ubuntu20.04 as timemachine


### PR DESCRIPTION
Reduces the production container to ~4GB from ~8GB.
- Switch to the runtime container for the final container, means you can't build timemachine from the final container thought there is an intermediate container still that supports building.
- Remove the build directory (~200MB)

Some minor changes to the gitlab config to remove what is now a redundant env variable. 