### PR TITLE
Re-enable chiral MCS filter (& disable pyramidal nitrogen SMARTS)

### DIFF
--- a/examples/relative_free_energy.py
+++ b/examples/relative_free_energy.py
@@ -116,6 +116,7 @@ def read_from_args():
         max_cores=1e6,
         enforce_core_core=True,
         complete_rings=True,
+        enforce_chiral=True,
     )
 
     core = all_cores[0]

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from rdkit import Chem
+from rdkit.Chem import AllChem
 
 from timemachine.fe import atom_mapping
 from timemachine.fe.utils import plot_atom_mapping_grid
@@ -498,3 +499,31 @@ def test_cyclohexane_stereo():
     assert tuples_to_set(expected_core) in all_cores_fzset
 
     assert len(all_cores) == 1
+
+
+def test_chiral_atom_map():
+    mol_a = Chem.AddHs(Chem.MolFromSmiles("C"))
+    mol_b = Chem.AddHs(Chem.MolFromSmiles("C"))
+
+    AllChem.EmbedMolecule(mol_a, randomSeed=0)
+    AllChem.EmbedMolecule(mol_b, randomSeed=0)
+
+    core_kwargs = dict(
+        ring_cutoff=np.inf,
+        chain_cutoff=np.inf,
+        max_visits=1e7,
+        connected_core=True,
+        max_cores=1e6,
+        enforce_core_core=True,
+        complete_rings=True,
+    )
+
+    chiral_aware_cores = atom_mapping.get_cores(mol_a, mol_b, enforce_chiral=True, **core_kwargs)
+    chiral_oblivious_cores = atom_mapping.get_cores(mol_a, mol_b, enforce_chiral=False, **core_kwargs)
+
+    assert len(chiral_oblivious_cores) == 4 * 3 * 2 * 1, "expected all hydrogen permutations to be valid"
+    assert len(chiral_aware_cores) == (len(chiral_oblivious_cores) // 2), "expected only rotations to be valid"
+
+    for (key, val) in chiral_aware_cores[0]:
+        assert key == val, "expected first core to be identity map"
+    assert len(chiral_aware_cores[0]) == 5

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -47,6 +47,7 @@ def test_all_pairs(filepath):
                 max_cores=1000,
                 enforce_core_core=True,
                 complete_rings=False,
+                enforce_chiral=True,
             )
 
             # useful for visualization
@@ -96,6 +97,7 @@ def test_complete_rings_only():
         max_cores=1000,
         enforce_core_core=True,
         complete_rings=True,
+        enforce_chiral=True,
     )
 
     assert len(all_cores) == 1
@@ -231,6 +233,7 @@ $$$$""",
         max_cores=1000000,
         enforce_core_core=False,
         complete_rings=False,
+        enforce_chiral=True,
     )
 
     assert len(all_cores) == 1
@@ -250,6 +253,7 @@ $$$$""",
         max_cores=1000000,
         enforce_core_core=True,
         complete_rings=False,
+        enforce_chiral=True,
     )
 
     # 2 possible matches, returned core ordering is fully determined
