### PR TITLE
Atom Mapping Modifications

### DIFF
--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -90,7 +90,7 @@ def test_complete_rings_only():
         mol_b,
         ring_cutoff=0.1,
         chain_cutoff=0.2,
-        max_visits=1e7,  # 10 million max nodes to visit
+        max_visits=100,  # 100 max nodes to visit
         connected_core=True,
         max_cores=1000,
         enforce_core_core=True,

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -379,6 +379,7 @@ def _get_core_by_mcs(mol_a, mol_b):
         enforce_core_core=True,
         complete_rings=True,
         enforce_chiral=True,
+        min_threshold=0,
     )
 
     core = all_cores[0]

--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -42,6 +42,7 @@ def run_edge(mol_a, mol_b, protein_path, n_windows):
         enforce_core_core=True,
         complete_rings=True,
         enforce_chiral=True,
+        min_threshold=0,
     )
     core = all_cores[0]
     res = utils.plot_atom_mapping_grid(mol_a, mol_b, core)

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -55,6 +55,7 @@ def get_cores(
     enforce_core_core,
     complete_rings,
     enforce_chiral,
+    min_threshold,
 ):
     """
     Finds set of cores between two molecules that maximizes the number of common edges.
@@ -105,10 +106,19 @@ def get_cores(
     enforce_chiral: bool
         Filter out cores that would flip atom chirality
 
+    min_threshold: int
+        Number of atoms to require for a valid mapping
+
     Returns
     -------
     Returns a list of all_cores
 
+    Raises
+    ------
+    timemachine.fe.mcgregor.NoMappingError
+        If no mapping is found
+    timemachine.fe.mcgregor.MaxVisitsError
+        If max_visits is exceeding to find a mapping
     """
 
     assert max_cores > 0
@@ -122,6 +132,7 @@ def get_cores(
         enforce_core_core=enforce_core_core,
         complete_rings=complete_rings,
         enforce_chiral=enforce_chiral,
+        min_threshold=min_threshold,
     )
 
     # we require that mol_a.GetNumAtoms() <= mol_b.GetNumAtoms()
@@ -284,6 +295,7 @@ def _get_cores_impl(
     enforce_core_core,
     complete_rings,
     enforce_chiral,
+    min_threshold,
 ):
     mol_a, perm = reorder_atoms_by_degree(mol_a)  # UNINVERT
 
@@ -344,6 +356,7 @@ def _get_cores_impl(
         max_visits,
         max_cores,
         enforce_core_core,
+        min_threshold,
         filter_fxn=filter_fxn,
     )
 

--- a/timemachine/fe/mcgregor.py
+++ b/timemachine/fe/mcgregor.py
@@ -159,8 +159,21 @@ class MaxVisitsError(Exception):
     pass
 
 
+class NoMappingError(Exception):
+    pass
+
+
 def mcs(
-    n_a, n_b, priority_idxs, bonds_a, bonds_b, max_visits, max_cores, enforce_core_core, filter_fxn=(lambda core: True)
+    n_a,
+    n_b,
+    priority_idxs,
+    bonds_a,
+    bonds_b,
+    max_visits,
+    max_cores,
+    enforce_core_core,
+    min_threshold,
+    filter_fxn=(lambda core: True),
 ):
 
     assert n_a <= n_b
@@ -179,6 +192,8 @@ def mcs(
     max_threshold = _arcs_left(marcs)
     for idx in range(max_threshold):
         cur_threshold = max_threshold - idx
+        if cur_threshold < min_threshold:
+            raise NoMappingError(f"Unable to find mapping with at least {min_threshold} atoms")
         map_a_to_b = [UNMAPPED] * n_a
         map_b_to_a = [UNMAPPED] * n_b
         mcs_result = MCSResult()
@@ -213,7 +228,8 @@ def mcs(
         if mcs_result.timed_out:
             raise MaxVisitsError(f"Reached max number of visits: {max_visits}")
 
-    assert len(mcs_result.all_maps) > 0
+    if len(mcs_result.all_maps) <= 0:
+        raise NoMappingError("Unable to find mapping")
 
     all_cores = []
 

--- a/timemachine/fe/mcgregor.py
+++ b/timemachine/fe/mcgregor.py
@@ -198,9 +198,6 @@ def mcs(
             filter_fxn,
         )
 
-        if mcs_result.timed_out:
-            raise MaxVisitsError()
-
         if len(mcs_result.all_maps) > 0:
             # don't remove this comment and the one below, useful for debugging!
             # print(
@@ -211,6 +208,10 @@ def mcs(
         # print(
         # f"==FAILED==[NODES VISITED {mcs_result.nodes_visited} | time taken: {time.time()-start_time} | time out? {mcs_result.timed_out}]====="
         # )
+
+        # If timed out and no maps found, raise exception.
+        if mcs_result.timed_out:
+            raise MaxVisitsError()
 
     assert len(mcs_result.all_maps) > 0
 

--- a/timemachine/fe/mcgregor.py
+++ b/timemachine/fe/mcgregor.py
@@ -172,7 +172,8 @@ def mcs(
     marcs = _initialize_marcs_given_predicate(g_a, g_b, predicate)
 
     priority_idxs = tuple(tuple(x) for x in priority_idxs)
-    start_time = time.time()
+    # Keep start time for debugging purposes below
+    start_time = time.time()  # noqa
 
     # run in reverse by guessing max # of edges to avoid getting stuck in minima.
     max_threshold = _arcs_left(marcs)
@@ -190,7 +191,6 @@ def mcs(
             marcs,
             mcs_result,
             priority_idxs,
-            start_time,
             max_visits,
             max_cores,
             cur_threshold,
@@ -247,7 +247,6 @@ def recursion(
     marcs,
     mcs_result,
     priority_idxs,
-    start_time,
     max_visits,
     max_cores,
     threshold,
@@ -298,7 +297,6 @@ def recursion(
                     new_marcs,
                     mcs_result,
                     priority_idxs,
-                    start_time,
                     max_visits,
                     max_cores,
                     threshold,
@@ -319,7 +317,6 @@ def recursion(
         new_marcs,
         mcs_result,
         priority_idxs,
-        start_time,
         max_visits,
         max_cores,
         threshold,

--- a/timemachine/fe/mcgregor.py
+++ b/timemachine/fe/mcgregor.py
@@ -211,7 +211,7 @@ def mcs(
 
         # If timed out and no maps found, raise exception.
         if mcs_result.timed_out:
-            raise MaxVisitsError()
+            raise MaxVisitsError(f"Reached max number of visits: {max_visits}")
 
     assert len(mcs_result.all_maps) > 0
 

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -804,6 +804,7 @@ def run_edge_and_save_results(
             enforce_core_core=True,
             complete_rings=True,
             enforce_chiral=True,
+            min_threshold=0,
         )
         core = all_cores[0]
 


### PR DESCRIPTION
When playing around with our atom mapping on large datasets I noticed that sometimes it took a lot longer then expected to map compounds.

Changes:
* Return core if you found one, regardless of timing out
* Adds a test for the max visits
* Remove an unused parameter in the recursion
* Add parameter for specifying the smallest mapping that is acceptable.