### PR TITLE
Fixes for NB potentials

### DIFF
--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -366,6 +366,7 @@ def test_combine_with_host():
 @pytest.mark.parametrize("use_tiny_mol", [True, False])
 def test_nonbonded_split(precision, rtol, atol, use_tiny_mol):
 
+    # mol with no intramolecular NB terms and no dihedrals
     if use_tiny_mol:
         mol_a = ligand_from_smiles("S")
         mol_b = ligand_from_smiles("O")

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -363,11 +363,17 @@ def test_combine_with_host():
 
 
 @pytest.mark.parametrize("precision, rtol, atol", [(np.float64, 1e-8, 1e-8), (np.float32, 1e-4, 5e-4)])
-def test_nonbonded_split(precision, rtol, atol):
-    with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
-        mols = {get_mol_name(mol): mol for mol in read_sdf(path_to_ligand)}
-    mol_a = mols["338"]
-    mol_b = mols["43"]
+@pytest.mark.parametrize("use_tiny_mol", [True, False])
+def test_nonbonded_split(precision, rtol, atol, use_tiny_mol):
+
+    if use_tiny_mol:
+        mol_a = ligand_from_smiles("S")
+        mol_b = ligand_from_smiles("O")
+    else:
+        with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
+            mols = {get_mol_name(mol): mol for mol in read_sdf(path_to_ligand)}
+        mol_a = mols["338"]
+        mol_b = mols["43"]
     core = _get_core_by_mcs(mol_a, mol_b)
 
     # split forcefield has different parameters for intramol and intermol terms

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -117,6 +117,7 @@ def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
     with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
         mols_by_name = {get_mol_name(mol): mol for mol in read_sdf(path_to_ligand)}
 
+    # mol with no intramolecular NB terms and no dihedrals
     if use_tiny_mol:
         mol_h2s = Chem.AddHs(Chem.MolFromSmiles("S"))
         AllChem.EmbedMolecule(mol_h2s, randomSeed=2023)

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -175,21 +175,9 @@ class VacuumSystem:
         return U_fn
 
     def get_U_fns(self):
-
         # For molecules too small for to have certain terms,
         # skip when no params are present
-        all_U_fns = []
-
-        def append_if_params(pot):
-            if len(pot.params) > 0:
-                all_U_fns.append(pot)
-
-        append_if_params(self.bond)
-        append_if_params(self.angle)
-        append_if_params(self.torsion)
-        append_if_params(self.nonbonded)
-
-        return all_U_fns
+        return [p for p in [self.bond, self.angle, self.torsion, self.nonbonded] if len(p.params) > 0]
 
 
 class HostGuestSystem:

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -176,12 +176,20 @@ class VacuumSystem:
 
     def get_U_fns(self):
 
-        return [
-            self.bond,
-            self.angle,
-            self.torsion,
-            self.nonbonded,
-        ]
+        # For molecules too small for to have certain terms,
+        # skip when no params are present
+        all_U_fns = []
+
+        def append_if_params(pot):
+            if len(pot.params) > 0:
+                all_U_fns.append(pot)
+
+        append_if_params(self.bond)
+        append_if_params(self.angle)
+        append_if_params(self.torsion)
+        append_if_params(self.nonbonded)
+
+        return all_U_fns
 
 
 class HostGuestSystem:


### PR DESCRIPTION
- For molecules with < 4 atoms, the split NB code would fail
- Update the topology classes to handle this corner case and add to tests
- Also update VacuumSystem to be able to run on molecules < 4 atoms
- Also fix DualTopology.parameterize_nonbonded_pairlist() - was using beta instead of cutoff in NonbondedPairListPrecomputed
-- Unclear what the full scope of this issue is
-- potentially affects minimizer.minimize_host_4d and align.align_mols_by_core