### PR TITLE
DRY, minor fix in RBFE test

### DIFF
--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -94,25 +94,25 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
         n_eq_steps=n_eq_steps,
     )
 
-    assert solvent_res.overlap_summary_png is not None
-    assert solvent_res.overlap_detail_png is not None
-    assert np.linalg.norm(solvent_res.all_errs) < 0.1
-    assert len(solvent_res.frames[0]) == n_frames
-    assert len(solvent_res.frames[-1]) == n_frames
-    assert len(solvent_res.boxes[0]) == n_frames
-    assert len(solvent_res.boxes[-1]) == n_frames
-    assert [x.lamb for x in solvent_res.initial_states] == lambda_schedule
-    assert solvent_res.protocol.n_frames == n_frames
-    assert solvent_res.protocol.n_eq_steps == n_eq_steps
+    def check_result(result: SimulationResult):
+        assert result.overlap_summary_png is not None
+        assert result.overlap_detail_png is not None
+        assert np.linalg.norm(result.all_errs) < 0.1
+        assert len(result.frames[0]) == n_frames
+        assert len(result.frames[-1]) == n_frames
+        assert len(result.boxes[0]) == n_frames
+        assert len(result.boxes[-1]) == n_frames
+        assert [x.lamb for x in result.initial_states] == lambda_schedule
+        assert result.protocol.n_frames == n_frames
+        assert result.protocol.n_eq_steps == n_eq_steps
 
-    def check_overlaps(result: SimulationResult):
         assert result.overlaps_by_lambda.shape == (len(lambda_schedule) - 1,)
         assert result.overlaps_by_lambda_by_component.shape[1] == len(lambda_schedule) - 1
         for overlaps in [result.overlaps_by_lambda, result.overlaps_by_lambda_by_component]:
             assert (0.0 < overlaps).all()
             assert (overlaps < 1.0).all()
 
-    check_overlaps(solvent_res)
+    check_result(solvent_res)
 
     seed = 2024
     complex_sys, complex_conf, _, _, complex_box, _ = builders.build_protein_system(
@@ -133,18 +133,7 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
         n_eq_steps=n_eq_steps,
     )
 
-    assert solvent_res.overlap_summary_png is not None
-    assert complex_res.overlap_detail_png is not None
-    assert np.linalg.norm(complex_res.all_errs) < 0.1
-    assert len(complex_res.frames[0]) == n_frames
-    assert len(complex_res.frames[-1]) == n_frames
-    assert len(complex_res.boxes[0]) == n_frames
-    assert len(complex_res.boxes[-1]) == n_frames
-    assert [x.lamb for x in complex_res.initial_states] == lambda_schedule
-    assert complex_res.protocol.n_frames == n_frames
-    assert complex_res.protocol.n_eq_steps == n_eq_steps
-
-    check_overlaps(complex_res)
+    check_result(complex_res)
 
 
 @pytest.mark.nightly(reason="Slow!")

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -97,7 +97,16 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
     def check_result(result: SimulationResult):
         assert result.overlap_summary_png is not None
         assert result.overlap_detail_png is not None
-        assert np.linalg.norm(result.all_errs) < 0.1
+
+        n_pairs = len(lambda_schedule) - 1
+        assert len(result.all_dGs) == n_pairs
+
+        assert len(result.all_errs) == n_pairs
+        assert result.dG_errs_by_lambda_by_component.shape[1] == n_pairs
+        for dg_errs in [result.all_errs, result.dG_errs_by_lambda_by_component]:
+            assert np.all(0.0 < np.asarray(dg_errs))
+            assert np.linalg.norm(dg_errs) < 0.1
+
         assert len(result.frames[0]) == n_frames
         assert len(result.frames[-1]) == n_frames
         assert len(result.boxes[0]) == n_frames
@@ -106,10 +115,11 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
         assert result.protocol.n_frames == n_frames
         assert result.protocol.n_eq_steps == n_eq_steps
 
-        assert result.overlaps_by_lambda.shape == (len(lambda_schedule) - 1,)
-        assert result.overlaps_by_lambda_by_component.shape[1] == len(lambda_schedule) - 1
+        assert len(result.overlaps_by_lambda) == n_pairs
+        assert result.overlaps_by_lambda_by_component.shape[0] == result.dG_errs_by_lambda_by_component.shape[0]
+        assert result.overlaps_by_lambda_by_component.shape[1] == n_pairs
         for overlaps in [result.overlaps_by_lambda, result.overlaps_by_lambda_by_component]:
-            assert (0.0 < overlaps).all()
+            assert np.all(0.0 < np.asarray(overlaps))
             assert (overlaps < 1.0).all()
 
     check_result(solvent_res)

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -95,9 +95,6 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
     )
 
     def check_result(result: SimulationResult):
-        assert result.overlap_summary_png is not None
-        assert result.overlap_detail_png is not None
-
         n_pairs = len(lambda_schedule) - 1
         assert len(result.all_dGs) == n_pairs
 
@@ -107,6 +104,17 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
             assert np.all(0.0 < np.asarray(dg_errs))
             assert np.linalg.norm(dg_errs) < 0.1
 
+        assert len(result.overlaps_by_lambda) == n_pairs
+        assert result.overlaps_by_lambda_by_component.shape[0] == result.dG_errs_by_lambda_by_component.shape[0]
+        assert result.overlaps_by_lambda_by_component.shape[1] == n_pairs
+        for overlaps in [result.overlaps_by_lambda, result.overlaps_by_lambda_by_component]:
+            assert np.all(0.0 < np.asarray(overlaps))
+            assert (overlaps < 1.0).all()
+
+        assert result.dG_errs_png is not None
+        assert result.overlap_summary_png is not None
+        assert result.overlap_detail_png is not None
+
         assert len(result.frames[0]) == n_frames
         assert len(result.frames[-1]) == n_frames
         assert len(result.boxes[0]) == n_frames
@@ -114,13 +122,6 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
         assert [x.lamb for x in result.initial_states] == lambda_schedule
         assert result.protocol.n_frames == n_frames
         assert result.protocol.n_eq_steps == n_eq_steps
-
-        assert len(result.overlaps_by_lambda) == n_pairs
-        assert result.overlaps_by_lambda_by_component.shape[0] == result.dG_errs_by_lambda_by_component.shape[0]
-        assert result.overlaps_by_lambda_by_component.shape[1] == n_pairs
-        for overlaps in [result.overlaps_by_lambda, result.overlaps_by_lambda_by_component]:
-            assert np.all(0.0 < np.asarray(overlaps))
-            assert (overlaps < 1.0).all()
 
     check_result(solvent_res)
 

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -46,10 +46,10 @@ class InitialState:
 
 @dataclass
 class SimulationResult:
-    all_dGs: List[np.ndarray]
+    all_dGs: List[float]
     all_errs: List[float]
     dG_errs_by_lambda_by_component: np.ndarray  # (len(U_names), L - 1)
-    overlaps_by_lambda: np.ndarray  # (L - 1,)
+    overlaps_by_lambda: List[float]  # L - 1
     overlaps_by_lambda_by_component: np.ndarray  # (len(U_names), L - 1)
     dG_errs_png: bytes
     overlap_summary_png: bytes

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -291,7 +291,7 @@ def pair_overlap_from_ukln(u_kln):
 def plot_overlap_summary(ax, components, lambdas, overlaps):
     # one line per energy component
     for component, ys in zip(components, overlaps):
-        percentages = 100 * ys
+        percentages = 100 * np.asarray(ys)
         ax.plot(lambdas[:-1], percentages, marker=".", label=component)
 
     # min and max within axis limits

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -464,7 +464,7 @@ def estimate_free_energy_given_initial_states(initial_states, protocol, temperat
     ukln_by_lambda_by_component = np.array(ukln_by_component_by_lambda).swapaxes(0, 1)
 
     lambdas = [s.lamb for s in initial_states]
-    overlaps_by_lambda = np.array([pair_overlap_from_ukln(u_kln) for u_kln in ukln_by_lambda_by_component.sum(axis=0)])
+    overlaps_by_lambda = [pair_overlap_from_ukln(u_kln) for u_kln in ukln_by_lambda_by_component.sum(axis=0)]
     dG_errs_by_lambda_by_component = np.array(
         [[df_err_from_ukln(u_kln) / beta for u_kln in ukln_by_lambda] for ukln_by_lambda in ukln_by_lambda_by_component]
     )


### PR DESCRIPTION
- Removes duplicated `assert solvent_res.overlap_summary_png is not None`
- Adds missing `assert complex_res.overlap_summary_png is not None`
- Strengthens test to assert expected length of `all_dGs`, shape consistency of `dG_errs_by_lambda_by_component`, `overlaps_by_lambda_by_component`
- Fixes incorrect type annotation of `all_dGs` in `SimulationResult`