### PR TITLE
Fix name-swap typo

### DIFF
--- a/tests/test_jax_nonbonded.py
+++ b/tests/test_jax_nonbonded.py
@@ -356,10 +356,10 @@ def test_lj_basis():
     def lj_ref(sig, eps):
         return np.sum(lennard_jones(r_i, sig_i + sig, eps_i * eps))
 
-    lj_prefactors = basis_expand_lj_atom(sig_i, eps_i, r_i)
+    lj_prefactors = basis_expand_lj_env(sig_i, eps_i, r_i)
 
     def lj_basis(sig, eps):
-        projection = basis_expand_lj_env(sig, eps)
+        projection = basis_expand_lj_atom(sig, eps)
         return jnp.dot(projection, lj_prefactors)
 
     for _ in range(100):

--- a/timemachine/potentials/nonbonded.py
+++ b/timemachine/potentials/nonbonded.py
@@ -501,7 +501,7 @@ def _basis_expand_lj_term(sig_env, eps_env, r_env, power):
     Compute expansion of
         sum_i (4 * eps * eps_env[i] * (sig_env[i] / r_env[i])^power)
 
-    (called by basis_expand_lj_atom with power=12 and power=6)
+    (called by basis_expand_lj_env with power=12 and power=6)
 
     Parameters
     ----------
@@ -532,14 +532,14 @@ def _basis_expand_lj_term(sig_env, eps_env, r_env, power):
     return h_n
 
 
-def basis_expand_lj_atom(sig_env, eps_env, r_env):
+def basis_expand_lj_env(sig_env, eps_env, r_env):
     """Precomputed part of basis expansion that allows fast computation of
 
     f(sig, eps)
         = sum_i LJ(r_env[i]; sig + sig_env[i], eps * eps_env[i])
         = dot(
-            basis_expand_lj_env(sig, eps),
-            basis_expand_lj_atom(sig_env, eps_env, r_env)
+            basis_expand_lj_atom(sig, eps),
+            basis_expand_lj_env(sig_env, eps_env, r_env)
         )
     Parameters
     ----------
@@ -551,7 +551,7 @@ def basis_expand_lj_atom(sig_env, eps_env, r_env):
     Returns
     -------
     h_n : [20] array
-        can be dotted with output of basis_expand_lj_env(sig, eps)
+        can be dotted with output of basis_expand_lj_atom(sig, eps)
         to compute energy of one atom interacting with all environment atoms
     """
     h_n_12 = _basis_expand_lj_term(sig_env, eps_env, r_env, 12)
@@ -559,14 +559,14 @@ def basis_expand_lj_atom(sig_env, eps_env, r_env):
     return jnp.hstack([h_n_12, h_n_6])
 
 
-def basis_expand_lj_env(sig: float, eps: float) -> Array:
+def basis_expand_lj_atom(sig: float, eps: float) -> Array:
     """Variable part of basis expansion that allows fast computation of
 
     f(sig, eps)
         = sum_i LJ(r_env[i]; sig + sig_env[i], eps * eps_env[i])
         = dot(
-            basis_expand_lj_env(sig, eps),
-            basis_expand_lj_atom(sig_env, eps_env, r_env)
+            basis_expand_lj_atom(sig, eps),
+            basis_expand_lj_env(sig_env, eps_env, r_env)
         )
 
     Parameters
@@ -577,7 +577,7 @@ def basis_expand_lj_env(sig: float, eps: float) -> Array:
     Returns
     -------
     projection : [20] array
-        can be dotted with output of basis_expand_lj_atom(sig_env, eps_env, r_env)
+        can be dotted with output of basis_expand_lj_env(sig_env, eps_env, r_env)
         to compute energy of one atom interacting with all environment atoms
     """
     exponents = jnp.hstack([jnp.arange(12 + 1), jnp.arange(6 + 1)])
@@ -608,10 +608,10 @@ def lj_prefactors_on_atom(x, x_others, sig_others, eps_others, box=None, cutoff=
 
     See Also
     --------
-    basis_expand_lj_env : computes a basis expansion of (sig, eps) that can be dotted with these prefactors
+    basis_expand_lj_atom : computes a basis expansion of an atom's (sig, eps) that can be dotted with these prefactors
     """
     r_env = jax_utils.distance_from_one_to_others(x, x_others, box, cutoff)
-    prefactors = basis_expand_lj_atom(sig_others, eps_others, r_env)
+    prefactors = basis_expand_lj_env(sig_others, eps_others, r_env)
     return prefactors
 
 
@@ -688,5 +688,5 @@ def lj_interaction_group_energy(sig_ligand, eps_ligand, lj_prefactors):
     energy: float
     """
 
-    projection = vmap(basis_expand_lj_env)(sig_ligand, eps_ligand)
+    projection = vmap(basis_expand_lj_atom)(sig_ligand, eps_ligand)
     return jnp.sum(projection * lj_prefactors)


### PR DESCRIPTION
Fix typo from https://github.com/proteneer/timemachine/pull/931 -- had swapped the names of `basis_expand_lj_env` and `basis_expand_lj_atom`