### PR TITLE
Remove deceptive warning around FF loading

### DIFF
--- a/tests/test_forcefields.py
+++ b/tests/test_forcefields.py
@@ -45,7 +45,7 @@ def test_loading_forcefield_from_file():
             Forcefield.load_from_file(Path(path))
         assert path in str(e.value)
 
-    with temporary_working_dir():
+    with temporary_working_dir() as tempdir:
         # Verify that if a local file shadows a builtin
         for path in builtin_ffs:
             basename = os.path.basename(path)
@@ -55,3 +55,11 @@ def test_loading_forcefield_from_file():
                 Forcefield.load_from_file(basename)
             assert len(w) == 1
             assert basename in str(w[0].message)
+        with catch_warnings(record=True) as w:
+            bad_ff = Path(tempdir, "jut.py")
+            assert bad_ff.is_absolute(), "Must be absolute to cover test case"
+            with open(bad_ff, "w") as ofs:
+                ofs.write("{}")
+            with pytest.raises(ValueError, match="Unsupported charge handler"):
+                Forcefield.load_from_file(bad_ff)
+        assert len(w) == 0

--- a/timemachine/ff/__init__.py
+++ b/timemachine/ff/__init__.py
@@ -84,7 +84,7 @@ class Forcefield:
         path = Path(path_or_str)  # Safe to construct a Path object from another Path object
 
         with resources.files("timemachine.ff.params") as params_path:
-            built_in_path = params_path / original_path
+            built_in_path = params_path / path.name
             if built_in_path.is_file():
                 if path.is_file():
                     warn(f"Provided path {original_path} shares name with builtin forcefield, falling back to builtin")

--- a/timemachine/ff/__init__.py
+++ b/timemachine/ff/__init__.py
@@ -79,6 +79,11 @@ class Forcefield:
         -------
         Forcefield
             Return a ForceField object constructed from parameters file
+
+        Note
+        ----
+        If a path is provided that has the same file name as a built-in forcefield, it will throw a warning and load
+        the built-in forcefield.
         """
         original_path = str(path_or_str)
         path = Path(path_or_str)  # Safe to construct a Path object from another Path object
@@ -87,11 +92,13 @@ class Forcefield:
             built_in_path = params_path / path.name
             if built_in_path.is_file():
                 if path.is_file():
-                    warn(f"Provided path {original_path} shares name with builtin forcefield, falling back to builtin")
+                    warn(
+                        f"Provided path {original_path} shares name with built-in forcefield, falling back to built-in"
+                    )
                 # Search built in params for the forcefields
                 path = built_in_path
             if not path.is_file():
-                raise ValueError(f"Unable to find {original_path} in file system or built in forcefields")
+                raise ValueError(f"Unable to find {original_path} in file system or built-in forcefields")
             with open(path, "r") as ifs:
                 handlers, protein_ff, water_ff = deserialize_handlers(ifs.read())
 


### PR DESCRIPTION
* Path("some_path") / "/bar" returns "Path(/bar)" which resulted in warning when reading an absolute path file