### PR TITLE
Update nx version to fix nx.draw with new matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy==1.23.5
 scipy==1.10.1
 pymbar==3.0.5
 pyyaml==5.4.1
-networkx==2.5
+networkx==2.8.8
 matplotlib==3.7.1
 rdkit==2022.3.5


### PR DESCRIPTION
- nx.draw fails with nx==2.5 and the new matplotlib
- bug fixed in newer nx version
