### PR TITLE
Increase max frc norm to 50k

### DIFF
--- a/tests/test_fe_utils.py
+++ b/tests/test_fe_utils.py
@@ -163,4 +163,4 @@ def test_get_strained_atoms():
     x0 = utils.get_romol_conf(mol)
     x0[-2, :] = x0[-1, :] + 0.01
     utils.set_romol_conf(mol, x0)
-    assert model_utils.get_strained_atoms(mol, ff) == [4, 10, 11]
+    assert model_utils.get_strained_atoms(mol, ff) == [10, 11]

--- a/timemachine/constants.py
+++ b/timemachine/constants.py
@@ -25,4 +25,4 @@ WATER_FF_TAG = "WaterForcefield"
 
 
 # used to check norms in the gradient computations
-MAX_FORCE_NORM = 25000
+MAX_FORCE_NORM = 50000


### PR DESCRIPTION
- Relative hydration free energy case was failing due to frc cut off during minimization
- Turning off check let simulation run without issue
- 50k comes from https://github.com/proteneer/timemachine/pull/904 (where I lowered the value to 25k to make it consistent with the steric clash check)