### PR TITLE
Simplify anchor group selection

### DIFF
--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -92,16 +92,16 @@ def test_find_dummy_groups_and_anchors():
     AllChem.EmbedMolecule(mol_a, randomSeed=2022)
     AllChem.EmbedMolecule(mol_b, randomSeed=2022)
 
-    core_pairs = np.array([[1, 2], [2, 1], [3, 0]])
+    core_atoms = np.array([2, 1, 0])
 
-    dgs, jks = single_topology.find_dummy_groups_and_anchors(mol_b, core_pairs[:, 1])
+    dgs, jks = single_topology.find_dummy_groups_and_anchors(mol_b, core_atoms)
     assert dgs == [{3}]
     assert jks == [(2, 1)]
 
     # angle should swap
-    core_pairs = np.array([[1, 2], [2, 0], [3, 1]])
+    core_atoms = np.array([2, 0, 1])
 
-    dgs, jks = single_topology.find_dummy_groups_and_anchors(mol_b, core_pairs[:, 1])
+    dgs, jks = single_topology.find_dummy_groups_and_anchors(mol_b, core_atoms)
     assert dgs == [{3}]
     assert jks == [(2, 1)]
 
@@ -116,20 +116,18 @@ def test_find_dummy_groups_and_anchors_multiple_angles():
     AllChem.EmbedMolecule(mol_a, randomSeed=2022)
     AllChem.EmbedMolecule(mol_b, randomSeed=2022)
 
-    core_pairs = np.array([[0, 2], [1, 1], [2, 3]])
-    dgs, jks = single_topology.find_dummy_groups_and_anchors(mol_b, core_pairs[:, 1])
+    core_atoms = np.array([2, 1, 3])
+    dgs, jks = single_topology.find_dummy_groups_and_anchors(mol_b, core_atoms)
     assert dgs == [{0}]
     assert jks == [(1, 2)] or jks == [(1, 3)]
-
-    dgs_zero, jks_zero = single_topology.find_dummy_groups_and_anchors(mol_b, core_pairs[:, 1])
 
     # this code should be invariant to different random seeds and different ordering of core pairs
     for idx in range(100):
         np.random.seed(idx)
-        core_pairs_shuffle = np.random.permutation(core_pairs)
-        dgs, jks = single_topology.find_dummy_groups_and_anchors(mol_b, core_pairs_shuffle[:, 1])
-        assert dgs == dgs_zero
-        assert jks == jks_zero
+        core_atoms_shuffle = np.random.permutation(core_atoms)
+        dgs_rep, jks_rep = single_topology.find_dummy_groups_and_anchors(mol_b, core_atoms_shuffle)
+        assert dgs_rep == dgs
+        assert jks_rep == jks
 
 
 def testing_find_dummy_groups_and_multiple_anchors():
@@ -143,21 +141,20 @@ def testing_find_dummy_groups_and_multiple_anchors():
     AllChem.EmbedMolecule(mol_a, randomSeed=2022)
     AllChem.EmbedMolecule(mol_b, randomSeed=2022)
 
-    core_pairs = np.array([[1, 1], [2, 2]])
+    core_atoms = np.array([1, 2])
 
     with pytest.warns(MultipleAnchorWarning):
-        dgs, jks = single_topology.find_dummy_groups_and_anchors(mol_b, core_pairs[:, 1])
+        dgs, jks = single_topology.find_dummy_groups_and_anchors(mol_b, core_atoms)
         assert dgs == [{0}]
         assert jks == [(1, 2)] or jks == [(2, 1)]
 
     # test determinism, should be robust against seeds
-    dgs_zero, jks_zero = single_topology.find_dummy_groups_and_anchors(mol_b, core_pairs[:, 1])
     for idx in range(100):
         np.random.seed(idx)
-        core_pairs_shuffle = np.random.permutation(core_pairs)
-        dgs, jks = single_topology.find_dummy_groups_and_anchors(mol_b, core_pairs_shuffle[:, 1])
-        assert dgs == dgs_zero
-        assert jks == jks_zero
+        core_atoms_shuffle = np.random.permutation(core_atoms)
+        dgs_rep, jks_rep = single_topology.find_dummy_groups_and_anchors(mol_b, core_atoms_shuffle)
+        assert dgs_rep == dgs
+        assert jks_rep == jks
 
     mol_a = Chem.MolFromSmiles("C(C)(C)C")
     mol_b = Chem.MolFromSmiles("O1CCCC1")
@@ -168,9 +165,9 @@ def testing_find_dummy_groups_and_multiple_anchors():
     core_b = [2, 1, 4, 3]
 
     with pytest.warns(MultipleAnchorWarning):
