### PR TITLE
Check compatibility of atom map with chiral endstates

### DIFF
--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -207,8 +207,8 @@ def test_get_core_with_alignment():
     mol_b_shuffled = Chem.RenumberAtoms(mol_b, new_idxs)
 
     shuffled_core, _ = get_core_with_alignment(mol_a_shuffled, mol_b_shuffled)
-    assert len(core) == mol_a.GetNumAtoms()
-    assert len(core) == mol_b.GetNumAtoms()
+    assert len(shuffled_core) == mol_a.GetNumAtoms()
+    assert len(shuffled_core) == mol_b.GetNumAtoms()
 
 
 @pytest.mark.nogpu

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -119,7 +119,6 @@ def get_core(mol_a, mol_b, threshold=2.0, skip_chiral_checks=False):
         query,
         threshold=threshold,
         allow_chiral_atom_flips=skip_chiral_checks,
-        allow_chiral_atom_undefined=skip_chiral_checks,
     )
     return core
 

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -109,11 +109,19 @@ $$$$""",
     return mol_a, mol_b
 
 
-def get_core(mol_a, mol_b, threshold=2.0):
+def get_core(mol_a, mol_b, threshold=2.0, skip_chiral_checks=False):
     """Simple utility that finds a core by using the conformers with a threshold"""
     mcs_result = mcs(mol_a, mol_b, threshold=threshold)
     query = Chem.MolFromSmarts(mcs_result.smartsString)
-    return get_core_by_mcs(mol_a, mol_b, query, threshold=threshold)
+    core = get_core_by_mcs(
+        mol_a,
+        mol_b,
+        query,
+        threshold=threshold,
+        allow_chiral_atom_flips=skip_chiral_checks,
+        allow_chiral_atom_undefined=skip_chiral_checks,
+    )
+    return core
 
 
 @pytest.mark.nogpu
@@ -125,7 +133,7 @@ def test_align_mols_by_core():
 
     assert mol_a.GetNumAtoms() == mol_b.GetNumAtoms()
 
-    core = get_core(mol_a, mol_b)
+    core = get_core(mol_a, mol_b, skip_chiral_checks=True)
 
     # The difference in conformer prevents a complete mapping
     assert len(core) != mol_a.GetNumAtoms()

--- a/tests/test_chiral_utils.py
+++ b/tests/test_chiral_utils.py
@@ -165,12 +165,15 @@ def test_chiral_flip_check():
     swap_map[1, 1] = 2
     swap_map[2, 1] = 1
 
-    identity_conflicts = find_atom_map_chiral_conflicts(identity_map, chiral_set_a, chiral_set_b)
-    assert len(identity_conflicts) == 0
+    identity_flips = find_atom_map_chiral_conflicts(identity_map, chiral_set_a, chiral_set_b, mode="flip")
+    identity_undefineds = find_atom_map_chiral_conflicts(identity_map, chiral_set_a, chiral_set_b, mode="undefined")
+    assert len(identity_flips) == 0
+    assert len(identity_undefineds) == 0
 
-    swap_conflicts = find_atom_map_chiral_conflicts(swap_map, chiral_set_a, chiral_set_b)
-    assert len(swap_conflicts) == 8  # TODO: deduplicate idxs?
-    assert all("flipped" in msg.lower() for msg in swap_conflicts)
+    swap_map_flips = find_atom_map_chiral_conflicts(swap_map, chiral_set_a, chiral_set_b, mode="flip")
+    swap_map_undefineds = find_atom_map_chiral_conflicts(swap_map, chiral_set_a, chiral_set_b, mode="undefined")
+    assert len(swap_map_flips) == 8  # TODO: deduplicate idxs?
+    assert len(swap_map_undefineds) == 0
 
     # test maps where atom chirality is defined in one endstate, undefined in other
     mol_b = Chem.AddHs(Chem.MolFromSmiles("N"))
@@ -180,6 +183,7 @@ def test_chiral_flip_check():
     assert len(chiral_set_b.restr_idxs) == 0
 
     partial_map = identity_map[:4]
-    partial_conflicts = find_atom_map_chiral_conflicts(partial_map, chiral_set_a, chiral_set_b)
-    assert len(partial_conflicts) > 0
-    assert all("undefined" in msg.lower() for msg in partial_conflicts)
+    partial_map_flips = find_atom_map_chiral_conflicts(partial_map, chiral_set_a, chiral_set_b, mode="flip")
+    partial_map_undefineds = find_atom_map_chiral_conflicts(partial_map, chiral_set_a, chiral_set_b, mode="undefined")
+    assert len(partial_map_flips) == 0
+    assert len(partial_map_undefineds) > 0

--- a/tests/test_chiral_utils.py
+++ b/tests/test_chiral_utils.py
@@ -234,6 +234,7 @@ def test_chiral_conflict_flip():
 
     identity_map = np.array([(i, i) for i in range(len(conf_a))])
 
+    # swap any pair of atoms around a tetrahedral center to flip chirality
     swap_map = np.array(identity_map)
     swap_map[1, 1] = 2
     swap_map[2, 1] = 1
@@ -288,6 +289,7 @@ def test_chiral_conflict_mixed():
 
     mixed_map = np.array([[i, i] for i in range(mol_b.GetNumAtoms())])
 
+    # swap any pair of atoms around a tetrahedral center to flip chirality
     mixed_map[2, 0] = 3
     mixed_map[3, 0] = 2
 

--- a/tests/test_chiral_utils.py
+++ b/tests/test_chiral_utils.py
@@ -186,4 +186,4 @@ def test_chiral_flip_check():
     partial_map_flips = find_atom_map_chiral_conflicts(partial_map, chiral_set_a, chiral_set_b, mode="flip")
     partial_map_undefineds = find_atom_map_chiral_conflicts(partial_map, chiral_set_a, chiral_set_b, mode="undefined")
     assert len(partial_map_flips) == 0
-    assert len(partial_map_undefineds) > 0
+    assert len(partial_map_undefineds) == 1

--- a/tests/test_chiral_utils.py
+++ b/tests/test_chiral_utils.py
@@ -141,14 +141,87 @@ def test_find_chiral_bonds():
     assert res == set([(0, 2)])
 
 
+# next few strings named molblock_{smi} are generated
+# using rdkit version 2022.03.5:
+# -----------------------------------------
+# mol = Chem.AddHs(Chem.MolFromSmiles(smi))
+# AllChem.EmbedMolecule(mol, randomSeed=0)
+# print(Chem.MolToMolBlock(mol))
+# -----------------------------------------
+molblock_C = """
+     RDKit          3D
+
+  5  4  0  0  0  0  0  0  0  0999 V2000
+    0.0051   -0.0106    0.0060 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.5497    0.7554   -0.5970 H   0  0  0  0  0  0  0  0  0  0  0  0
+    0.7498   -0.5879    0.5853 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.5868   -0.6521   -0.6761 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.7178    0.4953    0.6818 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  1  3  1  0
+  1  4  1  0
+  1  5  1  0
+M  END"""
+
+molblock_N = """
+     RDKit          3D
+
+  4  3  0  0  0  0  0  0  0  0999 V2000
+    0.0195   -0.0020    0.2429 N   0  0  0  0  0  0  0  0  0  0  0  0
+    0.9942   -0.1240   -0.0852 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.5944   -0.7730   -0.0788 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.4193    0.8989   -0.0789 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  1  3  1  0
+  1  4  1  0
+M  END"""
+
+molblock_CC = """
+     RDKit          3D
+
+  8  7  0  0  0  0  0  0  0  0999 V2000
+   -0.7455    0.0414    0.0117 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.7473    0.0029    0.0012 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.1297   -0.6374    0.8144 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.1849    1.0256    0.1996 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.1999   -0.3346   -0.9389 H   0  0  0  0  0  0  0  0  0  0  0  0
+    1.0842   -0.7365   -0.7732 H   0  0  0  0  0  0  0  0  0  0  0  0
+    1.2266    0.9617   -0.2681 H   0  0  0  0  0  0  0  0  0  0  0  0
+    1.2019   -0.3231    0.9532 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  1  3  1  0
+  1  4  1  0
+  1  5  1  0
+  2  6  1  0
+  2  7  1  0
+  2  8  1  0
+M  END"""
+
+molblock_CN = """
+     RDKit          3D
+
+  7  6  0  0  0  0  0  0  0  0999 V2000
+   -0.5732    0.0243   -0.0031 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.8233   -0.0403   -0.0341 N   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.0026   -0.4265    0.9182 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.9088    1.0746   -0.0741 H   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.9930   -0.5345   -0.8755 H   0  0  0  0  0  0  0  0  0  0  0  0
+    1.2903   -0.9052    0.2005 H   0  0  0  0  0  0  0  0  0  0  0  0
+    1.3640    0.8076   -0.1320 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  1  3  1  0
+  1  4  1  0
+  1  5  1  0
+  2  6  1  0
+  2  7  1  0
+M  END"""
+
+
 def test_chiral_conflict_flip():
     # exercise case of no conflicts or a flip conflict
 
-    mol_a = Chem.AddHs(Chem.MolFromSmiles("C"))
-    mol_b = Chem.AddHs(Chem.MolFromSmiles("C"))
-
-    AllChem.EmbedMolecule(mol_a, randomSeed=0)
-    AllChem.EmbedMolecule(mol_b, randomSeed=0)
+    mol_a = Chem.MolFromMolBlock(molblock_C, removeHs=False)
+    mol_b = Chem.MolFromMolBlock(molblock_C, removeHs=False)
 
     conf_a = mol_a.GetConformer(0).GetPositions()
     conf_b = mol_b.GetConformer(0).GetPositions()
@@ -179,11 +252,8 @@ def test_chiral_conflict_flip():
 def test_chiral_conflict_undefined():
     # exercise case where atom chirality is defined in one endstate, undefined in other
 
-    mol_a = Chem.AddHs(Chem.MolFromSmiles("C"))
-    mol_b = Chem.AddHs(Chem.MolFromSmiles("N"))
-
-    AllChem.EmbedMolecule(mol_a, randomSeed=0)
-    AllChem.EmbedMolecule(mol_b, randomSeed=0)
+    mol_a = Chem.MolFromMolBlock(molblock_C, removeHs=False)
+    mol_b = Chem.MolFromMolBlock(molblock_N, removeHs=False)
 
     conf_a = mol_a.GetConformer(0).GetPositions()
     conf_b = mol_b.GetConformer(0).GetPositions()
@@ -204,11 +274,8 @@ def test_chiral_conflict_undefined():
 def test_chiral_conflict_mixed():
     # test case containing both a flip and a partial undefined
 
-    mol_a = Chem.AddHs(Chem.MolFromSmiles("CC"))
-    mol_b = Chem.AddHs(Chem.MolFromSmiles("CN"))
-
-    AllChem.EmbedMolecule(mol_a, randomSeed=0)
-    AllChem.EmbedMolecule(mol_b, randomSeed=0)
+    mol_a = Chem.MolFromMolBlock(molblock_CC, removeHs=False)
+    mol_b = Chem.MolFromMolBlock(molblock_CN, removeHs=False)
 
     conf_a = mol_a.GetConformer(0).GetPositions()
     conf_b = mol_b.GetConformer(0).GetPositions()

--- a/tests/test_chiral_utils.py
+++ b/tests/test_chiral_utils.py
@@ -4,7 +4,7 @@ from rdkit import Chem
 from rdkit.Chem import AllChem
 
 from timemachine.fe import chiral_utils, utils
-from timemachine.fe.chiral_utils import ChiralRestrIdxSet, find_atom_map_chiral_conflicts
+from timemachine.fe.chiral_utils import ChiralCheckMode, ChiralRestrIdxSet, find_atom_map_chiral_conflicts
 from timemachine.potentials.chiral_restraints import U_chiral_atom_batch, U_chiral_bond_batch
 
 pytestmark = [pytest.mark.nogpu]
@@ -239,13 +239,17 @@ def test_chiral_conflict_flip():
     swap_map[1, 1] = 2
     swap_map[2, 1] = 1
 
-    identity_flips = find_atom_map_chiral_conflicts(identity_map, chiral_set_a, chiral_set_b, mode="flip")
-    identity_undefineds = find_atom_map_chiral_conflicts(identity_map, chiral_set_a, chiral_set_b, mode="undefined")
+    identity_flips = find_atom_map_chiral_conflicts(identity_map, chiral_set_a, chiral_set_b, mode=ChiralCheckMode.FLIP)
+    identity_undefineds = find_atom_map_chiral_conflicts(
+        identity_map, chiral_set_a, chiral_set_b, mode=ChiralCheckMode.UNDEFINED
+    )
     assert len(identity_flips) == 0
     assert len(identity_undefineds) == 0
 
-    swap_map_flips = find_atom_map_chiral_conflicts(swap_map, chiral_set_a, chiral_set_b, mode="flip")
-    swap_map_undefineds = find_atom_map_chiral_conflicts(swap_map, chiral_set_a, chiral_set_b, mode="undefined")
+    swap_map_flips = find_atom_map_chiral_conflicts(swap_map, chiral_set_a, chiral_set_b, mode=ChiralCheckMode.FLIP)
+    swap_map_undefineds = find_atom_map_chiral_conflicts(
+        swap_map, chiral_set_a, chiral_set_b, mode=ChiralCheckMode.UNDEFINED
+    )
     assert len(swap_map_flips) == 8  # TODO: deduplicate idxs?
     assert len(swap_map_undefineds) == 0
 
@@ -266,8 +270,12 @@ def test_chiral_conflict_undefined():
     assert len(chiral_set_b.restr_idxs) == 0
 
     partial_map = np.array([(i, i) for i in range(4)])
-    partial_map_flips = find_atom_map_chiral_conflicts(partial_map, chiral_set_a, chiral_set_b, mode="flip")
-    partial_map_undefineds = find_atom_map_chiral_conflicts(partial_map, chiral_set_a, chiral_set_b, mode="undefined")
+    partial_map_flips = find_atom_map_chiral_conflicts(
+        partial_map, chiral_set_a, chiral_set_b, mode=ChiralCheckMode.FLIP
+    )
+    partial_map_undefineds = find_atom_map_chiral_conflicts(
+        partial_map, chiral_set_a, chiral_set_b, mode=ChiralCheckMode.UNDEFINED
+    )
     assert len(partial_map_flips) == 0
     assert len(partial_map_undefineds) == 1
 
@@ -293,8 +301,10 @@ def test_chiral_conflict_mixed():
     mixed_map[2, 0] = 3
     mixed_map[3, 0] = 2
 
-    mixed_map_flips = find_atom_map_chiral_conflicts(mixed_map, chiral_set_a, chiral_set_b, mode="flip")
-    mixed_map_undefineds = find_atom_map_chiral_conflicts(mixed_map, chiral_set_a, chiral_set_b, mode="undefined")
+    mixed_map_flips = find_atom_map_chiral_conflicts(mixed_map, chiral_set_a, chiral_set_b, mode=ChiralCheckMode.FLIP)
+    mixed_map_undefineds = find_atom_map_chiral_conflicts(
+        mixed_map, chiral_set_a, chiral_set_b, mode=ChiralCheckMode.UNDEFINED
+    )
 
     assert len(mixed_map_flips) == 8
     assert len(mixed_map_undefineds) == 1

--- a/tests/test_chiral_utils.py
+++ b/tests/test_chiral_utils.py
@@ -170,7 +170,7 @@ def test_chiral_flip_check():
 
     swap_conflicts = find_atom_map_chiral_conflicts(swap_map, chiral_set_a, chiral_set_b)
     assert len(swap_conflicts) == 8  # TODO: deduplicate idxs?
-    assert all("flipped" in msg for msg in swap_conflicts)
+    assert all("flipped" in msg.lower() for msg in swap_conflicts)
 
     # test maps where atom chirality is defined in one endstate, undefined in other
     mol_b = Chem.AddHs(Chem.MolFromSmiles("N"))
@@ -182,4 +182,4 @@ def test_chiral_flip_check():
     partial_map = identity_map[:4]
     partial_conflicts = find_atom_map_chiral_conflicts(partial_map, chiral_set_a, chiral_set_b)
     assert len(partial_conflicts) > 0
-    assert all("undefined" in msg for msg in partial_conflicts)
+    assert all("undefined" in msg.lower() for msg in partial_conflicts)

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -277,6 +277,10 @@ def test_combine_masses():
 
     mol_a = Chem.MolFromSmiles("BrC1=CC=CC=C1")
     mol_b = Chem.MolFromSmiles("C1=CN=CC=C1F")
+
+    AllChem.EmbedMolecule(mol_a, seed=2022)
+    AllChem.EmbedMolecule(mol_b, seed=2022)
+
     core = np.array([[1, 0], [2, 1], [3, 2], [4, 3], [5, 4], [6, 5]])
     ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
 

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -39,6 +39,8 @@ def test_phenol():
     are present when either a single root anchor is provided, or when a root anchor and a neighbor anchor is provided.
     """
     mol = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1O"))
