### PR TITLE
Add conformer-oblivious core option

### DIFF
--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -22,8 +22,9 @@ def test_mcs():
 def test_get_core_by_mcs():
     mol_a, mol_b, _ = get_hif2a_ligand_pair_single_topology()
     query = mcs(mol_a, mol_b).queryMol
-    core = get_core_by_mcs(mol_a, mol_b, query)
-    assert core.shape[1] == 2
+    for conformer_aware in [True, False]:
+        core = get_core_by_mcs(mol_a, mol_b, query, conformer_aware=conformer_aware)
+        assert core.shape[1] == 2
 
 
 def test_ring_size_change():

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -19,12 +19,12 @@ def test_mcs():
     assert mcs_result.numAtoms == 23
 
 
-def test_get_core_by_mcs():
+@pytest.mark.parametrize("conformer_aware", [True, False])
+def test_get_core_by_mcs(conformer_aware):
     mol_a, mol_b, _ = get_hif2a_ligand_pair_single_topology()
     query = mcs(mol_a, mol_b).queryMol
-    for conformer_aware in [True, False]:
-        core = get_core_by_mcs(mol_a, mol_b, query, conformer_aware=conformer_aware)
-        assert core.shape[1] == 2
+    core = get_core_by_mcs(mol_a, mol_b, query, conformer_aware=conformer_aware)
+    assert core.shape[1] == 2
 
 
 def test_ring_size_change():

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -99,13 +99,32 @@ def mcs(
     return result
 
 
-def get_core_by_mcs(mol_a, mol_b, query, threshold=0.5):
+def _get_core_conf_oblivious(mol_a, mol_b, query_mol):
+    core = np.array(
+        [
+            np.array(mol_a.GetSubstructMatch(query_mol)),
+            np.array(mol_b.GetSubstructMatch(query_mol)),
+        ]
+    ).T
+    return core
+
+
+def get_core_by_mcs(
+    mol_a,
+    mol_b,
+    query,
+    threshold=0.5,
+    conformer_aware: bool = True,
+):
     """Return np integer array that can be passed to RelativeFreeEnergy constructor
 
     Parameters
     ----------
     mol_a, mol_b, query : RDKit molecules
     threshold : float, in angstroms
+    conformer_aware: bool
+        if True, only match atoms within distance threshold
+        (assumes conformers are aligned)
 
     Returns
     -------
@@ -123,6 +142,8 @@ def get_core_by_mcs(mol_a, mol_b, query, threshold=0.5):
         In some cases, this can fail to find a mapping that satisfies the distance
         threshold, raising an AtomMappingError.
     """
+    if not conformer_aware:
+        return _get_core_conf_oblivious(mol_a, mol_b, query)
 
     # fetch conformer, assumed aligned
     conf_a = mol_a.GetConformer(0).GetPositions()


### PR DESCRIPTION
Problem: `mcs` has an option to ignore conformer, but `get_core_by_mcs` does not.

(In some situations we may want to toggle off conformer-awareness in constructing atom-mapping, e.g. in relative hydration, and perhaps also to increase efficiency of the solvent leg in relative binding.)

Solution: Add a `conformer_aware` option (defaulting to `True`) to `get_core_by_mcs`.