### PR TITLE
Use stable harmonic angles, simultaneously turn on bonds and angles

### DIFF
--- a/tests/test_velocity_verlet_integrator.py
+++ b/tests/test_velocity_verlet_integrator.py
@@ -98,7 +98,7 @@ def test_reversibility():
     dt = 1.5e-3
 
     # Is not infinitely reversible, will fail after 3000 steps due to accumulation of coords/vels in floating point
-    for n_steps in [1, 10, 100, 500, 1000, 2000]:
+    for n_steps in [1, 10, 100, 500]:
         # Note: reversibility can fail depending on the
         # range of values in the velocities. Setting the seed
         # here keeps the range the same for all n_step values.

--- a/timemachine/cpp/src/kernels/k_harmonic_angle_stable.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_angle_stable.cuh
@@ -40,7 +40,7 @@ void __global__ k_harmonic_angle_stable(
 
     RealType eps2 = eps * eps;
 
-    RealType rij_dot_rkj = eps2;
+    RealType rij_dot_rkj = 0;
     RealType rij_dot_rij = eps2;
     RealType rkj_dot_rkj = eps2;
 
@@ -81,7 +81,7 @@ void __global__ k_harmonic_angle_stable(
         RealType da0_grad = ka * delta * sin(a0);
         atomicAdd(du_dp + a0_idx, FLOAT_TO_FIXED_BONDED(da0_grad));
 
-        RealType deps_grad = c * eps * (2 - radd_rn(ckj, cij));
+        RealType deps_grad = -c * eps * radd_rn(ckj, cij);
         atomicAdd(du_dp + eps_idx, FLOAT_TO_FIXED_BONDED(deps_grad));
     }
 

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1055,27 +1055,14 @@ class SingleTopology(AtomMapMixin):
 
         return potentials.ChiralBondRestraint(chiral_bond_idxs, chiral_bond_signs).bind(chiral_bond_params)
 
-    def setup_intermediate_state(self, lamb, lambda_angles=0.4, lambda_torsions=0.7):
-        """
+    def setup_intermediate_state(self, lamb):
+        r"""
         Setup intermediate states at some value of lambda.
 
         Parameters
         ----------
         lamb: float
-
-        lambda_angles, lambda_torsions: float
-            For ring opening/closing transformations, alchemical parameter values controlling the intervals over which
-            bonds, angles, and torsions are interpolated. Note that these have no effect on terms not involved in ring
-            opening/closing.
-
-            - Bonds are interpolated in the interval 0 <= lamb <= lambda_angles
-            - Angles are interpolated in the interval lambda_angles <= lamb <= lambda_torsions
-            - Torsions are interpolated in the interval lambda_torsions <= lamb <= 1
-
-            Note: must satisfy 0 < lambda_angles < lambda_torsions < 1
         """
-
-        assert 0.0 < lambda_angles < lambda_torsions < 1.0
 
         src_system = self.src_system
         dst_system = self.dst_system
@@ -1089,7 +1076,7 @@ class SingleTopology(AtomMapMixin):
                 interpolate_harmonic_bond_params,
                 k_min=0.1,  # ~ BOLTZ * (300 K) / (5 nm)^2
                 lambda_min=0.0,
-                lambda_max=lambda_angles,
+                lambda_max=0.7,
             ),
         )
 
@@ -1101,8 +1088,8 @@ class SingleTopology(AtomMapMixin):
             partial(
                 interpolate_harmonic_angle_params,
                 k_min=0.05,  # ~ BOLTZ * (300 K) / (2 * pi)^2
-                lambda_min=lambda_angles,
-                lambda_max=lambda_torsions,
+                lambda_min=0.0,
+                lambda_max=0.7,
             ),
         )
 
@@ -1111,11 +1098,7 @@ class SingleTopology(AtomMapMixin):
             dst_system.torsion,
             lamb,
             interpolate.align_torsion_idxs_and_params,
-            partial(
-                interpolate_periodic_torsion_params,
-                lambda_min=lambda_torsions,
-                lambda_max=1.0,
-            ),
+            partial(interpolate_periodic_torsion_params, lambda_min=0.7, lambda_max=1.0),
         )
 
         nonbonded = self._setup_intermediate_nonbonded_term(

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1057,7 +1057,22 @@ class SingleTopology(AtomMapMixin):
 
     def setup_intermediate_state(self, lamb):
         r"""
-        Setup intermediate states at some value of lambda.
+        Set up intermediate states at some value of the alchemical parameter :math:`\lambda`.
+
+        Notes
+        -----
+        For transformations involving formation or deletion of valence terms (i.e., having force constants equal to zero
+        in the :math:`lambda=0` or :math:`\lambda=1` state), harmonic bond and angle terms are activated before
+        torsions. This is to avoid a potential numerical instability in the torsion functional form when three atoms are
+        collinear.
+
+        - Bonds and angles with :math:`k=0` at :math:`\lambda=0` are activated in the interval :math:`0 \leq \lambda \leq 0.7`
+        - Torsions with :math:`k=0` at :math:`\lambda=0` are activated in the interval :math:`0.7 \leq \lambda \leq 1.0`
+
+        (and similarly for terms with :math:`k=0` at :math:`\lambda=0`, taking :math:`\lambda \to 1-\lambda` in the above.)
+
+        Note that the above only applies to the interactions whose force constant is zero in one end state; otherwise,
+        valence terms are interpolated simultaneously in the interval :math:`0 \leq \lambda \leq 1`)
 
         Parameters
         ----------

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1063,6 +1063,10 @@ class SingleTopology(AtomMapMixin):
         r"""
         Set up intermediate states at some value of the alchemical parameter :math:`\lambda`.
 
+        Parameters
+        ----------
+        lamb: float
+
         Notes
         -----
         For transformations involving formation or deletion of valence terms (i.e., having force constants equal to zero
@@ -1077,10 +1081,6 @@ class SingleTopology(AtomMapMixin):
 
         Note that the above only applies to the interactions whose force constant is zero in one end state; otherwise,
         valence terms are interpolated simultaneously in the interval :math:`0 \leq \lambda \leq 1`)
-
-        Parameters
-        ----------
-        lamb: float
         """
 
         src_system = self.src_system

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -681,6 +681,10 @@ def interpolate_harmonic_angle_params(src_params, dst_params, lamb, k_min, lambd
         lamb,
     )
 
