### PR TITLE
Add nightly test for rbfe_edge_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ make build  # Must have installed dev dependencies for this to work
 
 ### Running Tests
 
-Note that `PYTHONPATH` must be set to include the `timemachine` repo root. To run tests that use `openeye`, ensure that either `OE_LICENSE` or `OE_DIR` are set appropriately.
+To run tests that use `openeye`, ensure that either `OE_LICENSE` or `OE_DIR` are set appropriately.
 
 For example, starting from a clean environment with the openeye license file in `~/.openeye`:
 
 ```shell
-OE_DIR=~/.openeye PYTHONPATH=$PWD:$PYTHONPATH pytest -xsv tests/
+OE_DIR=~/.openeye pytest -xsv tests/
 ```
 
 Note: we currently only support and test on python 3.7, use other versions at your own peril.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Note that `PYTHONPATH` must be set to include the `timemachine` repo root. To ru
 For example, starting from a clean environment with the openeye license file in `~/.openeye`:
 
 ```shell
-OE_DIR=~/.openeye PYTHONPATH=. pytest -xsv tests/
+OE_DIR=~/.openeye PYTHONPATH=$PWD:$PYTHONPATH pytest -xsv tests/
 ```
 
 Note: we currently only support and test on python 3.7, use other versions at your own peril.

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -24,6 +24,7 @@ def parse_args():
     parser.add_argument("--protein", type=str, help="PDB of the protein complex", required=True)
     parser.add_argument("--n_gpus", type=int, help="number of gpus", required=True)
     parser.add_argument("--seed", type=int, help="random seed for the runs", required=True)
+    parser.add_argument("--n_windows", type=int, help="number of lambda windows", required=False)
 
     return parser.parse_args()
 
@@ -72,4 +73,5 @@ if __name__ == "__main__":
         args.n_frames,
         args.n_gpus,
         args.seed,
+        n_windows=args.n_windows,
     )

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -25,7 +25,6 @@ def parse_args():
     parser.add_argument("--n_gpus", type=int, help="number of gpus", required=True)
     parser.add_argument("--seed", type=int, help="random seed for the runs", required=True)
     parser.add_argument("--n_windows", type=int, help="number of lambda windows", required=False)
-    parser.add_argument("--n_eq_steps", type=int, help="number of steps used for equilibration", required=False)
 
     return parser.parse_args()
 
@@ -74,6 +73,5 @@ if __name__ == "__main__":
         args.n_frames,
         args.n_gpus,
         args.seed,
-        n_eq_steps=args.n_eq_steps,
         n_windows=args.n_windows,
     )

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -25,6 +25,7 @@ def parse_args():
     parser.add_argument("--n_gpus", type=int, help="number of gpus", required=True)
     parser.add_argument("--seed", type=int, help="random seed for the runs", required=True)
     parser.add_argument("--n_windows", type=int, help="number of lambda windows", required=False)
+    parser.add_argument("--n_eq_steps", type=int, help="number of steps used for equilibration", required=False)
 
     return parser.parse_args()
 
@@ -73,5 +74,6 @@ if __name__ == "__main__":
         args.n_frames,
         args.n_gpus,
         args.seed,
+        n_eq_steps=args.n_eq_steps,
         n_windows=args.n_windows,
     )

--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -24,6 +24,7 @@ def parse_args():
     parser.add_argument("--protein", type=str, help="PDB of the protein complex", required=True)
     parser.add_argument("--n_gpus", type=int, help="number of gpus", required=True)
     parser.add_argument("--seed", type=int, help="random seed for the runs", required=True)
+    parser.add_argument("--n_eq_steps", type=int, help="number of steps used for equilibration", required=False)
     parser.add_argument("--n_windows", type=int, help="number of lambda windows", required=False)
 
     return parser.parse_args()
@@ -73,5 +74,6 @@ if __name__ == "__main__":
         args.n_frames,
         args.n_gpus,
         args.seed,
