### PR TITLE
Skips installation of Custom ops automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,11 @@ conda install openmm=7.5.1 -c conda-forge # only if using openmm from conda
 
 ### Install Time Machine
 
-#### Linux
+The CUDA extension module implementing custom ops is only supported on Linux, but partial functionality is still available on non-Linux OSes.
 
 ```shell
 pip install -r requirements.txt
 pip install .
-```
-
-#### Non-Linux
-
-The CUDA extension module implementing custom ops is only supported on Linux, but partial functionality is still available on non-Linux OSes. To install without the extension:
-
-```shell
-pip install -r requirements.txt
-SKIP_CUSTOM_OPS=1 pip install .
 ```
 
 ## Developing Time Machine
@@ -75,10 +66,7 @@ Possible variants of the last step include
 ```shell
 pip install -e .[dev,test]                 # optionally install dev and test dependencies
 CMAKE_ARGS=-DCUDA_ARCH=86 pip install -e . # override CUDA_ARCH
-SKIP_CUSTOM_OPS=1 pip install -e .         # skip building CUDA extension (non-Linux)
-
-# use parallel CMake build with `nproc` threads
-CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) pip install -e .
+SKIP_CUSTOM_OPS=1 pip install -e .         # skip building CUDA extension
 ```
 
 To rebuild the extension module after making changes to the C++/CUDA code, either rerun

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Possible variants of the last step include
 ```shell
 pip install -e .[dev,test]                 # optionally install dev and test dependencies
 CMAKE_ARGS=-DCUDA_ARCH=86 pip install -e . # override CUDA_ARCH
-SKIP_CUSTOM_OPS=1 pip install -e .         # skip building CUDA extension
+SKIP_CUSTOM_OPS=1 pip install -e .         # skip building CUDA extension, no effect on non-Linux OSes
 ```
 
 To rebuild the extension module after making changes to the C++/CUDA code, either rerun

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ follow_imports = "silent"
 
 [build-system]
 requires = [
-  "cmake==3.22.1",
+  # Don't need cmake if not on linux
+  "cmake==3.22.1; sys_platform == 'linux'",
   "mypy==0.942",
   "setuptools >= 43.0.0, < 64.0.0",
   "wheel",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import versioneer
 def install_custom_ops() -> bool:
     """Determine if we should install the custom ops.
 
-    If it is not a linux machine and doesn't have at least nvidia-smi we skip it. Can
+    If it is not a linux machine and doesn't have at least nvcc we skip it. Can
     still use the reference platform if needed in such cases.
     """
     if os.environ.get("SKIP_CUSTOM_OPS"):
@@ -26,7 +26,7 @@ def install_custom_ops() -> bool:
     if "linux" not in sys.platform:
         return False
     try:
-        subprocess.check_call(["nvidia-smi"])
+        subprocess.check_call(["nvcc"])
     except FileNotFoundError:
         return False
 
@@ -75,9 +75,9 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 cmdclass = versioneer.get_cmdclass()
 cmdclass.update(build_ext=CMakeBuild)
 
-external_modules = None
+ext_modules = None
 if install_custom_ops():
-    external_modules = [CMakeExtension("timemachine.lib.custom_ops", "timemachine/cpp")]
+    ext_modules = [CMakeExtension("timemachine.lib.custom_ops", "timemachine/cpp")]
 
 setup(
     name="timemachine",
@@ -94,7 +94,7 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     keywords="molecular dynamics",
-    ext_modules=external_modules,
+    ext_modules=ext_modules,
     packages=find_packages(),
     python_requires=">=3.7",
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def install_custom_ops() -> bool:
     if "linux" not in sys.platform:
         return False
     try:
-        subprocess.check_call(["nvcc"])
+        subprocess.check_call(["nvcc", "--version"])
     except FileNotFoundError:
         return False
 


### PR DESCRIPTION
* If not linux, if env variable set or if there is no nvidia-smi
* Don't install cmake on anything but linux

Please try running the following on your linux and OSX boxes to make sure this works everywhere, works on my machine but my machines have known to lie.

```
pip install 'timemachine @ git+https://github.com/proteneer/timemachine@a07a2e3437503d4a03115c39b519a0024764f3a5'
```