+    AllChem.EmbedMolecule(mol, randomSeed=2022)
+
     ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
 
     # set [O,H] as the dummy group
@@ -86,6 +88,10 @@ def test_find_dummy_groups_and_anchors():
     """
     mol_a = Chem.MolFromSmiles("OCCC")
     mol_b = Chem.MolFromSmiles("CCCF")
+
+    AllChem.EmbedMolecule(mol_a, randomSeed=2022)
+    AllChem.EmbedMolecule(mol_b, randomSeed=2022)
+
     core_pairs = np.array([[1, 2], [2, 1], [3, 0]])
 
     dgs, jks = single_topology.find_dummy_groups_and_anchors(mol_a, mol_b, core_pairs[:, 0], core_pairs[:, 1])
@@ -107,6 +113,9 @@ def test_find_dummy_groups_and_anchors_multiple_angles():
     """
     mol_a = Chem.MolFromSmiles("CCC")
     mol_b = Chem.MolFromSmiles("CC(C)C")
+
+    AllChem.EmbedMolecule(mol_a, randomSeed=2022)
+    AllChem.EmbedMolecule(mol_b, randomSeed=2022)
 
     core_pairs = np.array([[0, 2], [1, 1], [2, 3]])
     dgs, jks = single_topology.find_dummy_groups_and_anchors(mol_a, mol_b, core_pairs[:, 0], core_pairs[:, 1])
