### PR TITLE
Use linear lambda spacing, specialized interpolation for nonbonded decoupling

### DIFF
--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -22,6 +22,7 @@ from timemachine.fe.single_topology import (
     cyclic_difference,
     handle_ring_opening_closing,
     interpolate_harmonic_force_constant,
+    interpolate_w_coord,
     setup_dummy_interactions_from_ff,
 )
 from timemachine.fe.system import convert_bps_into_system, minimize_scipy, simulate_system
@@ -388,7 +389,12 @@ nonzero_force_constants = finite_floats(1e-9, 1e9)
 
 lambdas = finite_floats(0.0, 1.0)
 
-lambda_intervals = st.lists(finite_floats(1e-9, 1.0 - 1e-9), min_size=2, max_size=2, unique=True).map(sorted)
+
+def pairs(elem, unique=False):
+    return st.lists(elem, min_size=2, max_size=2, unique=unique)
+
+
+lambda_intervals = pairs(finite_floats(1e-9, 1.0 - 1e-9), unique=True).map(sorted)
 
 
 @given(nonzero_force_constants, lambda_intervals, lambdas)
@@ -454,14 +460,7 @@ def test_interpolate_harmonic_force_constant(src_k, dst_k, k_min, lambda_interva
     assert_nondecreasing(lambda lam: f(k2, k1, 1.0 - lam))
 
 
-@given(
-    st.lists(
-        nonzero_force_constants,
-        min_size=2,
-        max_size=2,
-        unique=True,
-    ).filter(lambda ks: np.abs(ks[0] - ks[1]) / ks[1] > 1e-6)
-)
+@given(pairs(nonzero_force_constants, unique=True).filter(lambda ks: np.abs(ks[0] - ks[1]) / ks[1] > 1e-6))
 @seed(2022)
 def test_interpolate_harmonic_force_constant_sublinear(ks):
     src_k, dst_k = ks
@@ -540,3 +539,20 @@ def test_cyclic_difference_translation_invariant(a, b, t, period):
         cyclic_difference(a, b, period),
         period,
     )
+
+
+@given(pairs(finite_floats()))
+def test_interpolate_w_coord_valid_at_end_states(end_states):
+    f = interpolate_w_coord
+    a, b = end_states
+    assert f(a, b, 0.0) == a
+    assert f(a, b, 1.0) == b
+
+
+@given(pairs(finite_floats()).map(sorted), pairs(lambdas).map(sorted))
+def test_interpolate_w_coord_monotonic(end_states, lambdas):
+    f = interpolate_w_coord
+    a, b = end_states
+    l1, l2 = lambdas
+    assert f(a, b, 0.0) <= f(a, b, l1) <= f(a, b, l2) <= f(a, b, 1.0)
+    assert f(b, a, 1.0) <= f(b, a, l2) <= f(b, a, l1) <= f(b, a, 0.0)