+        n_eq_steps=args.n_eq_steps,
         n_windows=args.n_windows,
     )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -214,7 +214,7 @@ def test_rbfe_edge_list_hif2a(rbfe_edge_list_hif2a_path):
             N, _ = result.frames[0][0].shape
             assert N > 0
             assert all(
-                frame.ndims == 2 and frame.shape[0] == N and frame.shape[1] == 3
+                frame.ndim == 2 and frame.shape[0] == N and frame.shape[1] == 3
                 for frames in result.frames
                 for frame in frames
             )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -210,15 +210,16 @@ def test_rbfe_edge_list_hif2a(rbfe_edge_list_hif2a_path):
             assert isinstance(result, SimulationResult)
             assert isinstance(result.frames, list)
             assert len(result.frames) == 2
-            assert all(len(frames) == config["n_frames"] for frames in result.frames)
+            for frames in result.frames:
+                assert len(frames) == config["n_frames"]
 
             N, _ = result.frames[0][0].shape
             assert N > 0
-            assert all(
-                frame.ndim == 2 and frame.shape[0] == N and frame.shape[1] == 3
-                for frames in result.frames
-                for frame in frames
-            )
+
+            for frames in result.frames:
+                for frame in frames:
+                    assert frame.ndim == 2
+                    assert frame.shape == (N, 3)
 
     for mol_a_name, mol_b_name in edges:
         check_results(path / f"success_rbfe_result_{mol_a_name}_{mol_b_name}.pkl")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,10 +3,10 @@ import pickle
 import subprocess
 import sys
 from glob import glob
