### PR TITLE
Updates default FF to OpenFF 2.0.0

### DIFF
--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -133,7 +133,7 @@ def test_functional():
 
             for perturb in perturbations:
                 abs_err = check_grad(low_dim_f, grad(low_dim_f), perturb, epsilon=1e-4)
-                assert abs_err < 1e-3
+                assert abs_err < 1.5e-3
 
         # grad w.r.t. box shouldn't be allowed
         with pytest.raises(RuntimeError) as e:

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -179,7 +179,7 @@ def test_absolute_vacuum():
         mols = utils.read_sdf(path_to_ligand)
     mol = mols[0]
 
-    ff = Forcefield.load_from_file("smirnoff_1_1_0_ccc.py")
+    ff = Forcefield.load_from_file(DEFAULT_FF)
     ff_params = ff.get_params()
 
     bt = topology.BaseTopology(mol, ff)
@@ -196,7 +196,7 @@ def test_vacuum_and_solvent_edge_types():
         mols = utils.read_sdf(path_to_ligand)
     mol = mols[0]
 
-    ff = Forcefield.load_from_file("smirnoff_1_1_0_ccc.py")
+    ff = Forcefield.load_from_file(DEFAULT_FF)
     solvent_system, solvent_coords, solvent_box, _ = builders.build_water_system(3.0, ff.water_ff)
 
     ff_params = ff.get_params()

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -12,7 +12,6 @@ from timemachine.fe import utils
 from timemachine.ff import Forcefield
 from timemachine.ff.charges import AM1CCC_CHARGES
 from timemachine.ff.handlers import bonded, nonbonded
-from timemachine.ff.handlers.deserialize import deserialize_handlers
 
 pytestmark = [pytest.mark.nogpu]
 
@@ -558,7 +557,7 @@ def test_gbsa_handler():
 
 def test_am1ccc_throws_error_on_phosphorus():
     """Temporary, until phosphorus patterns are added to AM1CCC port"""
-    ff = Forcefield.load_from_file("smirnoff_1_1_0_ccc.py")
+    ff = Forcefield.load_from_file(DEFAULT_FF)
 
     # contains phosphorus
     smi = "[H]c1c(OP(=S)(OC([H])([H])C([H])([H])[H])OC([H])([H])C([H])([H])[H])nc(C([H])(C([H])([H])[H])C([H])([H])[H])nc1C([H])([H])[H]"
@@ -570,12 +569,10 @@ def test_am1ccc_throws_error_on_phosphorus():
 
 
 def test_am1_differences():
+    ff = Forcefield.load_from_file(DEFAULT_FF)
 
-    ff_raw = open("timemachine/ff/params/smirnoff_1_1_0_ccc.py").read()
-    ff_handlers, _, _ = deserialize_handlers(ff_raw)
-    for ccc in ff_handlers:
-        if isinstance(ccc, nonbonded.AM1CCCHandler):
-            break
+    ccc = ff.q_handle
+    assert isinstance(ccc, nonbonded.AM1CCCHandler)
 
     smi = "Clc1c(Cl)c(Cl)c(-c2c(Cl)c(Cl)c(Cl)c(Cl)c2Cl)c(Cl)c1Cl"
     mol = Chem.MolFromSmiles(smi)

--- a/tests/test_interpolate_fe.py
+++ b/tests/test_interpolate_fe.py
@@ -6,7 +6,7 @@ import numpy as np
 import pymbar
 import pytest
 
-from timemachine.constants import BOLTZ
+from timemachine.constants import BOLTZ, DEFAULT_FF
 from timemachine.fe import atom_mapping, pdb_writer, single_topology, utils
 from timemachine.fe.system import simulate_system
 from timemachine.fe.utils import get_romol_conf
@@ -17,7 +17,7 @@ from timemachine.ff import Forcefield
 def test_hif2a_free_energy_estimates():
     # Test that we can estimate the free energy differences for some simple transformations
 
-    forcefield = Forcefield.load_from_file("smirnoff_1_1_0_ccc.py")
+    forcefield = Forcefield.load_from_file(DEFAULT_FF)
 
     with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
         all_mols = utils.read_sdf(path_to_ligand)

--- a/tests/test_mtm.py
+++ b/tests/test_mtm.py
@@ -8,7 +8,7 @@ import jax.random as jrandom
 import numpy as np
 
 from timemachine import testsystems
-from timemachine.constants import BOLTZ
+from timemachine.constants import BOLTZ, DEFAULT_FF
 from timemachine.ff import Forcefield
 from timemachine.md import enhanced
 from timemachine.md.moves import NPTMove, OptimizedMTMMove, ReferenceMTMMove