--- a/tests/test_single_topology_combined.py
+++ b/tests/test_single_topology_combined.py
@@ -211,10 +211,10 @@ def test_combined_parameters_nonbonded_intermediate(
         assert all(w == 0.0 for w in ws_core)
 
         # dummy groups have consistent w coords
-        assert len(np.unique(ws_a)) == 1
-        assert len(np.unique(ws_b)) == 1
-        w_a = np.unique(ws_a)[0]
-        w_b = np.unique(ws_b)[0]
+        assert len(set(ws_a)) == 1
+        assert len(set(ws_b)) == 1
+        (w_a,) = set(ws_a)
+        (w_b,) = set(ws_b)
 
         # w in [0, cutoff]
         assert 0 < w_a < cutoff

--- a/tests/test_single_topology_combined.py
+++ b/tests/test_single_topology_combined.py
@@ -34,7 +34,7 @@ def _test_combined_parameters_impl_bonded(host_system_omm):
 
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     forcefield = Forcefield.load_from_file(DEFAULT_FF)
-    st3 = SingleTopology(mol_a, mol_b, core, forcefield)
+    st = SingleTopology(mol_a, mol_b, core, forcefield)
 
     host_bps, masses = openmm_deserializer.deserialize_system(host_system_omm, cutoff=1.2)
     num_host_atoms = len(masses)
@@ -51,7 +51,7 @@ def _test_combined_parameters_impl_bonded(host_system_omm):
     for lamb in [0.0, 1.0]:
 
         # generate host guest system
-        hgs = st3.combine_with_host(host_sys, lamb=lamb)
+        hgs = st.combine_with_host(host_sys, lamb=lamb)
 
         # check bonds
         check_bonded_idxs_consistency(hgs.bond.get_idxs(), len(host_sys.bond.get_idxs()))

--- a/tests/test_single_topology_combined.py
+++ b/tests/test_single_topology_combined.py
@@ -5,9 +5,8 @@ import pytest
 
 from timemachine.constants import DEFAULT_FF
 from timemachine.fe.single_topology import SingleTopology
-from timemachine.fe.system import convert_bps_into_system
+from timemachine.fe.system import convert_omm_system
 from timemachine.ff import Forcefield
-from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md import builders
 from timemachine.testsystems.dhfr import get_dhfr_system
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
@@ -18,13 +17,6 @@ def hif2a_ligand_pair_single_topology():
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     forcefield = Forcefield.load_from_file(DEFAULT_FF)
     return SingleTopology(mol_a, mol_b, core, forcefield)
-
-
-def convert_omm_system(omm_system):
-    bps, masses = openmm_deserializer.deserialize_system(omm_system, cutoff=1.2)
-    num_atoms = len(masses)
-    system = convert_bps_into_system(bps)
-    return system, num_atoms
 
 
 @pytest.fixture(scope="module")
@@ -48,7 +40,8 @@ def test_combined_parameters_bonded(host_system_fixture, hif2a_ligand_pair_singl
     # 3) we expected nonbonded parameters on the core to be linearly interpolated
 
     st = hif2a_ligand_pair_single_topology
-    host_sys, num_host_atoms = request.getfixturevalue(host_system_fixture)
+    host_sys, host_masses = request.getfixturevalue(host_system_fixture)
+    num_host_atoms = len(host_masses)
 
     def check_bonded_idxs_consistency(bonded_idxs, num_host_idxs):
 
@@ -93,7 +86,8 @@ def test_combined_parameters_nonbonded(host_system_fixture, hif2a_ligand_pair_si
     # 3) we expected nonbonded parameters on the core to be linearly interpolated
 
     st = hif2a_ligand_pair_single_topology
-    host_sys, num_host_atoms = request.getfixturevalue(host_system_fixture)
+    host_sys, host_masses = request.getfixturevalue(host_system_fixture)
+    num_host_atoms = len(host_masses)
 
     for lamb in [0.0, 1.0]:
 
@@ -192,7 +186,8 @@ def test_combined_parameters_nonbonded_intermediate(
     host_system_fixture, hif2a_ligand_pair_single_topology: SingleTopology, request
 ):
     st = hif2a_ligand_pair_single_topology
-    host_sys, num_host_atoms = request.getfixturevalue(host_system_fixture)
+    host_sys, host_masses = request.getfixturevalue(host_system_fixture)
+    num_host_atoms = len(host_masses)
 
     rng = np.random.default_rng(2022)
 

--- a/tests/test_single_topology_combined.py
+++ b/tests/test_single_topology_combined.py
@@ -139,11 +139,11 @@ def test_combined_parameters_nonbonded(host_system_fixture, hif2a_ligand_pair_si
                     if lamb == 0.0:
                         assert w == 0.0
                     elif lamb == 1.0:
-                        assert w == pytest.approx(cutoff)
+                        assert w == cutoff
                 elif indicator == 2:
                     # mol_b dummy
                     if lamb == 0.0:
-                        assert w == pytest.approx(cutoff)
+                        assert w == cutoff
                     elif lamb == 1.0:
                         assert w == 0.0
                 else:

--- a/tests/test_single_topology_combined.py
+++ b/tests/test_single_topology_combined.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 from timemachine.constants import DEFAULT_FF
-from timemachine.fe.interpolate import linear_interpolation
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.system import convert_bps_into_system
 from timemachine.ff import Forcefield

--- a/tests/test_single_topology_combined.py
+++ b/tests/test_single_topology_combined.py
@@ -137,7 +137,7 @@ def _test_combined_parameters_impl_nonbonded(host_system_omm):
                 elif indicator == 2:
                     # mol_b dummy
                     if lamb == 0.0:
-                        assert w == pytest.approx(-cutoff)
+                        assert w == pytest.approx(cutoff)
                     elif lamb == 1.0:
                         assert w == 0.0
                 else:

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -13,9 +13,8 @@ from timemachine.constants import BOLTZ, DEFAULT_TEMP
 from timemachine.fe import model_utils
 from timemachine.fe.bar import bar_with_bootstrapped_uncertainty
 from timemachine.fe.single_topology import SingleTopology
-from timemachine.fe.system import convert_bps_into_system, convert_omm_system
+from timemachine.fe.system import convert_omm_system
 from timemachine.fe.utils import get_mol_name, get_romol_conf
-from timemachine.ff.handlers import openmm_deserializer
 from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, custom_ops
 from timemachine.lib.potentials import CustomOpWrapper
 from timemachine.md import builders, minimizer

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -12,7 +12,6 @@ import pymbar
 from timemachine.constants import BOLTZ, DEFAULT_TEMP
 from timemachine.fe import model_utils
 from timemachine.fe.bar import bar_with_bootstrapped_uncertainty
-from timemachine.fe.lambda_schedule import construct_pre_optimized_relative_lambda_schedule
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.system import convert_bps_into_system
 from timemachine.fe.utils import get_mol_name, get_romol_conf
@@ -635,7 +634,7 @@ def estimate_relative_free_energy(
     single_topology = SingleTopology(mol_a, mol_b, core, ff)
 
     if lambda_schedule is None:
-        lambda_schedule = construct_pre_optimized_relative_lambda_schedule(n_windows)
+        lambda_schedule = np.linspace(0, 1, n_windows or 30)
     else:
         assert n_windows is None
         warnings.warn("Warning: setting lambda_schedule manually, this argument may be removed in a future release.")

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -729,7 +729,7 @@ def interpolate_periodic_torsion_params(src_params, dst_params, lamb, lambda_min
 
 
 def interpolate_w_coord(w0: float, w1: float, lamb: float):
-    """Interpolate 4D coordinate using pre-optimized schedule for relative free energy calculations
+    """Interpolate 4D coordinate using schedule optimized for RBFE calculations.
 
     Parameters
     ----------

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1,7 +1,7 @@
 import warnings
 from collections.abc import Iterable
 from functools import partial
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Tuple
 
 import jax.numpy as jnp
 import numpy as np

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -828,15 +828,6 @@ class SingleTopology(AtomMapMixin):
 
         forcefield: ff.Forcefield
             Forcefield to be used for parameterization.
-
-        lambda_angles, lambda_torsions: float
-            For ring opening/closing transformations, alchemical parameter values controlling the intervals over which
-            bonds, angles, and torsions are interpolated. Note that these have no effect on terms not involved in ring
-            opening/closing.
-
-            - Bonds are interpolated in the interval [0, lambda_angles]
-            - Angles are interpolated in the interval [lambda_angles, lambda_torsions]
-            - Torsions are interpolated in the interval [lambda_torsions, 1]
         """
         # initialize the mixin to get the a_to_c, b_to_c, c_to_a, c_to_b, and c_flags
         super().__init__(mol_a, mol_b, core)
@@ -1066,14 +1057,22 @@ class SingleTopology(AtomMapMixin):
 
         return potentials.ChiralBondRestraint(chiral_bond_idxs, chiral_bond_signs).bind(chiral_bond_params)
 
-    def setup_intermediate_state(
-        self,
-        lamb,
-        lambda_angles=0.4,
-        lambda_torsions=0.7,
-    ):
+    def setup_intermediate_state(self, lamb, lambda_angles=0.4, lambda_torsions=0.7):
         """
         Setup intermediate states at some value of lambda.
+
+        Parameters
+        ----------
+        lamb: float
+
+        lambda_angles, lambda_torsions: float
+            For ring opening/closing transformations, alchemical parameter values controlling the intervals over which
+            bonds, angles, and torsions are interpolated. Note that these have no effect on terms not involved in ring
+            opening/closing.
+
+            - Bonds are interpolated in the interval [0, lambda_angles]
+            - Angles are interpolated in the interval [lambda_angles, lambda_torsions]
+            - Torsions are interpolated in the interval [lambda_torsions, 1]
         """
         src_system = self.src_system
         dst_system = self.dst_system

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -521,18 +521,18 @@ def handle_ring_opening_closing(
         interpolated force constant
     """
 
-    def ring_closing(src_k, dst_k, lamb):
-        return interpolate.pad(f, src_k, dst_k, lamb, lambda_min, lambda_max)
+    def ring_closing(dst_k, lamb):
+        return interpolate.pad(f, 0.0, dst_k, lamb, lambda_min, lambda_max)
 
-    def ring_opening(src_k, dst_k, lamb):
-        return ring_closing(dst_k, src_k, 1.0 - lamb)
+    def ring_opening(src_k, lamb):
+        return ring_closing(src_k, 1.0 - lamb)
 
     return jnp.where(
         src_k == 0.0,
-        ring_closing(src_k, dst_k, lamb),
+        ring_closing(dst_k, lamb),
         jnp.where(
             dst_k == 0.0,
-            ring_opening(src_k, dst_k, lamb),
+            ring_opening(src_k, lamb),
             f(src_k, dst_k, lamb),
         ),
     )

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1159,19 +1159,19 @@ class SingleTopology(AtomMapMixin):
     def _parameterize_host_guest_nonbonded(self, lamb, host_nonbonded, interpolate_w_fn: ParameterInterpolationFxn):
         # Parameterize nonbonded potential for the host guest interaction
 
-        guest_exclusions = []
-        guest_scale_factors = []
+        guest_exclusions_ = []
+        guest_scale_factors_ = []
 
         num_host_atoms = host_nonbonded.params.shape[0]
         num_guest_atoms = self.get_num_atoms()
 
         for i in range(num_guest_atoms):
             for j in range(i + 1, num_guest_atoms):
-                guest_exclusions.append((i, j))
-                guest_scale_factors.append((1.0, 1.0))
+                guest_exclusions_.append((i, j))
+                guest_scale_factors_.append((1.0, 1.0))
 
-        guest_exclusions = np.array(guest_exclusions, dtype=np.int32) + num_host_atoms
-        guest_scale_factors = np.array(guest_scale_factors, dtype=np.float64)
+        guest_exclusions = np.array(guest_exclusions_, dtype=np.int32) + num_host_atoms
+        guest_scale_factors = np.array(guest_scale_factors_, dtype=np.float64)
 
         combined_exclusion_idxs = np.concatenate([host_nonbonded.get_exclusion_idxs(), guest_exclusions])
         combined_scale_factors = np.concatenate([host_nonbonded.get_scale_factors(), guest_scale_factors])

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1148,19 +1148,19 @@ class SingleTopology(AtomMapMixin):
     def _parameterize_host_guest_nonbonded(self, lamb, host_nonbonded):
         # Parameterize nonbonded potential for the host guest interaction
 
-        guest_exclusions_ = []
-        guest_scale_factors_ = []
+        guest_exclusions = []
+        guest_scale_factors = []
 
         num_host_atoms = host_nonbonded.params.shape[0]
         num_guest_atoms = self.get_num_atoms()
 
         for i in range(num_guest_atoms):
             for j in range(i + 1, num_guest_atoms):
-                guest_exclusions_.append((i, j))
-                guest_scale_factors_.append((1.0, 1.0))
+                guest_exclusions.append((i, j))
+                guest_scale_factors.append((1.0, 1.0))
 
-        guest_exclusions = np.array(guest_exclusions_, dtype=np.int32) + num_host_atoms
-        guest_scale_factors = np.array(guest_scale_factors_, dtype=np.float64)
+        guest_exclusions = np.array(guest_exclusions, dtype=np.int32) + num_host_atoms
+        guest_scale_factors = np.array(guest_scale_factors, dtype=np.float64)
 
         combined_exclusion_idxs = np.concatenate([host_nonbonded.get_exclusion_idxs(), guest_exclusions])
         combined_scale_factors = np.concatenate([host_nonbonded.get_scale_factors(), guest_scale_factors])

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1074,6 +1074,9 @@ class SingleTopology(AtomMapMixin):
             - Angles are interpolated in the interval [lambda_angles, lambda_torsions]
             - Torsions are interpolated in the interval [lambda_torsions, 1]
         """
+
+        assert 0.0 < lambda_angles < lambda_torsions < 1.0
+
         src_system = self.src_system
         dst_system = self.dst_system
 

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1070,9 +1070,9 @@ class SingleTopology(AtomMapMixin):
             bonds, angles, and torsions are interpolated. Note that these have no effect on terms not involved in ring
             opening/closing.
 
-            - Bonds are interpolated in the interval [0, lambda_angles]
-            - Angles are interpolated in the interval [lambda_angles, lambda_torsions]
-            - Torsions are interpolated in the interval [lambda_torsions, 1]
+            - Bonds are interpolated in the interval 0 <= lamb <= lambda_angles
+            - Angles are interpolated in the interval lambda_angles <= lamb <= lambda_torsions
+            - Torsions are interpolated in the interval lambda_torsions <= lamb <= 1
 
             Note: must satisfy 0 < lambda_angles < lambda_torsions < 1
         """

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1073,6 +1073,8 @@ class SingleTopology(AtomMapMixin):
             - Bonds are interpolated in the interval [0, lambda_angles]
             - Angles are interpolated in the interval [lambda_angles, lambda_torsions]
             - Torsions are interpolated in the interval [lambda_torsions, 1]
+
+            Note: must satisfy 0 < lambda_angles < lambda_torsions < 1
         """
 
         assert 0.0 < lambda_angles < lambda_torsions < 1.0

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -5,8 +5,8 @@ from typing import List, Tuple
 import jax
 import jax.numpy as jnp
 import numpy as np
-import openmm
 import scipy
+from simtk import openmm
 
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.integrator import simulate

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -1,11 +1,14 @@
 import functools
 import multiprocessing
+from typing import List, Tuple
 
 import jax
 import jax.numpy as jnp
 import numpy as np
+import openmm
 import scipy
 
+from timemachine.ff.handlers import openmm_deserializer
 from timemachine.integrator import simulate
 from timemachine.lib import potentials
 from timemachine.potentials import bonded, nonbonded
@@ -86,6 +89,12 @@ def convert_bps_into_system(bps):
             assert 0, "Unknown potential"
 
     return system
+
+
+def convert_omm_system(omm_system: openmm.System) -> Tuple["VacuumSystem", List[float]]:
+    bps, masses = openmm_deserializer.deserialize_system(omm_system, cutoff=1.2)
+    system = convert_bps_into_system(bps)
+    return system, masses
 
 
 class VacuumSystem:

--- a/timemachine/ff/handlers/openmm_deserializer.py
+++ b/timemachine/ff/handlers/openmm_deserializer.py
@@ -1,3 +1,5 @@
+from typing import List, Tuple
+
 import numpy as np
 from simtk import openmm as mm
 from simtk import unit
@@ -10,7 +12,7 @@ def value(quantity):
     return quantity.value_in_unit_system(unit.md_unit_system)
 
 
-def deserialize_system(system, cutoff):
+def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potentials.CustomOpWrapper], List[float]]:
     """
     Deserialize an OpenMM XML file
 

--- a/timemachine/ff/handlers/openmm_deserializer.py
+++ b/timemachine/ff/handlers/openmm_deserializer.py
@@ -46,25 +46,25 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
     for force in system.getForces():
 
         if isinstance(force, mm.HarmonicBondForce):
-            bond_idxs = []
-            bond_params = []
+            bond_idxs_ = []
+            bond_params_ = []
 
             for b_idx in range(force.getNumBonds()):
                 src_idx, dst_idx, length, k = force.getBondParameters(b_idx)
                 length = value(length)
                 k = value(k)
 
-                bond_idxs.append([src_idx, dst_idx])
-                bond_params.append((k, length))
+                bond_idxs_.append([src_idx, dst_idx])
+                bond_params_.append((k, length))
 
-            bond_idxs = np.array(bond_idxs, dtype=np.int32)
-            bond_params = np.array(bond_params, dtype=np.float64)
+            bond_idxs = np.array(bond_idxs_, dtype=np.int32)
+            bond_params = np.array(bond_params_, dtype=np.float64)
             bps.append(potentials.HarmonicBond(bond_idxs).bind(bond_params))
 
         if isinstance(force, mm.HarmonicAngleForce):
 
-            angle_idxs = []
-            angle_params = []
+            angle_idxs_ = []
+            angle_params_ = []
 
             for a_idx in range(force.getNumAngles()):
 
@@ -72,18 +72,18 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
                 angle = value(angle)
                 k = value(k)
 
-                angle_idxs.append([src_idx, mid_idx, dst_idx])
-                angle_params.append((k, angle))
+                angle_idxs_.append([src_idx, mid_idx, dst_idx])
+                angle_params_.append((k, angle))
 
-            angle_idxs = np.array(angle_idxs, dtype=np.int32)
-            angle_params = np.array(angle_params, dtype=np.float64)
+            angle_idxs = np.array(angle_idxs_, dtype=np.int32)
+            angle_params = np.array(angle_params_, dtype=np.float64)
 
             bps.append(potentials.HarmonicAngle(angle_idxs).bind(angle_params))
 
         if isinstance(force, mm.PeriodicTorsionForce):
 
-            torsion_idxs = []
-            torsion_params = []
+            torsion_idxs_ = []
+            torsion_params_ = []
 
             for t_idx in range(force.getNumTorsions()):
                 a_idx, b_idx, c_idx, d_idx, period, phase, k = force.getTorsionParameters(t_idx)
@@ -91,19 +91,19 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
                 phase = value(phase)
                 k = value(k)
 
-                torsion_params.append((k, phase, period))
-                torsion_idxs.append([a_idx, b_idx, c_idx, d_idx])
+                torsion_params_.append((k, phase, period))
+                torsion_idxs_.append([a_idx, b_idx, c_idx, d_idx])
 
-            torsion_idxs = np.array(torsion_idxs, dtype=np.int32)
-            torsion_params = np.array(torsion_params, dtype=np.float64)
+            torsion_idxs = np.array(torsion_idxs_, dtype=np.int32)
+            torsion_params = np.array(torsion_params_, dtype=np.float64)
             bps.append(potentials.PeriodicTorsion(torsion_idxs).bind(torsion_params))
 
         if isinstance(force, mm.NonbondedForce):
 
             num_atoms = force.getNumParticles()
 
-            charge_params = []
-            lj_params = []
+            charge_params_ = []
+            lj_params_ = []
 
             for a_idx in range(num_atoms):
 
@@ -122,13 +122,13 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
                 # eps += 1e-3
 
                 # charge_params.append(charge_idx)
-                charge_params.append(charge)
-                lj_params.append((sig, eps))
+                charge_params_.append(charge)
+                lj_params_.append((sig, eps))
 
-            charge_params = np.array(charge_params, dtype=np.float64)
+            charge_params = np.array(charge_params_, dtype=np.float64)
 
             # print("Protein net charge:", np.sum(np.array(global_params)[charge_param_idxs]))
-            lj_params = np.array(lj_params, dtype=np.float64)
+            lj_params = np.array(lj_params_, dtype=np.float64)
 
             # 1 here means we fully remove the interaction
             # 1-2, 1-3
@@ -137,8 +137,8 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
             # 1-4, remove half of the interaction
             # scale_half = insert_parameters(0.5, 21)
 
-            exclusion_idxs = []
-            scale_factors = []
+            exclusion_idxs_ = []
+            scale_factors_ = []
 
             all_sig = lj_params[:, 0]
             all_eps = lj_params[:, 1]
@@ -159,7 +159,7 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
                 expected_sig = (src_sig + dst_sig) / 2
                 expected_eps = np.sqrt(src_eps * dst_eps)
 
-                exclusion_idxs.append([src, dst])
+                exclusion_idxs_.append([src, dst])
 
                 # sanity check this (expected_eps can be zero), redo this thing
 
@@ -172,13 +172,13 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
                 else:
                     lj_scale_factor = 1 - new_eps / expected_eps
 
-                scale_factors.append(lj_scale_factor)
+                scale_factors_.append(lj_scale_factor)
 
                 # tbd fix charge_scale_factors using new_cp
                 if new_eps != 0:
                     np.testing.assert_almost_equal(expected_sig, new_sig)
 
-            exclusion_idxs = np.array(exclusion_idxs, dtype=np.int32)
+            exclusion_idxs = np.array(exclusion_idxs_, dtype=np.int32)
 
             # cutoff = 1000.0
 
@@ -198,7 +198,7 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
             beta = 2.0  # erfc correction
 
             # use the same scale factors for electrostatics and lj
-            scale_factors = np.stack([scale_factors, scale_factors], axis=1)
+            scale_factors = np.stack([scale_factors_, scale_factors_], axis=1)
 
             bps.append(potentials.Nonbonded(N, exclusion_idxs, scale_factors, beta, cutoff).bind(nb_params))
 


### PR DESCRIPTION
This is a step toward independently parametrizing alchemical parameter transformations.

Previously, parameters for all interactions were linearly interpolated as a function of lambda, with the overall lambda spacing being adjusted to optimize overlap.

With #820, we introduced specialized parameter interpolation functions (e.g. log-linear for harmonic force constants) that generate reasonable protocols given linearly-spaced lambda windows, but did not yet modify the overall lambda schedule to be linear because we didn't have the ability to use a custom interpolation function for nonbonded decoupling parameters (which require a nonlinear schedule for reasonable efficiency). The result was suboptimal performance of harmonic force constant protocols, since their interpolation functions are chosen assuming near-linear lambda spacing.

This PR switches to a linear overall lambda spacing, using the existing pre-optimized nonlinear schedule for the nonbonded decoupling parameters only (possible since #893).

## Todo
- [x] Test on hif2a