@@ -133,6 +142,10 @@ def testing_find_dummy_groups_and_multiple_anchors():
     """
     mol_a = Chem.MolFromSmiles("OCC")
     mol_b = Chem.MolFromSmiles("O1CC1")
+
+    AllChem.EmbedMolecule(mol_a, randomSeed=2022)
+    AllChem.EmbedMolecule(mol_b, randomSeed=2022)
+
     core_pairs = np.array([[1, 1], [2, 2]])
 
     with pytest.warns(MultipleAnchorWarning):
@@ -154,6 +167,9 @@ def testing_find_dummy_groups_and_multiple_anchors():
     mol_a = Chem.MolFromSmiles("C(C)(C)C")
     mol_b = Chem.MolFromSmiles("O1CCCC1")
 
+    AllChem.EmbedMolecule(mol_a, randomSeed=2022)
+    AllChem.EmbedMolecule(mol_b, randomSeed=2022)
+
     core_a = [0, 1, 2, 3]
     core_b = [2, 1, 4, 3]
 
@@ -166,6 +182,9 @@ def testing_find_dummy_groups_and_multiple_anchors():
 def test_charge_perturbation_is_invalid():
     mol_a = Chem.AddHs(Chem.MolFromSmiles("Cc1cc[nH]c1"))
     mol_b = Chem.AddHs(Chem.MolFromSmiles("C[n+]1cc[nH]c1"))
+
+    AllChem.EmbedMolecule(mol_a, randomSeed=2022)
+    AllChem.EmbedMolecule(mol_b, randomSeed=2022)
 
     ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
 
@@ -329,6 +348,10 @@ def test_combine_with_host():
     """Verifies that combine_with_host correctly sets up all of the U functions"""
     mol_a = Chem.MolFromSmiles("BrC1=CC=CC=C1")
     mol_b = Chem.MolFromSmiles("C1=CN=CC=C1F")
+
+    AllChem.EmbedMolecule(mol_a, randomSeed=2022)
+    AllChem.EmbedMolecule(mol_b, randomSeed=2022)
+
     core = np.array([[1, 0], [2, 1], [3, 2], [4, 3], [5, 4], [6, 5]])
     ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
 

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -278,8 +278,8 @@ def test_combine_masses():
     mol_a = Chem.MolFromSmiles("BrC1=CC=CC=C1")
     mol_b = Chem.MolFromSmiles("C1=CN=CC=C1F")
 
-    AllChem.EmbedMolecule(mol_a, seed=2022)
-    AllChem.EmbedMolecule(mol_b, seed=2022)
+    AllChem.EmbedMolecule(mol_a, randomSeed=2022)
+    AllChem.EmbedMolecule(mol_b, randomSeed=2022)
 
     core = np.array([[1, 0], [2, 1], [3, 2], [4, 3], [5, 4], [6, 5]])
     ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -101,7 +101,12 @@ def mcs(
 
 
 def get_core_by_mcs(
-    mol_a, mol_b, query, threshold=0.5, allow_chiral_atom_flips=False, allow_chiral_atom_undefined=False
+    mol_a,
+    mol_b,
+    query,
+    threshold=0.5,
+    allow_chiral_atom_flips=False,
+    allow_chiral_atom_undefined=False,
 ):
     """Return np integer array that can be passed to RelativeFreeEnergy constructor
 
