### PR TITLE
Expose typing information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ setup(
             "datasets/**/*.csv",
             "datasets/**/*.pdb",
             "datasets/**/*.sdf",
+            "py.typed",
             "testsystems/data/**/*.pdb",
             "testsystems/data/**/*.sdf",
         ],


### PR DESCRIPTION
Includes a `py.typed` file in the package, allowing downstream code to be typechecked using typing information exposed by the timemachine API.

(See https://peps.python.org/pep-0561/#packaging-type-information)