### PR TITLE
Handle `box=None` in `pairwise_distances`, add tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,12 @@ setup(
             "mypy==0.942",
             "pre-commit==2.17.0",
         ],
-        "test": ["pytest", "pytest-cov", "hilbertcurve==1.0.5", "hypothesis==6.54.6"],
+        "test": [
+            "pytest",
+            "pytest-cov",
+            "hilbertcurve==1.0.5",
+            "hypothesis[numpy]==6.54.6",
+        ],
     },
     package_data={
         "timemachine": [

--- a/tests/test_jax_utils.py
+++ b/tests/test_jax_utils.py
@@ -195,5 +195,5 @@ def test_pairwise_distances_periodic_lifting(coords_box_w):
     assert (dij >= dij0).all()
 
     # guard assertion to prevent spurious failure due to roundoff error
-    if np.std(w) / (1.0 + np.std(x)) > 1e-6:
+    if np.std(w) / (1.0 + np.linalg.norm(x)) > 1e-6:
         assert dij.sum() > dij0.sum()

--- a/tests/test_jax_utils.py
+++ b/tests/test_jax_utils.py
@@ -1,5 +1,10 @@
+from functools import partial
+
+import hypothesis.strategies as st
 import numpy as np
 import pytest
+from hypothesis import given, seed
+from hypothesis.extra.numpy import array_shapes, arrays
 from jax import jit
 from jax import numpy as jnp
 from jax import vmap
@@ -13,6 +18,7 @@ from timemachine.potentials.jax_utils import (
     get_all_pairs_indices,
     get_interacting_pair_indices_batch,
     pairs_from_interaction_groups,
+    pairwise_distances,
 )
 
 pytestmark = [pytest.mark.nogpu]
@@ -129,3 +135,57 @@ def test_batched_neighbor_inds():
 
     assert neighbor_distances.shape == (n_confs, n_neighbor_pairs)
     assert np.sum(neighbor_distances < cutoff) == np.sum(full_distances < cutoff)
+
+
+def test_pairwise_distances_assertions():
+    with pytest.raises(AssertionError):
+        pairwise_distances(np.empty((4, 3)), np.empty((1, 1)))  # inconsistent box shape
+    _ = pairwise_distances(np.empty((4, 3)), np.empty((3, 3)))  # ok
+
+    with pytest.raises(AssertionError):
+        pairwise_distances(np.empty((4, 3)), np.empty((3, 3)), np.empty((3,)))  # inconsistent w_coords shape
+    _ = pairwise_distances(np.empty((4, 3)), np.empty((3, 3)), np.empty((4,)))  # ok
+
+
+finite_floats = partial(st.floats, allow_nan=False, allow_infinity=False, allow_subnormal=False)
+coordinates = arrays(np.float64, array_shapes(min_dims=2, max_dims=2), elements=finite_floats(-1e6, 1e6))
+
+
+@given(coordinates)
+@seed(2022)
+def test_pairwise_distances(x):
+    n, _ = x.shape
+    dij = pairwise_distances(x)
+    assert dij.shape == (n, n)
+    assert (dij >= 0.0).all()
+
+
+@st.composite
+def coords_box_w_triples(draw):
+    x = draw(coordinates)
+    n, d = x.shape
+    box_diag = draw(arrays(np.float64, d, elements=finite_floats(1e-6, 1e6)))
+    w = draw(arrays(np.float64, n, elements=finite_floats(-1e6, 1e6)))
+    return x, box_diag, w
+
+
+@given(coords_box_w_triples())
+@seed(2022)
+def test_pairwise_distances_periodic(coords_box_w):
+    x, box_diag, _ = coords_box_w
+    n, _ = x.shape
+    dij = pairwise_distances(x, np.diagflat(box_diag))
+    assert dij.shape == (n, n)
+    assert (dij >= 0.0).all()
+    assert (dij <= box_diag.max()).all()
+
+
+@given(coords_box_w_triples())
+@seed(2022)
+def test_pairwise_distances_periodic_lifting(coords_box_w):
+    x, box_diag, w = coords_box_w
+    n, _ = x.shape
+    dij0 = pairwise_distances(x, np.diagflat(box_diag))
+    dij = pairwise_distances(x, np.diagflat(box_diag), w)
+    assert dij.shape == (n, n)
+    assert (dij >= dij0).all()

--- a/timemachine/potentials/jax_utils.py
+++ b/timemachine/potentials/jax_utils.py
@@ -127,10 +127,10 @@ def get_interacting_pair_indices_batch(confs, boxes, pairs, cutoff=1.2):
     return batch_pairs
 
 
-def pairwise_distances(x, box, w=None):
+def pairwise_distances(x, box=None, w=None):
     """
-    Compute the (N, N) periodic distance matrix given an (N, D) array of
-    coordinates.
+    Compute the (N, N) distance matrix given an (N, D) array of coordinates. If
+    `box` is passed, computes nearest distances assuming periodic boundaries.
 
     Optionally accepts an (N, 1) array of coordinates in the "lifting"
     (typically 4th) dimension; if passed, computes distances assuming periodic
@@ -142,21 +142,21 @@ def pairwise_distances(x, box, w=None):
     x : ndarray (N, D)
         input coordinates
 
-    box : ndarray (D, D)
+    box : ndarray (D, D), optional
         dimensions of periodic box
 
     w : ndarray (N, 1), optional
         coordinates in aperiodic lifting dimension
     """
     n, d = x.shape
-    assert box.shape == (d, d)
-    if w is not None:
-        assert w.shape[0] == n
+    if box is not None:
+        assert box.shape == (d, d)
 
     d_ijk = delta_r(x[:, None], x[None, :], box)  # (x_i, x_j, dimension)
     d2_ij = jnp.sum(d_ijk ** 2, axis=2)
 
     if w is not None:
+        assert w.shape == (n,)
         dw_ij = w[:, None] - w[None, :]
         d2_ij += dw_ij ** 2
 


### PR DESCRIPTION
* Fixes regression introduced in 95dc14a32cb7c07b2a02d3fbd72811f0263c130d where passing `box=None` fails with a `TypeError` (this affects nightly tests)
* Refines assertion on shape of `w`
* Adds tests for `jax_utils.pairwise_distances`