### PR TITLE
Update SimulationResult to allow storing intermediate BAR results

### DIFF
--- a/tests/test_fe_absolute_hydration.py
+++ b/tests/test_fe_absolute_hydration.py
@@ -17,9 +17,9 @@ def test_run_solvent():
         mol, ff, None, n_frames, seed, n_eq_steps=n_eq_steps, n_windows=n_windows
     )
 
-    assert res.overlap_summary_png is not None
-    assert res.overlap_detail_png is not None
-    assert np.linalg.norm(res.all_errs) < 10
+    assert res.plots.overlap_summary_png is not None
+    assert res.plots.overlap_detail_png is not None
+    assert np.linalg.norm(res.result.all_errs) < 10
     assert len(res.frames) == 2
     assert len(res.boxes) == 2
     assert len(res.frames[0]) == n_frames

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -1,12 +1,13 @@
 # test that we can run relative free energy simulations in complex and in solvent
 # this doesn't test for accuracy, just that everything mechanically runs.
 from importlib import resources
+from typing import Sequence
 
 import numpy as np
 import pytest
 
 from timemachine.constants import DEFAULT_FF
-from timemachine.fe.free_energy import HostConfig, PairBarResult, SimulationResult, image_frames, sample
+from timemachine.fe.free_energy import HostConfig, InitialState, PairBarResult, SimulationResult, image_frames, sample
 from timemachine.fe.rbfe import estimate_relative_free_energy, run_solvent, run_vacuum
 from timemachine.ff import Forcefield
 from timemachine.md import builders
@@ -38,7 +39,7 @@ def run_bitwise_reproducibility(mol_a, mol_b, core, forcefield, n_frames):
     )
 
     all_frames, all_boxes = [], []
-    for state in solvent_res.results[-1].initial_states:
+    for state in solvent_res.initial_states:
         frames, boxes = sample(state, solvent_res.md_params)
         all_frames.append(frames)
         all_boxes.append(boxes)
@@ -51,39 +52,40 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
 
     seed = 2023
 
-    def check_sim_result(sim: SimulationResult):
+    def check_sim_result(sim_res: SimulationResult):
+        assert [x.lamb for x in sim_res.initial_states] == lambda_schedule
 
-        assert sim.plots.dG_errs_png is not None
-        assert sim.plots.overlap_summary_png is not None
-        assert sim.plots.overlap_detail_png is not None
+        assert sim_res.plots.dG_errs_png is not None
+        assert sim_res.plots.overlap_summary_png is not None
+        assert sim_res.plots.overlap_detail_png is not None
 
-        assert len(sim.frames[0]) == n_frames
-        assert len(sim.frames[-1]) == n_frames
-        assert len(sim.boxes[0]) == n_frames
-        assert len(sim.boxes[-1]) == n_frames
-        assert sim.md_params.n_frames == n_frames
-        assert sim.md_params.n_eq_steps == n_eq_steps
+        assert len(sim_res.frames[0]) == n_frames
+        assert len(sim_res.frames[-1]) == n_frames
+        assert len(sim_res.boxes[0]) == n_frames
+        assert len(sim_res.boxes[-1]) == n_frames
+        assert sim_res.md_params.n_frames == n_frames
+        assert sim_res.md_params.n_eq_steps == n_eq_steps
 
-        def check_pair_bar_result(bar: PairBarResult):
-            n_pairs = len(lambda_schedule) - 1
-            assert len(bar.all_dGs) == n_pairs
+        def check_pair_bar_result(initial_states: Sequence[InitialState], bar_res: PairBarResult):
+            n_pairs = len(initial_states) - 1
+            assert len(bar_res.all_dGs) == n_pairs
 
-            assert len(bar.all_errs) == n_pairs
-            assert bar.dG_errs_by_lambda_by_component.shape[1] == n_pairs
-            for dg_errs in [bar.all_errs, bar.dG_errs_by_lambda_by_component]:
+            assert len(bar_res.all_errs) == n_pairs
+            assert bar_res.dG_errs_by_lambda_by_component.shape[1] == n_pairs
+            for dg_errs in [bar_res.all_errs, bar_res.dG_errs_by_lambda_by_component]:
                 assert np.all(0.0 < np.asarray(dg_errs))
                 assert np.linalg.norm(dg_errs) < 0.1
 
