### PR TITLE
Add dG errors by component, plot to RBFE results

### DIFF
--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -47,8 +47,10 @@ class InitialState:
 class SimulationResult:
     all_dGs: List[np.ndarray]
     all_errs: List[float]
+    dG_errs_by_lambda_by_component: np.ndarray  # (len(U_names), L - 1)
     overlaps_by_lambda: np.ndarray  # (L - 1,)
     overlaps_by_lambda_by_component: np.ndarray  # (len(U_names), L - 1)
+    dG_errs_png: bytes
     overlap_summary_png: bytes
     overlap_detail_png: bytes
     frames: List[np.ndarray]

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -249,7 +249,7 @@ def plot_BAR(df, df_err, fwd_delta_u, rev_delta_u, title, axes):
     plot_work(fwd_delta_u, rev_delta_u, axes)
 
 
-def dG_err_from_ukln(u_kln):
+def df_err_from_ukln(u_kln):
     k, l, _ = u_kln.shape
     assert k == l == 2
     w_fwd = u_kln[1, 0, :] - u_kln[0, 0, :]
@@ -264,7 +264,7 @@ def plot_dG_errs(ax, components, lambdas, dG_errs):
         ax.plot(lambdas[:-1], ys, marker=".", label=component)
 
     ax.set_xlabel(r"$\lambda_i$")
-    ax.set_ylabel(r"$\Delta G$ error ($\lambda_i$, $\lambda_{i+1}$)")
+    ax.set_ylabel(r"$\Delta G$ error ($\lambda_i$, $\lambda_{i+1}$) / (kJ / mol)")
     ax.legend()
 
 
