### PR TITLE
Rename SimulationProtocol -> MDParams

### DIFF
--- a/tests/test_fe_absolute_hydration.py
+++ b/tests/test_fe_absolute_hydration.py
@@ -26,8 +26,8 @@ def test_run_solvent():
     assert len(res.frames[-1]) == n_frames
     assert len(res.boxes[0]) == n_frames
     assert len(res.boxes[-1]) == n_frames
-    assert res.protocol.n_frames == n_frames
-    assert res.protocol.n_eq_steps == n_eq_steps
+    assert res.md_params.n_frames == n_frames
+    assert res.md_params.n_eq_steps == n_eq_steps
     assert host_config.omm_system is not None
     assert host_config.conf.shape == (6282, 3)
     assert host_config.box.shape == (3, 3)

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -10,13 +10,7 @@ from simtk.openmm import app
 
 from timemachine.constants import BOLTZ, DEFAULT_FF, DEFAULT_TEMP
 from timemachine.fe import functional, model_utils
-from timemachine.fe.free_energy import (
-    AbsoluteFreeEnergy,
-    HostConfig,
-    InitialState,
-    SimulationProtocol,
-    SimulationResult,
-)
+from timemachine.fe.free_energy import AbsoluteFreeEnergy, HostConfig, InitialState, MDParams, SimulationResult
 from timemachine.fe.lambda_schedule import construct_pre_optimized_absolute_lambda_schedule_solvent
 from timemachine.fe.rbfe import estimate_free_energy_given_initial_states
 from timemachine.fe.topology import BaseTopology
@@ -234,7 +228,7 @@ def estimate_absolute_free_energy(
 
     temperature = DEFAULT_TEMP
     initial_states = setup_initial_states(afe, ff, host_config, temperature, lambda_schedule, seed)
-    protocol = SimulationProtocol(n_frames=n_frames, n_eq_steps=n_eq_steps, steps_per_frame=steps_per_frame)
+    md_params = MDParams(n_frames=n_frames, n_eq_steps=n_eq_steps, steps_per_frame=steps_per_frame)
 
     if keep_idxs is None:
         keep_idxs = [0, len(initial_states) - 1]  # keep first and last windows
@@ -243,11 +237,11 @@ def estimate_absolute_free_energy(
     combined_prefix = get_mol_name(mol) + "_" + prefix
     try:
         return estimate_free_energy_given_initial_states(
-            initial_states, protocol, temperature, combined_prefix, keep_idxs
+            initial_states, md_params, temperature, combined_prefix, keep_idxs
         )
     except Exception as err:
         with open(f"failed_ahfe_result_{combined_prefix}.pkl", "wb") as fh:
-            pickle.dump((initial_states, protocol, err), fh)
+            pickle.dump((initial_states, md_params, err), fh)
         raise err
 
 


### PR DESCRIPTION
Rationale:
- "Protocol" is an overloaded term and we generally use it to refer to the spacing of lambda windows / set of intermediate states
- As we move to introduce new methods of generating intermediate states (e.g. bisection), we might want to reserve `protocol` to mean the latter to avoid confusion