-        dgs, jks = single_topology.find_dummy_groups_and_anchors(mol_b, core_b)
-        assert dgs == [{0}]
-        assert jks == [(1, 2)]
+        dgs_rep, jks_rep = single_topology.find_dummy_groups_and_anchors(mol_b, core_b)
+        assert dgs_rep == [{0}]
+        assert jks_rep == [(1, 2)]
 
 
 def test_charge_perturbation_is_invalid():

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -406,7 +406,7 @@ def find_dummy_groups_and_anchors(mol, core_atoms):
     -------
     list of 2-tuples
         Returns a set of dummy_groups, and a list of 2-tuples (j,k). j is the root_anchor atom,
-        and k is a neighboring core atom. Note that `k` may be None if no suitable neighbor can be found.
+        and k is a neighboring core atom. Note that `k` may be None if core_atoms has length 1.
 
     """
     assert len(set(core_atoms)) == len(core_atoms)
@@ -422,6 +422,9 @@ def find_dummy_groups_and_anchors(mol, core_atoms):
 
         if len(root_anchors) == 0:
             assert 0, "Disconnected dummy group"
+
+        # pick an (potentially arbitrary) anchor
+        ra = root_anchors[0]
 
         if len(root_anchors) > 1:
             # Consider the following situation:
@@ -439,19 +442,18 @@ def find_dummy_groups_and_anchors(mol, core_atoms):
             #
             # the lhs is more difficult because it has significantly more phase space that can be
             # sampled than the fused case, but it's not super obvious how to best detect this.
-            # So instead, we will pick a random anchor atom. One possible solution later on is to
+            # So instead, we will pick an arbitrary anchor atom. One possible solution later on is to
             # minimize the number of rotatable bonds?
             warnings.warn(
-                f"Multiple root anchors {root_anchors} found for dummy group: {dg}, picking a random anchor.",
+                f"Multiple root anchors {root_anchors} found for dummy group: {dg}, picking arbitrary anchor {ra}",
                 MultipleAnchorWarning,
             )
 
-        # pick an arbitrary angle core atom
-        ra = root_anchors[0]
+        # pick an arbitrary angle anchor (or None, if mol has only atom in the core)
         nbs = [a.GetIdx() for a in mol.GetAtomWithIdx(ra).GetNeighbors() if a.GetIdx() in core_atoms]
         nb = nbs[0] if nbs else None
 
-        # (i,j,k) where i is a dummy, j is anchor, and k is the angle anchor
+        # convention: (i, j, k) where i is a dummy, j is anchor, and k is the angle anchor
         angle_jk = ra, nb
 
         all_jks.append(angle_jk)

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -451,6 +451,13 @@ def find_dummy_groups_and_anchors(mol, core_atoms):
 
         # pick an arbitrary angle anchor (or None, if mol has only atom in the core)
         nbs = [a.GetIdx() for a in mol.GetAtomWithIdx(ra).GetNeighbors() if a.GetIdx() in core_atoms]
+
+        # NOTE: The selection of an arbitrary neighbor can result in a numerically unstable angle (i, j, k) in the case where
+        #
+        # 1. the bond (j, k) is not present in mol_a and
+        # 2. we use the standard HarmonicAngle force.
+        #
+        # The arbitrary choice is justified here because we use HarmonicAngleStable for intermediates.
         nb = nbs[0] if nbs else None
 
         # convention: (i, j, k) where i is a dummy, j is anchor, and k is the angle anchor


### PR DESCRIPTION
Currently, we check whether a bond (anchor, neighbor) is present in mol_a when selecting a suitable anchor group for a given mol_b dummy group. The original motivation was to ensure numerical stability near $\lambda = 0$: since we might have an angle term like (dummy_b, anchor, neighbor), stability of the standard harmonic angle force in particular requires the bond (anchor, neighbor) be present in mol_a.

Since we have moved to using a stable form of the harmonic angle force (#935), this check should no longer be necessary; For  $0 < \lambda < 1$, angle terms are stable even when interatomic distances shrink to zero; at $\lambda = 0$, where we use the standard harmonic angle force, angles involving dummy atoms have zero force constant.

This PR:

* removes logic ensuring that the (anchor, neighbor) bond is present in mol_a when setting up an anchor group for mol_b
* removes now unused `mol_a`, `core_a` arguments from the signature of `find_dummy_groups_and_anchors`
* removes `CoreBondChangeWarning`, which was previously raised when (anchor, neighbor) was missing in mol_a
* updates test

Note: Related to #1016 (but does not yet resolve). The proposed fix for the latter will not perform the check removed here, so testing and merging this first should make the eventual fix simpler to validate.