### PR TITLE
Updates RDKit to 2022.3.5

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,20 @@
-# Python Related
-*/__pycache__/*
-**/.Python/*
-**/build/*
-**/dist/*
-**/*.egg-info/*
-**/.coverage/*
-*/.ipynb_checkpoints*
+# Development Related
+**/__pycache__/
+**/.Python/
+**/build/
+**/dist/
+*.egg-info/
+**/.coverage/
+**/.ipynb_checkpoints*/
+**/attic/
+**/examples/
+**/coverage/
+**/.pytest*
+**/.mypy*
+**/.clang*
+Dockerfile
+.dockerignore
+
 
 # Git Files
 **/.git*
@@ -23,7 +32,7 @@
 # Licensing
 oe_license.txt
 
-Dockerfile
-
 # Files from tests
 *.svg
+*.pkl
+*.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
+ARG LIBXRENDER_VERSION=1:0.9.10-*
+ARG LIBXEXT_VERSION=2:1.3.4-*
+
 FROM nvidia/cuda:11.6.0-devel-ubuntu20.04 AS tm_base_env
+ARG LIBXRENDER_VERSION
+ARG LIBXEXT_VERSION
 
 # Copied out of anaconda's dockerfile
 ARG MINICONDA_VERSION=4.6.14
 ARG MAKE_VERSION=4.2.1-1.2
 ARG GIT_VERSION=1:2.25.1-*
 ARG WGET_VERSION=1.20.3-1ubuntu2
-RUN apt-get update && apt-get install --no-install-recommends -y wget=${WGET_VERSION} git=${GIT_VERSION} make=${MAKE_VERSION} vim \
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    wget=${WGET_VERSION} git=${GIT_VERSION} make=${MAKE_VERSION} libxrender1=${LIBXRENDER_VERSION} libxext-dev=${LIBXEXT_VERSION} vim \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -O ~/miniconda.sh && \
@@ -103,6 +109,11 @@ RUN pip install --no-cache-dir -e .[test] && rm -rf ./build
 
 # Container with only cuda runtime, half the size of dev container
 FROM nvidia/cuda:11.6.0-runtime-ubuntu20.04 as timemachine
+ARG LIBXRENDER_VERSION
+ARG LIBXEXT_VERSION
+RUN apt-get update && apt-get install --no-install-recommends -y libxrender1=${LIBXRENDER_VERSION} libxext-dev=${LIBXEXT_VERSION} \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=timemachine_dev /opt/ /opt/
 COPY --from=timemachine_dev /code/ /code/
 COPY --from=timemachine_dev /root/.bashrc /root/.bashrc

--- a/environment.yml
+++ b/environment.yml
@@ -7,4 +7,3 @@ dependencies:
   - jax=0.3.14
   - jaxlib=0.3.14=cpu*
   - openeye-toolkits=2020.2.0
-  - rdkit=2021.03.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ networkx==2.5
 importlib-resources==5.4.0
 typing-extensions==4.1.1
 matplotlib==3.3.3
+rdkit==2022.3.5

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
         "numpy",
         "pymbar>3.0.4,<4",
         "pyyaml",
+        "rdkit",
         "scipy",
         "typing-extensions",
         "matplotlib",


### PR DESCRIPTION
- Install via Pypi
- Requires additional packages libXext and libXrender which were previously installed by conda
- Reduces size of docker container using .dockerignore, helps with caching as well.