### PR TITLE
Return full paths of results in RBFE driver

### DIFF
--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -831,7 +831,7 @@ def run_edge_and_save_results(
         print(err)
         traceback.print_exc()
 
-        return path
+        return file_client.full_path(path)
 
     path = f"success_rbfe_result_{edge.mol_a_name}_{edge.mol_b_name}.pkl"
     pkl_obj = (mol_a, mol_b, edge.metadata, core, solvent_res, solvent_top, complex_res, complex_top)
@@ -861,7 +861,7 @@ def run_edge_and_save_results(
         ),
     )
 
-    return path
+    return file_client.full_path(path)
 
 
 def run_edges_parallel(


### PR DESCRIPTION
Minor quality of life improvement to return the full path of the result from `run_edge_and_save_results`, e.g. `2022-12-20-14-34-62b78856/success_rbfe_result_254_50.pkl` instead of just `success_rbfe_result_254_50.pkl`. This should remove any guesswork from locating results and allow automating the download.