### PR TITLE
Avoid recomputation of pair BAR results in simulations with bisection

### DIFF
--- a/tests/test_fe_absolute_hydration.py
+++ b/tests/test_fe_absolute_hydration.py
@@ -19,7 +19,7 @@ def test_run_solvent():
 
     assert res.plots.overlap_summary_png is not None
     assert res.plots.overlap_detail_png is not None
-    assert np.linalg.norm(res.result.all_errs) < 10
+    assert np.linalg.norm([r.dG_err for r in res.pair_bar_results]) < 10
     assert len(res.frames) == 2
     assert len(res.boxes) == 2
     assert len(res.frames[0]) == n_frames

--- a/tests/test_fe_absolute_hydration.py
+++ b/tests/test_fe_absolute_hydration.py
@@ -19,7 +19,7 @@ def test_run_solvent():
 
     assert res.plots.overlap_summary_png is not None
     assert res.plots.overlap_detail_png is not None
-    assert np.linalg.norm([r.dG_err for r in res.final_result.pair_bar_results]) < 10
+    assert np.linalg.norm([r.dG_err for r in res.final_result.bar_results]) < 10
     assert len(res.frames) == 2
     assert len(res.boxes) == 2
     assert len(res.frames[0]) == n_frames

--- a/tests/test_fe_absolute_hydration.py
+++ b/tests/test_fe_absolute_hydration.py
@@ -19,7 +19,7 @@ def test_run_solvent():
 
     assert res.plots.overlap_summary_png is not None
     assert res.plots.overlap_detail_png is not None
-    assert np.linalg.norm([r.dG_err for r in res.pair_bar_results]) < 10
+    assert np.linalg.norm([r.dG_err for r in res.final_result.pair_bar_results]) < 10
     assert len(res.frames) == 2
     assert len(res.boxes) == 2
     assert len(res.frames[0]) == n_frames

--- a/tests/test_fe_absolute_hydration.py
+++ b/tests/test_fe_absolute_hydration.py
@@ -19,7 +19,7 @@ def test_run_solvent():
 
     assert res.plots.overlap_summary_png is not None
     assert res.plots.overlap_detail_png is not None
-    assert np.linalg.norm([r.dG_err for r in res.final_result.bar_results]) < 10
+    assert np.linalg.norm(res.final_result.dG_errs) < 10
     assert len(res.frames) == 2
     assert len(res.boxes) == 2
     assert len(res.frames[0]) == n_frames

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -80,19 +80,13 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
             n_pairs = len(res.initial_states) - 1
             assert len(res.bar_results) == n_pairs
 
-            dG_errs = np.array([r.dG_err for r in res.bar_results])
-            dG_errs_by_component_by_lambda = np.array([r.dG_err_by_component for r in res.bar_results])
-
-            for dg_errs in [dG_errs, dG_errs_by_component_by_lambda]:
+            for dg_errs in [res.dG_errs, res.dG_err_by_component_by_lambda]:
                 assert np.all(0.0 < np.asarray(dg_errs))
                 assert np.linalg.norm(dg_errs) < 0.1
 
-            overlaps = np.array([r.overlap for r in res.bar_results])
-            overlaps_by_component_by_lambda = np.array([r.overlap_by_component for r in res.bar_results])
-
-            assert overlaps_by_component_by_lambda.shape[0] == n_pairs
-            assert overlaps_by_component_by_lambda.shape[1] == dG_errs_by_component_by_lambda.shape[1]
-            for overlaps in [overlaps, overlaps_by_component_by_lambda]:
+            assert res.overlap_by_component_by_lambda.shape[0] == n_pairs
+            assert res.overlap_by_component_by_lambda.shape[1] == res.dG_err_by_component_by_lambda.shape[1]
+            for overlaps in [res.overlaps, res.overlap_by_component_by_lambda]:
                 assert np.all(0.0 < np.asarray(overlaps))
                 assert np.all(np.asarray(overlaps) < 1.0)
 

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -1,13 +1,12 @@
 # test that we can run relative free energy simulations in complex and in solvent
 # this doesn't test for accuracy, just that everything mechanically runs.
 from importlib import resources
