### PR TITLE
Parallelize non-GPU tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ verify:
 
 .PHONY: nogpu_tests
 nogpu_tests:
-	pytest -m $(NOGPU_MARKER) $(PYTEST_CI_ARGS)
+	pytest -m $(NOGPU_MARKER) $(PYTEST_CI_ARGS) -n auto
 
 .PHONY: memcheck_tests
 memcheck_tests:

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
         "test": [
             "pytest",
             "pytest-cov",
+            "pytest-xdist",
             "hilbertcurve==1.0.5",
             "hypothesis[numpy]==6.54.6",
         ],


### PR DESCRIPTION
Experiment with configuring `nogpu` tests to run in parallel using `pytest-xdist`