### PR TITLE
Use separate Python API type for potentials bound to parameters

### DIFF
--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -21,7 +21,7 @@ from timemachine.fe.system import convert_bps_into_system
 from timemachine.fe.utils import get_mol_name, get_romol_conf
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, custom_ops
-from timemachine.lib.potentials import CustomOpWrapper
+from timemachine.lib.potentials import BoundCustomOp
 from timemachine.md import builders, minimizer
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 
@@ -166,7 +166,7 @@ class InitialState:
     This object can be pickled safely.
     """
 
-    potentials: List[CustomOpWrapper]
+    potentials: List[BoundCustomOp]
     integrator: LangevinIntegrator
     barostat: MonteCarloBarostat
     x0: np.ndarray

--- a/timemachine/lib/potentials.py
+++ b/timemachine/lib/potentials.py
@@ -13,12 +13,9 @@ class CustomOpWrapper:
     def __init__(self, *args):
         # needed in case we need to modify the args.
         self.args = list(args)
-        self.params = None
 
     def bind(self, params):
-        self.params = params
-        # return self is to allow chaining
-        return self
+        return BoundCustomOp(params, *self.args)
 
     def unbound_impl(self, precision):
         cls_name_base = type(self).__name__
@@ -31,10 +28,13 @@ class CustomOpWrapper:
 
         return custom_ctor(*self.args)
 
-    def bound_impl(self, precision):
-        if self.params is None:
-            raise ValueError("This op has not been bound to parameters.")
 
+class BoundCustomOp(CustomOpWrapper):
+    def __init__(self, params, *args):
+        self.params = params
+        super().__init__(*args)
+
+    def bound_impl(self, precision):
         return custom_ops.BoundPotential(self.unbound_impl(precision), self.params)
 
 

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -74,7 +74,7 @@ class CompoundMove(MonteCarloMove):
 class NVTMove(MonteCarloMove):
     def __init__(
         self,
-        ubps: List[potentials.CustomOpWrapper],
+        ubps: List[potentials.BoundCustomOp],
         lamb: float,
         masses: NDArray,
         temperature: float,
@@ -119,7 +119,7 @@ class NPTMove(NVTMove):
 
     def __init__(
         self,
-        ubps: List[potentials.CustomOpWrapper],
+        ubps: List[potentials.BoundCustomOp],
         lamb: float,
         masses: NDArray,
         temperature: float,


### PR DESCRIPTION
Small quality of life change intended to reduce confusion over whether a `CustomOpWrapper` is expected to be bound to parameters (i.e. whether we previously called `.bind(params)`).

For example, forgetting to call `bind` before `bound_impl`

```python
HarmonicBond(bond_idxs).bound_impl(np.float32)
```

will now fail to typecheck (in addition to failing at runtime).