@@ -17,7 +17,7 @@ from timemachine.potentials import nonbonded
 
 
 def get_ff_am1ccc():
-    ff = Forcefield.load_from_file("smirnoff_1_1_0_ccc.py")
+    ff = Forcefield.load_from_file(DEFAULT_FF)
     return ff
 
 

--- a/tests/test_mtm_condensed.py
+++ b/tests/test_mtm_condensed.py
@@ -29,7 +29,7 @@ def test_condensed_phase_mtm():
     np.random.seed(seed)
 
     mol, torsion_idxs = testsystems.ligands.get_biphenyl()
-    ff = Forcefield.load_from_file("smirnoff_1_1_0_ccc.py")
+    ff = Forcefield.load_from_file(DEFAULT_FF)
 
     masses = get_mol_masses(mol)
     num_ligand_atoms = len(masses)

--- a/tests/test_reweighting.py
+++ b/tests/test_reweighting.py
@@ -5,7 +5,7 @@ from jax import grad, jit
 from jax import numpy as jnp
 from jax import value_and_grad, vmap
 
-from timemachine.constants import BOLTZ
+from timemachine.constants import BOLTZ, DEFAULT_FF
 from timemachine.datasets import fetch_freesolv
 from timemachine.fe.functional import construct_differentiable_interface_fast
 from timemachine.fe.reweighting import (
@@ -187,7 +187,7 @@ def make_ahfe_test_system():
     * fake "endpoint samples" (random perturbations of initial (conf, box) -- not actual samples!)
     """
     mol = fetch_freesolv()[123]
-    ff = Forcefield.load_from_file("smirnoff_1_1_0_ccc.py")
+    ff = Forcefield.load_from_file(DEFAULT_FF)
     temperature = 300
     ref_delta_f = -23.0  # from a short SMC calculation on mobley_242480, in kB T
 

--- a/tests/test_terminal_bond_maps.py
+++ b/tests/test_terminal_bond_maps.py
@@ -162,7 +162,6 @@ def test_on_methane():
     mbar = MBAR(u_kn, N_k)
     estimated_delta_f_mbar = mbar.f_k[1]
 
-    # assert that all estimates are close to precomputed result
     estimates = np.array(
         [
             estimated_delta_f_forward,
@@ -171,4 +170,5 @@ def test_on_methane():
             estimated_delta_f_mbar,
         ]
     )
-    np.testing.assert_allclose(estimates, -2.8, atol=1e-1)
+    # assert that all estimates are in agreement
+    np.testing.assert_allclose(estimates[:3], estimates[-1], atol=1e-1)

--- a/tests/test_terminal_bond_maps.py
+++ b/tests/test_terminal_bond_maps.py
@@ -171,4 +171,4 @@ def test_on_methane():
             estimated_delta_f_mbar,
         ]
     )
-    np.testing.assert_allclose(estimates, -4.2, atol=1e-1)
+    np.testing.assert_allclose(estimates, -2.8, atol=1e-1)

--- a/tests/test_vacuum_importance_sampling.py
+++ b/tests/test_vacuum_importance_sampling.py
@@ -5,13 +5,14 @@ import numpy as np
 import pytest
 
 from timemachine import testsystems
+from timemachine.constants import DEFAULT_FF
 from timemachine.ff import Forcefield
 from timemachine.md import enhanced
 from timemachine.potentials import bonded
 
 
 def get_ff_am1ccc():
-    ff = Forcefield.load_from_file("smirnoff_1_1_0_ccc.py")
+    ff = Forcefield.load_from_file(DEFAULT_FF)
     return ff
 
 

--- a/timemachine/constants.py
+++ b/timemachine/constants.py
@@ -11,7 +11,7 @@ ENERGY_UNIT = unit.kilojoule_per_mole
 DISTANCE_UNIT = unit.nanometer
 
 kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA
-DEFAULT_FF = "smirnoff_1_1_0_ccc.py"
+DEFAULT_FF = "smirnoff_2_0_0_ccc.py"
 DEFAULT_TEMP = 300  # kelvin
 DEFAULT_KT = BOLTZ * DEFAULT_TEMP  # kJ/mol
 


### PR DESCRIPTION
* Fixes sulfonamide angles (OFF 1.3.1 release)
* Adds 4 periodic torsion patterns (OFF 1.3.* release)
* Adds 2 LJ patterns
* Performance on JACS/Merck is slightly better, though within precision of rerunning simulations