### PR TITLE
Add option to make RBFE memory usage constant in trajectory length

### DIFF
--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -319,7 +319,7 @@ def test_sample_max_buffer_frames(hif2a_ligand_pair_single_topology_lam0_state, 
     frames_ref, _ = sample(hif2a_ligand_pair_single_topology_lam0_state, protocol, max_buffer_frames=None)
     frames_test, _ = sample(hif2a_ligand_pair_single_topology_lam0_state, protocol, max_buffer_frames=max_buffer_frames)
 
-    assert isinstance(frames_ref, list)
+    assert isinstance(frames_ref, np.ndarray)
     assert isinstance(frames_test, StoredArrays)
     assert len(frames_ref) == len(frames_test)
 

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -4,10 +4,12 @@ from importlib import resources
 
 import numpy as np
 import pytest
+from hypothesis import given, seed
+from hypothesis.strategies import integers
 
 from timemachine.constants import DEFAULT_FF
 from timemachine.fe.bar import pair_overlap_from_ukln
-from timemachine.fe.free_energy import HostConfig, SimulationResult, image_frames, sample
+from timemachine.fe.free_energy import HostConfig, SimulationResult, batches, image_frames, sample
 from timemachine.fe.rbfe import estimate_relative_free_energy, run_solvent, run_vacuum
 from timemachine.ff import Forcefield
 from timemachine.md import builders
@@ -279,6 +281,21 @@ def test_pair_overlap_from_ukln():
 
     # overlapping
     assert gaussian_overlap((0, 0.1), (0.5, 0.2)) > 0.1
+
+
+@given(integers(min_value=1))
+@seed(2023)
+def test_batches_of_nothing(batch_size):
+    assert list(batches(0, batch_size)) == []
+
+
+@given(integers(min_value=1, max_value=1000), integers(min_value=1))
+@seed(2023)
+def test_batches(n, batch_size):
+    assert sum(batches(n, batch_size)) == n
+    assert all(batch == batch_size for batch in list(batches(n, batch_size))[:-1])
+    *_, last = batches(n, batch_size)
+    assert 0 < last <= batch_size
 
 
 if __name__ == "__main__":

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -305,7 +305,7 @@ def hif2a_ligand_pair_single_topology_lam0_state():
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     forcefield = Forcefield.load_from_file(DEFAULT_FF)
     st = SingleTopology(mol_a, mol_b, core, forcefield)
-    [state] = setup_initial_states(st, None, DEFAULT_TEMP, [0.0], 2023)
+    state = setup_initial_states(st, None, DEFAULT_TEMP, [0.0], 2023)[0]
     return state
 
 

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -166,13 +166,13 @@ def test_steps_per_frames():
     seed = 2022
     frames = 5
     res = run_vacuum(mol_a, mol_b, core, forcefield, None, frames, seed, n_eq_steps=10, steps_per_frame=2, n_windows=2)
-    assert res.frames[0].shape[0] == frames
+    assert len(res.frames[0]) == frames
 
     frames = 2
     test_res = run_vacuum(
         mol_a, mol_b, core, forcefield, None, frames, seed, n_eq_steps=10, steps_per_frame=5, n_windows=2
     )
-    assert test_res.frames[0].shape[0] == frames
+    assert len(test_res.frames[0]) == frames
     assert len(test_res.frames) == 2
     # The last frame from the trajectories should match as num_frames * steps_per_frame are equal
     for frame, test_frame in zip(res.frames, test_res.frames):

--- a/tests/test_stored_arrays.py
+++ b/tests/test_stored_arrays.py
@@ -3,7 +3,7 @@ import weakref
 
 import numpy as np
 import pytest
-from hypothesis import assume, given, seed
+from hypothesis import assume, example, given, seed
 from hypothesis.extra.numpy import array_shapes, arrays, floating_dtypes, from_dtype
 from hypothesis.strategies import composite, integers, lists
 
@@ -86,6 +86,7 @@ def test_stored_arrays_eq(chunks):
 
 @given(lists(chunks(), max_size=3), lists(chunks(), max_size=3))
 @seed(2023)
+@example([np.array([]), np.array([1])], [np.array([1])])
 def test_stored_arrays_neq(chunks1, chunks2):
     assume(not all(np.array_equal(a, b, equal_nan=True) for a, b in zip(chunks1, chunks2)))
     a = StoredArrays()

--- a/tests/test_stored_arrays.py
+++ b/tests/test_stored_arrays.py
@@ -4,7 +4,7 @@ import weakref
 import numpy as np
 import pytest
 from hypothesis import given, seed
-from hypothesis.extra.numpy import array_shapes, arrays, floating_dtypes
+from hypothesis.extra.numpy import array_shapes, arrays, floating_dtypes, from_dtype
 from hypothesis.strategies import composite, integers, lists
 
 from timemachine.fe.stored_arrays import StoredArrays
@@ -14,7 +14,7 @@ from timemachine.fe.stored_arrays import StoredArrays
 def chunks(draw):
     shape = draw(array_shapes())
     dtype = draw(floating_dtypes())
-    return draw(lists(arrays(dtype, shape)))
+    return draw(lists(arrays(dtype, shape, elements=from_dtype(dtype, allow_subnormal=False))))
 
 
 @given(lists(chunks()))
@@ -32,7 +32,7 @@ def test_stored_arrays_extend_iter_roundtrip(chunks):
 def lists_of_chunks_with_index(draw):
     shape = draw(array_shapes())
     dtype = draw(floating_dtypes())
-    chunks = lists(min_size=1, elements=arrays(dtype, shape))
+    chunks = lists(min_size=1, elements=arrays(dtype, shape, elements=from_dtype(dtype, allow_subnormal=False)))
     list_of_chunks = draw(lists(min_size=1, elements=chunks))
     n = sum(len(c) for c in list_of_chunks)
     ix = draw(integers(-n, n - 1))

--- a/tests/test_stored_arrays.py
+++ b/tests/test_stored_arrays.py
@@ -1,0 +1,47 @@
+import numpy as np
+from hypothesis import given, seed
+from hypothesis.extra.numpy import array_shapes, arrays, floating_dtypes
+from hypothesis.strategies import composite, integers, lists
+
+from timemachine.fe.stored_arrays import StoredArrays
+
+
+@composite
+def chunks(draw):
+    shape = draw(array_shapes())
+    dtype = draw(floating_dtypes())
+    return draw(lists(arrays(dtype, shape)))
+
+
+@given(lists(chunks()))
+@seed(2023)
+def test_stored_arrays_extend_iter_roundtrip(chunks):
+    sas = StoredArrays()
+    for chunk in chunks:
+        sas.extend(chunk)
+
+    for actual, expected in zip(sas, (arr for chunk in chunks for arr in chunk)):
+        np.testing.assert_array_equal(actual, expected)
+
+
+@composite
+def lists_of_chunks_with_index(draw):
+    shape = draw(array_shapes())
+    dtype = draw(floating_dtypes())
+    chunks = lists(min_size=1, elements=arrays(dtype, shape))
+    list_of_chunks = draw(lists(min_size=1, elements=chunks))
+    n = sum(len(c) for c in list_of_chunks)
+    ix = draw(integers(-n, n - 1))
+    return list_of_chunks, ix
+
+
+@given(lists_of_chunks_with_index())
+@seed(2023)
+def test_stored_arrays_getitem(chunks_index):
+    chunks, ix = chunks_index
+    sas = StoredArrays()
+    for chunk in chunks:
+        sas.extend(chunk)
+
+    ref = [arr for chunk in chunks for arr in chunk]
+    np.testing.assert_array_equal(sas[ix], ref[ix])

--- a/tests/test_stored_arrays.py
+++ b/tests/test_stored_arrays.py
@@ -106,7 +106,7 @@ def test_stored_arrays_neq(chunks1, chunks2):
 def test_stored_arrays_cleanup():
     sa = StoredArrays()
     sa.extend([np.array([1, 2, 3])])
-    path = sa._dir
+    path = sa._path()
     assert path.exists()
 
     del sa

--- a/tests/test_stored_arrays.py
+++ b/tests/test_stored_arrays.py
@@ -79,12 +79,9 @@ def test_stored_arrays_doesnt_hold_references(ctor):
 @given(lists(chunks()))
 @seed(2023)
 def test_stored_arrays_eq(chunks):
-    a = StoredArrays()
-    b = StoredArrays()
-    for chunk in chunks:
-        a.extend(chunk)
-        b.extend(chunk)
-
+    a = stored_arrays_from_chunks(chunks)
+    b = stored_arrays_from_chunks(chunks)
+    assert a == a
     assert a is not b
     assert a == b
 
@@ -94,12 +91,8 @@ def test_stored_arrays_eq(chunks):
 @example([np.array([]), np.array([1])], [np.array([1])])
 def test_stored_arrays_neq(chunks1, chunks2):
     assume(not all(np.array_equal(a, b, equal_nan=True) for a, b in zip(chunks1, chunks2)))
-    a = StoredArrays()
-    for chunk in chunks1:
-        a.extend(chunk)
-    b = StoredArrays()
-    for chunk in chunks2:
-        b.extend(chunk)
+    a = stored_arrays_from_chunks(chunks1)
+    b = stored_arrays_from_chunks(chunks2)
     assert a != b
 
 

--- a/tests/test_stored_arrays.py
+++ b/tests/test_stored_arrays.py
@@ -69,6 +69,8 @@ def test_stored_arrays_doesnt_hold_references(ctor):
     xs.extend([data])
 
     ref = weakref.ref(data)
+    assert ref() is not None
+
     del data
     gc.collect()
 

--- a/tests/test_stored_arrays.py
+++ b/tests/test_stored_arrays.py
@@ -10,7 +10,6 @@ from hypothesis import assume, example, given, seed
 from hypothesis.extra.numpy import array_shapes, arrays, floating_dtypes, from_dtype
 from hypothesis.strategies import composite, integers, lists
 
-from timemachine.fe import stored_arrays
 from timemachine.fe.stored_arrays import StoredArrays
 from timemachine.parallel.client import FileClient
 
@@ -128,17 +127,17 @@ def file_client():
 @seed(2023)
 def test_stored_arrays_store_load_roundtrip(sa_ref):
     with file_client() as fc:
-        stored_arrays.store(sa_ref, fc)
-        sa_test = stored_arrays.load(fc)
+        sa_ref.store(fc)
+        sa_test = StoredArrays.load(fc)
     assert sa_ref == sa_test
 
 
 def test_stored_arrays_store_raises_on_file_collision():
     with file_client() as fc:
         sa = stored_arrays_from_chunks([np.array([1, 2, 3])])
-        stored_arrays.store(sa, fc)
+        sa.store(fc)
 
         with pytest.raises(FileExistsError):
-            stored_arrays.store(sa, fc)
+            sa.store(fc)
 
-        stored_arrays.store(sa, fc, prefix=Path("subdir"))  # no collision
+        sa.store(fc, prefix=Path("subdir"))  # no collision

--- a/timemachine/fe/energy_decomposition.py
+++ b/timemachine/fe/energy_decomposition.py
@@ -71,11 +71,11 @@ def compute_energy_decomposed_u_kln(states: List[EnergyDecomposedState]) -> np.n
     """
 
     K = len(states)
-    n_frames = states[0].frames.shape[0]
+    n_frames = len(states[0].frames)
     n_components = len(states[0].batch_u_fns)
 
     for state in states:
-        assert state.frames.shape[0] == n_frames
+        assert len(state.frames) == n_frames
         assert len(state.batch_u_fns) == n_components
 
     u_kln_by_component = np.zeros((n_components, K, K, n_frames))

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -232,7 +232,7 @@ def batches(n: int, batch_size: int) -> Iterable[int]:
 
 
 def sample(
-    initial_state: InitialState, protocol: SimulationProtocol, max_buffer_frames: Optional[int] = 1000
+    initial_state: InitialState, protocol: SimulationProtocol, max_buffer_frames: Optional[int] = None
 ) -> Tuple[Sequence[NDArray], List[NDArray]]:
     """Generate a trajectory given an initial state and a simulation protocol
 

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -85,7 +85,6 @@ def image_frames(initial_state: InitialState, frames: Sequence[np.ndarray], boxe
     -------
         imaged_coordinates
     """
-    assert all(frame.ndim == 2 and frame.shape[-1] == 3 for frame in frames), "All frames must have shape (N, 3)"
     assert np.array(boxes).shape[1:] == (3, 3), "Boxes are not 3x3"
     assert len(frames) == len(boxes), "Number of frames and boxes don't match"
 
@@ -93,6 +92,7 @@ def image_frames(initial_state: InitialState, frames: Sequence[np.ndarray], boxe
     group_indices = get_group_indices(get_bond_list(hb_potential))
     imaged_frames = np.empty_like(frames)
     for i, (frame, box) in enumerate(zip(frames, boxes)):
+        assert frame.ndim == 2 and frame.shape[-1] == 3, "frames must have shape (N, 3)"
         # Recenter the frame around the centroid of the ligand
         ligand_centroid = np.mean(frame[initial_state.ligand_idxs], axis=0)
         center = compute_box_center(box)

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -222,13 +222,13 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
 
 
 def batches(n: int, batch_size: int) -> Iterable[int]:
-    while True:
-        if n <= batch_size:
-            yield n
-            break
-        else:
-            yield batch_size
-            n -= batch_size
+    assert n >= 0
+    assert batch_size > 0
+    quot, rem = divmod(n, batch_size)
+    for _ in range(quot):
+        yield batch_size
+    if rem:
+        yield rem
 
 
 def sample(

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -56,18 +56,18 @@ class SimulationResult:
     dG_errs_png: bytes
     overlap_summary_png: bytes
     overlap_detail_png: bytes
-    frames: List[np.ndarray]
+    frames: List[Sequence[np.ndarray]]  # (len(keep_idxs), n_frames, N, 3)
     boxes: List[np.ndarray]
     initial_states: List[InitialState]
     protocol: SimulationProtocol
 
 
 def image_frames(initial_state: InitialState, frames: Sequence[np.ndarray], boxes: np.ndarray) -> np.ndarray:
-    """Images a set of frames within the periodic box given an Initial state. Recenters the simulation
-    around the centroid of the coordinates specified by initial_state.ligand_idxs prior to imaging.
+    """Images a sequence of frames within the periodic box given an Initial state. Recenters the simulation around the
+    centroid of the coordinates specified by initial_state.ligand_idxs prior to imaging.
 
-    Calling this function on a set of frames will NOT produce identical energies/du_dp/du_dx. Should only
-    be used for visualization convenience.
+    Calling this function on a sequence of frames will NOT produce identical energies/du_dp/du_dx. Should only be used
+    for visualization convenience.
 
     Parameters
     ----------
@@ -75,11 +75,11 @@ def image_frames(initial_state: InitialState, frames: Sequence[np.ndarray], boxe
     initial_state: InitialState
         State that the frames came from
 
-    frames: np.ndarray of coordinates
-        Coordinates to image, shape (K, N, 3)
+    frames: sequence of np.ndarray of coordinates
+        Coordinates to image, sequence of K arrays with shape (N, 3)
 
     boxes: list of boxes
-        Boxes to image coordinates into, shape (K, 3, 3)
+        Boxes to image coordinates into, list of K arrays with shape (3, 3)
 
     Returns
     -------

--- a/timemachine/fe/stored_arrays.py
+++ b/timemachine/fe/stored_arrays.py
@@ -52,3 +52,6 @@ class StoredArrays(Sequence[NDArray]):
 
     def _get_path(self, block: int):
         return (self._path / f"{block}").with_suffix(".npy")
+
+    def __eq__(self, other):
+        return len(self) == len(other) and all(np.array_equal(a, b, equal_nan=True) for a, b in zip(self, other))

--- a/timemachine/fe/stored_arrays.py
+++ b/timemachine/fe/stored_arrays.py
@@ -2,7 +2,7 @@ import io
 import tempfile
 from itertools import count
 from pathlib import Path
-from typing import Iterator, List, NoReturn, Sequence, overload
+from typing import Collection, Iterator, List, NoReturn, Sequence, overload
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -83,7 +83,7 @@ class StoredArrays(Sequence[NDArray]):
     def _path(self) -> Path:
         return Path(self._dir.name)
 
-    def extend(self, xs: Sequence[ArrayLike]):
+    def extend(self, xs: Collection[ArrayLike]):
         np.save(self._get_chunk_path(len(self._chunk_sizes)), np.array(xs))
         self._chunk_sizes.append(len(xs))
 

--- a/timemachine/fe/stored_arrays.py
+++ b/timemachine/fe/stored_arrays.py
@@ -1,30 +1,30 @@
+import io
 import shutil
 import tempfile
 import weakref
+from itertools import count
 from pathlib import Path
-from typing import Iterator, NoReturn, Sequence, overload
+from typing import Iterator, List, NoReturn, Optional, Sequence, overload
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
+from timemachine.parallel.client import AbstractFileClient
+
 
 class StoredArrays(Sequence[NDArray]):
     def __init__(self):
-        self._block_sizes = []
-        self._path = Path(tempfile.mkdtemp())
-        self._finalizer = weakref.finalize(self, shutil.rmtree, self._path)
-
-    def extend(self, xs: Sequence[ArrayLike]):
-        np.save(self._get_path(len(self._block_sizes)), np.array(xs))
-        self._block_sizes.append(len(xs))
+        self._chunk_sizes: List[int] = []
+        self._dir = Path(tempfile.mkdtemp())
+        self._finalizer = weakref.finalize(self, shutil.rmtree, self._dir)
 
     def __iter__(self) -> Iterator[NDArray]:
-        for block, _ in enumerate(self._block_sizes):
-            for x in np.load(self._get_path(block)):
-                yield x
+        for chunk in self.chunks():
+            for array in chunk:
+                yield array
 
     def __len__(self) -> int:
-        return sum(self._block_sizes)
+        return sum(self._chunk_sizes)
 
     @overload
     def __getitem__(self, key: int) -> NDArray:
@@ -40,9 +40,9 @@ class StoredArrays(Sequence[NDArray]):
                 raise IndexError(f"index {key} out of range for sequence of length {len(self)}")
             if key < 0:
                 key += len(self)
-            for block, size in enumerate(self._block_sizes):
+            for idx, size in enumerate(self._chunk_sizes):
                 if key < size:
-                    return np.load(self._get_path(block))[key]
+                    return np.load(self._get_chunk_path(idx))[key]
                 key -= size
             assert False, "should not get here"
         elif isinstance(key, slice):
@@ -50,10 +50,57 @@ class StoredArrays(Sequence[NDArray]):
         else:
             raise ValueError("invalid subscript")
 
-    def _get_path(self, block: int):
-        return (self._path / f"{block}").with_suffix(".npy")
+    def _get_chunk_path(self, idx: int) -> Path:
+        return StoredArrays.get_chunk_path(self._dir, idx)
 
-    def __eq__(self, other):
-        return self._block_sizes == other._block_sizes and all(
+    def __eq__(self, other) -> bool:
+        return self._chunk_sizes == other._chunk_sizes and all(
             np.array_equal(a, b, equal_nan=True) for a, b in zip(self, other)
         )
+
+    def chunks(self) -> Iterator[List[NDArray]]:
+        for idx, _ in enumerate(self._chunk_sizes):
+            yield np.load(self._get_chunk_path(idx))
+
+    def extend(self, xs: Sequence[ArrayLike]):
+        np.save(self._get_chunk_path(len(self._chunk_sizes)), np.array(xs))
+        self._chunk_sizes.append(len(xs))
+
+    @staticmethod
+    def get_chunk_path(path: Path, idx: int) -> Path:
+        return (path / str(idx)).with_suffix(".npy")
+
+
+def serialize_array(array: NDArray) -> bytes:
+    fp = io.BytesIO()
+    np.save(fp, array)
+    fp.seek(0)
+    return fp.read()
+
+
+def deserialize_array(bs: bytes) -> NDArray:
+    fp = io.BytesIO(bs)
+    array = np.load(fp)
+    return array
+
+
+def store(sa: StoredArrays, client: AbstractFileClient, prefix: Optional[Path] = None):
+    for idx, chunk in enumerate(sa.chunks()):
+        serialized_array = serialize_array(np.array(chunk))
+        path = StoredArrays.get_chunk_path(prefix or Path("."), idx)
+        if client.exists(str(path)):
+            raise FileExistsError(f"file already exists: {path}")
+        client.store(str(path), serialized_array)
+
+
+def load(client: AbstractFileClient, prefix: Optional[Path] = None) -> StoredArrays:
+    sa = StoredArrays()
+    for idx in count():
+        path = StoredArrays.get_chunk_path(prefix or Path("."), idx)
+        if client.exists(str(path)):
+            bs = client.load(str(path))
+            chunk = list(deserialize_array(bs))
+            sa.extend(chunk)
+        else:
+            break
+    return sa

--- a/timemachine/fe/stored_arrays.py
+++ b/timemachine/fe/stored_arrays.py
@@ -38,6 +38,8 @@ class StoredArrays(Sequence[NDArray]):
         if isinstance(key, int):
             if key < -len(self) or key >= len(self):
                 raise IndexError(f"index {key} out of range for sequence of length {len(self)}")
+            if key < 0:
+                key += len(self)
             for block, size in enumerate(self._block_sizes):
                 if key < size:
                     return np.load(self._get_path(block))[key]

--- a/timemachine/fe/stored_arrays.py
+++ b/timemachine/fe/stored_arrays.py
@@ -1,0 +1,52 @@
+import shutil
+import tempfile
+import weakref
+from pathlib import Path
+from typing import Iterator, NoReturn, Sequence, overload
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+
+class StoredArrays(Sequence[NDArray]):
+    def __init__(self):
+        self._block_sizes = []
+        self._path = Path(tempfile.mkdtemp())
+        self._finalizer = weakref.finalize(self, shutil.rmtree, self._path)
+
+    def extend(self, xs: Sequence[ArrayLike]):
+        np.save(self._get_path(len(self._block_sizes)), np.array(xs))
+        self._block_sizes.append(len(xs))
+
+    def __iter__(self) -> Iterator[NDArray]:
+        for block, _ in enumerate(self._block_sizes):
+            for x in np.load(self._get_path(block)):
+                yield x
+
+    def __len__(self) -> int:
+        return sum(self._block_sizes)
+
+    @overload
+    def __getitem__(self, key: int) -> NDArray:
+        ...
+
+    @overload
+    def __getitem__(self, key: slice) -> NoReturn:
+        ...
+
+    def __getitem__(self, key) -> NDArray:
+        if isinstance(key, int):
+            if key < -len(self) or key >= len(self):
+                raise IndexError(f"index {key} out of range for sequence of length {len(self)}")
+            for block, size in enumerate(self._block_sizes):
+                if key < size:
+                    return np.load(self._get_path(block))[key]
+                key -= size
+            assert False, "should not get here"
+        elif isinstance(key, slice):
+            raise NotImplementedError("slices are not implemented")
+        else:
+            raise ValueError("invalid subscript")
+
+    def _get_path(self, block: int):
+        return (self._path / f"{block}").with_suffix(".npy")

--- a/timemachine/fe/stored_arrays.py
+++ b/timemachine/fe/stored_arrays.py
@@ -54,4 +54,6 @@ class StoredArrays(Sequence[NDArray]):
         return (self._path / f"{block}").with_suffix(".npy")
 
     def __eq__(self, other):
-        return len(self) == len(other) and all(np.array_equal(a, b, equal_nan=True) for a, b in zip(self, other))
+        return self._block_sizes == other._block_sizes and all(
+            np.array_equal(a, b, equal_nan=True) for a, b in zip(self, other)
+        )

--- a/timemachine/fe/stored_arrays.py
+++ b/timemachine/fe/stored_arrays.py
@@ -21,13 +21,9 @@ class StoredArrays(Sequence[NDArray]):
     >>> sa.extend([np.array([1, 2, 3]), np.array([4, 5, 6])])
     >>> len(sa)
     2
-    >>> len(list(sa._chunks()))
-    1
     >>> sa.extend([np.array([7, 8, 9])])
     >>> len(sa)
     3
-    >>> len(list(sa._chunks()))
-    2
     >>> list(sa)
     [array([1, 2, 3]), array([4, 5, 6]), array([7, 8, 9])]
     """
@@ -77,6 +73,10 @@ class StoredArrays(Sequence[NDArray]):
         )
 
     def _chunks(self) -> Iterator[List[NDArray]]:
+        """Returns an iterator over chunks.
+
+        Each chunk is a sequence of numpy arrays stored in a single .npy file
+        """
         for idx, _ in enumerate(self._chunk_sizes):
             yield np.load(self._get_chunk_path(idx))
 

--- a/timemachine/fe/stored_arrays.py
+++ b/timemachine/fe/stored_arrays.py
@@ -13,8 +13,7 @@ from timemachine.parallel.client import AbstractFileClient
 
 
 class StoredArrays(Sequence[NDArray]):
-    """
-    Sequence of numpy arrays using O(1) memory, backed by disk storage.
+    """Sequence of numpy arrays using O(1) memory, backed by disk storage.
 
     Data is stored in a temporary directory that is cleaned when the `StoredArrays` object is finalized.
 


### PR DESCRIPTION
In the current version, memory usage scales linearly with the number of frames simulated, limiting the maximum possible trajectory length for large systems to a few ns in practice. This PR aims to address the issue with the following changes:

- Introduces `max_buffer_frames` argument to `fe.rbfe.sample` (defaulting to ~1000~ `None`)
- We never store more than `max_buffer_frames` frames in memory; we split longer trajectories into chunks and write to disk
- This is done transparently using `StoredArrays`, which implements the `Sequence[NDArray]` interface but stores data in a temporary directory on disk
- This feature is disabled by default, since it will require changes downstream. A follow-up PR will enable this by default for RBFE: #957

#### TODO
- [x] Update RBFE analysis code to stream saved frames for BAR calculations (not much needed here; `StoredArrays` is a drop-in replacement for list)
- [x] ~Do we want to save all frames in the result? (this might complicate output format & downstream code)~ user is responsible for handling saving of frames; we provide an iterator over frames stored on disk
- [x] Fix unit tests
- [x] Run nightly tests ([successful pipeline run](https://gitlab.com/relaytx/physics-platform/timemachine/-/pipelines/769291768))
- [x] Merge changes from #936 
- [x] ~Compatibility with subprocess/pickling~
   - `StoredArrays` not pickleable; saving results should be handled in application code (example adaptation of `rbfe_edge_list.py` in #957)
   - Adds `StoredArrays.store`, `StoredArrays.load` accepting a `FileClient` to abstract over the storage method (currently a directory of `.npy` files; one file per chunk)