-            assert len(bar.overlaps_by_lambda) == n_pairs
-            assert bar.overlaps_by_lambda_by_component.shape[0] == bar.dG_errs_by_lambda_by_component.shape[0]
-            assert bar.overlaps_by_lambda_by_component.shape[1] == n_pairs
-            for overlaps in [bar.overlaps_by_lambda, bar.overlaps_by_lambda_by_component]:
+            assert len(bar_res.overlaps_by_lambda) == n_pairs
+            assert bar_res.overlaps_by_lambda_by_component.shape[0] == bar_res.dG_errs_by_lambda_by_component.shape[0]
+            assert bar_res.overlaps_by_lambda_by_component.shape[1] == n_pairs
+            for overlaps in [bar_res.overlaps_by_lambda, bar_res.overlaps_by_lambda_by_component]:
                 assert np.all(0.0 < np.asarray(overlaps))
                 assert np.all(np.asarray(overlaps) < 1.0)
-            assert [x.lamb for x in bar.initial_states] == lambda_schedule
 
-        for r in sim.results:
-            check_pair_bar_result(r)
+        check_pair_bar_result(sim_res.initial_states, sim_res.result)
+        for initial_states, res in sim_res.intermediate_results:
+            check_pair_bar_result(initial_states, res)
 
     lambda_schedule = [0.01, 0.02, 0.03]
     vacuum_host_config = None
@@ -197,13 +199,13 @@ def test_imaging_frames():
         steps_per_frame=steps_per_frame,
         n_windows=windows,
     )
-    keep_idxs = [0, len(res.results[-1].initial_states) - 1]
+    keep_idxs = [0, len(res.initial_states) - 1]
     assert len(keep_idxs) == len(res.frames)
 
     # A buffer, as imaging doesn't ensure everything is perfectly in the box
     padding = 0.3
     for i, (frames, boxes) in enumerate(zip(res.frames, res.boxes)):
-        initial_state = res.results[-1].initial_states[keep_idxs[i]]
+        initial_state = res.initial_states[keep_idxs[i]]
         box_center = compute_box_center(boxes[0])
         box_extents = np.max(boxes, axis=(0, 1))
 

--- a/timemachine/constants.py
+++ b/timemachine/constants.py
@@ -7,7 +7,7 @@ VIBRATIONAL_CONSTANT = 1302.79  # http://openmopac.net/manual/Hessian_Matrix.htm
 BAR_TO_KJ_PER_NM3 = 1e-25  # kJ/nm^3
 
 DEFAULT_FF = "smirnoff_2_0_0_ccc.py"
-DEFAULT_TEMP = 300  # kelvin
+DEFAULT_TEMP = 300.0  # kelvin
 DEFAULT_PRESSURE = 1.013  # bar
 DEFAULT_KT = BOLTZ * DEFAULT_TEMP  # kJ/mol
 

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -17,6 +17,7 @@ from timemachine.fe.free_energy import (
     MDParams,
     SimulationResult,
     estimate_free_energy_pair_bar,
+    make_pair_bar_plots,
     run_sequential_sims_given_initial_states,
 )
 from timemachine.fe.lambda_schedule import construct_pre_optimized_absolute_lambda_schedule_solvent