-from importlib import resources
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+import importlib_resources as resources
 import numpy as np
 import pytest
 from common import temporary_working_dir

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -51,15 +51,10 @@ def run_example(
     example_path = EXAMPLES_DIR / example_name
     assert example_path.is_file(), f"No such example {example_path}"
     subprocess_env = os.environ.copy()
-
-    # Without this, "." in PYTHONPATH expands to the current working directory, which may not coincide with the
-    # timemachine path if temporary_working_dir is used below
-    subprocess_env["PYTHONPATH"] = os.pathsep.join(sys.path)
-
     if env is not None:
         subprocess_env.update(env)
     subprocess_args = [sys.executable, str(example_path), *cli_args]
-    print("Running with args:", " ".join(subprocess_args))
+    print("Running with args:", "".join(subprocess_args))
     proc = subprocess.run(
         subprocess_args,
         env=subprocess_env,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -162,6 +162,7 @@ def rbfe_edge_list_hif2a_path():
             protein=hif2a_data / "5tbm_prepared.pdb",
             n_gpus=1,
             seed=2023,
+            n_eq_steps=2,
             n_windows=3,
         )
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -52,8 +52,8 @@ def run_example(
     assert example_path.is_file(), f"No such example {example_path}"
     subprocess_env = os.environ.copy()
 
-    # Without this, "." in PYTHONPATH expands to the current working directory, which may not coincide with the
-    # timemachine path if temporary_working_dir is used below
+    # Avoids potential confusion due to "." in PYTHONPATH expanding to a temporary directory path e.g. when called
+    # inside `temporary_working_dir`
     subprocess_env["PYTHONPATH"] = os.pathsep.join(sys.path)
 
     if env is not None:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -52,8 +52,8 @@ def run_example(
     assert example_path.is_file(), f"No such example {example_path}"
     subprocess_env = os.environ.copy()
 
-    # Avoids potential confusion due to "." in PYTHONPATH expanding to a temporary directory path e.g. when called
-    # inside `temporary_working_dir`
+    # Without this, "." in PYTHONPATH expands to the current working directory, which may not coincide with the
+    # timemachine path if temporary_working_dir is used below
     subprocess_env["PYTHONPATH"] = os.pathsep.join(sys.path)
 
     if env is not None:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -54,7 +54,7 @@ def run_example(
     if env is not None:
         subprocess_env.update(env)
     subprocess_args = [sys.executable, str(example_path), *cli_args]
-    print("Running with args:", "".join(subprocess_args))
+    print("Running with args:", " ".join(subprocess_args))
     proc = subprocess.run(
         subprocess_args,
         env=subprocess_env,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -162,7 +162,6 @@ def rbfe_edge_list_hif2a_path():
             protein=hif2a_data / "5tbm_prepared.pdb",
             n_gpus=1,
             seed=2023,
-            n_eq_steps=2,
             n_windows=3,
         )
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -147,7 +147,7 @@ def test_smc_freesolv(smc_free_solv_path):
 @pytest.fixture(scope="module")
 def rbfe_edge_list_hif2a_path():
     def run(results_csv, temp_dir):
-        # expect running this script to write summary_result_result_{mol_name}_*.pkl files
+        # expect running this script to write success_rbfe_result_{mol_a_name}_{mol_b_name}.pkl files
         output_path = str(Path(temp_dir) / "success_rbfe_result*.pkl")
         assert len(glob(output_path)) == 0
         config = dict(results_csv=results_csv, **base_config)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -51,10 +51,15 @@ def run_example(
     example_path = EXAMPLES_DIR / example_name
     assert example_path.is_file(), f"No such example {example_path}"
     subprocess_env = os.environ.copy()
+
+    # Without this, "." in PYTHONPATH expands to the current working directory, which may not coincide with the
+    # timemachine path if temporary_working_dir is used below
+    subprocess_env["PYTHONPATH"] = os.pathsep.join(sys.path)
+
     if env is not None:
         subprocess_env.update(env)
     subprocess_args = [sys.executable, str(example_path), *cli_args]
-    print("Running with args:", "".join(subprocess_args))
+    print("Running with args:", " ".join(subprocess_args))
     proc = subprocess.run(
         subprocess_args,
         env=subprocess_env,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,6 +3,7 @@ import pickle
 import subprocess
 import sys
 from glob import glob
+from importlib import resources
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -12,8 +13,9 @@ from common import temporary_working_dir
 from numpy.typing import NDArray as Array
 from scipy.special import logsumexp
 
-from timemachine.constants import DEFAULT_KT, KCAL_TO_KJ
+from timemachine.constants import DEFAULT_FF, DEFAULT_KT, KCAL_TO_KJ
 from timemachine.datasets import fetch_freesolv
+from timemachine.fe.free_energy import SimulationResult
 from timemachine.fe.utils import get_mol_name
 
 # All examples are to be tested nightly
@@ -140,3 +142,82 @@ def test_smc_freesolv(smc_free_solv_path):
     # * MAE of ~1.1 kcal/mol: FreeSolv reference calculations
     #   https://www.biorxiv.org/content/10.1101/104281v1.full
     assert mean_abs_err_kcalmol <= 2
+
+
+@pytest.fixture(scope="module")
+def rbfe_edge_list_hif2a_path():
+    def run(results_csv, temp_dir):
+        # expect running this script to write summary_result_result_{mol_name}_*.pkl files
+        output_path = str(Path(temp_dir) / "success_rbfe_result*.pkl")
+        assert len(glob(output_path)) == 0
+        config = dict(results_csv=results_csv, **base_config)
+        _ = run_example("rbfe_edge_list.py", get_cli_args(config), cwd=temp_dir)
+        return Path(temp_dir)
+
+    with resources.as_file(resources.files("timemachine.datasets.fep_benchmark.hif2a")) as hif2a_data:
+        base_config = dict(
+            n_frames=2,
+            ligands=hif2a_data / "ligands.sdf",
+            forcefield=DEFAULT_FF,
+            protein=hif2a_data / "5tbm_prepared.pdb",
+            n_gpus=1,
+            seed=2023,
+            n_windows=3,
+        )
+
+        with open(hif2a_data / "results_edges_5ns.csv", "r") as fp:
+            edges_rows = fp.readlines()
+
+        edges_rows_sample = edges_rows[:3]  # keep header and first 2 edges (338 -> 165, 338 -> 215)
+        edges = [("338", "165"), ("338", "215")]
+
+        with temporary_working_dir() as temp_dir:
+            with (Path(temp_dir) / "edges.csv").open("w") as fp:
+                fp.writelines(edges_rows_sample)
+                fp.flush()
+                path = run(fp.name, temp_dir)
+            yield path, base_config, edges
+
+
+def test_rbfe_edge_list_hif2a(rbfe_edge_list_hif2a_path):
+    path, config, edges = rbfe_edge_list_hif2a_path
+
+    def check_results(results_path):
+        # Just check that results are present and have the expected shape
+        # (we don't do enough sampling here for statistical checks)
+
+        # NOTE: We're mainly interested in checking that simulation frames have been serialized properly; we already
+        # have more exhaustive checks in test_relative_free_energy.py
+
+        assert results_path.exists()
+
+        with results_path.open("rb") as fp:
+            results = pickle.load(fp)
+
+        (
+            _,  # mol_a
+            _,  # mol_b
+            _,  # edge_metadata
+            _,  # core,
+            solvent_res,
+            _,  # solvent_top,
+            complex_res,
+            _,  # complex_top,
+        ) = results
+
+        for result in solvent_res, complex_res:
+            assert isinstance(result, SimulationResult)
+            assert isinstance(result.frames, list)
+            assert len(result.frames) == 2
+            assert all(len(frames) == config["n_frames"] for frames in result.frames)
+
+            N, _ = result.frames[0][0].shape
+            assert N > 0
+            assert all(
+                frame.ndims == 2 and frame.shape[0] == N and frame.shape[1] == 3
+                for frames in result.frames
+                for frame in frames
+            )
+
+    for mol_a_name, mol_b_name in edges:
+        check_results(path / f"success_rbfe_result_{mol_a_name}_{mol_b_name}.pkl")

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -682,7 +682,6 @@ def run_edge_and_save_results(
     n_frames: int,
     seed: int,
     file_client: AbstractFileClient,
-    n_eq_steps=10000,
     n_windows: Optional[int] = None,
 ):
     # Ensure that all mol props (e.g. _Name) are included in pickles
@@ -709,10 +708,10 @@ def run_edge_and_save_results(
         core = all_cores[0]
 
         complex_res, complex_top = run_complex(
-            mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_eq_steps=n_eq_steps, n_windows=n_windows
+            mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_windows=n_windows
         )
         solvent_res, solvent_top = run_solvent(
-            mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_eq_steps=n_eq_steps, n_windows=n_windows
+            mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_windows=n_windows
         )
 
     except Exception as err:
@@ -779,7 +778,6 @@ def run_edges_parallel(
     seed: int,
     pool_client: Optional[AbstractClient] = None,
     file_client: Optional[AbstractFileClient] = None,
-    n_eq_steps: Optional[int] = None,
     n_windows: Optional[int] = None,
 ):
     mols = {get_mol_name(mol): mol for mol in ligands}
@@ -803,7 +801,6 @@ def run_edges_parallel(
             n_frames,
             seed + edge_idx,
             file_client,
-            n_eq_steps,
             n_windows,
         )
         for edge_idx, edge in enumerate(edges)

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -607,7 +607,7 @@ def run_solvent(
     _,
     n_frames,
     seed,
-    n_eq_steps=10000,
+    n_eq_steps=None,
     steps_per_frame=400,
     n_windows=None,
     min_cutoff=0.7,
@@ -625,7 +625,7 @@ def run_solvent(
         seed,
         n_frames=n_frames,
         prefix="solvent",
-        n_eq_steps=n_eq_steps,
+        n_eq_steps=n_eq_steps or 10000,
         n_windows=n_windows,
         steps_per_frame=steps_per_frame,
         min_cutoff=min_cutoff,
@@ -641,7 +641,7 @@ def run_complex(
     protein,
     n_frames,
     seed,
-    n_eq_steps=10000,
+    n_eq_steps=None,
     steps_per_frame=400,
     n_windows=None,
     min_cutoff=0.7,
@@ -660,7 +660,7 @@ def run_complex(
         seed,
         n_frames=n_frames,
         prefix="complex",
-        n_eq_steps=n_eq_steps,
+        n_eq_steps=n_eq_steps or 10000,
         n_windows=n_windows,
         steps_per_frame=steps_per_frame,
         min_cutoff=min_cutoff,
@@ -682,7 +682,8 @@ def run_edge_and_save_results(
     n_frames: int,
     seed: int,
     file_client: AbstractFileClient,
-    n_windows: Optional[int] = None,
+    n_eq_steps: Optional[int],
+    n_windows: Optional[int],
 ):
     # Ensure that all mol props (e.g. _Name) are included in pickles
     # Without this get_mol_name(mol) will fail on roundtripped mol
@@ -708,10 +709,10 @@ def run_edge_and_save_results(
         core = all_cores[0]
 
         complex_res, complex_top = run_complex(
-            mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_windows=n_windows
+            mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_eq_steps=n_eq_steps, n_windows=n_windows
         )
         solvent_res, solvent_top = run_solvent(
-            mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_windows=n_windows
+            mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_eq_steps=n_eq_steps, n_windows=n_windows
         )
 
     except Exception as err:
@@ -778,6 +779,7 @@ def run_edges_parallel(
     seed: int,
     pool_client: Optional[AbstractClient] = None,
     file_client: Optional[AbstractFileClient] = None,
+    n_eq_steps: Optional[int] = None,
     n_windows: Optional[int] = None,
 ):
     mols = {get_mol_name(mol): mol for mol in ligands}
@@ -801,6 +803,7 @@ def run_edges_parallel(
             n_frames,
             seed + edge_idx,
             file_client,
+            n_eq_steps,
             n_windows,
         )
         for edge_idx, edge in enumerate(edges)

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -682,6 +682,7 @@ def run_edge_and_save_results(
     n_frames: int,
     seed: int,
     file_client: AbstractFileClient,
+    n_windows: Optional[int] = None,
 ):
     # Ensure that all mol props (e.g. _Name) are included in pickles
     # Without this get_mol_name(mol) will fail on roundtripped mol
@@ -706,8 +707,12 @@ def run_edge_and_save_results(
         )
         core = all_cores[0]
 
-        complex_res, complex_top = run_complex(mol_a, mol_b, core, forcefield, protein, n_frames, seed)
-        solvent_res, solvent_top = run_solvent(mol_a, mol_b, core, forcefield, protein, n_frames, seed)
+        complex_res, complex_top = run_complex(
+            mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_windows=n_windows
+        )
+        solvent_res, solvent_top = run_solvent(
+            mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_windows=n_windows
+        )
 
     except Exception as err:
         print(
@@ -773,6 +778,7 @@ def run_edges_parallel(
     seed: int,
     pool_client: Optional[AbstractClient] = None,
     file_client: Optional[AbstractFileClient] = None,
+    n_windows: Optional[int] = None,
 ):
     mols = {get_mol_name(mol): mol for mol in ligands}
 
@@ -795,6 +801,7 @@ def run_edges_parallel(
             n_frames,
             seed + edge_idx,
             file_client,
+            n_windows,
         )
         for edge_idx, edge in enumerate(edges)
     ]

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -682,6 +682,7 @@ def run_edge_and_save_results(
     n_frames: int,
     seed: int,
     file_client: AbstractFileClient,
+    n_eq_steps=10000,
     n_windows: Optional[int] = None,
 ):
     # Ensure that all mol props (e.g. _Name) are included in pickles
@@ -708,10 +709,10 @@ def run_edge_and_save_results(
         core = all_cores[0]
 
         complex_res, complex_top = run_complex(
-            mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_windows=n_windows
+            mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_eq_steps=n_eq_steps, n_windows=n_windows
         )
         solvent_res, solvent_top = run_solvent(
-            mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_windows=n_windows
+            mol_a, mol_b, core, forcefield, protein, n_frames, seed, n_eq_steps=n_eq_steps, n_windows=n_windows
         )
 
     except Exception as err:
@@ -778,6 +779,7 @@ def run_edges_parallel(
     seed: int,
     pool_client: Optional[AbstractClient] = None,
     file_client: Optional[AbstractFileClient] = None,
+    n_eq_steps: Optional[int] = None,
     n_windows: Optional[int] = None,
 ):
     mols = {get_mol_name(mol): mol for mol in ligands}
@@ -801,6 +803,7 @@ def run_edges_parallel(
             n_frames,
             seed + edge_idx,
             file_client,
+            n_eq_steps,
             n_windows,
         )
         for edge_idx, edge in enumerate(edges)


### PR DESCRIPTION
While working on #950, I realized it would be useful to have a test that exercises running RBFE in a subprocess to catch potential issues with serialization of `SimulationResult`s. This PR

- Adds a (minimal) test for `examples/rbfe_edge_list.py` that checks that the script runs and that frames are accessible in the result pickle
- ~Fixes an issue where `.` in `PYTHONPATH` could be expanded to a directory other than the timemachine source directory (when using `with temporary_working_dir:`)~ don't handle relative paths in `PYTHONPATH` (user should know better :stuck_out_tongue:), update readme example

#### TODO
- [ ] Pass [nightly test pipeline](https://gitlab.com/relaytx/physics-platform/timemachine/-/pipelines/771811950)