### PR TITLE
Improve minimization of the initial states

### DIFF
--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -1,0 +1,100 @@
+import csv
+
+import numpy as np
+import pytest
+from rdkit import Chem
+
+from timemachine.constants import DEFAULT_FF, DEFAULT_TEMP
+from timemachine.fe import atom_mapping, pdb_writer, utils
+from timemachine.fe.rbfe import HostConfig, setup_initial_states
+from timemachine.fe.single_topology import AtomMapMixin, SingleTopology
+from timemachine.fe.utils import get_mol_name
+from timemachine.ff import Forcefield
+from timemachine.md import builders
+
+
+def get_mol_by_name(mols, name):
+    for m in mols:
+        if get_mol_name(m) == name:
+            return m
+    assert 0, "Mol not found"
+
+
+def write_trajectory_as_pdb(mol_a, mol_b, core, all_frames, host_topology, out_path):
+    atom_map_mixin = AtomMapMixin(mol_a, mol_b, core)
+    writer = pdb_writer.PDBWriter([host_topology, mol_a, mol_b], out_path)
+    for frame in all_frames:
+        host_frame = frame[: host_topology.getNumAtoms()]
+        ligand_frame = frame[host_topology.getNumAtoms() :]
+        mol_ab_frame = pdb_writer.convert_single_topology_mols(ligand_frame, atom_map_mixin)
+        writer.write_frame(np.concatenate([host_frame, mol_ab_frame]) * 10)
+    writer.close()
+
+
+def run_edge(mol_a, mol_b, protein_path):
+
+    threshold = 2.0
+    core, smarts = atom_mapping.get_core_with_alignment(mol_a, mol_b, threshold=threshold)
+    res = utils.plot_atom_mapping_grid(mol_a, mol_b, smarts, core)
+    with open(f"edge_map_{get_mol_name(mol_a)}_{get_mol_name(mol_b)}.svg", "w") as fh:
+        fh.write(res)
+
+    ff = Forcefield.load_from_file(DEFAULT_FF)
+    st = SingleTopology(mol_a, mol_b, core, ff)
+
+    lambda_schedule = np.linspace(0, 1, 12)
+    seed = 2023
+
+    # solvent
+    box_width = 4.0
+    solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(box_width, ff.water_ff)
+    solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
+    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box)
+    initial_states = setup_initial_states(st, solvent_host_config, DEFAULT_TEMP, lambda_schedule, seed)
+    all_frames = [state.x0 for state in initial_states]
+    write_trajectory_as_pdb(
+        mol_a,
+        mol_b,
+        core,
+        all_frames,
+        solvent_top,
+        f"solvent_{get_mol_name(mol_a)}_{get_mol_name(mol_b)}.pdb",
+    )
+
+    # complex
+    complex_sys, complex_conf, _, _, complex_box, complex_top = builders.build_protein_system(
+        protein_path, ff.protein_ff, ff.water_ff
+    )
+    complex_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
+    complex_host_config = HostConfig(complex_sys, complex_conf, complex_box)
+    initial_states = setup_initial_states(st, complex_host_config, DEFAULT_TEMP, lambda_schedule, seed)
+    all_frames = [state.x0 for state in initial_states]
+    write_trajectory_as_pdb(
+        mol_a,
+        mol_b,
+        core,
+        all_frames,
+        complex_top,
+        f"complex_{get_mol_name(mol_a)}_{get_mol_name(mol_b)}.pdb",
+    )
+
+
+@pytest.mark.nightly(reason="Takes a while to run")
+def test_confgen():
+
+    protein_path = "timemachine/testsystems/data/hif2a_nowater_min.pdb"
+    ligands = "timemachine/datasets/fep_benchmark/hif2a/ligands.sdf"
+    mols = [mol for mol in Chem.SDMolSupplier(ligands, removeHs=False)]
+
+    results_csv = "timemachine/datasets/fep_benchmark/hif2a/results_edges_5ns.csv"
+    with open(results_csv) as csvfile:
+        reader = csv.reader(csvfile, delimiter=",")
+        next(reader)
+        rows = [row for row in reader]
+        for row_idx, row in enumerate(rows):
+            mol_a_name, mol_b_name, exp_ddg, fep_ddg, fep_ddg_err, ccc_ddg, ccc_ddg_err = row
+            print("Processing", mol_a_name, "->", mol_b_name)
+            mol_a = get_mol_by_name(mols, mol_a_name)
+            mol_b = get_mol_by_name(mols, mol_b_name)
+
+            run_edge(mol_a, mol_b, protein_path)

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -148,6 +148,9 @@ def setup_initial_states(st, host_config, temperature, lambda_schedule, seed):
 
     Parameters
     ----------