@@ -167,13 +172,13 @@ def get_core_by_mcs(
         conflicts = find_atom_map_chiral_conflicts(trial_core, chiral_set_a, chiral_set_b)
 
         # TODO: refactor to use boolean flags instead of strings
-        any_flips = any("flipped" in msg.lower() for msg in conflicts.values())
-        any_undefined = any("undefined" in msg.lower() for msg in conflicts.values())
+        num_flips = sum("flipped" in msg.lower() for msg in conflicts.values())
+        num_undefineds = sum("undefined" in msg.lower() for msg in conflicts.values())
 
-        if (not allow_chiral_atom_flips) and any_flips:
+        if (not allow_chiral_atom_flips) and (num_flips > 0):
             return False
 
-        if (not allow_chiral_atom_undefined) and any_undefined:
+        if (not allow_chiral_atom_undefined) and (num_undefineds > 0):
             return False
 
     for i, a in enumerate(matches_a):

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -134,7 +134,7 @@ def get_core_by_mcs(
         allow mappings where a chiral atom restraint
         is defined for (c, i, j, k) in A (resp. B)
         but undefined for (m(c), m(i), m(j), m(k)) in B (resp. A)
-    
+
     Returns
     -------
     core : np.ndarray of ints, shape (n_MCS, 2)

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -176,14 +176,15 @@ def get_core_by_mcs(
     chiral_set_a = ChiralRestrIdxSet.from_mol(mol_a, conf_a)
     chiral_set_b = ChiralRestrIdxSet.from_mol(mol_b, conf_b)
 
-    def valid_chiral_atoms(trial_core):
-        # return False if chiral atom chick is active and a conflict is found
+    def chiral_atoms_valid(trial_core):
+
+        # skip search for conflicts unless needed
         valid = True
         if not allow_chiral_atom_flips:
-            n_flips = len(
-                find_atom_map_chiral_conflicts(trial_core, chiral_set_a, chiral_set_b, mode=ChiralCheckMode.FLIP)
+            conflicts = find_atom_map_chiral_conflicts(
+                trial_core, chiral_set_a, chiral_set_b, mode=ChiralCheckMode.FLIP
             )
-            if n_flips > 0:
+            if len(conflicts) > 0:
                 valid = False
 
         return valid
@@ -194,7 +195,7 @@ def get_core_by_mcs(
 
             if np.any(gt_threshold[a, b]):
                 cost[i, j] = +np.inf
-            elif not valid_chiral_atoms(trial_core):
+            elif not chiral_atoms_valid(trial_core):
                 cost[i, j] = +np.inf
             else:
                 dij = all_distances[a, b]

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -182,20 +182,16 @@ def get_core_by_mcs(
     chiral_set_b = ChiralRestrIdxSet.from_mol(mol_b, conf_b)
 
     def valid_chiral_atoms(trial_core):
-        if allow_chiral_atom_flips and allow_chiral_atom_undefined:
-            return True
-
-        flips = find_atom_map_chiral_conflicts(trial_core, chiral_set_a, chiral_set_b, mode="flip")
-        undefineds = find_atom_map_chiral_conflicts(trial_core, chiral_set_a, chiral_set_b, mode="undefined")
-
-        num_flips = len(flips)
-        num_undefineds = len(undefineds)
-
-        # TODO: de-DeMorgan-ify
-        invalid_due_to_flips = (not allow_chiral_atom_flips) and (num_flips > 0)
-        invalid_due_to_undefineds = (not allow_chiral_atom_undefined) and (num_undefineds > 0)
-        invalid = invalid_due_to_flips or invalid_due_to_undefineds
-        valid = not invalid
+        # return False if either active filter is violated
+        valid = True
+        if not allow_chiral_atom_flips:
+            n_flips = len(find_atom_map_chiral_conflicts(trial_core, chiral_set_a, chiral_set_b, mode="flip"))
+            if n_flips > 0:
+                valid = False
+        if valid and (not allow_chiral_atom_undefined):
+            n_undefined = len(find_atom_map_chiral_conflicts(trial_core, chiral_set_a, chiral_set_b, mode="undefined"))
+            if n_undefined > 0:
+                valid = False
 
         return valid
 

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -8,6 +8,7 @@ from rdkit.Chem import rdFMCS
 from scipy.spatial.distance import cdist
 
 from timemachine.constants import DEFAULT_FF
+from timemachine.fe.chiral_utils import ChiralRestrIdxSet, find_atom_map_chiral_conflicts
 from timemachine.fe.topology import AtomMappingError
 from timemachine.fe.utils import set_romol_conf
 from timemachine.ff import Forcefield
@@ -99,13 +100,21 @@ def mcs(
     return result
 
 
-def get_core_by_mcs(mol_a, mol_b, query, threshold=0.5):
+def get_core_by_mcs(
+    mol_a, mol_b, query, threshold=0.5, allow_chiral_atom_flips=False, allow_chiral_atom_undefined=False
+):
     """Return np integer array that can be passed to RelativeFreeEnergy constructor
 
     Parameters
     ----------
     mol_a, mol_b, query : RDKit molecules
     threshold : float, in angstroms
+    allow_chiral_atom_flips: bool
+        allow mappings that flip the sign of chiral atom restraints
+    allow_chiral_atom_undefined: bool
+        allow mappings where a chiral atom restraint
+        is defined for (c, i, j, k) in A (resp. B)
+        but undefined for (m(c), m(i), m(j), m(k)) in B (resp. A)
 
     Returns
     -------
@@ -148,9 +157,32 @@ def get_core_by_mcs(mol_a, mol_b, query, threshold=0.5):
 
     cost = np.zeros((len(matches_a), len(matches_b)))
 
+    chiral_set_a = ChiralRestrIdxSet.from_mol(mol_a, conf_a)
+    chiral_set_b = ChiralRestrIdxSet.from_mol(mol_b, conf_b)
+
+    def valid_chiral_atoms(trial_core):
+        if allow_chiral_atom_flips and allow_chiral_atom_undefined:
+            return True
+
+        conflicts = find_atom_map_chiral_conflicts(trial_core, chiral_set_a, chiral_set_b)
+
+        # TODO: refactor to use boolean flags instead of strings
+        any_flips = any("flipped" in msg.lower() for msg in conflicts.values())
+        any_undefined = any("undefined" in msg.lower() for msg in conflicts.values())
+
+        if (not allow_chiral_atom_flips) and any_flips:
+            return False
+
+        if (not allow_chiral_atom_undefined) and any_undefined:
+            return False
+
     for i, a in enumerate(matches_a):
         for j, b in enumerate(matches_b):
+            trial_core = np.array([a, b]).T
+
             if np.any(gt_threshold[a, b]):
+                cost[i, j] = +np.inf
+            elif not valid_chiral_atoms(trial_core):
                 cost[i, j] = +np.inf
             else:
                 dij = all_distances[a, b]
@@ -164,7 +196,7 @@ def get_core_by_mcs(mol_a, mol_b, query, threshold=0.5):
     core = np.array([inds_a, inds_b]).T
 
     if np.isinf(cost[min_i, min_j]):
-        raise AtomMappingError(f"not all mapped atoms are within {threshold:.3f}Å of each other")
+        raise AtomMappingError("not all mapped atoms satisfy feasibility conditions")
 
     return core
 
@@ -191,6 +223,9 @@ def get_core_with_alignment(
 
     n_steps: float
         number of steps to run for alignment
+
+    k: float
+        force constant for harmonic bond restraints on core
 
     ff: Forcefield or None
         Forcefield to use for alignment, defaults to DEFAULT_FF forcefield if None

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -175,11 +175,13 @@ def get_core_by_mcs(
         num_flips = sum("flipped" in msg.lower() for msg in conflicts.values())
         num_undefineds = sum("undefined" in msg.lower() for msg in conflicts.values())
 
-        if (not allow_chiral_atom_flips) and (num_flips > 0):
-            return False
+        # TODO: de-DeMorgan-ify
+        invalid_due_to_flips = (not allow_chiral_atom_flips) and (num_flips > 0)
+        invalid_due_to_undefineds = (not allow_chiral_atom_undefined) and (num_undefineds > 0)
+        invalid = invalid_due_to_flips or invalid_due_to_undefineds
+        valid = not invalid
 
-        if (not allow_chiral_atom_undefined) and (num_undefineds > 0):
-            return False
+        return valid
 
     for i, a in enumerate(matches_a):
         for j, b in enumerate(matches_b):

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -185,11 +185,11 @@ def get_core_by_mcs(
         if allow_chiral_atom_flips and allow_chiral_atom_undefined:
             return True
 
-        conflicts = find_atom_map_chiral_conflicts(trial_core, chiral_set_a, chiral_set_b)
+        flips = find_atom_map_chiral_conflicts(trial_core, chiral_set_a, chiral_set_b, mode="flip")
+        undefineds = find_atom_map_chiral_conflicts(trial_core, chiral_set_a, chiral_set_b, mode="undefined")
 
-        # TODO: refactor to use boolean flags instead of strings
-        num_flips = sum("flipped" in msg.lower() for msg in conflicts.values())
-        num_undefineds = sum("undefined" in msg.lower() for msg in conflicts.values())
+        num_flips = len(flips)
+        num_undefineds = len(undefineds)
 
         # TODO: de-DeMorgan-ify
         invalid_due_to_flips = (not allow_chiral_atom_flips) and (num_flips > 0)

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -117,7 +117,7 @@ def get_core_by_mcs(
     threshold=0.5,
     conformer_aware: bool = True,
     allow_chiral_atom_flips=False,
-    allow_chiral_atom_undefined=False,
+    allow_chiral_atom_undefined=True,
 ):
     """Return np integer array that can be passed to RelativeFreeEnergy constructor
 

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -247,14 +247,21 @@ def find_atom_map_chiral_conflicts(
         chiral restraint sets for mols a and b
 
     mode : str, one of "flip" or "undefined"
-        "flip" : find cases where chiral atom restraints are defined for both a and b with opposite signs
-        "undefined" : find cases where chiral atom restraints are defined for a (resp. b) but not b (resp. a)
+        "flip" : find cases where chiral atom restraints are defined
+            for both mols a and b with opposite signs
+        "undefined" : find cases where chiral atom restraints are defined
+            for mol a (resp. b) but not mol b (resp. a)
 
     Returns
     -------
     conflicts
         set of conflicting pairs of 4-tuples
         ((a_c, a_i, a_j, a_k), (b_c, b_i, b_j, b_k))
+
+    See Also
+    --------
+    * find_chiral_atoms -- definition of atom chirality used here -- notably: hydrogens are distinguishable
+        (see additional motivation in https://github.com/proteneer/timemachine/pull/754 and related PR discussion)
     """
     conflicts_fwd = _find_atom_map_chiral_conflicts_one_direction(core, chiral_set_a, chiral_set_b, mode)
     conflicts_rev = _find_atom_map_chiral_conflicts_one_direction(core[:, ::-1], chiral_set_b, chiral_set_a, mode)

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -1,5 +1,4 @@
 import itertools
-from dataclasses import dataclass
 from enum import Enum
 from typing import List, Set, Tuple
 
@@ -160,11 +159,12 @@ def setup_all_chiral_atom_restr_idxs(mol, conf) -> List[FourTuple]:
     return chiral_atom_restr_idxs
 
 
-@dataclass
 class ChiralRestrIdxSet:
-    """Support fast checks of whether a given 4-tuple is disallowed"""
+    """Support fast checks of whether a trial 4-tuple is consistent with a set of chiral atom idxs"""
 
-    restr_idxs: List[FourTuple]
+    def __init__(self, restr_idxs: List[FourTuple]):
+        self.restr_idxs = restr_idxs
+        self.allowed_set, self.disallowed_set = self.expand_symmetries()
 
     @classmethod
     def from_mol(cls, mol, conf):
@@ -189,9 +189,6 @@ class ChiralRestrIdxSet:
         assert allowed_set.isdisjoint(disallowed_set)
 
         return allowed_set, disallowed_set
-
-    def __post_init__(self):
-        self.allowed_set, self.disallowed_set = self.expand_symmetries()
 
     def defines(self, trial_tuple: FourTuple) -> bool:
         return (trial_tuple in self.allowed_set) or (trial_tuple in self.disallowed_set)

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -214,8 +214,10 @@ def find_atom_map_chiral_conflicts(
     Returns
     -------
     conflicts
-        dictionary whose keys are paired idx tuples
-        and whose values are descriptions of whether the
+        dictionary whose
+            keys are paired idx tuples, and whose
+            values are descriptions of the inconsistency
+            ("flipped" vs. partially "undefined")
 
     TODO: refactor conflicts.values() to be flag values instead of strings
     """

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -1,8 +1,13 @@
 import itertools
+from dataclasses import dataclass
+from typing import Dict, List, Set, Tuple
 
+import numpy as np
 from rdkit import Chem
 
 from timemachine.potentials.chiral_restraints import pyramidal_volume, torsion_volume
+
+FourTuple = Tuple[int, int, int, int]
 
 
 def setup_chiral_atom_restraints(mol, conf, a_idx):
@@ -19,7 +24,7 @@ def setup_chiral_atom_restraints(mol, conf, a_idx):
         conformation of the molecule
 
     a_idx: int
-        Which atom to setup restraints for
+        Which atom to set up restraints for
 
     Returns
     -------
@@ -34,6 +39,7 @@ def setup_chiral_atom_restraints(mol, conf, a_idx):
         i, j, k = a_i.GetIdx(), a_j.GetIdx(), a_k.GetIdx()
         vol = pyramidal_volume(conf[a_idx], conf[i], conf[j], conf[k])
         # vol may be >0 or <0, our chiral restraint always enforces vol < 0.
+
         if vol < 0:
             restr_idxs.append((a_idx, i, j, k))
         else:
@@ -113,6 +119,10 @@ def find_chiral_atoms(mol):
     set of int
         Chiral atoms
 
+    Notes
+    -----
+    May want to split this function into two definitions,
+    one that says methane has a chiral center, and one that doesn't.
     """
     # these should be mutually exclusive, but if any pattern is hit then the results
     # are accumulated to a set
@@ -130,6 +140,129 @@ def find_chiral_atoms(mol):
             chiral_atoms.add(match[0])
 
     return chiral_atoms
+
+
+def setup_all_chiral_atom_restr_idxs(mol, conf) -> List[FourTuple]:
+    """Apply setup_chiral_atom_restraints to all atoms found by find_chiral_atoms"""
+    chiral_atom_set = find_chiral_atoms(mol)
+    chiral_atom_restr_idxs = []
+    for a_idx in chiral_atom_set:
+        idxs = setup_chiral_atom_restraints(mol, conf, a_idx)
+        for ii in idxs:
+            assert ii not in chiral_atom_restr_idxs
+        chiral_atom_restr_idxs.extend(idxs)
+    return chiral_atom_restr_idxs
+
+
+@dataclass
+class ChiralRestrIdxSet:
+    """Support fast checks of whether a given 4-tuple is disallowed"""
+
+    restr_idxs: List[FourTuple]
+
+    @classmethod
+    def from_mol(cls, mol, conf):
+        restr_idxs = setup_all_chiral_atom_restr_idxs(mol, conf)
+        return ChiralRestrIdxSet(restr_idxs)
+
+    def expand_symmetries(self) -> Tuple[Set[FourTuple], Set[FourTuple]]:
+        allowed_set = set()
+        disallowed_set = set()
+
+        for (center, i, j, k) in self.restr_idxs:
+            # rotations
+            allowed_set.add((center, i, j, k))
+            allowed_set.add((center, j, k, i))
+            allowed_set.add((center, k, i, j))
+
+            # swaps
+            disallowed_set.add((center, i, k, j))
+            disallowed_set.add((center, j, i, k))
+            disallowed_set.add((center, k, j, i))
+
+        assert allowed_set.isdisjoint(disallowed_set)
+
+        return allowed_set, disallowed_set
+
+    def __post_init__(self):
+        self.allowed_set, self.disallowed_set = self.expand_symmetries()
+
+    def defines(self, trial_tuple: FourTuple) -> bool:
+        return (trial_tuple in self.allowed_set) or (trial_tuple in self.disallowed_set)
+
+    def disallows(self, trial_tuple: FourTuple) -> bool:
+        return trial_tuple in self.disallowed_set
+
+
+def find_atom_map_chiral_conflicts(
+    core: np.ndarray,
+    chiral_set_a: ChiralRestrIdxSet,
+    chiral_set_b: ChiralRestrIdxSet,
+) -> Dict[Tuple[FourTuple, FourTuple], str]:
+    """
+
+    Parameters
+    ----------
+    core
+        atom map, establishing correspondences
+            mol_a[a_i] <--> mol_b[b_i]
+        for (a_i, b_i) in core
+
+    chiral_set_a, chiral_set_b
+        chiral restraint sets for mols a and b
+
+    Returns
+    -------
+    conflicts
+        dictionary whose keys are paired idx tuples
+        and whose values are descriptions of whether the
+
+    TODO: refactor conflicts.values() to be flag values instead of strings
+    """
+    K = len(core)
+    assert core.shape == (K, 2)
+
+    mapped_set_a = set(core[:, 0])
+    mapped_set_b = set(core[:, 1])
+
+    conflicts = {}
+
+    # mypy
+    restr_tuples_a = [(int(c), int(i), int(j), int(k)) for (c, i, j, k) in chiral_set_a.restr_idxs]
+    restr_tuples_b = [(int(c), int(i), int(j), int(k)) for (c, i, j, k) in chiral_set_b.restr_idxs]
+
+    mapping_a_to_b = {int(a_i): int(b_i) for (a_i, b_i) in core}
+    mapping_b_to_a = {int(b_i): int(a_i) for (a_i, b_i) in core}
+
+    # A -> B
+    for restr_tuple_a in restr_tuples_a:
+        c, i, j, k = restr_tuple_a
+        if set(restr_tuple_a).issubset(mapped_set_a):
+            mapped_tuple_b = (mapping_a_to_b[c], mapping_a_to_b[i], mapping_a_to_b[j], mapping_a_to_b[k])
+            key = (restr_tuple_a, mapped_tuple_b)
+
+            if chiral_set_b.disallows(mapped_tuple_b):
+                conflicts[key] = "FLIPPED -- chiral restraints have opposite signs in A and B"
+
+            if not chiral_set_b.defines(mapped_tuple_b):
+                conflicts[key] = "UNDEFINED -- chiral restraints defined in A but undefined in B"
+
+    # B -> A
+    for restr_tuple_b in restr_tuples_b:
+        c, i, j, k = restr_tuple_b
+        if set(restr_tuple_b).issubset(mapped_set_b):
+            mapped_tuple_a = (mapping_b_to_a[c], mapping_b_to_a[i], mapping_b_to_a[j], mapping_b_to_a[k])
+            key = (mapped_tuple_a, restr_tuple_b)
+
+            if chiral_set_a.disallows(mapped_tuple_a):
+                conflicts[key] = "FLIPPED -- chiral restraints have opposite signs in A and B"
+
+            if not chiral_set_a.defines(mapped_tuple_a):
+                conflicts[key] = "UNDEFINED -- chiral restraints defined in B but undefined in A"
+
+    # TODO: reduce 2x duplication between A -> B and B -> A checks
+
+    return conflicts
 
 
 def find_chiral_bonds(mol):

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -304,7 +304,6 @@ class BaseTopology:
             Returns a ChiralAtomRestraint and a ChiralBondRestraint
 
         """
-        _ = chiral_utils.find_chiral_atoms(self.mol)
         chiral_bonds = chiral_utils.find_chiral_bonds(self.mol)
 
         chiral_atom_restr_idxs = chiral_utils.setup_all_chiral_atom_restr_idxs(self.mol, get_romol_conf(self.mol))

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -289,7 +289,6 @@ class BaseTopology:
         combined_potential = potentials.PeriodicTorsion(combined_idxs)
         return combined_params, combined_potential
 
-    # def setup_chiral_restraints(self, restraint_k=1000.0):
     def setup_chiral_restraints(self, restraint_k=1000.0):
         """
         Create chiral atom and bond potentials.
@@ -308,13 +307,10 @@ class BaseTopology:
         chiral_atoms = chiral_utils.find_chiral_atoms(self.mol)
         chiral_bonds = chiral_utils.find_chiral_bonds(self.mol)
 
-        chiral_atom_restr_idxs = []
+        chiral_atom_restr_idxs = chiral_atoms.setup_all_chiral_atom_restr_idxs(self.mol, get_romol_conf(self.mol))
+
         chiral_atom_params = []
-        for a_idx in chiral_atoms:
-            idxs = chiral_utils.setup_chiral_atom_restraints(self.mol, get_romol_conf(self.mol), a_idx)
-            for ii in idxs:
-                assert ii not in chiral_atom_restr_idxs
-            chiral_atom_restr_idxs.extend(idxs)
+        for idxs in chiral_atom_restr_idxs:
             chiral_atom_params.extend(restraint_k for _ in idxs)
 
         chiral_atom_params = np.array(chiral_atom_params)

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -304,10 +304,9 @@ class BaseTopology:
             Returns a ChiralAtomRestraint and a ChiralBondRestraint
 
         """
-        chiral_atoms = chiral_utils.find_chiral_atoms(self.mol)
         chiral_bonds = chiral_utils.find_chiral_bonds(self.mol)
 
-        chiral_atom_restr_idxs = chiral_atoms.setup_all_chiral_atom_restr_idxs(self.mol, get_romol_conf(self.mol))
+        chiral_atom_restr_idxs = chiral_utils.setup_all_chiral_atom_restr_idxs(self.mol, get_romol_conf(self.mol))
 
         chiral_atom_params = []
         for idxs in chiral_atom_restr_idxs:

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -304,6 +304,7 @@ class BaseTopology:
             Returns a ChiralAtomRestraint and a ChiralBondRestraint
 
         """
+        _ = chiral_utils.find_chiral_atoms(self.mol)
         chiral_bonds = chiral_utils.find_chiral_bonds(self.mol)
 
         chiral_atom_restr_idxs = chiral_utils.setup_all_chiral_atom_restr_idxs(self.mol, get_romol_conf(self.mol))


### PR DESCRIPTION
Defines a filter that can be applied to a trial atom mapping, to determine if it is in some sense inconsistent with the set of chiral atom restraints defined on the endstates A and B.

Inconsistency can currently take two forms: "flipped" (the atom mapping would flip the sign of chiral restraints defined in both endstates) or "undefined" (the atom mapping includes a chiral restraint that is defined in one endstate but not the other).

TODOs for this PR:
- [x] Expand tests
- [x] Decide defaults (PR currently changes default behavior of `get_core_by_mcs`, now filtering out "flipped" cases by default)
- [x] Clean-up: `"flipped" in message` -> `status.is_flipped`, `"undefined" in message` -> `status.is_undefined` or similar
- [x] Clean-up: Avoid 2x duplication in `find_atom_map_chiral_conflicts`

TODOs for later:
- [ ] Consider changing definition of `find_chiral_atoms`. (This PR does not change timemachine's current definition.)
- [ ] Consider checking consistency on bonds as well
- [ ] Consider porting to https://github.com/proteneer/bgl 