### PR TITLE
Fix performance regression in single topology conformation optimization

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -279,7 +279,8 @@ def prepare_hif2a_initial_state(st, host_system, host_coords, host_box):
     host_config = rbfe.HostConfig(host_system, host_coords, host_box)
     temperature = 300.0
     lamb = 0.1
-    initial_state = rbfe.setup_initial_states(st, host_config, temperature, [lamb], seed=2022)[0]
+    host = rbfe.setup_optimized_host(st, host_config)
+    initial_state = rbfe.setup_initial_states(st, host, temperature, [lamb], seed=2022)[0]
     bound_impls = [p.bound_impl(np.float32) for p in initial_state.potentials]
     val_and_grad_fn = minimizer.get_val_and_grad_fn(bound_impls, initial_state.box0)
     assert np.all(np.isfinite(initial_state.x0)), "Initial coordinates contain nan or inf"

--- a/tests/test_reference_velocity_verlet_integrator.py
+++ b/tests/test_reference_velocity_verlet_integrator.py
@@ -113,8 +113,8 @@ def test_reversibility_with_custom_ops_potentials():
     rfe = SingleTopology(mol_a, mol_b, core, forcefield)
     masses = np.array(rfe.combine_masses())
     coords = rfe.combine_confs(get_romol_conf(mol_a), get_romol_conf(mol_b))
-    host_config = None  # vacuum
-    initial_states = setup_initial_states(rfe, host_config, temperature, [lamb], seed)
+    host = None  # vacuum
+    initial_states = setup_initial_states(rfe, host, temperature, [lamb], seed)
     unbound_potentials = initial_states[0].potentials
     bound_potentials = [pot.bound_impl(precision=np.float32) for pot in unbound_potentials]
     box = 100 * np.eye(3)

--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -4,7 +4,7 @@ import pytest
 from timemachine.constants import DEFAULT_FF, DEFAULT_TEMP
 from timemachine.fe import atom_mapping, pdb_writer, utils
 from timemachine.fe.lambda_schedule import construct_pre_optimized_relative_lambda_schedule
-from timemachine.fe.rbfe import HostConfig, setup_initial_states
+from timemachine.fe.rbfe import HostConfig, setup_initial_states, setup_optimized_host
 from timemachine.fe.single_topology import AtomMapMixin, SingleTopology
 from timemachine.fe.utils import get_mol_name, read_sdf
 from timemachine.ff import Forcefield
@@ -60,7 +60,8 @@ def run_edge(mol_a, mol_b, protein_path, n_windows):
     solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(box_width, ff.water_ff)
     solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box)
-    initial_states = setup_initial_states(st, solvent_host_config, DEFAULT_TEMP, lambda_schedule, seed)
+    solvent_host = setup_optimized_host(st, solvent_host_config)
+    initial_states = setup_initial_states(st, solvent_host, DEFAULT_TEMP, lambda_schedule, seed)
     all_frames = [state.x0 for state in initial_states]
     write_trajectory_as_pdb(
         mol_a,
@@ -77,7 +78,8 @@ def run_edge(mol_a, mol_b, protein_path, n_windows):
     )
     complex_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     complex_host_config = HostConfig(complex_sys, complex_conf, complex_box)
