### PR TITLE
Removes duplicate CLI arg from relative free energy example

### DIFF
--- a/examples/relative_free_energy.py
+++ b/examples/relative_free_energy.py
@@ -98,7 +98,6 @@ def read_from_args():
     parser.add_argument("--mol_b_name", type=str, help="name of the end molecule", required=True)
     parser.add_argument("--forcefield", type=str, help="location of the ligand forcefield", required=True)
     parser.add_argument("--protein", type=str, help="PDB of the protein complex", required=True)
-    parser.add_argument("--n_frames", type=int, help="Number of frames to run", required=True)
     parser.add_argument("--seed", type=int, help="Random number seed", required=True)
 
     args = parser.parse_args()


### PR DESCRIPTION
* Raises an exception if you try to pass CLI args

This example might be destined for the attic, so maybe not worth merging. Had simply been using it and noticed this issue

```
Traceback (most recent call last):
  File "examples/relative_free_energy.py", line 144, in <module>
    read_from_args()
  File "examples/relative_free_energy.py", line 101, in read_from_args
    parser.add_argument("--n_frames", type=int, help="Number of frames to run", required=True)
  File "/home/fyork/miniconda3/envs/timemachine/lib/python3.7/argparse.py", line 1373, in add_argument
    return self._add_action(action)
  File "/home/fyork/miniconda3/envs/timemachine/lib/python3.7/argparse.py", line 1736, in _add_action
    self._optionals._add_action(action)
  File "/home/fyork/miniconda3/envs/timemachine/lib/python3.7/argparse.py", line 1577, in _add_action
    action = super(_ArgumentGroup, self)._add_action(action)
  File "/home/fyork/miniconda3/envs/timemachine/lib/python3.7/argparse.py", line 1387, in _add_action
    self._check_conflict(action)
  File "/home/fyork/miniconda3/envs/timemachine/lib/python3.7/argparse.py", line 1526, in _check_conflict
    conflict_handler(action, confl_optionals)
  File "/home/fyork/miniconda3/envs/timemachine/lib/python3.7/argparse.py", line 1535, in _handle_conflict_error
    raise ArgumentError(action, message % conflict_string)
argparse.ArgumentError: argument --n_frames: conflicting option string: --n_frames
```