@@ -246,15 +247,14 @@ def estimate_absolute_free_energy(
         u_kln_by_component_by_lambda, stored_frames, stored_boxes = run_sequential_sims_given_initial_states(
             initial_states, md_params, temperature, keep_idxs
         )
-        return estimate_free_energy_pair_bar(
-            u_kln_by_component_by_lambda,
-            stored_frames,
-            stored_boxes,
+        pair_bar_result = estimate_free_energy_pair_bar(
             initial_states,
-            md_params,
+            u_kln_by_component_by_lambda,
             temperature,
             combined_prefix,
         )
+        plots = make_pair_bar_plots(pair_bar_result, temperature, combined_prefix)
+        return SimulationResult([pair_bar_result], plots, stored_frames, stored_boxes, md_params)
     except Exception as err:
         with open(f"failed_ahfe_result_{combined_prefix}.pkl", "wb") as fh:
             pickle.dump((initial_states, md_params, err), fh)

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -247,14 +247,9 @@ def estimate_absolute_free_energy(
         u_kln_by_component_by_lambda, stored_frames, stored_boxes = run_sequential_sims_given_initial_states(
             initial_states, md_params, temperature, keep_idxs
         )
-        pair_bar_result = estimate_free_energy_pair_bar(
-            initial_states,
-            u_kln_by_component_by_lambda,
-            temperature,
-            combined_prefix,
-        )
-        plots = make_pair_bar_plots(pair_bar_result, temperature, combined_prefix)
-        return SimulationResult([pair_bar_result], plots, stored_frames, stored_boxes, md_params)
+        pair_bar_result = estimate_free_energy_pair_bar(u_kln_by_component_by_lambda, temperature, combined_prefix)
+        plots = make_pair_bar_plots(initial_states, pair_bar_result, temperature, combined_prefix)
+        return SimulationResult(initial_states, pair_bar_result, plots, stored_frames, stored_boxes, md_params, [])
     except Exception as err:
         with open(f"failed_ahfe_result_{combined_prefix}.pkl", "wb") as fh:
             pickle.dump((initial_states, md_params, err), fh)

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -254,7 +254,7 @@ def estimate_absolute_free_energy(
             combined_prefix,
         )
         plots = make_pair_bar_plots(pair_bar_result, temperature, combined_prefix)
-        return SimulationResult([pair_bar_result], plots, stored_frames, stored_boxes, initial_states, md_params)
+        return SimulationResult([pair_bar_result], plots, stored_frames, stored_boxes, md_params)
     except Exception as err:
         with open(f"failed_ahfe_result_{combined_prefix}.pkl", "wb") as fh:
             pickle.dump((initial_states, md_params, err), fh)

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -254,7 +254,7 @@ def estimate_absolute_free_energy(
             combined_prefix,
         )
         plots = make_pair_bar_plots(pair_bar_result, temperature, combined_prefix)
-        return SimulationResult([pair_bar_result], plots, stored_frames, stored_boxes, md_params)
+        return SimulationResult([pair_bar_result], plots, stored_frames, stored_boxes, initial_states, md_params)
     except Exception as err:
         with open(f"failed_ahfe_result_{combined_prefix}.pkl", "wb") as fh:
             pickle.dump((initial_states, md_params, err), fh)

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -16,7 +16,8 @@ from timemachine.fe.free_energy import (
     InitialState,
     MDParams,
     SimulationResult,
-    estimate_free_energy_given_initial_states,
+    estimate_free_energy_pair_bar,
+    run_sequential_sims_given_initial_states,
 )
 from timemachine.fe.lambda_schedule import construct_pre_optimized_absolute_lambda_schedule_solvent
 from timemachine.fe.topology import BaseTopology
@@ -242,8 +243,17 @@ def estimate_absolute_free_energy(
 
     combined_prefix = get_mol_name(mol) + "_" + prefix
     try:
-        return estimate_free_energy_given_initial_states(
-            initial_states, md_params, temperature, combined_prefix, keep_idxs
+        u_kln_by_component_by_lambda, stored_frames, stored_boxes = run_sequential_sims_given_initial_states(
+            initial_states, md_params, temperature, keep_idxs
+        )
+        return estimate_free_energy_pair_bar(
+            u_kln_by_component_by_lambda,
+            stored_frames,
+            stored_boxes,
+            initial_states,
+            md_params,
+            temperature,
+            combined_prefix,
         )
     except Exception as err:
         with open(f"failed_ahfe_result_{combined_prefix}.pkl", "wb") as fh:

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -249,7 +249,15 @@ def estimate_absolute_free_energy(
         )
         pair_bar_result = estimate_free_energy_pair_bar(u_kln_by_component_by_lambda, temperature, combined_prefix)
         plots = make_pair_bar_plots(initial_states, pair_bar_result, temperature, combined_prefix)
-        return SimulationResult(initial_states, pair_bar_result, plots, stored_frames, stored_boxes, md_params, [])
+        return SimulationResult(
+            initial_states,
+            pair_bar_result,
+            plots,
+            stored_frames,
+            stored_boxes,
+            md_params,
+            [(initial_states, pair_bar_result)],
+        )
     except Exception as err:
         with open(f"failed_ahfe_result_{combined_prefix}.pkl", "wb") as fh:
             pickle.dump((initial_states, md_params, err), fh)

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -74,7 +74,6 @@ class SimulationResult:
     plots: PairBarPlots
     frames: List[NDArray]  # (len(keep_idxs), n_frames, N, 3)
     boxes: List[NDArray]
-    initial_states: List[InitialState]
     md_params: MDParams
 
 

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -422,6 +422,7 @@ def make_pair_bar_plots(
         U_names,
         result.all_dGs,
         result.all_errs,
+        # u_kln_by_lambda_by_component -> u_kln_by_component_by_lambda
         result.u_kln_by_lambda_by_component.swapaxes(0, 1),
         temperature,
         prefix,

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -331,9 +331,7 @@ def sample(initial_state: InitialState, md_params: MDParams, max_buffer_frames: 
 
 
 def estimate_free_energy_pair_bar(
-    u_kln_by_component_by_lambda: NDArray,
-    temperature: float,
-    prefix: str,
+    u_kln_by_component_by_lambda: NDArray, temperature: float, prefix: str
 ) -> PairBarResult:
     """
     Estimate free energies given pre-generated samples. This implements the pair-BAR method, where

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -318,12 +318,14 @@ def sample(initial_state: InitialState, md_params: MDParams, max_buffer_frames: 
     return all_coords, all_boxes
 
 
-def estimate_free_energy_given_initial_states(
+def estimate_free_energy_pair_bar(
+    u_kln_by_component_by_lambda: NDArray,
+    stored_frames: List[NDArray],
+    stored_boxes: List[NDArray],
     initial_states: List[InitialState],
     md_params: MDParams,
     temperature: float,
     prefix: str,
-    keep_idxs: List[int],
 ) -> SimulationResult:
     """
     Estimate free energies given pre-generated samples. This implements the pair-BAR method, where
@@ -358,11 +360,6 @@ def estimate_free_energy_given_initial_states(
         object containing results of the simulation
 
     """
-
-    # run n_lambdas simulations in sequence
-    u_kln_by_component_by_lambda, stored_frames, stored_boxes = run_sequential_sims_given_initial_states(
-        initial_states, md_params, temperature, keep_idxs
-    )
 
     # "pair BAR" free energy analysis
     kBT = BOLTZ * temperature

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -385,7 +385,15 @@ def estimate_relative_free_energy(
         )
         pair_bar_result = estimate_free_energy_pair_bar(u_kln_by_component_by_lambda, temperature, combined_prefix)
         plots = make_pair_bar_plots(initial_states, pair_bar_result, temperature, combined_prefix)
-        return SimulationResult(initial_states, pair_bar_result, plots, stored_frames, stored_boxes, md_params, [])
+        return SimulationResult(
+            initial_states,
+            pair_bar_result,
+            plots,
+            stored_frames,
+            stored_boxes,
+            md_params,
+            [(initial_states, pair_bar_result)],
+        )
     except Exception as err:
         with open(f"failed_rbfe_result_{combined_prefix}.pkl", "wb") as fh:
             pickle.dump((initial_states, md_params, err), fh)

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -9,7 +9,13 @@ from simtk.openmm import app
 
 from timemachine.constants import DEFAULT_PRESSURE, DEFAULT_TEMP
 from timemachine.fe import atom_mapping, model_utils
-from timemachine.fe.free_energy import HostConfig, InitialState, MDParams, estimate_free_energy_given_initial_states
+from timemachine.fe.free_energy import (
+    HostConfig,
+    InitialState,
+    MDParams,
+    estimate_free_energy_pair_bar,
+    run_sequential_sims_given_initial_states,
+)
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.system import convert_omm_system
 from timemachine.fe.utils import get_mol_name, get_romol_conf
@@ -372,8 +378,17 @@ def estimate_relative_free_energy(
     # TODO: rename prefix to postfix, or move to beginning of combined_prefix?
     combined_prefix = get_mol_name(mol_a) + "_" + get_mol_name(mol_b) + "_" + prefix
     try:
-        sim_result = estimate_free_energy_given_initial_states(
-            initial_states, md_params, temperature, combined_prefix, keep_idxs
+        u_kln_by_component_by_lambda, stored_frames, stored_boxes = run_sequential_sims_given_initial_states(
+            initial_states, md_params, temperature, keep_idxs
+        )
+        sim_result = estimate_free_energy_pair_bar(
+            u_kln_by_component_by_lambda,
+            stored_frames,
+            stored_boxes,
+            initial_states,
+            md_params,
+            temperature,
+            combined_prefix,
         )
         return sim_result
     except Exception as err:

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -383,14 +383,9 @@ def estimate_relative_free_energy(
         u_kln_by_component_by_lambda, stored_frames, stored_boxes = run_sequential_sims_given_initial_states(
             initial_states, md_params, temperature, keep_idxs
         )
-        pair_bar_result = estimate_free_energy_pair_bar(
-            initial_states,
-            u_kln_by_component_by_lambda,
-            temperature,
-            combined_prefix,
-        )
-        plots = make_pair_bar_plots(pair_bar_result, temperature, combined_prefix)
-        return SimulationResult([pair_bar_result], plots, stored_frames, stored_boxes, md_params)
+        pair_bar_result = estimate_free_energy_pair_bar(u_kln_by_component_by_lambda, temperature, combined_prefix)
+        plots = make_pair_bar_plots(initial_states, pair_bar_result, temperature, combined_prefix)
+        return SimulationResult(initial_states, pair_bar_result, plots, stored_frames, stored_boxes, md_params, [])
     except Exception as err:
         with open(f"failed_rbfe_result_{combined_prefix}.pkl", "wb") as fh:
             pickle.dump((initial_states, md_params, err), fh)

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -13,7 +13,9 @@ from timemachine.fe.free_energy import (
     HostConfig,
     InitialState,
     MDParams,
+    SimulationResult,
     estimate_free_energy_pair_bar,
+    make_pair_bar_plots,
     run_sequential_sims_given_initial_states,
 )
 from timemachine.fe.single_topology import SingleTopology
@@ -381,16 +383,14 @@ def estimate_relative_free_energy(
         u_kln_by_component_by_lambda, stored_frames, stored_boxes = run_sequential_sims_given_initial_states(
             initial_states, md_params, temperature, keep_idxs
         )
-        sim_result = estimate_free_energy_pair_bar(
-            u_kln_by_component_by_lambda,
-            stored_frames,
-            stored_boxes,
+        pair_bar_result = estimate_free_energy_pair_bar(
             initial_states,
-            md_params,
+            u_kln_by_component_by_lambda,
             temperature,
             combined_prefix,
         )
-        return sim_result
+        plots = make_pair_bar_plots(pair_bar_result, temperature, combined_prefix)
+        return SimulationResult([pair_bar_result], plots, stored_frames, stored_boxes, md_params)
     except Exception as err:
         with open(f"failed_rbfe_result_{combined_prefix}.pkl", "wb") as fh:
             pickle.dump((initial_states, md_params, err), fh)


### PR DESCRIPTION
Spun out of work on greedy bisection.

* Decouples code for running simulations, estimating free energy, and plotting
* Introduces `PairBarResult` dataclass to store results of pair BAR
* Updates `SimulationResult` with an additional field,

   ```python
   intermediate_results: List[Tuple[List[InitialState], PairBarResult]]
   ```

   This is useful for storing BAR $\Delta G$ and overlap estimates for each iteration of bisection, for example
* Minor refactor of `run_sequential_sims_given_initial_states` to simplify type annotations