-    initial_states = setup_initial_states(st, complex_host_config, DEFAULT_TEMP, lambda_schedule, seed)
+    complex_host = setup_optimized_host(st, complex_host_config)
+    initial_states = setup_initial_states(st, complex_host, DEFAULT_TEMP, lambda_schedule, seed)
 
     all_frames = [state.x0 for state in initial_states]
     write_trajectory_as_pdb(

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -189,7 +189,7 @@ def setup_initial_states(
         A single topology object
 
     host: Host or None
-        Pre-optimized host configuration. If None, then a vacuum state will be setup.
+        Pre-optimized host configuration, generated using `setup_optimized_host`. If None, return vacuum states.
 
     temperature: float
         Temperature to run the simulation at.

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -1,5 +1,6 @@
 import pickle
 import traceback
+from dataclasses import dataclass
 from functools import partial
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Sequence, Tuple, Union
 
@@ -98,10 +99,18 @@ def assert_all_states_have_same_masses(initial_states: List[InitialState]):
     np.testing.assert_array_almost_equal(deviation_among_windows, 0, err_msg="masses assumed constant w.r.t. lambda")
 
 
+@dataclass
+class Host:
+    system: VacuumSystem
+    masses: List[float]
+    conf: NDArray
+    box: NDArray
+
+
 def setup_initial_state(
     st: SingleTopology,
     lamb: float,
-    host_config: Optional[HostConfig],
+    host: Optional[Host],
     temperature: float,
     seed: int,
 ) -> InitialState:
@@ -115,19 +124,11 @@ def setup_initial_state(
     # A -> B vs. B -> A edge definitions
     init_seed = int(seed + hash(ligand_conf.tobytes())) % 10000
 
-    if host_config:
-        host_system, host_masses = convert_omm_system(host_config.omm_system)
-        host_conf = minimizer.minimize_host_4d(
-            [st.mol_a, st.mol_b],
-            host_config.omm_system,
-            host_config.conf,
-            st.ff,
-            host_config.box,
-        )
-        box0 = host_config.box
+    if host:
         x0, hmr_masses, potentials, baro = setup_in_env(
-            st, host_system, host_masses, host_conf, ligand_conf, lamb, temperature, init_seed
+            st, host.system, host.masses, host.conf, ligand_conf, lamb, temperature, init_seed
         )
+        box0 = host.box
     else:
         x0, box0, hmr_masses, potentials, baro = setup_in_vacuum(st, ligand_conf, lamb)
 
@@ -154,9 +155,22 @@ def setup_initial_state(
     return InitialState(potentials, intg, baro, x0, v0, box0, lamb, ligand_idxs)
 
 
+def setup_optimized_host(st: SingleTopology, config: HostConfig) -> Host:
+    system, masses = convert_omm_system(config.omm_system)
+    conf = minimizer.minimize_host_4d(
+        [st.mol_a, st.mol_b],
+        config.omm_system,
+        config.conf,
+        st.ff,
+        config.box,
+    )
+    box = config.box
+    return Host(system, masses, conf, box)
+
+
 def setup_initial_states(
     st: SingleTopology,
-    host_config: Optional[HostConfig],
+    host: Optional[Host],
     temperature: float,
     lambda_schedule: Union[NDArray, Sequence[float]],
     seed: int,
@@ -174,8 +188,8 @@ def setup_initial_states(
     st: SingleTopology
         A single topology object
 
-    host_config: HostConfig or None
-        Configurations of the host. If None, then a vacuum state will be setup.
+    host: Host or None
+        Pre-optimized host configuration. If None, then a vacuum state will be setup.
 
     temperature: float
         Temperature to run the simulation at.
@@ -198,10 +212,7 @@ def setup_initial_states(
     # check that the lambda schedule is monotonically increasing.
     assert np.all(np.diff(lambda_schedule) > 0)
 
-    initial_states = [
-        setup_initial_state(st, lamb, host_config=host_config, temperature=temperature, seed=seed)
-        for lamb in lambda_schedule
-    ]
+    initial_states = [setup_initial_state(st, lamb, host, temperature, seed) for lamb in lambda_schedule]
 
     # minimize ligand and environment atoms within min_cutoff of the ligand
     # optimization introduces dependencies among states with lam < 0.5, and among states with lam >= 0.5
@@ -220,7 +231,7 @@ def setup_initial_states(
 def setup_optimized_initial_state(
     st: SingleTopology,
     lamb: float,
-    host_config: Optional[HostConfig],
+    host: Optional[Host],
     optimized_initial_states: Sequence[InitialState],
     temperature: float,
     seed: int,
@@ -236,7 +247,7 @@ def setup_optimized_initial_state(
     if lamb == nearest_optimized.lamb:
         return nearest_optimized
     else:
-        initial_state = setup_initial_state(st, lamb, host_config=host_config, temperature=temperature, seed=seed)
+        initial_state = setup_initial_state(st, lamb, host, temperature, seed)
         free_idxs = get_free_idxs(nearest_optimized)
         initial_state.x0 = optimize_coords_state(
             initial_state.potentials,
@@ -424,8 +435,11 @@ def estimate_relative_free_energy(
     lambda_schedule = np.linspace(lambda_min, lambda_max, n_windows or DEFAULT_NUM_WINDOWS)
 
     temperature = DEFAULT_TEMP
+
+    host = setup_optimized_host(single_topology, host_config) if host_config else None
+
     initial_states = setup_initial_states(
-        single_topology, host_config, temperature, lambda_schedule, seed, min_cutoff=min_cutoff
+        single_topology, host, temperature, lambda_schedule, seed, min_cutoff=min_cutoff
     )
     md_params = MDParams(n_frames=n_frames, n_eq_steps=n_eq_steps, steps_per_frame=steps_per_frame)
 
@@ -542,14 +556,14 @@ def estimate_relative_free_energy_via_greedy_bisection(
 
     temperature = DEFAULT_TEMP
 
-    initial_states = setup_initial_states(
-        single_topology, host_config, temperature, lambda_grid, seed, min_cutoff=min_cutoff
-    )
+    host = setup_optimized_host(single_topology, host_config) if host_config else None
+
+    initial_states = setup_initial_states(single_topology, host, temperature, lambda_grid, seed, min_cutoff=min_cutoff)
 
     make_optimized_initial_state = partial(
         setup_optimized_initial_state,
         single_topology,
-        host_config=host_config,
+        host=host,
         optimized_initial_states=initial_states,
         temperature=temperature,
         seed=seed,

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -102,7 +102,7 @@ def assert_all_states_have_same_masses(initial_states: List[InitialState]):
 @dataclass
 class Host:
     system: VacuumSystem
-    masses: List[float]
+    physical_masses: List[float]
     conf: NDArray
     box: NDArray
 
@@ -126,7 +126,7 @@ def setup_initial_state(
 
     if host:
         x0, hmr_masses, potentials, baro = setup_in_env(
-            st, host.system, host.masses, host.conf, ligand_conf, lamb, temperature, init_seed
+            st, host.system, host.physical_masses, host.conf, ligand_conf, lamb, temperature, init_seed
         )
         box0 = host.box
     else:

--- a/timemachine/testsystems/relative.py
+++ b/timemachine/testsystems/relative.py
@@ -65,8 +65,8 @@ def get_relative_hif2a_in_vacuum():
     temperature = 300
     seed = 2022
     lam = 0.5
-    host_config = None  # vacuum
-    initial_states = setup_initial_states(rfe, host_config, temperature, [lam], seed)
+    host = None  # vacuum
+    initial_states = setup_initial_states(rfe, host, temperature, [lam], seed)
     unbound_potentials = initial_states[0].potentials
     sys_params = [np.array(u.params, dtype=np.float64) for u in unbound_potentials]
     coords = rfe.combine_confs(get_romol_conf(mol_a), get_romol_conf(mol_b))


### PR DESCRIPTION
#959 inadvertently changed the behavior of `setup_initial_states` to rerun host minimization for each lambda window. Host optimization is independent of lambda and should be run only once.

This regression was breaking nightly tests on master:

- Last good run on master (2h 41m): https://gitlab.com/relaytx/physics-platform/timemachine/-/pipelines/793714466
- Failed run on current master (timed out at 6h): https://gitlab.com/relaytx/physics-platform/timemachine/-/pipelines/794987570
- Successful run on this branch (2h 51m): https://gitlab.com/relaytx/physics-platform/timemachine/-/pipelines/795620590

The time is increased by ~10 minutes relative to last passing, but this is expected since we run RBFE tests with bisection in addition to sequentially as of #959.