### PR TITLE
Suppress "No GPU/TPU" warning from jax

### DIFF
--- a/timemachine/__init__.py
+++ b/timemachine/__init__.py
@@ -1,3 +1,18 @@
 from . import _version
 
 __version__ = _version.get_versions()["version"]
+
+
+def _suppress_jax_no_gpu_warning():
+    """Suppresses the following warning:
+
+       WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
+
+    See https://github.com/google/jax/issues/6805
+    """
+    import jax
+
+    jax.config.update("jax_platform_name", "cpu")
+
+
+_suppress_jax_no_gpu_warning()


### PR DESCRIPTION
Minor quality of life improvement to suppress the following warning from jax:

> WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)

This warning can be avoided if we tell jax we intend to run in CPU mode (see https://github.com/google/jax/issues/6805).