+    st: SingleTopology
+        A single topology object
+
     host_config: HostConfig or None
         Configurations of the host. If None, then a vacuum state will be setup.
 
@@ -533,7 +536,7 @@ def optimize_coordinates(initial_states):
 
     # go from lambda 1 -> 0.5 and reverse the coordinate trajectory and lambda schedule
     if len(rhs_initial_states) > 0:
-        rhs_xs = _optimize_coords_along_states(rhs_initial_states)[::-1][::-1]
+        rhs_xs = _optimize_coords_along_states(rhs_initial_states[::-1])[::-1]
         for xs in rhs_xs:
             all_xs.append(xs)
 

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -533,7 +533,7 @@ def optimize_coordinates(initial_states):
 
     # go from lambda 1 -> 0.5 and reverse the coordinate trajectory and lambda schedule
     if len(rhs_initial_states) > 0:
-        rhs_xs = _optimize_coords_along_states(lhs_initial_states)[::-1][::-1]
+        rhs_xs = _optimize_coords_along_states(rhs_initial_states)[::-1][::-1]
         for xs in rhs_xs:
             all_xs.append(xs)
 

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -933,6 +933,8 @@ class SingleTopology(AtomMapMixin):
         Combine x_a and x_b conformations for lambda=1
         """
         # place a first, then b overrides a
+        assert x_a.shape == (self.mol_a.GetNumAtoms(), 3)
+        assert x_b.shape == (self.mol_b.GetNumAtoms(), 3)
         x0 = np.zeros((self.get_num_atoms(), 3))
         for src, dst in enumerate(self.a_to_c):
             x0[dst] = x_a[src]

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -785,6 +785,28 @@ class AtomMapMixin:
         self.c_to_a = {v: k for k, v in enumerate(self.a_to_c)}
         self.c_to_b = {v: k for k, v in enumerate(self.b_to_c)}
 
+    def get_num_atoms(self):
+        """
+        Get the total number of atoms in the alchemical hybrid.
+
+        Returns
+        -------
+        int
+            Total number of atoms.
+        """
+        return self.mol_a.GetNumAtoms() + self.mol_b.GetNumAtoms() - len(self.core)
+
+    def get_num_dummy_atoms(self):
+        """
+        Get the total number of dummy atoms in the alchemical hybrid.
+
+        Returns
+        -------
+        int
+            Total number of atoms.
+        """
+        return self.mol_a.GetNumAtoms() + self.mol_b.GetNumAtoms() - len(self.core) - len(self.core)
+
 
 class SingleTopology(AtomMapMixin):
     def __init__(self, mol_a, mol_b, core, forcefield, lambda_angles=0.4, lambda_torsions=0.7):
@@ -853,28 +875,6 @@ class SingleTopology(AtomMapMixin):
         self.default_interpolate_chiral_atom_params_fxn = interpolate.linear_interpolation
         self.default_interpolate_chiral_bond_params_fxn = interpolate.linear_interpolation
 
-    def get_num_atoms(self):
-        """
-        Get the total number of atoms in the alchemical hybrid.
-
-        Returns
-        -------
-        int
-            Total number of atoms.
-        """
-        return self.mol_a.GetNumAtoms() + self.mol_b.GetNumAtoms() - len(self.core)
-
-    def get_num_dummy_atoms(self):
-        """
-        Get the total number of dummy atoms in the alchemical hybrid.
-
-        Returns
-        -------
-        int
-            Total number of atoms.
-        """
-        return self.mol_a.GetNumAtoms() + self.mol_b.GetNumAtoms() - len(self.core) - len(self.core)
-
     def combine_masses(self):
         """
         Combine masses between two end-states by taking the heavier of the two core atoms.
