### PR TITLE
Fixes Vacuum Importance Sampling nightly test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 MKFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 CPP_DIR := $(MKFILE_DIR)timemachine/cpp/
 INSTALL_PREFIX := $(MKFILE_DIR)timemachine/
-PYTEST_CI_ARGS := --color=yes --cov=. --cov-report=html:coverage/ --cov-append --durations=100 --hypothesis-profile ci
+# Conditionally set pytest args, to be able to override in CI
+PYTEST_CI_ARGS ?= --color=yes --cov=. --cov-report=html:coverage/ --cov-append --durations=100 --hypothesis-profile ci
 
 NOGPU_MARKER := nogpu
 MEMCHECK_MARKER := memcheck

--- a/timemachine/md/enhanced.py
+++ b/timemachine/md/enhanced.py
@@ -347,7 +347,7 @@ def generate_log_weighted_samples(
     if num_workers is None:
         num_workers = os.cpu_count()
 
-    burn_in_batches = 1000
+    burn_in_batches = 2000
 
     # wraps a callable fn so it runs in a subprocess with the device_count set explicitly
     with multiprocessing.get_context("spawn").Pool(1, init_env, [num_workers]) as pool:


### PR DESCRIPTION
Increasing the sampling does not fix this test, increasing the burn in does.

A more thorough investigation needs to be had, but wanted to fix the nightly build.

Nightly test all pass: https://gitlab.com/relaytx/physics-platform/timemachine/-/jobs/3659458567