### PR TITLE
Include remaining data files from datasets/ and testsystems/ in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,11 +108,11 @@ setup(
     },
     package_data={
         "timemachine": [
-            "datasets/freesolv/freesolv.sdf",
-            "testsystems/data/5dfr_solv_equil.pdb",
-            "testsystems/data/ligands_40.sdf",
-            "testsystems/data/mobley_820789.sdf",
-            "testsystems/data/hif2a_nowater_min.pdb",
+            "datasets/**/*.csv",
+            "datasets/**/*.pdb",
+            "datasets/**/*.sdf",
+            "testsystems/data/**/*.pdb",
+            "testsystems/data/**/*.sdf",
         ],
     },
     # entry_points={


### PR DESCRIPTION
Includes all public data files in `timemachine.datasets` and `timemachine.testsystems.data` with CSV, PDB, and SDF extensions in the Python package. This is useful to allow importing data files in an environment outside of the source tree, e.g. in a notebook.