### PR TITLE
Move RBFE driver into module, make client-agnostic

### DIFF
--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -2,6 +2,8 @@ import argparse
 import csv
 from typing import List
 
+from simtk.openmm import app
+
 from timemachine.constants import KCAL_TO_KJ
 from timemachine.fe import rbfe
 from timemachine.fe.utils import read_sdf
@@ -52,6 +54,7 @@ if __name__ == "__main__":
     ligands = read_sdf(args.ligands)
     edges = read_edges_csv(args.results_csv)
     forcefield = Forcefield.load_from_file(args.forcefield)
+    protein = app.PDBFile(str(args.protein))
 
     _ = rbfe.run_edges_parallel(
         ligands,

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -57,11 +57,11 @@ if __name__ == "__main__":
     protein = app.PDBFile(str(args.protein))
 
     paths = rbfe.run_edges_parallel(
-        args.n_frames,
         ligands,
         edges,
         forcefield,
         args.protein,
+        args.n_frames,
         args.n_gpus,
         args.seed,
     )

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -2,8 +2,6 @@ import argparse
 import csv
 from typing import List
 
-# HACK: import rdkit first to work around free(): invalid pointer
-import rdkit  # noqa: F401
 from simtk.openmm import app
 
 from timemachine.constants import KCAL_TO_KJ

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     edges = read_edges_csv(args.results_csv)
     forcefield = Forcefield.load_from_file(args.forcefield)
 
-    paths = rbfe.run_edges_parallel(
+    _ = rbfe.run_edges_parallel(
         ligands,
         edges,
         forcefield,
@@ -62,5 +62,3 @@ if __name__ == "__main__":
         args.n_gpus,
         args.seed,
     )
-    for path in paths:
-        print(path)

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -23,7 +23,7 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
-    rbfe.run_parallel(
+    paths = rbfe.run_parallel(
         args.n_frames,
         args.ligands,
         args.results_csv,
@@ -32,3 +32,5 @@ if __name__ == "__main__":
         args.n_gpus,
         args.seed,
     )
+    for path in paths:
+        print(path)

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -4,6 +4,7 @@ from typing import List
 
 # HACK: import rdkit first to work around free(): invalid pointer
 import rdkit  # noqa: F401
+from simtk.openmm import app
 
 from timemachine.constants import KCAL_TO_KJ
 from timemachine.fe import rbfe
@@ -55,6 +56,7 @@ if __name__ == "__main__":
     ligands = read_sdf(args.ligands)
     edges = read_edges_csv(args.results_csv)
     forcefield = Forcefield.load_from_file(args.forcefield)
+    protein = app.PDBFile(str(args.protein))
 
     paths = rbfe.run_parallel(
         args.n_frames,

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -28,9 +28,9 @@ def parse_args():
     return parser.parse_args()
 
 
-def read_edges_csv(csv_file: str) -> List[rbfe.Edge]:
-    with open(args.results_csv) as csvfile:
-        reader = csv.reader(csvfile, delimiter=",")
+def read_edges_csv(path: str) -> List[rbfe.Edge]:
+    with open(path) as fp:
+        reader = csv.reader(fp, delimiter=",")
         next(reader, None)  # skip header
         return [
             rbfe.Edge(

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -37,14 +37,22 @@ def read_edges_csv(path: str) -> List[rbfe.Edge]:
                 mol_a_name,
                 mol_b_name,
                 {
-                    "exp_ddg_kcal": float(exp_ddg) * KCAL_TO_KJ,
-                    "fep_ddg_kcal": float(fep_ddg) * KCAL_TO_KJ,
-                    "fep_ddg_err_kcal": float(fep_ddg_err) * KCAL_TO_KJ,
-                    "ccc_ddg_kcal": float(ccc_ddg) * KCAL_TO_KJ,
-                    "ccc_ddg_err_kcal": float(ccc_ddg_err) * KCAL_TO_KJ,
+                    "exp_ddg": float(exp_ddg_kcal) * KCAL_TO_KJ,
+                    "fep_ddg": float(fep_ddg_kcal) * KCAL_TO_KJ,
+                    "fep_ddg_err": float(fep_ddg_err_kcal) * KCAL_TO_KJ,
+                    "ccc_ddg": float(ccc_ddg_kcal) * KCAL_TO_KJ,
+                    "ccc_ddg_err": float(ccc_ddg_err_kcal) * KCAL_TO_KJ,
                 },
             )
-            for mol_a_name, mol_b_name, exp_ddg, fep_ddg, fep_ddg_err, ccc_ddg, ccc_ddg_err in reader
+            for (
+                mol_a_name,
+                mol_b_name,
+                exp_ddg_kcal,
+                fep_ddg_kcal,
+                fep_ddg_err_kcal,
+                ccc_ddg_kcal,
+                ccc_ddg_err_kcal,
+            ) in reader
         ]
 
 

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -2,8 +2,6 @@ import argparse
 import csv
 from typing import List
 
-from simtk.openmm import app
-
 from timemachine.constants import KCAL_TO_KJ
 from timemachine.fe import rbfe
 from timemachine.fe.utils import read_sdf
@@ -54,7 +52,6 @@ if __name__ == "__main__":
     ligands = read_sdf(args.ligands)
     edges = read_edges_csv(args.results_csv)
     forcefield = Forcefield.load_from_file(args.forcefield)
-    protein = app.PDBFile(str(args.protein))
 
     paths = rbfe.run_edges_parallel(
         ligands,

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
         ligands,
         edges,
         forcefield,
-        args.protein,
+        protein,
         args.n_frames,
         args.n_gpus,
         args.seed,

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -82,7 +82,7 @@ def run_edge_and_save_results(
         traceback.print_exc()
 
 
-def read_from_args():
+def parse_args():
 
     parser = argparse.ArgumentParser(
         description="Estimate relative free energy difference between complex and solvent given a results csv file."
@@ -97,17 +97,19 @@ def read_from_args():
     parser.add_argument("--n_gpus", type=int, help="number of gpus", required=True)
     parser.add_argument("--seed", type=int, help="random seed for the runs", required=True)
 
-    args = parser.parse_args()
+    return parser.parse_args()
 
-    mols = read_sdf(str(args.ligands))
 
-    cpc = CUDAPoolClient(args.n_gpus)
+def run_parallel(n_frames, ligands, results_csv, forcefield, protein, n_gpus, seed):
+    mols = read_sdf(str(ligands))
+
+    cpc = CUDAPoolClient(n_gpus)
     cpc.verify()
 
-    forcefield = Forcefield.load_from_file(args.forcefield)
-    protein = app.PDBFile(args.protein)
+    ff = Forcefield.load_from_file(forcefield)
+    protein = app.PDBFile(protein)
 
-    with open(args.results_csv) as csvfile:
+    with open(results_csv) as csvfile:
         reader = csv.reader(csvfile, delimiter=",")
         next(reader)
         rows = [row for row in reader]
@@ -146,5 +148,13 @@ def read_from_args():
 
 
 if __name__ == "__main__":
-
-    read_from_args()
+    args = parse_args()
+    run_parallel(
+        args.n_frames,
+        args.ligands,
+        args.results_csv,
+        args.forcefield,
+        args.protein,
+        args.n_gpus,
+        args.seed,
+    )

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     forcefield = Forcefield.load_from_file(args.forcefield)
     protein = app.PDBFile(str(args.protein))
 
-    paths = rbfe.run_parallel(
+    paths = rbfe.run_edges_parallel(
         args.n_frames,
         ligands,
         edges,

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -723,7 +723,8 @@ def run_edge_and_save_results(
         )
 
         path = f"failure_rbfe_result_{edge.mol_a_name}_{edge.mol_b_name}.pkl"
-        pkl_obj = (edge, err)
+        tb = traceback.format_exception(None, err, err.__traceback__)
+        pkl_obj = (edge, err, tb)
         file_client.store(path, pickle.dumps(pkl_obj))
 
         print(err)

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -695,8 +695,8 @@ class Edge(NamedTuple):
 
 
 def run_edge_and_save_results(
-    mols: Dict[str, Chem.rdchem.Mol],
     edge: Edge,
+    mols: Dict[str, Chem.rdchem.Mol],
     forcefield: Forcefield,
     protein: app.PDBFile,
     n_frames: int,
@@ -758,11 +758,11 @@ def run_edge_and_save_results(
 
 
 def run_edges_parallel(
-    n_frames: int,
     ligands: Sequence[Chem.rdchem.Mol],
     edges: Sequence[Edge],
     ff: Forcefield,
     protein: app.PDBFile,
+    n_frames: int,
     n_gpus: int,
     seed: int,
     pool_client: Optional[AbstractClient] = None,
@@ -784,8 +784,8 @@ def run_edges_parallel(
     jobs = (
         pool_client.submit(
             run_edge_and_save_results,
-            mols,
             edge,
+            mols,
             ff,
             protein,
             n_frames,

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -794,7 +794,7 @@ def run_parallel(
             )
         )
 
-    # Block until subprocesses finish
+    # Block until jobs finish
     paths = [fut.result() for fut in futures]
 
     return paths

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -779,10 +779,10 @@ def run_edges_parallel(
     # Without this get_mol_name(mol) will fail on roundtripped mol
     Chem.SetDefaultPickleProperties(Chem.PropertyPickleOptions.AllProps)
 
-    jobs = []
+    jobs = set()
     for edge_idx, edge in enumerate(edges):
         print(f"Submitting job for {edge.mol_a_name} -> {edge.mol_b_name}")
-        jobs.append(
+        jobs.add(
             pool_client.submit(
                 run_edge_and_save_results,
                 mols,
@@ -797,8 +797,8 @@ def run_edges_parallel(
 
     # Block until jobs finish
     paths = []
-    for fut in futures.as_completed(jobs):
-        paths.append(fut.result())
-        del fut  # allow future to be GC'd
+    for job in futures.as_completed(jobs):
+        paths.append(job.result())
+        jobs.remove(job)  # allow future object to be GC'd
 
     return paths

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -3,8 +3,7 @@ import io
 import pickle
 import traceback
 import warnings
-from pathlib import Path
-from typing import Any, Dict, NamedTuple, Optional, Sequence, Union
+from typing import Any, Dict, NamedTuple, Optional, Sequence
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -697,10 +696,10 @@ class Edge(NamedTuple):
 def run_edge_and_save_results(
     mols: Dict[str, Chem.rdchem.Mol],
     edge: Edge,
-    forcefield,
-    protein,
-    n_frames,
-    seed,
+    forcefield: Forcefield,
+    protein: app.PDBFile,
+    n_frames: int,
+    seed: int,
     file_client: AbstractFileClient,
 ):
     try:
@@ -762,7 +761,7 @@ def run_parallel(
     ligands: Sequence[Chem.rdchem.Mol],
     edges: Sequence[Edge],
     ff: Forcefield,
-    protein_pdb: Union[Path, str],
+    protein: app.PDBFile,
     n_gpus: int,
     seed: int,
     pool_client: Optional[AbstractClient] = None,
@@ -774,8 +773,6 @@ def run_parallel(
     pool_client.verify()
 
     file_client = file_client or FileClient()
-
-    protein = app.PDBFile(str(protein_pdb))
 
     # Ensure that all mol props (e.g. _Name) are included in pickles
     # Without this get_mol_name(mol) will fail on roundtripped mol

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -724,8 +724,7 @@ def run_edge_and_save_results(
 
         path = f"failure_rbfe_result_{edge.mol_a_name}_{edge.mol_b_name}.pkl"
         tb = traceback.format_exception(None, err, err.__traceback__)
-        pkl_obj = (edge, err, tb)
-        file_client.store(path, pickle.dumps(pkl_obj))
+        file_client.store(path, pickle.dumps((edge, err, tb)))
 
         print(err)
         traceback.print_exc()

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -3,7 +3,6 @@ import io
 import pickle
 import traceback
 import warnings
-from concurrent import futures
 from typing import Any, Dict, NamedTuple, Optional, Sequence
 
 import matplotlib.pyplot as plt
@@ -795,5 +794,5 @@ def run_edges_parallel(
         for edge_idx, edge in enumerate(edges)
     )
 
-    paths = [job.result() for job in futures.as_completed(jobs)]
+    paths = [job.result() for job in jobs]
     return paths

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pymbar
 from rdkit import Chem
+from simtk.openmm import app
 
 from timemachine.constants import BOLTZ, DEFAULT_TEMP
 from timemachine.fe import atom_mapping, model_utils
@@ -696,7 +697,7 @@ def run_edge_and_save_results(
     edge: Edge,
     mols: Dict[str, Chem.rdchem.Mol],
     forcefield: Forcefield,
-    protein_path: str,
+    protein: app.PDBFile,
     n_frames: int,
     seed: int,
     file_client: AbstractFileClient,
@@ -706,8 +707,8 @@ def run_edge_and_save_results(
         mol_b = mols[edge.mol_b_name]
         core, smarts = atom_mapping.get_core_with_alignment(mol_a, mol_b, threshold=2.0)
 
-        complex_res, complex_top = run_complex(mol_a, mol_b, core, forcefield, protein_path, n_frames, seed)
-        solvent_res, solvent_top = run_solvent(mol_a, mol_b, core, forcefield, protein_path, n_frames, seed)
+        complex_res, complex_top = run_complex(mol_a, mol_b, core, forcefield, protein, n_frames, seed)
+        solvent_res, solvent_top = run_solvent(mol_a, mol_b, core, forcefield, protein, n_frames, seed)
 
     except Exception as err:
         print(
@@ -765,7 +766,7 @@ def run_edges_parallel(
     ligands: Sequence[Chem.rdchem.Mol],
     edges: Sequence[Edge],
     ff: Forcefield,
-    protein_path: str,
+    protein: app.PDBFile,
     n_frames: int,
     n_gpus: int,
     seed: int,
@@ -791,7 +792,7 @@ def run_edges_parallel(
             edge,
             mols,
             ff,
-            protein_path,
+            protein,
             n_frames,
             seed + edge_idx,
             file_client,

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -721,9 +721,15 @@ def run_edge_and_save_results(
                 ]
             ),
         )
+
+        path = f"failure_rbfe_result_{edge.mol_a_name}_{edge.mol_b_name}.pkl"
+        pkl_obj = (edge, err)
+        file_client.store(path, pickle.dumps(pkl_obj))
+
         print(err)
         traceback.print_exc()
-        return None
+
+        return path
 
     path = f"success_rbfe_result_{edge.mol_a_name}_{edge.mol_b_name}.pkl"
     pkl_obj = (mol_a, mol_b, edge.metadata, smarts, core, solvent_res, solvent_top, complex_res, complex_top)

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -756,7 +756,7 @@ def run_edge_and_save_results(
     return path
 
 
-def run_parallel(
+def run_edges_parallel(
     n_frames: int,
     ligands: Sequence[Chem.rdchem.Mol],
     edges: Sequence[Edge],

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -9,7 +9,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pymbar
 from rdkit import Chem
-from simtk.openmm import app
 
 from timemachine.constants import BOLTZ, DEFAULT_TEMP
 from timemachine.fe import atom_mapping, model_utils
@@ -697,7 +696,7 @@ def run_edge_and_save_results(
     edge: Edge,
     mols: Dict[str, Chem.rdchem.Mol],
     forcefield: Forcefield,
-    protein: app.PDBFile,
+    protein_path: str,
     n_frames: int,
     seed: int,
     file_client: AbstractFileClient,
@@ -707,8 +706,8 @@ def run_edge_and_save_results(
         mol_b = mols[edge.mol_b_name]
         core, smarts = atom_mapping.get_core_with_alignment(mol_a, mol_b, threshold=2.0)
 
-        complex_res, complex_top = run_complex(mol_a, mol_b, core, forcefield, protein, n_frames, seed)
-        solvent_res, solvent_top = run_solvent(mol_a, mol_b, core, forcefield, protein, n_frames, seed)
+        complex_res, complex_top = run_complex(mol_a, mol_b, core, forcefield, protein_path, n_frames, seed)
+        solvent_res, solvent_top = run_solvent(mol_a, mol_b, core, forcefield, protein_path, n_frames, seed)
 
     except Exception as err:
         print(
@@ -766,7 +765,7 @@ def run_edges_parallel(
     ligands: Sequence[Chem.rdchem.Mol],
     edges: Sequence[Edge],
     ff: Forcefield,
-    protein: app.PDBFile,
+    protein_path: str,
     n_frames: int,
     n_gpus: int,
     seed: int,
@@ -792,7 +791,7 @@ def run_edges_parallel(
             edge,
             mols,
             ff,
-            protein,
+            protein_path,
             n_frames,
             seed + edge_idx,
             file_client,

--- a/timemachine/md/builders.py
+++ b/timemachine/md/builders.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from typing import Union
 
 import numpy as np
@@ -13,7 +12,7 @@ def strip_units(coords):
     return unit.Quantity(np.array(coords / coords.unit), coords.unit)
 
 
-def build_protein_system(host_pdbfile: Union[app.PDBFile, str, Path], protein_ff: str, water_ff: str):
+def build_protein_system(host_pdbfile: Union[app.PDBFile, str], protein_ff: str, water_ff: str):
     """
     Build a solvated protein system with a 10A padding.
 
@@ -25,13 +24,13 @@ def build_protein_system(host_pdbfile: Union[app.PDBFile, str, Path], protein_ff
     """
 
     host_ff = app.ForceField(f"{protein_ff}.xml", f"{water_ff}.xml")
-    if isinstance(host_pdbfile, str) or isinstance(host_pdbfile, Path):
+    if isinstance(host_pdbfile, str):
         assert os.path.exists(host_pdbfile)
-        host_pdb = app.PDBFile(str(host_pdbfile))
+        host_pdb = app.PDBFile(host_pdbfile)
     elif isinstance(host_pdbfile, app.PDBFile):
         host_pdb = host_pdbfile
     else:
-        raise TypeError("host_pdb must be a path or an openmm PDBFile object")
+        raise TypeError("host_pdb must be a string or an openmm PDBFile object")
 
     modeller = app.Modeller(host_pdb.topology, host_pdb.positions)
     host_coords = strip_units(host_pdb.positions)

--- a/timemachine/md/builders.py
+++ b/timemachine/md/builders.py
@@ -33,7 +33,7 @@ def build_protein_system(host_pdbfile: Union[app.PDBFile, PathLike], protein_ff:
     elif isinstance(host_pdbfile, app.PDBFile):
         host_pdb = host_pdbfile
     else:
-        raise TypeError("host_pdb must be a path or a openmm PDBFile object")
+        raise TypeError("host_pdb must be a path or an openmm PDBFile object")
 
     modeller = app.Modeller(host_pdb.topology, host_pdb.positions)
     host_coords = strip_units(host_pdb.positions)

--- a/timemachine/md/builders.py
+++ b/timemachine/md/builders.py
@@ -15,7 +15,7 @@ def strip_units(coords):
     return unit.Quantity(np.array(coords / coords.unit), coords.unit)
 
 
-def build_protein_system(host_pdbfile: Union[app.PDBFile, str], protein_ff: str, water_ff: str):
+def build_protein_system(host_pdbfile: Union[app.PDBFile, PathLike], protein_ff: str, water_ff: str):
     """
     Build a solvated protein system with a 10A padding.
 

--- a/timemachine/md/builders.py
+++ b/timemachine/md/builders.py
@@ -30,7 +30,7 @@ def build_protein_system(host_pdbfile: Union[app.PDBFile, str], protein_ff: str,
     elif isinstance(host_pdbfile, app.PDBFile):
         host_pdb = host_pdbfile
     else:
-        raise TypeError("host_pdb must be a string or an openmm PDBFile object")
+        raise TypeError("host_pdbfile must be a string or an openmm PDBFile object")
 
     modeller = app.Modeller(host_pdb.topology, host_pdb.positions)
     host_coords = strip_units(host_pdb.positions)

--- a/timemachine/md/builders.py
+++ b/timemachine/md/builders.py
@@ -8,14 +8,12 @@ from simtk.openmm import Vec3, app
 
 from timemachine.ff import sanitize_water_ff
 
-PathLike = Union[str, Path]
-
 
 def strip_units(coords):
     return unit.Quantity(np.array(coords / coords.unit), coords.unit)
 
 
-def build_protein_system(host_pdbfile: Union[app.PDBFile, PathLike], protein_ff: str, water_ff: str):
+def build_protein_system(host_pdbfile: Union[app.PDBFile, str, Path], protein_ff: str, water_ff: str):
     """
     Build a solvated protein system with a 10A padding.
 
@@ -27,7 +25,7 @@ def build_protein_system(host_pdbfile: Union[app.PDBFile, PathLike], protein_ff:
     """
 
     host_ff = app.ForceField(f"{protein_ff}.xml", f"{water_ff}.xml")
-    if isinstance(host_pdbfile, PathLike):
+    if isinstance(host_pdbfile, str) or isinstance(host_pdbfile, Path):
         assert os.path.exists(host_pdbfile)
         host_pdb = app.PDBFile(str(host_pdbfile))
     elif isinstance(host_pdbfile, app.PDBFile):

--- a/timemachine/parallel/client.py
+++ b/timemachine/parallel/client.py
@@ -94,12 +94,6 @@ class WrappedFuture:
         self._future = future
         self._id = job_id
 
-    def result(self):
-        return self._future.result()
-
-    def done(self):
-        return self._future.done()
-
     @property
     def id(self):
         return self._id
@@ -107,6 +101,9 @@ class WrappedFuture:
     @property
     def name(self):
         return str(self._id)
+
+    def __getattr__(self, attr):
+        return getattr(self._future, attr)
 
 
 class SerialClient(AbstractClient):

--- a/timemachine/parallel/client.py
+++ b/timemachine/parallel/client.py
@@ -94,6 +94,12 @@ class WrappedFuture:
         self._future = future
         self._id = job_id
 
+    def result(self):
+        return self._future.result()
+
+    def done(self):
+        return self._future.done()
+
     @property
     def id(self):
         return self._id
@@ -101,9 +107,6 @@ class WrappedFuture:
     @property
     def name(self):
         return str(self._id)
-
-    def __getattr__(self, attr):
-        return getattr(self._future, attr)
 
 
 class SerialClient(AbstractClient):


### PR DESCRIPTION
* Separates command- and file-parsing logic from simulation driver code; moves the latter into the `timemachine.fe.rbfe` library module (as `run_edges_parallel`)
* Adds `pool_client: AbstractClient` and `file_client: AbstractFileClient` args to `run_edges_parallel`; this allows running e.g. on remote machines or AWS Batch by substituting different clients
* Deletes references to future objects as they complete[^1]; this should ensure that they are GC'd and memory is returned to the process pool ~(0770b54 .. c4942fc, [relevant SO thread](https://stackoverflow.com/questions/34770169/using-concurrent-futures-without-running-out-of-ram))~

[^1]: this is only approximate; we actually process futures in the order that they were submitted (processing in order of completion would require additional API changes for custom future objects)