### PR TITLE
Fixes Local MD implementation

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -22,6 +22,8 @@ from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.testsystems.dhfr import setup_dhfr
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
 
+SECONDS_PER_DAY = 24 * 60 * 60
+
 
 @pytest.fixture(scope="module")
 def hi2fa_test_frames():
@@ -158,7 +160,6 @@ def benchmark(
     dt = 1.5e-3
     temperature = constants.DEFAULT_TEMP
     pressure = constants.DEFAULT_PRESSURE
-    seconds_per_day = 86400
 
     harmonic_bond_potential = bound_potentials[0]
     bond_list = get_bond_list(harmonic_bond_potential)
@@ -213,7 +214,7 @@ def benchmark(
         batch_times.append(delta)
 
         steps_per_second = steps_per_batch / np.mean(batch_times)
-        steps_per_day = steps_per_second * seconds_per_day
+        steps_per_day = steps_per_second * SECONDS_PER_DAY
 
         ps_per_day = dt * steps_per_day
         ns_per_day = ps_per_day * 1e-3
@@ -250,7 +251,6 @@ def benchmark_local(
     dt = 1.5e-3
     temperature = constants.DEFAULT_TEMP
     friction = 1.0
-    seconds_per_day = 86400
 
     rng = np.random.default_rng(seed)
 
@@ -296,7 +296,7 @@ def benchmark_local(
         batch_times.append(delta)
 
         steps_per_second = steps_per_batch / np.mean(batch_times)
-        steps_per_day = steps_per_second * seconds_per_day
+        steps_per_day = steps_per_second * SECONDS_PER_DAY
 
         ps_per_day = dt * steps_per_day
         ns_per_day = ps_per_day * 1e-3

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -252,6 +252,8 @@ def benchmark_local(
     friction = 1.0
     seconds_per_day = 86400
 
+    rng = np.random.default_rng(seed)
+
     harmonic_bond_potential = bound_potentials[0]
     bond_list = get_bond_list(harmonic_bond_potential)
     if hmr:
@@ -283,9 +285,10 @@ def benchmark_local(
 
     for batch in range(num_batches):
 
+        local_seed = rng.integers(np.iinfo(np.int32).max)
         # time the current batch
         batch_start = time.time()
-        _, _ = ctxt.multiple_steps_local(steps_per_batch, ligand_idxs, burn_in=0)
+        _, _ = ctxt.multiple_steps_local(steps_per_batch, ligand_idxs, seed=local_seed, burn_in=0)
         batch_end = time.time()
 
         delta = batch_end - batch_start

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -278,8 +278,9 @@ def benchmark_local(
 
     ligand_idxs = ligand_idxs.astype(np.int32)
 
+    local_seed = rng.integers(np.iinfo(np.int32).max)
     # run once before timer starts
-    ctxt.multiple_steps_local(steps_per_batch, ligand_idxs, burn_in=0)
+    ctxt.multiple_steps_local(steps_per_batch, ligand_idxs, seed=local_seed, burn_in=0)
 
     start = time.time()
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -44,8 +44,8 @@ def generate_hif2a_frames(n_frames: int, frame_interval: int, seed=None, barosta
 
     ligand_idxs = np.arange(len(host_coords), len(initial_state.x0), dtype=np.int32)
 
-    temperature = 300
-    pressure = 1.0
+    temperature = constants.DEFAULT_TEMP
+    pressure = constants.DEFAULT_PRESSURE
 
     harmonic_bond_potential = initial_state.potentials[0]
     bond_list = get_bond_list(harmonic_bond_potential)
@@ -156,8 +156,8 @@ def benchmark(
 
     seed = 1234
     dt = 1.5e-3
-    temperature = 300
-    pressure = 1.0
+    temperature = constants.DEFAULT_TEMP
+    pressure = constants.DEFAULT_PRESSURE
     seconds_per_day = 86400
 
     harmonic_bond_potential = bound_potentials[0]
@@ -357,7 +357,7 @@ def benchmark_dhfr(verbose=False, num_batches=100, steps_per_batch=1000):
 def prepare_hif2a_initial_state(st, host_system, host_coords, host_box):
     st = rbfe.SingleTopology(st.mol_a, st.mol_b, st.core, st.ff)
     host_config = rbfe.HostConfig(host_system, host_coords, host_box)
-    temperature = 300.0
+    temperature = constants.DEFAULT_TEMP
     lamb = 0.1
     host = rbfe.setup_optimized_host(st, host_config)
     initial_state = rbfe.setup_initial_states(st, host, temperature, [lamb], seed=2022)[0]
@@ -394,7 +394,7 @@ def benchmark_hif2a(verbose=False, num_batches=100, steps_per_batch=1000):
         ("solvent", solvent_system, solvent_coords, solvent_box),
     ]:
 
-        host_fns, host_masses = openmm_deserializer.deserialize_system(host_system, cutoff=1.0)
+        host_fns, host_masses = openmm_deserializer.deserialize_system(host_system, cutoff=1.2)
 
         # resolve host clashes
         min_host_coords = minimizer.minimize_host_4d([st.mol_a, st.mol_b], host_system, host_coords, st.ff, host_box)

--- a/tests/test_local_move.py
+++ b/tests/test_local_move.py
@@ -230,7 +230,7 @@ def test_local_md_particle_density(k):
     for p, bp in zip(sys_params, unbound_potentials):
         bps.append(bp.bind(p).bound_impl(np.float32))
 
-    def observable(pair):
+    def num_particles_near_ligand(pair):
         new_coords, new_box = pair
         assert coords.shape == new_coords.shape
         assert box.shape == new_box.shape
@@ -254,4 +254,6 @@ def test_local_md_particle_density(k):
         xs, boxes = ctxt.multiple_steps_local(steps, local_idxs, burn_in=0, k=k, seed=local_seed)
         return (xs[-1], boxes[-1]), None
 
-    expect_no_drift((x0[-1], boxes[-1]), local_move, observable, n_local_resampling_iterations=250, threshold=0.05)
+    expect_no_drift(
+        (x0[-1], boxes[-1]), local_move, num_particles_near_ligand, n_local_resampling_iterations=250, threshold=0.05
+    )

--- a/timemachine/cpp/src/context.cu
+++ b/timemachine/cpp/src/context.cu
@@ -335,7 +335,7 @@ std::array<std::vector<double>, 2> Context::multiple_steps_local(
         // Commented out as if a particle moves away from the ligand, it may have interactions with
         // particles that aren't included in frozen
         // set_nonbonded_potential_idxs(nonbonded_potential, p_num_selected.data[0], d_row_idxs.data, stream);
-        intg_->initialize(bps_, d_x_t_, d_v_t_, d_box_t_, nullptr, stream);
+        intg_->initialize(local_bps, d_x_t_, d_v_t_, d_box_t_, d_shell_idxs_inner.data, stream);
         for (int i = 0; i < burn_in; i++) {
             this->_step(local_bps, d_shell_idxs_inner.data, stream);
         }
@@ -356,7 +356,7 @@ std::array<std::vector<double>, 2> Context::multiple_steps_local(
                     stream));
             }
         }
-        intg_->finalize(bps_, d_x_t_, d_v_t_, d_box_t_, nullptr, stream);
+        intg_->finalize(local_bps, d_x_t_, d_v_t_, d_box_t_, d_shell_idxs_inner.data, stream);
         // Set the row indices back to the identity.
         k_arange<<<ceil_divide(N_, tpb), tpb, 0, stream>>>(N_, d_row_idxs.data);
         gpuErrchk(cudaPeekAtLastError());

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -294,7 +294,8 @@ void declare_context(py::module &m) {
             The flat bottom restraint K value to use for selection and restraint of atoms within the inner shell.
 
         seed: int
-            The seed that is used to randomly select a particle to freeze.
+            The seed that is used to randomly select a particle to freeze and for the probabilistic selection of
+            free particles.
 
         Returns
         -------

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -295,7 +295,7 @@ void declare_context(py::module &m) {
 
         seed: int
             The seed that is used to randomly select a particle to freeze and for the probabilistic selection of
-            free particles.
+            free particles. It is recommended to provide a unique seed at each call to `multiple_steps_local`.
 
         Returns
         -------

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -295,7 +295,7 @@ void declare_context(py::module &m) {
 
         seed: int
             The seed that is used to randomly select a particle to freeze and for the probabilistic selection of
-            free particles. It is recommended to provide a unique seed at each call to `multiple_steps_local`.
+            free particles. It is recommended to provide a new seed each time this function is called.
 
         Returns
         -------


### PR DESCRIPTION
This PR is to get local MD to a state where it is correct. There were several bugs in the original merge of the implementation. With these changes local md no longer has any performance improvement over global md. Changes to make it faster will come in future PRs.

### Bugfixes
* Use the restraints
* Ran NonbondedAllPairs on subset of system which did not consider particles moving beyond its starting point.
* Fixed the density test to properly fail (https://gitlab.com/relaytx/physics-platform/timemachine/-/pipelines/797870948)

### Additions
* Initialize/finalize integrators
* Add a benchmark (performance expected to be similar if not slower then global MD)


### Benchmark
From https://gitlab.com/relaytx/physics-platform/timemachine/-/jobs/3884085148

```
hif2a-rbfe: N=8840 speed: 588.37ns/day dt: 1.5fs (ran 200 steps in 0.04s)
hif2a-rbfe-local: N=8840 speed: 548.95ns/day dt: 1.5fs (ran 200 steps in 0.05s)
```