@@ -271,6 +275,7 @@ $$$$""",
         max_cores=1000000,
         enforce_core_core=True,
         complete_rings=False,
+        enforce_chiral=True,
     )
 
     # 2 possible matches, if we do not allow for connected_core but do
@@ -399,6 +404,7 @@ def test_hif2a_failure():
         max_cores=1e6,
         enforce_core_core=True,
         complete_rings=True,
+        enforce_chiral=True,
     )
 
     expected_core = np.array(
@@ -453,6 +459,7 @@ def test_cyclohexane_stereo():
         max_cores=100000,
         enforce_core_core=True,
         complete_rings=True,
+        enforce_chiral=True,
     )
 
     for core_idx, core in enumerate(all_cores[:1]):

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -490,5 +490,4 @@ def test_cyclohexane_stereo():
     all_cores_fzset = get_all_cores_fzset(all_cores)
     assert tuples_to_set(expected_core) in all_cores_fzset
 
-    # TBD: if we have check_chiral == True then we should expect length of all_cores == 1
-    # and the only valid result is the one equal to expected.
+    assert len(all_cores) == 1

--- a/tests/test_chiral_utils.py
+++ b/tests/test_chiral_utils.py
@@ -100,7 +100,7 @@ def test_find_chiral_atoms():
 
     mol = Chem.AddHs(Chem.MolFromSmiles(r"C1CC2CCC3CCC1N23"))
     res = chiral_utils.find_chiral_atoms(mol)
-    assert res == set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    assert res == set([0, 1, 2, 3, 4, 5, 6, 7, 8])  # TODO: add atom idx 9 if we handle pyramidal nitrogens
 
     mol = Chem.AddHs(Chem.MolFromSmiles(r"n1ccccc1"))
     res = chiral_utils.find_chiral_atoms(mol)

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -227,6 +227,7 @@ def test_intermediate_states(num_pairs_to_setup=10):
             max_cores=1e6,
             enforce_core_core=True,
             complete_rings=True,
+            enforce_chiral=True,
         )
 
         core = all_cores[0]

--- a/tests/test_interpolate_fe.py
+++ b/tests/test_interpolate_fe.py
@@ -35,6 +35,7 @@ def test_hif2a_free_energy_estimates():
         max_cores=1e6,
         enforce_core_core=True,
         complete_rings=True,
+        enforce_chiral=True,
     )
     core = all_cores[0]
     svg = utils.plot_atom_mapping_grid(mol_a, mol_b, core)

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -378,6 +378,7 @@ def _get_core_by_mcs(mol_a, mol_b):
         max_cores=1e6,
         enforce_core_core=True,
         complete_rings=True,
+        enforce_chiral=True,
     )
 
     core = all_cores[0]

--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -41,6 +41,7 @@ def run_edge(mol_a, mol_b, protein_path, n_windows):
         max_cores=1e6,
         enforce_core_core=True,
         complete_rings=True,
+        enforce_chiral=True,
     )
     core = all_cores[0]
     res = utils.plot_atom_mapping_grid(mol_a, mol_b, core)

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -447,7 +447,11 @@ def remove_chiral_flips(mol_a, conf_a, mol_b, conf_b, all_cores):
     def chiral_filter(trial_core):
         return not has_chiral_atom_flips(trial_core, chiral_set_a, chiral_set_b)
 
-    return list(filter(chiral_filter, all_cores))
+    assert len(all_cores) > 0
+    filtered_cores = list(filter(chiral_filter, all_cores))
+    assert len(filtered_cores) > 0
+
+    return filtered_cores
 
 
 def remove_cores_smaller_than_largest(cores):

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -54,7 +54,7 @@ def get_cores(
     max_cores,
     enforce_core_core,
     complete_rings,
-    enforce_chiral=True,
+    enforce_chiral,
 ):
     """
     Finds set of cores between two molecules that maximizes the number of common edges.

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -114,8 +114,6 @@ def get_cores(
     assert max_cores > 0
 
     core_kwargs = dict(
-        mol_a=mol_a,
-        mol_b=mol_b,
         ring_cutoff=ring_cutoff,
         chain_cutoff=chain_cutoff,
         max_visits=max_visits,
@@ -128,14 +126,14 @@ def get_cores(
 
     # we require that mol_a.GetNumAtoms() <= mol_b.GetNumAtoms()
     if mol_a.GetNumAtoms() > mol_b.GetNumAtoms():
-        all_cores = _get_cores_impl(**core_kwargs)
+        all_cores = _get_cores_impl(mol_b, mol_a, **core_kwargs)
         new_cores = []
         for core in all_cores:
             core = np.array([(x[1], x[0]) for x in core], dtype=core.dtype)
             new_cores.append(core)
         return new_cores
     else:
-        all_cores = _get_cores_impl(**core_kwargs)
+        all_cores = _get_cores_impl(mol_a, mol_b, **core_kwargs)
         return all_cores
 
 

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -363,8 +363,6 @@ def _get_cores_impl(
         enforce_core_core,
         filter_fxn=filter_fxn,
     )
-    # print('\ttime spent in chiral filter: ', chiral_filter_time)
-    # print('\tnum chiral filter calls: ', chiral_filter_call_count)
 
     if connected_core:
         all_cores = remove_disconnected_components(mol_a, mol_b, all_cores, all_marcs)

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -40,7 +40,6 @@ def setup_chiral_atom_restraints(mol, conf, a_idx):
         (c0, i0, j0, k0), (c0, i1, j1, k1), ...
 
     """
-    chiral_vol_threshold = 0.1  # don't infer a restraint unless abs(chiral_vol) >= threshold
 
     nbs = mol.GetAtomWithIdx(a_idx).GetNeighbors()
     restr_idxs = []
@@ -48,10 +47,6 @@ def setup_chiral_atom_restraints(mol, conf, a_idx):
         i, j, k = a_i.GetIdx(), a_j.GetIdx(), a_k.GetIdx()
         vol = pyramidal_volume(conf[a_idx], conf[i], conf[j], conf[k])
         # vol may be >0 or <0, our chiral restraint always enforces vol < 0.
-
-        if abs(vol) < chiral_vol_threshold:
-            print(f"skipping chiral atom restraint on {a_idx}, |chiral_vol| = {abs(vol)} < {chiral_vol_threshold}")
-            continue
 
         if vol < 0:
             restr_idxs.append((a_idx, i, j, k))

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -9,6 +9,8 @@ from timemachine.potentials.chiral_restraints import pyramidal_volume, torsion_v
 
 FourTuple = Tuple[int, int, int, int]
 
+ChiralConflict = Tuple[FourTuple, FourTuple]
+
 
 class ChiralCheckMode(Enum):
     FLIP = 1
@@ -163,7 +165,7 @@ class ChiralRestrIdxSet:
     """Support fast checks of whether a trial 4-tuple is consistent with a set of chiral atom idxs"""
 
     def __init__(self, restr_idxs: List[FourTuple]):
-        self.restr_idxs = restr_idxs
+        self.restr_idxs = [(int(c), int(i), int(j), int(k)) for (c, i, j, k) in restr_idxs]
         self.allowed_set, self.disallowed_set = self.expand_symmetries()
 
     @classmethod
@@ -202,8 +204,7 @@ def _find_atom_map_chiral_conflicts_one_direction(
     chiral_set_a: ChiralRestrIdxSet,
     chiral_set_b: ChiralRestrIdxSet,
     mode: ChiralCheckMode = ChiralCheckMode.FLIP,
-):
-    # parse mode
+) -> Set[ChiralConflict]:
     if mode == ChiralCheckMode.FLIP:
         conflict_condition_fxn = chiral_set_b.disallows
     elif mode == ChiralCheckMode.UNDEFINED:
@@ -214,14 +215,13 @@ def _find_atom_map_chiral_conflicts_one_direction(
     # initialize convenient representations
     mapped_set_a = set(core[:, 0])
     conflicts = set()
-    restr_tuples_a = [(int(c), int(i), int(j), int(k)) for (c, i, j, k) in chiral_set_a.restr_idxs]
     mapping_a_to_b = {int(a_i): int(b_i) for (a_i, b_i) in core}
 
     def apply_mapping(c, i, j, k):
         return mapping_a_to_b[c], mapping_a_to_b[i], mapping_a_to_b[j], mapping_a_to_b[k]
 
     # iterate over restraints defined in A, searching for possible conflicts
-    for restr_tuple_a in restr_tuples_a:
+    for restr_tuple_a in chiral_set_a.restr_idxs:
         if set(restr_tuple_a).issubset(mapped_set_a):
             mapped_tuple_b = apply_mapping(*restr_tuple_a)
 
@@ -231,12 +231,38 @@ def _find_atom_map_chiral_conflicts_one_direction(
     return conflicts
 
 
+def _has_chiral_atom_map_flips_one_direction(
+    core: np.ndarray,
+    chiral_set_a: ChiralRestrIdxSet,
+    chiral_set_b: ChiralRestrIdxSet,
+) -> bool:
+    # _find_atom_map_chiral_conflicts_one_direction, except (1) return bool not set, (2) hard-code mode = FLIP
+
+    conflict_condition_fxn = chiral_set_b.disallows
+
+    # initialize convenient representations
+    mapped_set_a = set(core[:, 0])
+    mapping_a_to_b = {int(a_i): int(b_i) for (a_i, b_i) in core}
+
+    def apply_mapping(c, i, j, k):
+        return mapping_a_to_b[c], mapping_a_to_b[i], mapping_a_to_b[j], mapping_a_to_b[k]
+
+    # iterate over restraints defined in A, searching for possible conflicts
+    for restr_tuple_a in chiral_set_a.restr_idxs:
+        if set(restr_tuple_a).issubset(mapped_set_a):
+            mapped_tuple_b = apply_mapping(*restr_tuple_a)
+
+            if conflict_condition_fxn(mapped_tuple_b):
+                return True
+    return False
+
+
 def find_atom_map_chiral_conflicts(
     core: np.ndarray,
     chiral_set_a: ChiralRestrIdxSet,
     chiral_set_b: ChiralRestrIdxSet,
     mode: ChiralCheckMode = ChiralCheckMode.FLIP,
-) -> Set[Tuple[FourTuple, FourTuple]]:
+) -> Set[ChiralConflict]:
     """
 
     Parameters
@@ -275,6 +301,16 @@ def find_atom_map_chiral_conflicts(
     conflicts = conflicts_fwd.union(conflicts_rev_ordered)
 
     return conflicts
+
+
+def has_chiral_atom_flips(core, chiral_set_a, chiral_set_b) -> bool:
+    """find_atom_map_chiral_conflicts, except (1) return bool not set, (2) hard-code mode = FLIP"""
+    # both directions
+    if _has_chiral_atom_map_flips_one_direction(core, chiral_set_a, chiral_set_b):
+        return True
+    if _has_chiral_atom_map_flips_one_direction(core[:, ::-1], chiral_set_b, chiral_set_a):
+        return True
+    return False
 
 
 def find_chiral_bonds(mol):

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -292,13 +292,10 @@ def find_atom_map_chiral_conflicts(
     * find_chiral_atoms -- definition of atom chirality used here -- notably: hydrogens are distinguishable
         (see additional motivation in https://github.com/proteneer/timemachine/pull/754 and related PR discussion)
     """
-    conflicts_fwd = _find_atom_map_chiral_conflicts_one_direction(core, chiral_set_a, chiral_set_b, mode)
-    conflicts_rev = _find_atom_map_chiral_conflicts_one_direction(core[:, ::-1], chiral_set_b, chiral_set_a, mode)
+    conflicts_a2b = _find_atom_map_chiral_conflicts_one_direction(core, chiral_set_a, chiral_set_b, mode)
+    conflicts_b2a = _find_atom_map_chiral_conflicts_one_direction(core[:, ::-1], chiral_set_b, chiral_set_a, mode)
 
-    # swap order of each 2-tuple in conflicts_rev
-    conflicts_rev_ordered = set((a, b) for (b, a) in conflicts_rev)
-
-    conflicts = conflicts_fwd.union(conflicts_rev_ordered)
+    conflicts = conflicts_a2b.union(set((a, b) for (b, a) in conflicts_b2a))
 
     return conflicts
 

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -40,12 +40,18 @@ def setup_chiral_atom_restraints(mol, conf, a_idx):
         (c0, i0, j0, k0), (c0, i1, j1, k1), ...
 
     """
+    chiral_vol_threshold = 0.1  # don't infer a restraint unless abs(chiral_vol) >= threshold
+
     nbs = mol.GetAtomWithIdx(a_idx).GetNeighbors()
     restr_idxs = []
     for a_i, a_j, a_k in itertools.combinations(nbs, 3):
         i, j, k = a_i.GetIdx(), a_j.GetIdx(), a_k.GetIdx()
         vol = pyramidal_volume(conf[a_idx], conf[i], conf[j], conf[k])
         # vol may be >0 or <0, our chiral restraint always enforces vol < 0.
+
+        if abs(vol) < chiral_vol_threshold:
+            print(f"skipping chiral atom restraint on {a_idx}, |chiral_vol| = {abs(vol)} < {chiral_vol_threshold}")
+            continue
 
         if vol < 0:
             restr_idxs.append((a_idx, i, j, k))

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -137,7 +137,7 @@ def find_chiral_atoms(mol):
     chiral_patterns = [
         "[X4:1]",  # any tetrahedral atom
         "[#16X3,#15X3:1]",  # trivalent sulfur, phosphorous are assumed to be non-invertible
-        "[#7X3:1](~[R])(~[R])~[R]",  # nitrogen directly bonded to three ring atoms
+        # "[#7X3:1](~[R])(~[R])~[R]",  # nitrogen directly bonded to three ring atoms  # TODO: handle pyramidal nitrogen
     ]
 
     chiral_atoms = set()

--- a/timemachine/fe/mcgregor.py
+++ b/timemachine/fe/mcgregor.py
@@ -159,7 +159,9 @@ class MaxVisitsError(Exception):
     pass
 
 
-def mcs(n_a, n_b, priority_idxs, bonds_a, bonds_b, max_visits, max_cores, enforce_core_core):
+def mcs(
+    n_a, n_b, priority_idxs, bonds_a, bonds_b, max_visits, max_cores, enforce_core_core, filter_fxn=(lambda core: True)
+):
 
     assert n_a <= n_b
 
@@ -193,6 +195,7 @@ def mcs(n_a, n_b, priority_idxs, bonds_a, bonds_b, max_visits, max_cores, enforc
             max_cores,
             cur_threshold,
             enforce_core_core,
+            filter_fxn,
         )
 
         if mcs_result.timed_out:
@@ -248,6 +251,7 @@ def recursion(
     max_cores,
     threshold,
     enforce_core_core,
+    filter_fxn,
 ):
 
     if mcs_result.nodes_visited > max_visits:
@@ -280,6 +284,8 @@ def recursion(
                 g1, g2, layer, jdx, atom_map_1_to_2, atom_map_2_to_1
             ):
                 pass
+            elif not filter_fxn(atom_map_1_to_2):
+                pass
             else:
                 new_marcs = refine_marcs(g1, g2, layer, jdx, marcs)
                 recursion(
@@ -296,6 +302,7 @@ def recursion(
                     max_cores,
                     threshold,
                     enforce_core_core,
+                    filter_fxn,
                 )
             atom_map_pop(atom_map_1_to_2, atom_map_2_to_1, layer, jdx)
 
@@ -316,4 +323,5 @@ def recursion(
         max_cores,
         threshold,
         enforce_core_core,
+        filter_fxn,
     )

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -720,6 +720,7 @@ def run_edge_and_save_results(
             max_cores=1e6,
             enforce_core_core=True,
             complete_rings=True,
+            enforce_chiral=True,
         )
         core = all_cores[0]
 


### PR DESCRIPTION
Address TM-187 by re-enabling the chiral filter added in https://github.com/proteneer/timemachine/pull/908 and disabled in https://github.com/proteneer/timemachine/pull/917


TODO:
- [x]  ~Expand tests using an example @proteneer provided, where the approach of filtering `all_cores` returned by `mcgregor.mcs` may not suffice.~ (An example of this behavior is in current tests.) If needed, move this filter into `mcgregor.py`. (Done in https://github.com/proteneer/timemachine/pull/919/commits/15a6327d805610001d31237b87bc824ce0de798e.)
- [x] Update this test: https://github.com/proteneer/timemachine/pull/917#discussion_r1031849102 (Done in https://github.com/proteneer/timemachine/pull/919/commits/5807d8205751c5d53f403e1f02ffa360f91cf236.)