@@ -465,7 +465,7 @@ def estimate_free_energy_given_initial_states(initial_states, protocol, temperat
     lambdas = [s.lamb for s in initial_states]
     overlaps_by_lambda = np.array([pair_overlap_from_ukln(u_kln) for u_kln in ukln_by_lambda_by_component.sum(axis=0)])
     dG_errs_by_lambda_by_component = np.array(
-        [[dG_err_from_ukln(u_kln) for u_kln in ukln_by_lambda] for ukln_by_lambda in ukln_by_lambda_by_component]
+        [[df_err_from_ukln(u_kln) / beta for u_kln in ukln_by_lambda] for ukln_by_lambda in ukln_by_lambda_by_component]
     )
     overlaps_by_lambda_by_component = np.array(
         [[pair_overlap_from_ukln(u_kln) for u_kln in ukln_by_lambda] for ukln_by_lambda in ukln_by_lambda_by_component]

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -660,7 +660,14 @@ def estimate_relative_free_energy(
         keep_idxs = [0, len(initial_states) - 1]  # keep first and last frames
     assert len(keep_idxs) <= len(lambda_schedule)
     combined_prefix = get_mol_name(mol_a) + "_" + get_mol_name(mol_b) + "_" + prefix
-    return estimate_free_energy_given_initial_states(initial_states, protocol, temperature, combined_prefix, keep_idxs)
+    try:
+        return estimate_free_energy_given_initial_states(
+            initial_states, protocol, temperature, combined_prefix, keep_idxs
+        )
+    except Exception as err:
+        with open(f"failed_rbfe_result_{combined_prefix}.pkl", "wb") as fh:
+            pickle.dump((initial_states, protocol, err), fh)
+        raise err
 
 
 def run_vacuum(

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -254,8 +254,8 @@ def df_err_from_ukln(u_kln):
     assert k == l == 2
     w_fwd = u_kln[1, 0, :] - u_kln[0, 0, :]
     w_rev = u_kln[0, 1, :] - u_kln[1, 1, :]
-    _, dG_err = bar_with_bootstrapped_uncertainty(w_fwd, w_rev)
-    return dG_err
+    _, df_err = bar_with_bootstrapped_uncertainty(w_fwd, w_rev)
+    return df_err
 
 
 def plot_dG_errs(ax, components, lambdas, dG_errs):

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -660,14 +660,7 @@ def estimate_relative_free_energy(
         keep_idxs = [0, len(initial_states) - 1]  # keep first and last frames
     assert len(keep_idxs) <= len(lambda_schedule)
     combined_prefix = get_mol_name(mol_a) + "_" + get_mol_name(mol_b) + "_" + prefix
-    try:
-        return estimate_free_energy_given_initial_states(
-            initial_states, protocol, temperature, combined_prefix, keep_idxs
-        )
-    except Exception as err:
-        with open(f"failed_rbfe_result_{combined_prefix}.pkl", "wb") as fh:
-            pickle.dump((initial_states, protocol, err), fh)
-        raise err
+    return estimate_free_energy_given_initial_states(initial_states, protocol, temperature, combined_prefix, keep_idxs)
 
 
 def run_vacuum(

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -249,6 +249,35 @@ def plot_BAR(df, df_err, fwd_delta_u, rev_delta_u, title, axes):
     plot_work(fwd_delta_u, rev_delta_u, axes)
 
 
+def dG_err_from_ukln(u_kln):
+    k, l, _ = u_kln.shape
+    assert k == l == 2
+    w_fwd = u_kln[1, 0, :] - u_kln[0, 0, :]
+    w_rev = u_kln[0, 1, :] - u_kln[1, 1, :]
+    _, dG_err = bar_with_bootstrapped_uncertainty(w_fwd, w_rev)
+    return dG_err
+
+
+def plot_dG_errs(ax, components, lambdas, dG_errs):
+    # one line per energy component
+    for component, ys in zip(components, dG_errs):
+        ax.plot(lambdas[:-1], ys, marker=".", label=component)
+
+    ax.set_xlabel(r"$\lambda_i$")
+    ax.set_ylabel(r"$\Delta G$ error ($\lambda_i$, $\lambda_{i+1}$)")
+    ax.legend()
+
+
+def make_dG_errs_figure(components, lambdas, dG_errs_by_lambda, dG_errs_by_lambda_by_component):
+    _, (ax_top, ax_btm) = plt.subplots(2, 1, figsize=(7, 9))
+    plot_dG_errs(ax_top, ["Overall"], lambdas, [dG_errs_by_lambda])
+    plot_dG_errs(ax_btm, components, lambdas, dG_errs_by_lambda_by_component)
+    buffer = io.BytesIO()
+    plt.savefig(buffer, format="png")
+    buffer.seek(0)
+    return buffer.read()
+
+
 def pair_overlap_from_ukln(u_kln):
     k, l, n = u_kln.shape
     assert k == l == 2
@@ -278,6 +307,16 @@ def plot_overlap_summary(ax, components, lambdas, overlaps):
     ax.set_xlabel(r"$\lambda_i$")
     ax.set_ylabel(r"pair BAR overlap ($\lambda_i$, $\lambda_{i+1}$)")
     ax.legend()
+
+
+def make_overlap_summary_figure(components, lambdas, overlaps_by_lambda, overlaps_by_lambda_by_component):
+    _, (ax_top, ax_btm) = plt.subplots(2, 1, figsize=(7, 9))
+    plot_overlap_summary(ax_top, ["Overall"], lambdas, [overlaps_by_lambda])
+    plot_overlap_summary(ax_btm, components, lambdas, overlaps_by_lambda_by_component)
+    buffer = io.BytesIO()
+    plt.savefig(buffer, format="png")
+    buffer.seek(0)
+    return buffer.read()
 
 
 def estimate_free_energy_given_initial_states(initial_states, protocol, temperature, prefix, keep_idxs):
@@ -424,27 +463,22 @@ def estimate_free_energy_given_initial_states(initial_states, protocol, temperat
     ukln_by_lambda_by_component = np.array(ukln_by_component_by_lambda).swapaxes(0, 1)
 
     lambdas = [s.lamb for s in initial_states]
-
-    _, (ax_top, ax_btm) = plt.subplots(2, 1, figsize=(7, 9))
     overlaps_by_lambda = np.array([pair_overlap_from_ukln(u_kln) for u_kln in ukln_by_lambda_by_component.sum(axis=0)])
-    plot_overlap_summary(ax_top, ["Overall"], lambdas, [overlaps_by_lambda])
-
+    dG_errs_by_lambda_by_component = np.array(
+        [[dG_err_from_ukln(u_kln) for u_kln in ukln_by_lambda] for ukln_by_lambda in ukln_by_lambda_by_component]
+    )
     overlaps_by_lambda_by_component = np.array(
         [[pair_overlap_from_ukln(u_kln) for u_kln in ukln_by_lambda] for ukln_by_lambda in ukln_by_lambda_by_component]
     )
-    plot_overlap_summary(ax_btm, U_names, lambdas, overlaps_by_lambda_by_component)
-
-    buffer = io.BytesIO()
-    plt.savefig(buffer, format="png")
-    buffer.seek(0)
-    overlap_summary_png = buffer.read()
 
     return SimulationResult(
         all_dGs,
         all_errs,
+        dG_errs_by_lambda_by_component,
         overlaps_by_lambda,
         overlaps_by_lambda_by_component,
-        overlap_summary_png,
+        make_dG_errs_figure(U_names, lambdas, all_errs, dG_errs_by_lambda_by_component),
+        make_overlap_summary_figure(U_names, lambdas, overlaps_by_lambda, overlaps_by_lambda_by_component),
         overlap_detail_png,
         stored_frames,
         stored_boxes,

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -263,6 +263,7 @@ def plot_dG_errs(ax, components, lambdas, dG_errs):
     for component, ys in zip(components, dG_errs):
         ax.plot(lambdas[:-1], ys, marker=".", label=component)
 
+    ax.set_ylim(bottom=0.0)
     ax.set_xlabel(r"$\lambda_i$")
     ax.set_ylabel(r"$\Delta G$ error ($\lambda_i$, $\lambda_{i+1}$) / (kJ / mol)")
     ax.legend()


### PR DESCRIPTION
* Adds new fields to `rbfe.SimulationResult`:
  - `dG_errs_by_lambda_by_component`: array of bootstrapped BAR errors for each energy component and pair of adjacent lambda windows
  - `dG_errs_png`: plot analogous to `overlap_summary_png` for bootstrapped BAR errors. Example:
     <img src="https://user-images.githubusercontent.com/319411/205732994-dfad4c1c-a271-4dfd-9336-42d1db570158.png" width="400"/>
