### PR TITLE
Save benchmark data as json, add script to plot comparison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,10 @@ unit_tests:
 nightly_tests:
 	pytest -m $(NIGHTLY_MARKER) $(PYTEST_CI_ARGS)
 
+.PHONY: benchmarks
+benchmarks: build
+	python tests/test_benchmark.py
+	python tests/compare_benchmarks.py
+
 .PHONY: ci
 ci: verify memcheck_tests unit_tests

--- a/README.md
+++ b/README.md
@@ -102,6 +102,22 @@ OE_DIR=~/.openeye PYTHONPATH=. pytest -xsv tests/
 
 Note: we currently only support and test on python 3.7, use other versions at your own peril.
 
+### Running benchmarks
+
+To run the benchmark suite
+
+```shell
+make benchmark
+```
+
+This produces JSON data files and summary plots in `./benchmark_results/`. Result data files are suffixed with the timemachine version, allowing comparison of benchmarks between multiple versions. In addition to plotting results from the current run, `make benchmark` plots results from previous runs found in `./benchmark_results/` for comparison.
+
+To regenerate the plots without running the benchmarks
+
+```shell
+python tests/compare_benchmarks.py
+```
+
 # Free Energy Methods
 
 ## Theory

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ setup(
             "isort==5.10.1",
             "mypy==0.942",
             "pre-commit==2.17.0",
+            "seaborn==0.12.1",  # for plotting benchmark results
         ],
         "test": [
             "pytest",

--- a/tests/compare_benchmarks.py
+++ b/tests/compare_benchmarks.py
@@ -1,4 +1,5 @@
 from glob import glob
+from pathlib import Path
 from typing import List, Tuple, TypeAlias
 
 import matplotlib.pyplot as plt
@@ -49,13 +50,16 @@ def load_benchmark_results_json(filename: str) -> Tuple[Group, Version, pd.DataF
 
 
 if __name__ == "__main__":
+    dir = Path("benchmark_results")
+
     plot_benchmark_results(
-        [load_benchmark_results_json(f) for f in glob("benchmark_results__*__*.json")],
+        [load_benchmark_results_json(f) for f in glob(str(dir / "benchmark_results__*__*.json"))],
         metric="ns_per_day",
         file_prefix="benchmark_results",
     )
+
     plot_benchmark_results(
-        [load_benchmark_results_json(f) for f in glob("benchmark_potential_results__*__*.json")],
+        [load_benchmark_results_json(f) for f in glob(str(dir / "benchmark_potential_results__*__*.json"))],
         metric="runs_per_second",
         file_prefix="benchmark_potential_results",
     )

--- a/tests/compare_benchmarks.py
+++ b/tests/compare_benchmarks.py
@@ -1,0 +1,61 @@
+from glob import glob
+from typing import List, Tuple, TypeAlias
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+
+Group: TypeAlias = str
+Version: TypeAlias = str
+
+
+def plot_benchmark_results(results: List[Tuple[Group, Version, pd.DataFrame]], metric: str, file_prefix: str):
+    assert len(results) > 0
+
+    data = pd.concat(
+        {(group, version): df for group, version, df in results},
+        names=["group", "version"],
+    ).sort_index()
+
+    assert data is not None
+
+    for group, df in data.groupby("group"):
+        df = df.reset_index().sort_values(["label", "version"])
+        g = sns.catplot(
+            data=df,
+            y="label",
+            x=metric,
+            hue="version",
+            kind="bar",
+            orient="horizontal",
+            legend=False,
+        )
+
+        # add bar labels
+        for c in g.ax.containers:
+            labels = [f"{v.get_width():.2f}" for v in c]
+            g.ax.bar_label(c, labels=labels, label_type="edge")
+
+        g.fig.set_size_inches(12, 5)
+        plt.legend(loc="upper left", bbox_to_anchor=(1, 1), borderaxespad=0)
+        plt.tight_layout()
+        plt.savefig(f"{file_prefix}__{group}.png")
+
+
+def load_benchmark_results_json(filename: str) -> Tuple[Group, Version, pd.DataFrame]:
+    df: pd.DataFrame = pd.read_json(filename).set_index(["label"])  # type: ignore
+    _, group, version = filename.removesuffix(".json").split("__")
+    return group, version, df
+
+
+if __name__ == "__main__":
+    plot_benchmark_results(
+        [load_benchmark_results_json(f) for f in glob("benchmark_results__*__*.json")],
+        metric="ns_per_day",
+        file_prefix="benchmark_results",
+    )
+    plot_benchmark_results(
+        [load_benchmark_results_json(f) for f in glob("benchmark_potential_results__*__*.json")],
+        metric="runs_per_second",
+        file_prefix="benchmark_potential_results",
+    )

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -600,8 +600,8 @@ def test_bonded_potentials(hi2fa_test_frames):
 
 if __name__ == "__main__":
 
-    benchmark_dhfr(verbose=False, num_batches=100)
-    benchmark_hif2a(verbose=False, num_batches=100)
+    save_results("benchmark_results", "dhfr", benchmark_dhfr(verbose=False, num_batches=100))
+    save_results("benchmark_results", "hif2a", benchmark_hif2a(verbose=False, num_batches=100))
 
     hif2a_frames = generate_hif2a_frames(1000, 5, seed=2022)
     test_nonbonded_interaction_group_potential(hif2a_frames)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -106,7 +106,7 @@ class BenchmarkPotentialResult(NamedTuple):
     frames: int
     param_batches: int
     num_lambdas: int
-    runs_per_second: int
+    runs_per_second: float
     runs_per_batch: int
     num_batches: int
     duration: float

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -20,7 +20,13 @@ from timemachine.fe.utils import to_md_units
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, custom_ops
-from timemachine.lib.potentials import Nonbonded, NonbondedInteractionGroup
+from timemachine.lib.potentials import (
+    HarmonicAngle,
+    HarmonicBond,
+    Nonbonded,
+    NonbondedInteractionGroup,
+    PeriodicTorsion,
+)
 from timemachine.md import builders, minimizer
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.testsystems.dhfr import setup_dhfr
@@ -570,8 +576,10 @@ def test_bonded_potentials(hi2fa_test_frames):
 
     lambdas = np.array([0.0, 1.0])
     results = []
-    for potential in pots[:-1]:
-        class_name = potential.__class__.__name__
+    for potential in pots:
+        if type(potential) not in {HarmonicAngle, HarmonicBond, PeriodicTorsion}:
+            continue
+        class_name = type(potential).__name__
         params = np.expand_dims(potential.params, axis=0)
         for precision in [np.float32, np.float64]:
             results.append(

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -5,6 +5,7 @@ relative binding free energy edge from the HIF2A test system"""
 import json
 import time
 from importlib import resources
+from pathlib import Path
 from typing import List, NamedTuple
 
 import numpy as np
@@ -473,11 +474,14 @@ def benchmark_hif2a(verbose=False, num_batches=100, steps_per_batch=1000) -> Lis
     return results
 
 
-def save_results(prefix, group, results):
+def save_results(prefix, group, results, dirname="benchmark_results"):
     version_info = timemachine._version.get_versions()
     rev = version_info["full-revisionid"][:7] + ("-dirty" if version_info["dirty"] else "")
-    filename = "__".join([prefix, group, rev]) + ".json"
-    with open(filename, "w") as f:
+    dir = Path(dirname)
+    dir.mkdir(exist_ok=True)
+    stem = "__".join([prefix, group, rev])
+    path = (dir / stem).with_suffix(".json")
+    with path.open("w") as f:
         json.dump([result._asdict() for result in results], f)
 
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -467,16 +467,22 @@ def benchmark_hif2a(verbose=False, num_batches=100, steps_per_batch=1000) -> Lis
     return results
 
 
+def save_results(prefix, group, results):
+    version_info = timemachine._version.get_versions()
+    rev = version_info["full-revisionid"][:7] + ("-dirty" if version_info["dirty"] else "")
+    filename = "__".join([prefix, group, rev]) + ".json"
+    with open(filename, "w") as f:
+        json.dump([result._asdict() for result in results], f)
+
+
 def test_dhfr():
     results = benchmark_dhfr(verbose=True, num_batches=2, steps_per_batch=100)
-    with open(f"benchmark_results__dhfr__{timemachine.__version__}.json", "w") as f:
-        json.dump([result._asdict() for result in results], f)
+    save_results("benchmark_results", "dhfr", results)
 
 
 def test_hif2a():
     results = benchmark_hif2a(verbose=True, num_batches=2, steps_per_batch=100)
-    with open(f"benchmark_results__hif2a__{timemachine.__version__}.json", "w") as f:
-        json.dump([result._asdict() for result in results], f)
+    save_results("benchmark_results", "hif2a", results)
 
 
 def test_nonbonded_interaction_group_potential(hi2fa_test_frames):
@@ -515,8 +521,7 @@ def test_nonbonded_interaction_group_potential(hi2fa_test_frames):
             )
         )
 
-    with open(f"benchmark_potential_results__nonbonded_interaction_group__{timemachine.__version__}.json", "w") as f:
-        json.dump([result._asdict() for result in results], f)
+    save_results("benchmark_potential_results", "nonbonded_interaction_group", results)
 
 
 def test_nonbonded_potential(hi2fa_test_frames):
@@ -557,8 +562,7 @@ def test_nonbonded_potential(hi2fa_test_frames):
             )
         )
 
-    with open(f"benchmark_potential_results__nonbonded__{timemachine.__version__}.json", "w") as f:
-        json.dump([result._asdict() for result in results], f)
+    save_results("benchmark_potential_results", "nonbonded", results)
 
 
 def test_bonded_potentials(hi2fa_test_frames):
@@ -583,8 +587,7 @@ def test_bonded_potentials(hi2fa_test_frames):
                 )
             )
 
-    with open(f"benchmark_potential_results__bonded__{timemachine.__version__}.json", "w") as f:
-        json.dump([result._asdict() for result in results], f)
+    save_results("benchmark_potential_results", "bonded", results)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Updates benchmarks to emit JSON files. Motivation is to allow easy comparison of benchmarks between development branches and master.

- Updates `tests/test_benchmark.py` to save benchmark data as json files (with the output path including the current commit hash)
- Adds a script to generate plots comparing benchmarks at various versions

#### Examples
![image](https://user-images.githubusercontent.com/319411/196803298-7ffee3e7-2a60-4237-9180-1448ef5c36e8.png)
![image](https://user-images.githubusercontent.com/319411/196803366-f2dc7f3a-a09c-4a18-931d-f0dae34e1467.png)
![image](https://user-images.githubusercontent.com/319411/196803418-95d3d72c-cdfc-4d56-ba28-5917940167a3.png)