-from typing import Sequence
 
 import numpy as np
 import pytest
 
 from timemachine.constants import DEFAULT_FF
-from timemachine.fe.free_energy import HostConfig, InitialState, PairBarResult, SimulationResult, image_frames, sample
+from timemachine.fe.free_energy import HostConfig, IntermediateResult, SimulationResult, image_frames, sample
 from timemachine.fe.rbfe import (
     estimate_relative_free_energy,
     estimate_relative_free_energy_via_greedy_bisection,
@@ -46,7 +45,7 @@ def run_bitwise_reproducibility(mol_a, mol_b, core, forcefield, n_frames, estima
     )
 
     all_frames, all_boxes = [], []
-    for state in solvent_res.initial_states:
+    for state in solvent_res.final_result.initial_states:
         frames, boxes = sample(state, solvent_res.md_params)
         all_frames.append(frames)
         all_boxes.append(boxes)
@@ -62,9 +61,9 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
     n_windows = 3
 
     def check_sim_result(sim_res: SimulationResult):
-        assert len(sim_res.initial_states) == n_windows
-        assert sim_res.initial_states[0].lamb == lambda_interval[0]
-        assert sim_res.initial_states[-1].lamb == lambda_interval[1]
+        assert len(sim_res.final_result.initial_states) == n_windows
+        assert sim_res.final_result.initial_states[0].lamb == lambda_interval[0]
+        assert sim_res.final_result.initial_states[-1].lamb == lambda_interval[1]
 
         assert sim_res.plots.dG_errs_png is not None
         assert sim_res.plots.overlap_summary_png is not None
@@ -77,19 +76,19 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
         assert sim_res.md_params.n_frames == n_frames
         assert sim_res.md_params.n_eq_steps == n_eq_steps
 
-        def check_pair_bar_results(initial_states: Sequence[InitialState], results: Sequence[PairBarResult]):
-            n_pairs = len(initial_states) - 1
-            assert len(results) == n_pairs
+        def check_result(res: IntermediateResult):
+            n_pairs = len(res.initial_states) - 1
+            assert len(res.pair_bar_results) == n_pairs
 
-            dG_errs = np.array([r.dG_err for r in results])
-            dG_errs_by_component_by_lambda = np.array([r.dG_err_by_component for r in results])
+            dG_errs = np.array([r.dG_err for r in res.pair_bar_results])
+            dG_errs_by_component_by_lambda = np.array([r.dG_err_by_component for r in res.pair_bar_results])
 
             for dg_errs in [dG_errs, dG_errs_by_component_by_lambda]:
                 assert np.all(0.0 < np.asarray(dg_errs))
                 assert np.linalg.norm(dg_errs) < 0.1
 
-            overlaps = np.array([r.overlap for r in results])
-            overlaps_by_component_by_lambda = np.array([r.overlap_by_component for r in results])
+            overlaps = np.array([r.overlap for r in res.pair_bar_results])
+            overlaps_by_component_by_lambda = np.array([r.overlap_by_component for r in res.pair_bar_results])
 
             assert overlaps_by_component_by_lambda.shape[0] == n_pairs
             assert overlaps_by_component_by_lambda.shape[1] == dG_errs_by_component_by_lambda.shape[1]
@@ -97,9 +96,9 @@ def run_triple(mol_a, mol_b, core, forcefield, n_frames, protein_path, n_eq_step
                 assert np.all(0.0 < np.asarray(overlaps))
                 assert np.all(np.asarray(overlaps) < 1.0)
 
-        check_pair_bar_results(sim_res.initial_states, sim_res.pair_bar_results)
+        check_result(sim_res.final_result)
         for res in sim_res.intermediate_results:
-            check_pair_bar_results(res.initial_states, res.pair_bar_results)
+            check_result(res)
 
     vacuum_res = estimate_relative_free_energy_fn(
         mol_a,
@@ -234,13 +233,13 @@ def test_imaging_frames():
         steps_per_frame=steps_per_frame,
         n_windows=windows,
     )
-    keep_idxs = [0, len(res.initial_states) - 1]
+    keep_idxs = [0, len(res.final_result.initial_states) - 1]
     assert len(keep_idxs) == len(res.frames)
 
     # A buffer, as imaging doesn't ensure everything is perfectly in the box
     padding = 0.3
     for i, (frames, boxes) in enumerate(zip(res.frames, res.boxes)):
-        initial_state = res.initial_states[keep_idxs[i]]
+        initial_state = res.final_result.initial_states[keep_idxs[i]]
         box_center = compute_box_center(boxes[0])
         box_extents = np.max(boxes, axis=(0, 1))
 

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -262,7 +262,7 @@ def estimate_absolute_free_energy(
             stored_frames,
             stored_boxes,
             md_params,
-            [result],
+            [],
         )
     except Exception as err:
         with open(f"failed_ahfe_result_{combined_prefix}.pkl", "wb") as fh:

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -14,10 +14,10 @@ from timemachine.fe.free_energy import (
     AbsoluteFreeEnergy,
     HostConfig,
     InitialState,
-    IntermediateResult,
     MDParams,
+    PairBarResult,
     SimulationResult,
-    estimate_free_energy_pair_bar,
+    estimate_free_energy_bar,
     make_pair_bar_plots,
     run_sims_sequential,
 )
@@ -248,12 +248,12 @@ def estimate_absolute_free_energy(
         u_kln_by_component_by_lambda, stored_frames, stored_boxes = run_sims_sequential(
             initial_states, md_params, temperature, keep_idxs
         )
-        pair_bar_results = [
-            estimate_free_energy_pair_bar(u_kln_by_component, temperature)
+        bar_results = [
+            estimate_free_energy_bar(u_kln_by_component, temperature)
             for u_kln_by_component in u_kln_by_component_by_lambda
         ]
 
-        result = IntermediateResult(initial_states, pair_bar_results)
+        result = PairBarResult(initial_states, bar_results)
         plots = make_pair_bar_plots(result, temperature, combined_prefix)
 
         return SimulationResult(

--- a/timemachine/fe/bar.py
+++ b/timemachine/fe/bar.py
@@ -175,8 +175,7 @@ def bar_with_bootstrapped_uncertainty(w_F, w_R, n_bootstrap=1000, timeout=10) ->
 
 
 def df_err_from_ukln(u_kln: np.ndarray) -> float:
-    """Extract forward and reverse works from 2-state u_kln matrix,
-        and return bootstrapped BAR error
+    """Extract forward and reverse works from 2-state u_kln matrix and return BAR error computed by pymbar
 
     Parameters
     ----------
@@ -192,7 +191,7 @@ def df_err_from_ukln(u_kln: np.ndarray) -> float:
     assert k == l == 2
     w_fwd = u_kln[1, 0, :] - u_kln[0, 0, :]
     w_rev = u_kln[0, 1, :] - u_kln[1, 1, :]
-    _, df_err = bar_with_bootstrapped_uncertainty(w_fwd, w_rev)
+    _, df_err = pymbar.BAR(w_fwd, w_rev)
     return df_err
 
 

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -59,12 +59,12 @@ class InitialState:
 
 @dataclass
 class PairBarResult:
-    all_dGs: List[float]  # L - 1
-    all_errs: List[float]  # L - 1
-    dG_errs_by_lambda_by_component: NDArray  # (len(U_names), L - 1)
-    overlaps_by_lambda: List[float]  # L - 1
-    overlaps_by_lambda_by_component: NDArray  # (len(U_names), L - 1)
-    u_kln_by_lambda_by_component: NDArray
+    dG: float
+    dG_err: float
+    dG_err_by_component: NDArray  # (len(U_names),)
+    overlap: float
+    overlap_by_component: NDArray  # (len(U_names),)
+    u_kln_by_component: NDArray  # (len(U_names), 2, 2, N)
 
 
 @dataclass
@@ -77,13 +77,13 @@ class PairBarPlots:
 @dataclass
 class IntermediateResult:
     initial_states: List[InitialState]
-    result: PairBarResult
+    pair_bar_results: List[PairBarResult]
 
 
 @dataclass
 class SimulationResult:
     initial_states: List[InitialState]
-    result: PairBarResult
+    pair_bar_results: List[PairBarResult]
     plots: PairBarPlots
     frames: List[NDArray]  # (len(keep_idxs), n_frames, N, 3)
     boxes: List[NDArray]
@@ -343,7 +343,7 @@ def sample(initial_state: InitialState, md_params: MDParams, max_buffer_frames: 
     return all_coords, all_boxes
 
 
-def estimate_free_energy_pair_bar(u_kln_by_component_by_lambda: NDArray, temperature: float) -> PairBarResult:
+def estimate_free_energy_pair_bar(u_kln_by_component_by_lambda: NDArray, temperature: float) -> List[PairBarResult]:
     """
     Estimate free energies given pre-generated samples. This implements the pair-BAR method, where
     windows assumed to be ordered with good overlap, with the final free energy being a sum
@@ -368,9 +368,8 @@ def estimate_free_energy_pair_bar(u_kln_by_component_by_lambda: NDArray, tempera
     kBT = BOLTZ * temperature
     beta = 1 / kBT
 
-    all_dGs = []
-    all_errs = []
-    for lamb_idx, u_kln_by_component in enumerate(u_kln_by_component_by_lambda):
+    results = []
+    for u_kln_by_component in u_kln_by_component_by_lambda:
         # pair BAR
         u_kln = u_kln_by_component.sum(0)
 
@@ -380,53 +379,35 @@ def estimate_free_energy_pair_bar(u_kln_by_component_by_lambda: NDArray, tempera
         df, df_err = bar_with_bootstrapped_uncertainty(w_fwd, w_rev)  # reduced units
         dG, dG_err = df / beta, df_err / beta  # kJ/mol
 
-        all_dGs.append(dG)
-        all_errs.append(dG_err)
+        dG_err_by_component = np.array([df_err_from_ukln(u_kln) / beta for u_kln in u_kln_by_component])
+        overlap = pair_overlap_from_ukln(u_kln_by_component.sum(axis=0))
+        overlap_by_component = np.array([pair_overlap_from_ukln(u_kln) for u_kln in u_kln_by_component])
+        result = PairBarResult(dG, dG_err, dG_err_by_component, overlap, overlap_by_component, u_kln_by_component)
+        results.append(result)
 
-    # (energy components, lambdas, energy fxns = 2, sampled states = 2, frames)
-    ukln_by_lambda_by_component = np.array(u_kln_by_component_by_lambda).swapaxes(0, 1)
-
-    # compute more diagnostics
-    overlaps_by_lambda = [pair_overlap_from_ukln(u_kln) for u_kln in ukln_by_lambda_by_component.sum(axis=0)]
-
-    dG_errs_by_lambda_by_component = np.array(
-        [[df_err_from_ukln(u_kln) / beta for u_kln in ukln_by_lambda] for ukln_by_lambda in ukln_by_lambda_by_component]
-    )
-    overlaps_by_lambda_by_component = np.array(
-        [[pair_overlap_from_ukln(u_kln) for u_kln in ukln_by_lambda] for ukln_by_lambda in ukln_by_lambda_by_component]
-    )
-
-    return PairBarResult(
-        all_dGs,
-        all_errs,
-        dG_errs_by_lambda_by_component,
-        overlaps_by_lambda,
-        overlaps_by_lambda_by_component,
-        ukln_by_lambda_by_component,
-    )
+    return results
 
 
 def make_pair_bar_plots(
-    initial_states: List[InitialState], result: PairBarResult, temperature: float, prefix: str
+    initial_states: List[InitialState], results: List[PairBarResult], temperature: float, prefix: str
 ) -> PairBarPlots:
     U_names = [type(U_fn).__name__ for U_fn in initial_states[0].potentials]
     lambdas = [s.lamb for s in initial_states]
 
+    dGs = np.array([r.dG for r in results])
+    dG_errs = np.array([r.dG_err for r in results])
+    u_kln_by_component_by_lambda = np.array([r.u_kln_by_component for r in results])
+
     overlap_detail_png = make_overlap_detail_figure(
-        U_names,
-        result.all_dGs,
-        result.all_errs,
-        # u_kln_by_lambda_by_component -> u_kln_by_component_by_lambda
-        result.u_kln_by_lambda_by_component.swapaxes(0, 1),
-        temperature,
-        prefix,
+        U_names, dGs, dG_errs, u_kln_by_component_by_lambda, temperature, prefix
     )
 
-    dG_errs_png = make_dG_errs_figure(U_names, lambdas, result.all_errs, result.dG_errs_by_lambda_by_component)
+    dG_errs_by_lambda_by_component = np.array([r.dG_err_by_component for r in results]).T
+    dG_errs_png = make_dG_errs_figure(U_names, lambdas, dG_errs, dG_errs_by_lambda_by_component)
 
-    overlap_summary_png = make_overlap_summary_figure(
-        U_names, lambdas, result.overlaps_by_lambda, result.overlaps_by_lambda_by_component
-    )
+    overlaps = np.array([r.overlap for r in results])
+    overlaps_by_lambda_by_component = np.array([r.overlap_by_component for r in results]).T
+    overlap_summary_png = make_overlap_summary_figure(U_names, lambdas, overlaps, overlaps_by_lambda_by_component)
 
     return PairBarPlots(dG_errs_png, overlap_summary_png, overlap_detail_png)
 
@@ -597,8 +578,8 @@ def run_sims_with_greedy_bisection(
         u_kln_by_component_by_lambda = np.array(
             [get_u_kln_by_component(lamb1, lamb2) for lamb1, lamb2 in zip(lambdas, lambdas[1:])]
         )
-        result = estimate_free_energy_pair_bar(u_kln_by_component_by_lambda, temperature)
-        return IntermediateResult(refined_initial_states, result)
+        pair_bar_results = estimate_free_energy_pair_bar(u_kln_by_component_by_lambda, temperature)
+        return IntermediateResult(refined_initial_states, pair_bar_results)
 
     lambdas = list(initial_lambdas)
     results = [compute_intermediate_result(lambdas)]

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -84,6 +84,30 @@ class PairBarResult:
     def __post_init__(self):
         assert len(self.bar_results) == len(self.initial_states) - 1
 
+    @property
+    def dGs(self) -> List[float]:
+        return [r.dG for r in self.bar_results]
+
+    @property
+    def dG_errs(self) -> List[float]:
+        return [r.dG_err for r in self.bar_results]
+
+    @property
+    def dG_err_by_component_by_lambda(self) -> NDArray:
+        return np.array([r.dG_err_by_component for r in self.bar_results])
+
+    @property
+    def overlaps(self) -> List[float]:
+        return [r.overlap for r in self.bar_results]
+
+    @property
+    def overlap_by_component_by_lambda(self) -> NDArray:
+        return np.array([r.overlap_by_component for r in self.bar_results])
+
+    @property
+    def u_kln_by_component_by_lambda(self) -> NDArray:
+        return np.array([r.u_kln_by_component for r in self.bar_results])
+
 
 @dataclass
 class SimulationResult:
@@ -386,20 +410,15 @@ def make_pair_bar_plots(res: PairBarResult, temperature: float, prefix: str) -> 
     U_names = [type(U_fn).__name__ for U_fn in res.initial_states[0].potentials]
     lambdas = [s.lamb for s in res.initial_states]
 
-    dGs = np.array([r.dG for r in res.bar_results])
-    dG_errs = np.array([r.dG_err for r in res.bar_results])
-    u_kln_by_component_by_lambda = np.array([r.u_kln_by_component for r in res.bar_results])
-
     overlap_detail_png = make_overlap_detail_figure(
-        U_names, dGs, dG_errs, u_kln_by_component_by_lambda, temperature, prefix
+        U_names, res.dGs, res.dG_errs, res.u_kln_by_component_by_lambda, temperature, prefix
     )
 
-    dG_errs_by_lambda_by_component = np.array([r.dG_err_by_component for r in res.bar_results]).T
-    dG_errs_png = make_dG_errs_figure(U_names, lambdas, dG_errs, dG_errs_by_lambda_by_component)
+    dG_errs_png = make_dG_errs_figure(U_names, lambdas, res.dG_errs, res.dG_err_by_component_by_lambda)
 
-    overlaps = np.array([r.overlap for r in res.bar_results])
-    overlaps_by_lambda_by_component = np.array([r.overlap_by_component for r in res.bar_results]).T
-    overlap_summary_png = make_overlap_summary_figure(U_names, lambdas, overlaps, overlaps_by_lambda_by_component)
+    overlap_summary_png = make_overlap_summary_figure(
+        U_names, lambdas, res.overlaps, res.overlap_by_component_by_lambda
+    )
 
     return PairBarPlots(dG_errs_png, overlap_summary_png, overlap_detail_png)
 

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -564,7 +564,7 @@ def run_sims_with_greedy_bisection(
             max_bar_error = max(costs)
             lamb1 = lambdas[left_idx]
             lamb2 = lambdas[left_idx + 1]
-            print(f"Maximum BAR ΔG error {max_bar_error:.3g} between states at λ={lamb1:.3g} and λ={lamb2:.3g}")
+            print(f"Maximum BAR ΔG error {max_bar_error:.3g} kJ/mol between states at λ={lamb1:.3g} and λ={lamb2:.3g}")
             print(f"Sampling new state at λ={lamb_new:.3g}…")
 
         lambdas = lambdas_new

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -76,8 +76,13 @@ class PairBarPlots:
 
 @dataclass
 class PairBarResult:
-    initial_states: List[InitialState]
-    bar_results: List[BarResult]
+    """Results of BAR analysis on L-1 adjacent pairs of states given a sequence of L states."""
+
+    initial_states: List[InitialState]  # length L
+    bar_results: List[BarResult]  # length L - 1
+
+    def __post_init__(self):
+        assert len(self.bar_results) == len(self.initial_states) - 1
 
 
 @dataclass

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -54,10 +54,10 @@ def plot_dG_errs(ax, components, lambdas, dG_errs):
     ax.legend()
 
 
-def make_dG_errs_figure(components, lambdas, dG_errs_by_lambda, dG_errs_by_lambda_by_component):
+def make_dG_errs_figure(components, lambdas, dG_err_by_lambda, dG_err_by_component_by_lambda):
     _, (ax_top, ax_btm) = plt.subplots(2, 1, figsize=(7, 9))
-    plot_dG_errs(ax_top, ["Overall"], lambdas, [dG_errs_by_lambda])
-    plot_dG_errs(ax_btm, components, lambdas, dG_errs_by_lambda_by_component)
+    plot_dG_errs(ax_top, ["Overall"], lambdas, [dG_err_by_lambda])
+    plot_dG_errs(ax_btm, components, lambdas, dG_err_by_component_by_lambda.T)
     buffer = io.BytesIO()
     plt.savefig(buffer, format="png")
     buffer.seek(0)
@@ -86,10 +86,10 @@ def plot_overlap_summary(ax, components, lambdas, overlaps):
     ax.legend()
 
 
-def make_overlap_summary_figure(components, lambdas, overlaps_by_lambda, overlaps_by_lambda_by_component):
+def make_overlap_summary_figure(components, lambdas, overlap_by_lambda, overlap_by_component_by_lambda):
     _, (ax_top, ax_btm) = plt.subplots(2, 1, figsize=(7, 9))
-    plot_overlap_summary(ax_top, ["Overall"], lambdas, [overlaps_by_lambda])
-    plot_overlap_summary(ax_btm, components, lambdas, overlaps_by_lambda_by_component)
+    plot_overlap_summary(ax_top, ["Overall"], lambdas, [overlap_by_lambda])
+    plot_overlap_summary(ax_btm, components, lambdas, overlap_by_component_by_lambda.T)
     buffer = io.BytesIO()
     plt.savefig(buffer, format="png")
     buffer.seek(0)

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -784,10 +784,10 @@ def run_edge_and_save_results(
     pkl_obj = (mol_a, mol_b, edge.metadata, core, solvent_res, solvent_top, complex_res, complex_top)
     file_client.store(path, pickle.dumps(pkl_obj))
 
-    solvent_ddg = np.sum(solvent_res.result.all_dGs)
-    solvent_ddg_err = np.linalg.norm(solvent_res.result.all_errs)
-    complex_ddg = np.sum(complex_res.result.all_dGs)
-    complex_ddg_err = np.linalg.norm(complex_res.result.all_errs)
+    solvent_ddg = sum(r.dG for r in solvent_res.pair_bar_results)
+    solvent_ddg_err = np.linalg.norm([r.dG_err for r in solvent_res.pair_bar_results])
+    complex_ddg = sum(r.dG for r in complex_res.pair_bar_results)
+    complex_ddg_err = np.linalg.norm([r.dG_err for r in complex_res.pair_bar_results])
 
     tm_ddg = complex_ddg - solvent_ddg
     tm_err = np.linalg.norm([complex_ddg_err, solvent_ddg_err])

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -787,10 +787,10 @@ def run_edge_and_save_results(
     pkl_obj = (mol_a, mol_b, edge.metadata, core, solvent_res, solvent_top, complex_res, complex_top)
     file_client.store(path, pickle.dumps(pkl_obj))
 
-    solvent_ddg = sum(r.dG for r in solvent_res.final_result.bar_results)
-    solvent_ddg_err = np.linalg.norm([r.dG_err for r in solvent_res.final_result.bar_results])
-    complex_ddg = sum(r.dG for r in complex_res.final_result.bar_results)
-    complex_ddg_err = np.linalg.norm([r.dG_err for r in complex_res.final_result.bar_results])
+    solvent_ddg = sum(solvent_res.final_result.dGs)
+    solvent_ddg_err = np.linalg.norm(solvent_res.final_result.dG_errs)
+    complex_ddg = sum(complex_res.final_result.dGs)
+    complex_ddg_err = np.linalg.norm(complex_res.final_result.dG_errs)
 
     tm_ddg = complex_ddg - solvent_ddg
     tm_err = np.linalg.norm([complex_ddg_err, solvent_ddg_err])

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -467,7 +467,7 @@ def estimate_relative_free_energy(
             stored_frames,
             stored_boxes,
             md_params,
-            [result],
+            [],
         )
     except Exception as err:
         with open(f"failed_rbfe_result_{combined_prefix}.pkl", "wb") as fh:

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -14,10 +14,10 @@ from timemachine.fe import atom_mapping, model_utils
 from timemachine.fe.free_energy import (
     HostConfig,
     InitialState,
-    IntermediateResult,
     MDParams,
+    PairBarResult,
     SimulationResult,
-    estimate_free_energy_pair_bar,
+    estimate_free_energy_bar,
     make_pair_bar_plots,
     run_sims_sequential,
     run_sims_with_greedy_bisection,
@@ -454,11 +454,11 @@ def estimate_relative_free_energy(
         u_kln_by_component_by_lambda, stored_frames, stored_boxes = run_sims_sequential(
             initial_states, md_params, temperature, keep_idxs
         )
-        pair_bar_results = [
-            estimate_free_energy_pair_bar(u_kln_by_component, temperature)
+        bar_results = [
+            estimate_free_energy_bar(u_kln_by_component, temperature)
             for u_kln_by_component in u_kln_by_component_by_lambda
         ]
-        result = IntermediateResult(initial_states, pair_bar_results)
+        result = PairBarResult(initial_states, bar_results)
         plots = make_pair_bar_plots(result, temperature, combined_prefix)
 
         return SimulationResult(
@@ -787,10 +787,10 @@ def run_edge_and_save_results(
     pkl_obj = (mol_a, mol_b, edge.metadata, core, solvent_res, solvent_top, complex_res, complex_top)
     file_client.store(path, pickle.dumps(pkl_obj))
 
-    solvent_ddg = sum(r.dG for r in solvent_res.final_result.pair_bar_results)
-    solvent_ddg_err = np.linalg.norm([r.dG_err for r in solvent_res.final_result.pair_bar_results])
-    complex_ddg = sum(r.dG for r in complex_res.final_result.pair_bar_results)
-    complex_ddg_err = np.linalg.norm([r.dG_err for r in complex_res.final_result.pair_bar_results])
+    solvent_ddg = sum(r.dG for r in solvent_res.final_result.bar_results)
+    solvent_ddg_err = np.linalg.norm([r.dG_err for r in solvent_res.final_result.bar_results])
+    complex_ddg = sum(r.dG for r in complex_res.final_result.bar_results)
+    complex_ddg_err = np.linalg.norm([r.dG_err for r in complex_res.final_result.bar_results])
 
     tm_ddg = complex_ddg - solvent_ddg
     tm_err = np.linalg.norm([complex_ddg_err, solvent_ddg_err])


### PR DESCRIPTION
Longer-term fix for the issue patched in #973. This adds back the computation of intermediate results, storing the results of BAR computations performed in the bisection phase to avoid recomputing them at the end.

* Performance improvements:
  * Caches BAR computations done during the bisection phase, avoiding the need for recomputation to construct the final `SimulationResult`. This improves the current $O(L^2)$ computation of intermediate results to $O(L)$, and further removes a constant factor of 2, since estimates computed during bisection are reused. ($L$ is number of lambda windows.)
  * Switches to using the $\Delta G$ error estimate from `pymbar.BAR` for componentwise analysis (we still bootstrap overall errors)
* Cleanups:
  * Renames/changes `estimate_free_energy_pair_bar` -> `estimate_free_energy_bar` to compute the result for a single pair of states. This simplifies the implementation of caching.
  * Removes duplicated code for computing BAR estimates given a $u_{kln}$ matrix
  * Renames `IntermediateResult` -> `PairBarResult`, reuses for final result
  * Uses consistent naming convention for "BAR" vs. "Pair BAR":
    *  "BAR" refers to BAR on a single pair of states
    * "Pair BAR" refers to estimator that accepts a list of K states and applies BAR to the K-1 adjacent pairs

Profile visualizations for hif2a 338 -> 165 complex leg, before and after changes:
<details>
<h3>Profile before #973</h3>
NOTE: absolute times not comparable with the other results (this was run locally, the other 2 on AWS)

![image](https://user-images.githubusercontent.com/319411/225067362-8a47a490-e495-41d9-9de3-941c2fc86c02.png)

<h3>Profile before this PR</h3>

![image](https://user-images.githubusercontent.com/319411/225064636-4a7f9abf-6497-43bc-8605-f2d7ab7d3136.png)

<h3>Profile after this PR</h3>
Comparable/slightly better than before (but we are now storing intermediate results)

![image](https://user-images.githubusercontent.com/319411/225064784-3de59cc0-daf5-421f-bacd-53803b35b04e.png)
</details>