### PR TITLE
Fix nightly test

### DIFF
--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -109,7 +109,7 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
         assert result.overlaps_by_lambda_by_component.shape[1] == n_pairs
         for overlaps in [result.overlaps_by_lambda, result.overlaps_by_lambda_by_component]:
             assert np.all(0.0 < np.asarray(overlaps))
-            assert (overlaps < 1.0).all()
+            assert np.all(np.asarray(overlaps) < 1.0)
 
         assert result.dG_errs_png is not None
         assert result.overlap_summary_png is not None


### PR DESCRIPTION
Adds missing array cast to fix

```
FAILED tests/test_relative_free_energy.py::test_run_hif2a_test_system - TypeError: '<' not supported between instances of 'list' and 'float'
```

in nightly-tests. (This was broken by #947)

Failure: https://gitlab.com/relaytx/physics-platform/timemachine/-/jobs/3694381302

#### TODO
- [x] Verify that nightly-tests pass (https://gitlab.com/relaytx/physics-platform/timemachine/-/pipelines/764292756)