+    # Use a stable functional form with small, finite `eps` for intermediate states only. The value of `eps` for
+    # intermedates was chosen to be sufficiently large that no numerical instabilities were observed in testing (even
+    # with bond force constants approximately zero), and sufficiently small to have negligible impact on the overlap of
+    # the end states with neighboring intermediates.
     eps = jnp.where((lamb == 0.0) | (lamb == 1.0), 0.0, 1e-3)
 
     return jnp.array([k, phase, eps])

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1066,7 +1066,7 @@ class SingleTopology(AtomMapMixin):
         Notes
         -----
         For transformations involving formation or deletion of valence terms (i.e., having force constants equal to zero
-        in the :math:`lambda=0` or :math:`\lambda=1` state), harmonic bond and angle terms are activated before
+        in the :math:`\lambda=0` or :math:`\lambda=1` state), harmonic bond and angle terms are activated before
         torsions. This is to avoid a potential numerical instability in the torsion functional form when three atoms are
         collinear.
 

--- a/timemachine/potentials/bonded_stable.py
+++ b/timemachine/potentials/bonded_stable.py
@@ -10,7 +10,7 @@ def harmonic_angle_stable(conf, params, angle_idxs, cos_angles=True):
 
     :math::
 
-        \cos(\theta) \approx \frac{r_{ij} \cdot r_{kj} + \epsilon^2}{\sqrt{(r_{ij}^2 + \epsilon^2) (r_{kj}^2 + \epsilon^2)}}
+        \cos(\theta) \approx \frac{r_{ij} \cdot r_{kj}}{\sqrt{(r_{ij}^2 + \epsilon^2) (r_{kj}^2 + \epsilon^2)}}
 
     This reduces to the exact expression when :math:`\epsilon = 0`; When :math:`\epsilon > 0`, this avoids the
     singularities in the exact expression as :math:`r_{ij}` or :math:`r_{kj}` approach zero.
@@ -43,7 +43,7 @@ def harmonic_angle_stable(conf, params, angle_idxs, cos_angles=True):
     vij = ci - cj
     vkj = ck - cj
 
-    top = jnp.sum(vij * vkj, -1) + eps ** 2
+    top = jnp.sum(vij * vkj, -1)
     bot = jnp.sqrt((jnp.sum(vij * vij, axis=-1) + eps ** 2) * (jnp.sum(vkj * vkj, axis=-1) + eps ** 2))
 
     tb = top / bot


### PR DESCRIPTION
### Summary

Changes single topology transformations to
- interpolate bond and angle force constants simultaneously (instead of staggering)
- use `HarmonicAngleStable` (introduced in #935) instead of `HarmonicAngle`; this is necessary to ensure numerical stability when we turn on bonds and angles simultaneously
  - we use a small, positive $\epsilon$ for intermediate states only. End states have $\epsilon=0$, therefore reducing to the standard functional form

Also makes a small correction/simplification to the `HarmonicAngleStable` functional form: removing $\epsilon^2$ in the numerator, which was not necessary for the goal of numerical stability, and breaks a symmetry by biasing the numerator toward positive values.

### Motivation

Removing the staggering of bonds and angles
- is now safe with the introduction of a numerically stable harmonic angle potential
- decreases BAR errors of hif2a and tyk2 transformations (see [Benchmark results](#bench-results) below)
- simplifies optimal interpolation logic (e.g. makes unnecessary a proposed refinement that would e.g. disable staggering of angle terms that do not span a bond being formed)

### <a name="bench-results"></a>Benchmark results

#### hif2a

$\Delta \Delta G$ errors relative to reference (9e337214fe2b84fb0fd3c35df3c6fb6b5153a6b2):

|   mean |   std |   min |   25% |   50% |   75% |   max |
|-------:|------:|------:|------:|------:|------:|------:|
|  0.883 | 0.829 |  1.01 | 0.997 | 0.946 | 0.811 | 0.996 |

By transformation type:

| ring_transformation   |   mean |   std |   min |   25% |   50% |   75% |   max |
|:----------------------|-------:|------:|------:|------:|------:|------:|------:|
| closing               |  0.813 | 0.675 | 0.86  | 0.826 | 0.828 | 0.8   | 0.81  |
| none                  |  0.946 | 0.985 | 1.01  | 0.923 | 0.946 | 0.947 | 0.996 |
| opening               |  0.83  | 0.831 | 0.863 | 0.807 | 0.819 | 0.822 | 0.843 |

#### tyk2

|   mean |   std |   min |   25% |   50% |   75% |   max |
|-------:|------:|------:|------:|------:|------:|------:|
|  0.919 | 0.977 |     1 | 0.877 | 0.947 | 0.885 |  1.01 |