### PR TITLE
Add reference distance with 4D offset, clean nonbonded reference potentials

### DIFF
--- a/attic/modules/potentials/gbsa.py
+++ b/attic/modules/potentials/gbsa.py
@@ -3,7 +3,7 @@
 
 import jax.numpy as jnp
 
-from timemachine.potentials.jax_utils import convert_to_4d, distance
+from timemachine.potentials.jax_utils import convert_to_4d, pairwise_distances
 
 
 def step(x):
@@ -49,7 +49,7 @@ def gbsa_obc(
     ri = jnp.expand_dims(coords_4d, 0)
     rj = jnp.expand_dims(coords_4d, 1)
 
-    dij = distance(ri, rj, box)
+    dij = pairwise_distances(ri, rj, box)
 
     eye = jnp.eye(N, dtype=dij.dtype)
 

--- a/tests/nonbonded/test_nonbonded_interaction_group.py
+++ b/tests/nonbonded/test_nonbonded_interaction_group.py
@@ -91,14 +91,11 @@ def test_nonbonded_interaction_group_correctness(
     host_idxs = np.setdiff1d(np.arange(num_atoms), ligand_idxs)
 
     def ref_ixngroups(conf, params, box, lamb):
-
         # compute 4d coordinates
-        w = jax_utils.compute_lifting_parameter(lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff)
-        conf_4d = jax_utils.augment_dim(conf, w)
-        box_4d = (1000 * jax.numpy.eye(4)).at[:3, :3].set(box)
+        w_coords = jax_utils.compute_lifting_parameter(lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff)
 
         vdW, electrostatics = nonbonded.nonbonded_interaction_groups(
-            conf_4d, params, box_4d, ligand_idxs, host_idxs, beta, cutoff
+            conf, params, box, ligand_idxs, host_idxs, beta, cutoff, w_coords
         )
         return jax.numpy.sum(vdW + electrostatics)
 
@@ -155,14 +152,11 @@ def test_nonbonded_interaction_group_interpolated_correctness(
 
     @nonbonded.interpolated
     def ref_ixngroups(conf, params, box, lamb):
-
         # compute 4d coordinates
-        w = jax_utils.compute_lifting_parameter(lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff)
-        conf_4d = jax_utils.augment_dim(conf, w)
-        box_4d = (1000 * jax.numpy.eye(4)).at[:3, :3].set(box)
+        w_coords = jax_utils.compute_lifting_parameter(lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff)
 
         vdW, electrostatics = nonbonded.nonbonded_interaction_groups(
-            conf_4d, params, box_4d, ligand_idxs, host_idxs, beta, cutoff
+            conf, params, box, ligand_idxs, host_idxs, beta, cutoff, w_coords
         )
         return jax.numpy.sum(vdW + electrostatics)
 

--- a/tests/nonbonded/test_nonbonded_pair_list.py
+++ b/tests/nonbonded/test_nonbonded_pair_list.py
@@ -35,13 +35,12 @@ def test_nonbonded_pair_list_invalid_pair_idxs():
 def make_ref_potential(pair_idxs, scales, lambda_plane_idxs, lambda_offset_idxs, beta, cutoff):
     @functools.wraps(nonbonded.nonbonded_on_specific_pairs)
     def wrapped(conf, params, box, lamb):
-
         # compute 4d coordinates
-        w = jax_utils.compute_lifting_parameter(lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff)
-        conf_4d = jax_utils.augment_dim(conf, w)
-        box_4d = (1000 * jax.numpy.eye(4)).at[:3, :3].set(box)
+        w_coords = jax_utils.compute_lifting_parameter(lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff)
 
-        vdW, electrostatics = nonbonded.nonbonded_on_specific_pairs(conf_4d, params, box_4d, pair_idxs, beta, cutoff)
+        vdW, electrostatics = nonbonded.nonbonded_on_specific_pairs(
+            conf, params, box, pair_idxs, beta, cutoff, w_coords
+        )
         return jax.numpy.sum(scales[:, 1] * vdW + scales[:, 0] * electrostatics)
 
     return wrapped

--- a/tests/test_jax_nonbonded.py
+++ b/tests/test_jax_nonbonded.py
@@ -23,9 +23,9 @@ from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md import builders
 from timemachine.potentials.jax_utils import (
     convert_to_4d,
-    distance,
     get_all_pairs_indices,
     pairs_from_interaction_groups,
+    pairwise_distances,
 )
 from timemachine.potentials.nonbonded import (
     coulomb_interaction_group_energy,
@@ -49,7 +49,7 @@ pytestmark = [pytest.mark.nogpu]
 
 def resolve_clashes(x0, box0, min_dist=0.1):
     def urt(x, box):
-        distance_matrix = distance(x, box)
+        distance_matrix = pairwise_distances(x, box)
         i, j = np.triu_indices(len(distance_matrix), k=1)
         return distance_matrix[i, j]
 

--- a/tests/test_jax_utils.py
+++ b/tests/test_jax_utils.py
@@ -11,7 +11,6 @@ from jax import vmap
 np.random.seed(2021)
 
 from timemachine.potentials.jax_utils import (
-    augment_dim,
     compute_lifting_parameter,
     delta_r,
     distance_on_pairs,
@@ -100,18 +99,6 @@ def test_compute_lifting_parameter():
 
     w1 = compute_lifting_parameter(1.0, lambda_plane_idxs, lambda_offset_idxs, cutoff)
     np.testing.assert_allclose(w1, cutoff * (lambda_offset_idxs + lambda_plane_idxs))
-
-
-def test_augment_dim():
-    """check xyz -> xyzw stacking"""
-    for _ in range(5):
-        n = np.random.randint(5, 10)
-        xyz = np.random.randn(n, 3)
-        w = np.random.randn(n)
-
-        xyzw = augment_dim(xyz, w)
-        np.testing.assert_allclose(xyzw[:, :3], xyz)
-        np.testing.assert_allclose(xyzw[:, -1], w)
 
 
 def test_batched_neighbor_inds():

--- a/tests/test_single_topology_v3.py
+++ b/tests/test_single_topology_v3.py
@@ -39,7 +39,7 @@ from timemachine.fe.utils import get_mol_name, get_romol_conf
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md.builders import build_water_system
-from timemachine.potentials.jax_utils import distance
+from timemachine.potentials.jax_utils import pairwise_distances
 
 
 def test_phenol():
@@ -220,7 +220,7 @@ def test_hif2a_end_state_stability(num_pairs_to_setup=25, num_pairs_to_simulate=
     np.random.shuffle(pairs)
     ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
 
-    compute_distance_matrix = functools.partial(distance, box=None)
+    compute_distance_matrix = functools.partial(pairwise_distances, box=None)
 
     def get_max_distance(x0):
         dij = compute_distance_matrix(x0)

--- a/timemachine/potentials/jax_utils.py
+++ b/timemachine/potentials/jax_utils.py
@@ -50,24 +50,6 @@ def compute_lifting_parameter(lamb, lambda_plane_idxs, lambda_offset_idxs, cutof
     return w
 
 
-def augment_dim(x3: Array, w: Array) -> Array:
-    """(x,y,z) -> (x,y,z,w)"""
-
-    d4 = jnp.expand_dims(w, axis=-1)
-    x4 = jnp.concatenate((x3, d4), axis=1)
-
-    assert len(x4) == len(x3)
-    assert x4.shape[1] == 4
-
-    return x4
-
-
-def convert_to_4d(x3, lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff):
-    """(x,y,z) -> (x,y,z,w) where w = cutoff * (lambda_plane_idxs + lambda_offset_idxs * lamb)"""
-    w = compute_lifting_parameter(lamb, lambda_plane_idxs, lambda_offset_idxs, cutoff)
-    return augment_dim(x3, w)
-
-
 def delta_r(ri, rj, box=None):
     diff = ri - rj  # this can be either N,N,3 or B,3
 

--- a/timemachine/potentials/jax_utils.py
+++ b/timemachine/potentials/jax_utils.py
@@ -140,7 +140,7 @@ def get_interacting_pair_indices_batch(confs, boxes, pairs, cutoff=1.2):
     return batch_pairs
 
 
-def distance(x, box):
+def pairwise_distances(x, box):
     # nonbonded distances require the periodic box
     assert x.shape[1] == 3 or x.shape[1] == 4  # 3d or 4d
     ri = jnp.expand_dims(x, 0)

--- a/timemachine/potentials/nonbonded.py
+++ b/timemachine/potentials/nonbonded.py
@@ -9,11 +9,12 @@ from typing_extensions import TypeAlias
 
 from timemachine.potentials import jax_utils
 from timemachine.potentials.jax_utils import (
+    compute_lifting_parameter,
     convert_to_4d,
     delta_r,
-    distance,
     distance_on_pairs,
     pairs_from_interaction_groups,
+    pairwise_distances,
 )
 
 Array: TypeAlias = NDArray
@@ -223,10 +224,9 @@ def nonbonded(
 
     eps_i = jnp.expand_dims(eps, 0)
     eps_j = jnp.expand_dims(eps, 1)
-
     eps_ij = combining_rule_epsilon(eps_i, eps_j)
 
-    dij = distance(conf, box)
+    dij = pairwise_distances(conf, box)
 
     keep_mask = jnp.ones((N, N)) - jnp.eye(N)
     keep_mask = jnp.where(eps_ij != 0, keep_mask, 0)


### PR DESCRIPTION
In preparation for switching to specifying 4-d coordinates for decoupling as parameters,

- renames `jax_utils.distance` -> `jax_utils.pairwise_distances` to be more specific
- updates JAX reference code to accept 4-d coordinates as a separate argument
- removes hack previously used to simulate an aperiodic 4th dimension via using a box that is ~infinite in the last dimension
- removes helper functions related to 3-d -> 4-d conversion previously used to implement the above, now unused