### PR TITLE
Fixes inconcistency in ref nonbonded

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -62,7 +62,7 @@ def prepare_system_params(x: NDArray, cutoff: float, sigma_scale: float = 5.0) -
 
     Returns
     -------
-    (N, 3) np.ndarray containing charges, sigmas and epsilons respectively.
+    (N, 4) np.ndarray containing charges, sigmas, epsilons and w coordinates respectively.
     """
     assert x.ndim == 2
     N = x.shape[0]

--- a/tests/common.py
+++ b/tests/common.py
@@ -307,11 +307,11 @@ class GradientTest(unittest.TestCase):
                     x, params, box, compute_du_dx, compute_du_dp, compute_u
                 )
 
-            np.testing.assert_array_equal(test_du_dx, test_du_dx_2)
-            np.testing.assert_array_equal(test_u, test_u_2)
+                np.testing.assert_array_equal(test_du_dx, test_du_dx_2)
+                np.testing.assert_array_equal(test_u, test_u_2)
 
-            if isinstance(test_potential, potentials.Nonbonded):
-                np.testing.assert_array_equal(test_du_dp, test_du_dp_2)
+                if isinstance(test_potential, potentials.Nonbonded):
+                    np.testing.assert_array_equal(test_du_dp, test_du_dp_2)
 
     def compare_forces_gpu_vs_reference(
         self,

--- a/timemachine/potentials/nonbonded.py
+++ b/timemachine/potentials/nonbonded.py
@@ -235,7 +235,7 @@ def nonbonded(
     # funny enough lim_{x->0} erfc(x)/x = 0
     eij_charge = jnp.where(keep_mask, qij * erfc(beta * dij) * inv_dij, 0)  # zero out diagonals
     if cutoff is not None:
-        eij_charge = jnp.where(dij > cutoff, 0, eij_charge)
+        eij_charge = jnp.where(dij < cutoff, eij_charge, 0)
 
     eij_total = eij_lj * lj_rescale_mask + eij_charge * charge_rescale_mask
 

--- a/timemachine/potentials/nonbonded.py
+++ b/timemachine/potentials/nonbonded.py
@@ -110,7 +110,7 @@ def nonbonded_block(xi, xj, box, params_i, params_j, beta, cutoff):
     es = direct_space_pme(dij, qij, beta)
     lj = lennard_jones(dij, sig_ij, eps_ij)
 
-    nrg = jnp.where(dij > cutoff, 0, es + lj)
+    nrg = jnp.where(dij < cutoff, es + lj, 0)
     return jnp.sum(nrg)
 
 


### PR DESCRIPTION
This was not an issue due to https://github.com/proteneer/timemachine/blob/8f97ebcf11b82bd315444f581e0aa6fc327f09db/tests/common.py#L286 which will take w=`1.2` and convert it to `1.20000005`.

If you remove the conversion to 32 and then to 64 some tests failed, so as a first pass I didn't remove it. Though we might want to update tests with new tolerances to pass, as in practice we don't do this conversion when running the C++ potentials.