@@ -925,14 +925,35 @@ class SingleTopology(AtomMapMixin):
             Combined conformation
 
         """
-        # tbd: allow input to take lambda schedule and return an array for each value of lambda
-        assert x_a.shape == (self.mol_a.GetNumAtoms(), 3)
-        assert x_b.shape == (self.mol_b.GetNumAtoms(), 3)
+        warnings.warn("combine confs is deprecated for SingleTopology", DeprecationWarning)
+        return self.combine_confs_rhs(x_a, x_b)
+
+    def combine_confs_rhs(self, x_a, x_b):
+        """
+        Combine x_a and x_b conformations for lambda=1
+        """
+        # place a first, then b overrides a
         x0 = np.zeros((self.get_num_atoms(), 3))
         for src, dst in enumerate(self.a_to_c):
             x0[dst] = x_a[src]
         for src, dst in enumerate(self.b_to_c):
             x0[dst] = x_b[src]
+
+        return x0
+
+    def combine_confs_lhs(self, x_a, x_b):
+        """
+        Combine x_a and x_b conformations for lambda=0
+        """
+        # place b first, then a overrides b
+        assert x_a.shape == (self.mol_a.GetNumAtoms(), 3)
+        assert x_b.shape == (self.mol_b.GetNumAtoms(), 3)
+        x0 = np.zeros((self.get_num_atoms(), 3))
+        for src, dst in enumerate(self.b_to_c):
+            x0[dst] = x_b[src]
+        for src, dst in enumerate(self.a_to_c):
+            x0[dst] = x_a[src]
+
         return x0
 
     def _setup_end_state_src(self):

--- a/timemachine/potentials/nonbonded.py
+++ b/timemachine/potentials/nonbonded.py
@@ -261,8 +261,8 @@ def nonbonded_on_specific_pairs(
     box,
     pairs,
     beta: float,
-    cutoff: Optional[float] = None,
-    w_coords: Optional[Array] = None,  # per-particle 4-d coordinate
+    cutoff=None,
+    w_coords=None,  # per-particle 4-d coordinate
     rescale_mask=None,
 ):
     """See `nonbonded` docstring for more details
@@ -379,8 +379,8 @@ def nonbonded_interaction_groups(
     a_idxs,
     b_idxs,
     beta: float,
-    cutoff: Optional[float] = None,
-    w_coords: Optional[Array] = None,  # per-particle 4-d coordinate
+    cutoff=None,
+    w_coords=None,  # per-particle 4-d coordinate
 ):
     """Nonbonded interactions between all pairs of atoms $(i, j)$
     where $i$ is in the first set and $j$ in the second.

--- a/timemachine/potentials/nonbonded.py
+++ b/timemachine/potentials/nonbonded.py
@@ -1,11 +1,10 @@
 import functools
+from typing import Any
 
 import jax.numpy as jnp
 import numpy as np
 from jax import vmap
 from jax.scipy.special import erfc
-from numpy.typing import NDArray
-from typing_extensions import TypeAlias
 
 from timemachine.potentials import jax_utils
 from timemachine.potentials.jax_utils import (
@@ -16,7 +15,7 @@ from timemachine.potentials.jax_utils import (
     pairwise_distances,
 )
 
-Array: TypeAlias = NDArray
+Array = Any
 
 
 def switch_fn(dij, cutoff):
@@ -261,8 +260,8 @@ def nonbonded_on_specific_pairs(
     box,
     pairs,
     beta: float,
-    cutoff=None,
-    w_coords=None,  # per-particle 4-d coordinate
+    cutoff: Optional[float] = None,
+    w_coords: Optional[Array] = None,  # per-particle 4-d coordinate
     rescale_mask=None,
 ):
     """See `nonbonded` docstring for more details
@@ -379,8 +378,8 @@ def nonbonded_interaction_groups(
     a_idxs,
     b_idxs,
     beta: float,
-    cutoff=None,
-    w_coords=None,  # per-particle 4-d coordinate
+    cutoff: Optional[float] = None,
+    w_coords: Optional[Array] = None,  # per-particle 4-d coordinate
 ):
     """Nonbonded interactions between all pairs of atoms $(i, j)$
     where $i$ is in the first set and $j$ in the second.


### PR DESCRIPTION
This PR improves the robustness of the initial states so that the intermediate states have an `x0` that is more numerically stable. Before we used a single structure (dummy atoms of mol_a attached to the full structure of mol_b, i.e. the `lambda=1` state)

1) It generates the end-states conformations at `lambda=0`, and `lambda=1` first
2) It then tries to meet in the middle by going from `lambda=[0 -> 0.5)` and `lambda=[1->0.5]` by allowing all the ligand atoms to move.

This does create a discontinuity in the initial structure when going from `lambda<0.50` to `lambda>=0.5`

This also fixes an issue where we used `cdist` as opposed to a proper periodic wrapping when doing the distance calculation for the selection of free idxs.