### PR TITLE
Modify heuristic for dummy group selection

### DIFF
--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -86,3 +86,9 @@ def test_generate_dummy_group_assignments():
     dgas = list(generate_dummy_group_assignments(g, core))
     # one or two groups depending on choice of anchor atom for {3, 4}
     assert equivalent_assignment(dgas, [{1: {0}, 2: {3, 4}}, {1: {0, 3, 4}}])
+
+
+def test_generate_dummy_group_assignments_empty_core():
+    g = convert_bond_list_to_nx(get_romol_bonds(Chem.MolFromSmiles("OC1COO1")))
+    core = []
+    assert list(generate_dummy_group_assignments(g, core)) == []

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,7 +1,10 @@
+from collections.abc import Iterable
+
 import pytest
 from rdkit import Chem
 
-from timemachine.fe.dummy import identify_dummy_groups, identify_root_anchors
+from timemachine.fe.dummy import convert_bond_list_to_nx, generate_dummy_group_assignments
+from timemachine.fe.utils import get_romol_bonds
 
 # These tests check the various utilities used to turn off interactions
 # such that the end-states are separable. A useful glossary of terms is as follows.
@@ -20,74 +23,12 @@ from timemachine.fe.dummy import identify_dummy_groups, identify_root_anchors
 pytestmark = [pytest.mark.nogpu]
 
 
-def get_bond_idxs(mol):
-    # not necessarily canonicalized!
-    idxs = []
-    for bond in mol.GetBonds():
-        idxs.append((bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()))
-    return idxs
+def deepfreeze(xs):
+    return frozenset(deepfreeze(x) if isinstance(x, Iterable) else x for x in xs)
 
 
-def test_identify_root_anchors():
-    """
-    Test the identification of root anchors given a dummy atom.
-
-    For example, if D were the dummy atom below:
-
-            D---1---2
-           /
-          0
-
-    its root anchors are the set of atoms {0, 1}
-
-    """
-    mol = get_bond_idxs(Chem.MolFromSmiles("C1CCC1N"))
-    core = [0, 1, 2, 3]
-    anchors = identify_root_anchors(mol, core, dummy_atom=4)
-    assert set(anchors) == set([3])
-
-    mol = get_bond_idxs(Chem.MolFromSmiles("C1CC2NC2C1"))
-    core = [0, 1, 2, 4, 5]
-    anchors = identify_root_anchors(mol, core, dummy_atom=3)
-    assert set(anchors) == set([2, 4])
-
-    mol = get_bond_idxs(Chem.MolFromSmiles("C1OCC11CCCCC1"))
-    core = [3, 4, 5, 6, 7, 8]
-    anchors = identify_root_anchors(mol, core, dummy_atom=0)
-    assert set(anchors) == set([3])
-    anchors = identify_root_anchors(mol, core, dummy_atom=1)
-    assert set(anchors) == set([3])
-    anchors = identify_root_anchors(mol, core, dummy_atom=2)
-    assert set(anchors) == set([3])
-
-    mol = get_bond_idxs(Chem.MolFromSmiles("C1CC1.C1CCCCC1"))
-    core = [3, 4, 5, 6, 7, 8]
-    anchors = identify_root_anchors(mol, core, dummy_atom=0)
-    assert set(anchors) == set()
-    anchors = identify_root_anchors(mol, core, dummy_atom=1)
-    assert set(anchors) == set()
-    anchors = identify_root_anchors(mol, core, dummy_atom=2)
-    assert set(anchors) == set()
-
-    mol = get_bond_idxs(Chem.MolFromSmiles("C1CC2NC2C1"))
-    core = [0, 1, 2, 5]
-    anchors = identify_root_anchors(mol, core, dummy_atom=3)
-    assert set(anchors) == set([2, 5])
-    anchors = identify_root_anchors(mol, core, dummy_atom=4)
-    assert set(anchors) == set([2, 5])
-
-    # cyclohexane with a nitrogen inside
-    mol = get_bond_idxs(Chem.MolFromSmiles("C1C2CC3CC1N23"))
-    core = [0, 1, 2, 3, 4, 5]
-    anchors = identify_root_anchors(mol, core, dummy_atom=6)
-    assert set(anchors) == set([1, 3, 5])
-
-
-def assert_set_equality(a_sets, b_sets):
-    # utility function to check that list of sets are equal
-    frozen_a = [frozenset(a) for a in a_sets]
-    frozen_b = [frozenset(b) for b in b_sets]
-    assert frozenset(frozen_a) == frozenset(frozen_b)
+def deep_set_equality(xs, ys):
+    return deepfreeze(xs) == deepfreeze(ys)
 
 
 def test_identify_dummy_groups():
@@ -122,34 +63,33 @@ def test_identify_dummy_groups():
       0-------1
 
     """
-    bond_idxs = get_bond_idxs(Chem.MolFromSmiles("FC1CC1(F)N"))
-    core = [1, 2, 3]
-    dg = identify_dummy_groups(bond_idxs, core)
-    assert_set_equality(dg, [{0}, {4, 5}])
 
-    bond_idxs = get_bond_idxs(Chem.MolFromSmiles("FC1CC1(F)NN"))
+    g = convert_bond_list_to_nx(get_romol_bonds(Chem.MolFromSmiles("FC1CC1(F)N")))
     core = [1, 2, 3]
-    dg = identify_dummy_groups(bond_idxs, core)
-    assert_set_equality(dg, [{0}, {4, 5, 6}])
+    dgas = list(generate_dummy_group_assignments(g, core))
+    # assert exactly 1 assignment with dummy groups {0} and {4, 5}
+    assert deep_set_equality([dgs.values() for dgs in dgas], [[{0}, {4, 5}]])
 
-    bond_idxs = get_bond_idxs(Chem.MolFromSmiles("C1CC11OO1"))
+    g = convert_bond_list_to_nx(get_romol_bonds(Chem.MolFromSmiles("FC1CC1(F)NN")))
+    core = [1, 2, 3]
+    dgas = list(generate_dummy_group_assignments(g, core))
+    assert deep_set_equality([dgs.values() for dgs in dgas], [[{0}, {4, 5, 6}]])
+
+    g = convert_bond_list_to_nx(get_romol_bonds(Chem.MolFromSmiles("C1CC11OO1")))
     core = [0, 1, 2]
-    dg = identify_dummy_groups(bond_idxs, core)
-    assert_set_equality(dg, [{3, 4}])
+    dgas = list(generate_dummy_group_assignments(g, core))
+    assert deep_set_equality([dgs.values() for dgs in dgas], [[{3, 4}]])
 
-    bond_idxs = get_bond_idxs(Chem.MolFromSmiles("C1CC2OOC12"))
+    g = convert_bond_list_to_nx(get_romol_bonds(Chem.MolFromSmiles("C1CC2OOC12")))
     core = [0, 1, 2, 5]
-    dg = identify_dummy_groups(bond_idxs, core)
-    assert_set_equality(dg, [{3, 4}])
+    dgas = list(generate_dummy_group_assignments(g, core))
+    assert len(dgas) == 2  # arbitrary choice of bond anchor
+    assert deep_set_equality([dgs.values() for dgs in dgas], [[{3, 4}]])
 
     # example above, where O's are dummy atoms, and Cs are core
-    bond_idxs = get_bond_idxs(Chem.MolFromSmiles("OC1COO1"))
+    g = convert_bond_list_to_nx(get_romol_bonds(Chem.MolFromSmiles("OC1COO1")))
     core = [1, 2]
-    dg = identify_dummy_groups(bond_idxs, core)
-    assert_set_equality(dg, [{0, 3, 4}])
-
-
-def assert_anchor_group_equality(a_groups, b_groups):
-    frozen_a = [tuple(a) for a in a_groups]
-    frozen_b = [tuple(b) for b in b_groups]
-    assert frozenset(frozen_a) == frozenset(frozen_b)
+    dgas = list(generate_dummy_group_assignments(g, core))
+    assert len(dgas) == 2
+    # one or two groups depending on choice of anchor atom for {3, 4}
+    assert deep_set_equality([dgs.values() for dgs in dgas], [[{0}, {3, 4}], [{0, 3, 4}]])

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -60,7 +60,6 @@ def test_identify_dummy_groups():
 
         return to_comparable(left) == to_comparable(right)
 
-    # [{1: frozenset({0}), 3: frozenset({4, 5})}]
     g = convert_bond_list_to_nx(get_romol_bonds(Chem.MolFromSmiles("FC1CC1(F)N")))
     core = [1, 2, 3]
     dgas = list(generate_dummy_group_assignments(g, core))

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -21,7 +21,7 @@ from timemachine.fe.utils import get_romol_bonds
 pytestmark = [pytest.mark.nogpu]
 
 
-def test_identify_dummy_groups():
+def test_generate_dummy_group_assignments():
     r"""
     Test the heuristic for partitioning dummy atoms into dummy groups.
 

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -174,7 +174,7 @@ def test_find_dummy_groups_and_multiple_anchors():
         assert dgs == {1: (2, {0})}
 
 
-def test_ethane_cyclobutane():
+def test_ethane_cyclobutadiene():
     """Test case where a naive heuristic for identifying dummy groups results in disconnected components"""
 
     mol_a = Chem.AddHs(Chem.MolFromSmiles("CC"))

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -136,7 +136,7 @@ def test_find_dummy_groups_and_anchors_multiple_angles():
         assert jks == jks_zero
 
 
-def testing_find_dummy_groups_and_multiple_anchors():
+def test_find_dummy_groups_and_multiple_anchors():
     """
     Test that we can find anchors and dummy groups with multiple anchors, we expect to find only a single
     root anchor and neighbor core atom pair.

--- a/timemachine/fe/dummy.py
+++ b/timemachine/fe/dummy.py
@@ -141,6 +141,8 @@ def generate_anchored_dummy_group_assignments(
         ]
         return valid_angle_anchors or [None]
 
+    # For each dummy group assignment, generate (possibly multiple) anchored dummy group assignments each corresponding
+    # to an independent choice of an angle anchor atom for each dummy group
     anchored_dummy_group_assignments = (
         dict(anchored_dummy_group)
         for dummy_group_assignment in dummy_group_assignments

--- a/timemachine/fe/dummy.py
+++ b/timemachine/fe/dummy.py
@@ -1,7 +1,7 @@
 import warnings
 from collections import defaultdict
 from itertools import product
-from typing import Collection, DefaultDict, Dict, FrozenSet, Iterable, Iterator, Optional, Tuple, TypeVar
+from typing import Collection, DefaultDict, Dict, FrozenSet, Iterable, Iterator, List, Optional, Tuple, TypeVar
 
 import networkx as nx
 
@@ -178,7 +178,7 @@ def convert_bond_list_to_nx(bond_list: Collection[Tuple[int, int]]) -> nx.Graph:
 
 def get_core_bonds(
     mol_a, mol_b, core_atoms_a: Collection[int], core_atoms_b: Collection[int]
-) -> FrozenSet[Tuple[int, int]]:
+) -> FrozenSet[Tuple[int, ...]]:
     """Returns core-core bonds that are present in both mol_a and mol_b"""
     bonds_a = get_romol_bonds(mol_a)
     bonds_b = get_romol_bonds(mol_b)
@@ -187,7 +187,10 @@ def get_core_bonds(
     return frozenset(translate_bonds(bonds_a, a_to_c)).intersection(frozenset(translate_bonds(bonds_b, b_to_c)))
 
 
-def translate_bonds(bonds: Collection[Tuple[int, int]], mapping: Dict[int, int]):
+def translate_bonds(bonds: Collection[Tuple[int, ...]], mapping: Dict[int, int]) -> List[Tuple[int, ...]]:
+    """Applies the given mapping of atom indices to a collection of bonds (i.e. tuples of atom indices)
+
+    Bonds containing indices that are missing from the input mapping are omitted in the output."""
     return [
         canonicalize_bond(tuple(mapping[idx] for idx in bond)) for bond in bonds if all(idx in mapping for idx in bond)
     ]

--- a/timemachine/fe/dummy.py
+++ b/timemachine/fe/dummy.py
@@ -63,8 +63,8 @@ def generate_dummy_group_assignments(
     dummy_atoms = frozenset(bond_graph.nodes()) - core_atoms_
     induced_g = nx.subgraph(bond_graph, dummy_atoms)
 
-    def get_bond_anchors(dummy_atom, dummy_group):
-        bond_anchors = [n for n in bond_graph.neighbors(dummy_atom) if n in core_atoms]
+    def get_bond_anchors(dummy_group):
+        bond_anchors = {n for dummy_atom in dummy_group for n in bond_graph.neighbors(dummy_atom) if n in core_atoms}
         if len(bond_anchors) > 1:
             warnings.warn(
                 f"Multiple bond anchors {bond_anchors} found for dummy group: {dummy_group}",
@@ -75,10 +75,7 @@ def generate_dummy_group_assignments(
     dummy_group_assignments = (
         union_by_key(bond_anchor_cc_pairs)
         for bond_anchor_cc_pairs in product(
-            *[
-                [(bond_anchor, cc) for dummy_atom in cc for bond_anchor in get_bond_anchors(dummy_atom, cc)]
-                for cc in nx.connected_components(induced_g)
-            ]
+            *[[(bond_anchor, cc) for bond_anchor in get_bond_anchors(cc)] for cc in nx.connected_components(induced_g)]
         )
     )
 

--- a/timemachine/fe/dummy.py
+++ b/timemachine/fe/dummy.py
@@ -1,7 +1,7 @@
 import warnings
 from collections import defaultdict
 from itertools import product
-from typing import Collection, DefaultDict, Dict, FrozenSet, Iterable, Iterator, Optional, Tuple, TypeVar, cast
+from typing import Collection, DefaultDict, Dict, FrozenSet, Iterable, Iterator, Optional, Tuple, TypeVar
 
 import networkx as nx
 
@@ -92,7 +92,7 @@ def generate_dummy_group_assignments(
 
 def generate_anchored_dummy_group_assignments(
     mol_a, mol_b, core_atoms_a: Collection[int], core_atoms_b: Collection[int]
-) -> Iterator[Dict[int, Tuple[int, FrozenSet[int]]]]:
+) -> Iterator[Dict[int, Tuple[Optional[int], FrozenSet[int]]]]:
     """Returns an iterator over candidate anchored dummy group assignments.
 
     An anchored dummy group assignment is a set of triples (dummy group, j = bond anchor atom, k = angle anchor atom),
@@ -150,7 +150,7 @@ def generate_anchored_dummy_group_assignments(
                     (bond_anchor, (angle_anchor, dummy_group))
                     for angle_anchor in (
                         [
-                            cast(Optional[int], angle_anchor)  # angle_anchor may be missing
+                            angle_anchor
                             for angle_anchor in [n for n in bond_graph_b.neighbors(bond_anchor) if n in core_atoms_b]
                             if is_core_bond((bond_anchor, angle_anchor))
                         ]

--- a/timemachine/fe/dummy.py
+++ b/timemachine/fe/dummy.py
@@ -1,8 +1,178 @@
+import warnings
+from collections import defaultdict
+from itertools import product
+from typing import Collection, DefaultDict, Dict, FrozenSet, Iterable, Iterator, Optional, Tuple, TypeVar, cast
+
 import networkx as nx
-import numpy as np
+
+from timemachine.fe.utils import get_romol_bonds
 
 
-def convert_bond_list_to_nx(bond_list):
+class MultipleAnchorWarning(UserWarning):
+    pass
+
+
+def generate_dummy_group_assignments(
+    bond_graph: nx.Graph, core_atoms: Collection[int]
+) -> Iterator[Dict[int, FrozenSet[int]]]:
+    """Returns an iterator over dummy group assignments (i.e., candidate partitionings of dummy atoms with each
+    partition assigned a bond anchor atom) for a given molecule (represented as a bond graph) and set of core atoms.
+
+    A dummy group is a set of dummy atoms that are inserted or deleted in alchemical free energy calculations. The
+    bonded terms that involve dummy atoms need to be judiciously pruned such that the partition function at the
+    end-states remain factorizable, and cancelleable. Dummy groups are subject to the following constraints:
+
+    1) They must not contain atoms in the core.
+    2) Dummy groups do not interact with other dummy groups.
+    3) Dummy groups interact with the core only through anchor atoms.
+
+    While the choices of dummy groups is arbitrary, this function partitions the dummy atoms into multiple dummy groups
+    using a heuristic:
+
+    1) Generate an induced subgraph containing only dummy atoms
+    2) Identify connected components of the induced subgraph
+    3) For each connected component, generate all possible choices of (bond) anchor atom
+    4) Merge connected components with the same bond anchor; this gives a mapping of anchor atom to dummy group for each
+       distinct assignment of anchor atoms in (3)
+
+    Example
+    -------
+    >>> mol = Chem.MolFromSmiles("OC1COO1")
+    >>> g = convert_bond_list_to_nx(get_romol_bonds(mol))
+    >>> core = [1, 2]
+    >>> list(generate_dummy_group_assignments(g, core))
+    [{1: frozenset({0}), 2: frozenset({3, 4})}, {1: frozenset({0, 3, 4})}]
+
+    Parameters
+    ----------
+    bond_graph: networkx.Graph
+        graph with atoms as nodes and bonds as edges
+
+    core_atoms: list of int
+        atoms in the core
+
+    Returns
+    -------
+    iterator of dict
+        each element is a mapping from bond anchor atom to dummy group
+    """
+    assert len(set(core_atoms)) == len(core_atoms)
+    assert len(list(nx.connected_components(bond_graph))) == 1
+
+    core_atoms_ = frozenset(core_atoms)
+    dummy_atoms = frozenset(bond_graph.nodes()) - core_atoms_
+    induced_g = nx.subgraph(bond_graph, dummy_atoms)
+
+    def maybe_warn_multiple_bond_anchors(bond_anchors, dummy_group):
+        if len(bond_anchors) > 1:
+            warnings.warn(
+                f"Multiple bond anchors {bond_anchors} found for dummy group: {dummy_group}",
+                MultipleAnchorWarning,
+            )
+        return bond_anchors
+
+    dummy_group_assignments = (
+        union_by_key(bond_anchor_cc_pairs)
+        for bond_anchor_cc_pairs in product(
+            *[
+                [
+                    (bond_anchor, cc)
+                    for dummy_atom in cc
+                    for bond_anchor in maybe_warn_multiple_bond_anchors(
+                        [n for n in bond_graph.neighbors(dummy_atom) if n in core_atoms], cc
+                    )
+                ]
+                for cc in nx.connected_components(induced_g)
+            ]
+        )
+    )
+
+    return dummy_group_assignments
+
+
+def generate_anchored_dummy_group_assignments(
+    mol_a, mol_b, core_atoms_a: Collection[int], core_atoms_b: Collection[int]
+) -> Iterator[Dict[int, Tuple[int, FrozenSet[int]]]]:
+    """Returns an iterator over candidate anchored dummy group assignments.
+
+    An anchored dummy group assignment is a set of triples (dummy group, j = bond anchor atom, k = angle anchor atom),
+    where dummy atoms are connected to the core only through j, and k is a core neighbor of j where the bond (j, k)
+    exists in both mol_a and mol_b. Note that k may be missing (None) if there are no valid choices.
+
+    See documentation for :py:func:`timemachine.fe.dummy.generate_dummy_group_assignments` for information on how
+    candidate dummy group assignments are generated.
+
+    Example
+    -------
+    >>> mol_a = Chem.MolFromSmiles("CC")
+    >>> mol_b = Chem.MolFromSmiles("c1(C)ccc1")
+    >>> core_atoms_a = [0, 1]
+    >>> core_atoms_b = [2, 0]
+    >>> list(generate_anchored_dummy_group_assignments(mol_a, mol_b, core_atoms_a, core_atoms_b))
+    [{0: (2, frozenset({1})), 2: (0, frozenset({3, 4}))},
+    {0: (2, frozenset({1, 3, 4}))}]
+
+    Parameters
+    ----------
+    mol_a, mol_b: Mol
+        Source and target molecules for alchemical transformation.
+        Dummy atoms are added to mol_a to transform it into a supergraph of mol_b.
+
+    core_atoms_a: collection of int
+        mol_a atoms in the core
+
+    core_atoms_b: collection of int
+        mol_b atoms in the core
+
+    Returns
+    -------
+    iterator of dict
+        each element is a mapping from bond anchor atom to the pair (angle anchor atom, dummy group)
+    """
+
+    bonds_b = get_romol_bonds(mol_b)
+    bond_graph_b = convert_bond_list_to_nx(bonds_b)
+    dummy_group_assignments = generate_dummy_group_assignments(bond_graph_b, core_atoms_b)
+
+    core_bonds_c = get_core_bonds(mol_a, mol_b, core_atoms_a, core_atoms_b)
+    c_to_b = {c: b for c, b in enumerate(core_atoms_b)}
+    core_bonds_b = frozenset(translate_bonds(core_bonds_c, c_to_b))
+
+    def is_core_bond(bond):
+        return canonicalize_bond(bond) in core_bonds_b
+
+    assignments = (
+        dict(anchored_dummy_group)
+        for dummy_group_assignment in dummy_group_assignments
+        for anchored_dummy_group in product(
+            *[
+                [
+                    (bond_anchor, (angle_anchor, dummy_group))
+                    for angle_anchor in (
+                        [
+                            cast(Optional[int], angle_anchor)  # angle_anchor may be missing
+                            for angle_anchor in [n for n in bond_graph_b.neighbors(bond_anchor) if n in core_atoms_b]
+                            if is_core_bond((bond_anchor, angle_anchor))
+                        ]
+                        or [None]  # no valid choices for angle anchor
+                    )
+                ]
+                for bond_anchor, dummy_group in dummy_group_assignment.items()
+            ]
+        )
+    )
+
+    return assignments
+
+
+def canonicalize_bond(ixn: Tuple[int, ...]) -> Tuple[int, ...]:
+    if ixn[0] > ixn[-1]:
+        return tuple(ixn[::-1])
+    else:
+        return tuple(ixn)
+
+
+def convert_bond_list_to_nx(bond_list: Collection[Tuple[int, int]]) -> nx.Graph:
     """
     Convert an ROMol into a networkx graph.
     """
@@ -14,138 +184,29 @@ def convert_bond_list_to_nx(bond_list):
     return g
 
 
-def identify_root_anchors(bond_idxs, core, dummy_atom):
-    """
-    Identify the root anchor(s) for a given atom. A root anchor is defined as the starting atom
-    in an anchor group (comprised of up to 3 anchor atoms). If this returns multiple root anchors
-    then the dummy_atom is a bridge between multiple core atoms.
-
-    Parameters
-    ----------
-    bond_idxs: list of 2-tuples of ints
-        list of (i,j) bonds denoting the atoms in the bond
-
-    core: list or set or iterable
-        core atoms
-
-    dummy_atom: int
-        atom we're initializing the search over
-
-    Returns
-    -------
-    list of int
-        List of root anchors that the dummy atom is connected to.
-
-    """
-    assert len(set(core)) == len(core)
-
-    core = set(core)
-    assert dummy_atom not in core
-
-    # first convert to a dense graph, and assume that bond_idxs start from zero
-    flat_idxs = np.array(bond_idxs).flatten()
-    N = np.amax(flat_idxs) + 1
-    assert N == len(set(flat_idxs))
-    dense_graph = np.zeros((N, N), dtype=np.int32)
-
-    for i, j in bond_idxs:
-        dense_graph[i, j] = 1
-        dense_graph[j, i] = 1
-
-    # sparsify to simplify and speed up traversal code
-    sparse_graph = []
-    for row in dense_graph:
-        nbs = []
-        for col_idx, col in enumerate(row):
-            if col == 1:
-                nbs.append(col_idx)
-        sparse_graph.append(nbs)
-
-    # conditional depth first search that terminates when
-    # we encounter a core atom.
-    def conditional_dfs(i, visited):
-        if i in visited:
-            return
-        else:
-            visited.add(i)
-            if i not in core:
-                for nb in sparse_graph[i]:
-                    conditional_dfs(nb, visited)
-
-    visited = set()
-
-    conditional_dfs(dummy_atom, visited)
-
-    anchors = [a_idx for a_idx in visited if a_idx in core]
-
-    return anchors
+def get_core_bonds(
+    mol_a, mol_b, core_atoms_a: Collection[int], core_atoms_b: Collection[int]
+) -> FrozenSet[Tuple[int, int]]:
+    """Returns core-core bonds that are present in both mol_a and mol_b"""
+    bonds_a = get_romol_bonds(mol_a)
+    bonds_b = get_romol_bonds(mol_b)
+    a_to_c = {a: c for c, a in enumerate(core_atoms_a)}
+    b_to_c = {b: c for c, b in enumerate(core_atoms_b)}
+    return frozenset(translate_bonds(bonds_a, a_to_c)).intersection(frozenset(translate_bonds(bonds_b, b_to_c)))
 
 
-def identify_dummy_groups(bond_idxs, core):
-    """
-    A dummy group is a set of dummy atoms that are inserted or deleted in alchemical
-    free energy calculations. The bonded terms that involve dummy atoms need to be
-    judiciously pruned such that the partition function at the end-states remain
-    factorizable, and cancelleable. Dummy groups are subject to the following constraints:
-
-    1) They must not contain atoms in the core.
-    2) Dummy groups do not interact with other dummy groups.
-    3) Dummy groups interact with the core only through anchor atoms.
-
-    While the choices of dummy groups is arbitrary, this function partitions the dummy
-    atoms into multiple dummy groups using a heuristic:
-
-    1) Identify all 1-2, 1-3 edges between dummy atoms.
-    2) Generate an induced graph using edges from above set.
-    3) Disconnected components of the resulting induced graph are our dummy groups.
-
-    Code example:
-
-    ```
-    mol = Chem.MolFromSmiles("FC1CC1(F)N")
-    core = [1, 2, 3]
-    dg = identify_dummy_groups(mol, core)
-    assert_set_equality(dg, [{0}, {4, 5}])
-    ```
-
-    Parameters
-    ----------
-    bond_idxs: list of 2-tuples of ints
-        list of (i,j) bonds denoting the atoms in the bond
-
-    core: list of int
-        atoms in the core
-
-    Returns
-    -------
-    List of set of ints:
-        eg: [{3,4}, {7,8,9}]
-
-    """
-    g = convert_bond_list_to_nx(bond_idxs)
-    N = g.number_of_nodes()
-    induced_g = nx.Graph()
-
-    # add nodes and edges into the induced graph.
-    for i in range(N):
-        if i not in core:
-            induced_g.add_node(i)
-            for j in range(i + 1, N):
-                if j not in core:
-                    dist = nx.shortest_path_length(g, source=i, target=j)
-                    if dist <= 2:
-                        induced_g.add_edge(i, j)
-
-    cc = list(nx.connected_components(induced_g))
-
-    # check that we didn't miss any dummy atoms
-    assert np.sum([len(c) for c in cc]) == (N - len(core))
-
-    return cc
+def translate_bonds(bonds: Collection[Tuple[int, int]], mapping: Dict[int, int]):
+    return [
+        canonicalize_bond(tuple(mapping[idx] for idx in bond)) for bond in bonds if all(idx in mapping for idx in bond)
+    ]
 
 
-def canonicalize_bond(ixn):
-    if ixn[0] > ixn[-1]:
-        return tuple(ixn[::-1])
-    else:
-        return tuple(ixn)
+_K = TypeVar("_K")
+_V = TypeVar("_V")
+
+
+def union_by_key(ts: Iterable[Tuple[_K, FrozenSet[_V]]]) -> Dict[_K, FrozenSet[_V]]:
+    d: DefaultDict[_K, FrozenSet[_V]] = defaultdict(frozenset)
+    for k, xs in ts:
+        d[k] = d[k].union(xs)
+    return dict(d)

--- a/timemachine/fe/dummy.py
+++ b/timemachine/fe/dummy.py
@@ -198,6 +198,7 @@ _V = TypeVar("_V")
 
 
 def union_by_key(ts: Iterable[Tuple[_K, FrozenSet[_V]]]) -> Dict[_K, FrozenSet[_V]]:
+    """Given an iterable of key-value pairs where the values are sets, returns a dictionary of sets merged by key."""
     d: DefaultDict[_K, FrozenSet[_V]] = defaultdict(frozenset)
     for k, xs in ts:
         d[k] = d[k].union(xs)

--- a/timemachine/fe/dummy.py
+++ b/timemachine/fe/dummy.py
@@ -31,9 +31,9 @@ def generate_dummy_group_assignments(
 
     1) Generate an induced subgraph containing only dummy atoms
     2) Identify connected components of the induced subgraph
-    3) For each connected component, generate all possible choices of (bond) anchor atom
-    4) Merge connected components with the same bond anchor; this gives a mapping of anchor atom to dummy group for each
-       distinct assignment of anchor atoms in (3)
+    3) Generate all possible mappings (bond anchor, connected component). In general there will be multiple
+       possibilities since there may be an arbitrary choice of anchor atom for each dummy group
+    4) For each mapping ("assignment"), merge connected components with the same bond anchor
 
     Example
     -------

--- a/timemachine/fe/dummy.py
+++ b/timemachine/fe/dummy.py
@@ -141,22 +141,20 @@ def generate_anchored_dummy_group_assignments(
     def is_core_bond(bond):
         return canonicalize_bond(bond) in core_bonds_b
 
+    def get_angle_anchors(bond_anchor):
+        valid_angle_anchors = [
+            angle_anchor
+            for angle_anchor in [n for n in bond_graph_b.neighbors(bond_anchor) if n in core_atoms_b]
+            if is_core_bond((bond_anchor, angle_anchor))
+        ]
+        return valid_angle_anchors or [None]
+
     assignments = (
         dict(anchored_dummy_group)
         for dummy_group_assignment in dummy_group_assignments
         for anchored_dummy_group in product(
             *[
-                [
-                    (bond_anchor, (angle_anchor, dummy_group))
-                    for angle_anchor in (
-                        [
-                            angle_anchor
-                            for angle_anchor in [n for n in bond_graph_b.neighbors(bond_anchor) if n in core_atoms_b]
-                            if is_core_bond((bond_anchor, angle_anchor))
-                        ]
-                        or [None]  # no valid choices for angle anchor
-                    )
-                ]
+                [(bond_anchor, (angle_anchor, dummy_group)) for angle_anchor in get_angle_anchors(bond_anchor)]
                 for bond_anchor, dummy_group in dummy_group_assignment.items()
             ]
         )

--- a/timemachine/fe/dummy.py
+++ b/timemachine/fe/dummy.py
@@ -30,7 +30,7 @@ def generate_dummy_group_assignments(
     using a heuristic:
 
     1) Generate an induced subgraph containing only dummy atoms
-    2) Identify connected components of the induced subgraph
+    2) Identify connected components of the induced subgraph (see note 1 below).
     3) Generate all possible mappings (bond anchor, connected component). In general there will be multiple
        possibilities since there may be an arbitrary choice of anchor atom for each dummy group
     4) For each mapping ("assignment"), merge connected components with the same bond anchor
@@ -55,6 +55,12 @@ def generate_dummy_group_assignments(
     -------
     iterator of dict
         each element is a mapping from bond anchor atom to dummy group
+
+    Notes
+    -----
+    1. The final dummy groups are constructed as unions of one or more of the connected components of the dummy induced
+       subgraph; in particular, we can never end up with a dummy group that is a subset of a connected component (the
+       latter might be desirable for efficiency but is more complicated to implement).
     """
     assert len(set(core_atoms)) == len(core_atoms)
     assert len(list(nx.connected_components(bond_graph))) == 1

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1,7 +1,7 @@
 import warnings
 from collections.abc import Iterable
 from functools import partial
-from typing import Callable, Collection, Dict, FrozenSet, List, Tuple, TypeVar, Union, cast
+from typing import Callable, Collection, Dict, FrozenSet, List, Optional, Tuple, TypeVar, Union, cast
 
 import jax.numpy as jnp
 import numpy as np
@@ -391,7 +391,7 @@ def setup_end_state(ff, mol_a, mol_b, core, a_to_c, b_to_c):
 
 def find_dummy_groups_and_anchors(
     mol_a, mol_b, core_atoms_a: Collection[int], core_atoms_b: Collection[int]
-) -> Dict[int, Tuple[int, FrozenSet[int]]]:
+) -> Dict[int, Tuple[Optional[int], FrozenSet[int]]]:
     """Returns an arbitrary partitioning of dummy atoms and anchor assignment for the A -> B transformation. See the
     documentation for :py:func:`timemachine.fe.dummy.generate_dummy_group_assignments` and notes below for more
     information.

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -420,7 +420,7 @@ def find_dummy_groups_and_anchors(
     assignments = generate_anchored_dummy_group_assignments(mol_a, mol_b, core_atoms_a, core_atoms_b)
 
     # TODO: consider refining to use a heuristic rather than arbitrary selection
-    # (e.g. number of angle terms, number of # rotatable bonds, etc.)
+    # (e.g. maximize core-dummy bonds, maximize angle terms, minimize rotatable bonds, etc.)
     arbitrary_assignment = next(assignments)
 
     for _, (angle_anchor, _) in arbitrary_assignment.items():


### PR DESCRIPTION
### Summary

* Adds test ensuring that the alchemical hybrid is fully connected for the methane -> cyclobutadiene example in #1016 
* Modifies heuristic to ensure dummy atoms are always connected
* Adds an assertion to `single_topology.setup_end_state` checking that the hybrid molecule has a single connected component

### Todo

* [x] Run vacuum benchmarks
* [ ] How does typical number of dummy groups change with the new heuristic?

### Background

The existing heuristic for dummy group identification ([here](https://github.com/proteneer/timemachine/blob/03b9dd1e8bb86f06291c941840563a66287475f2/timemachine/fe/dummy.py#L242-L261))

1. Builds a subgraph of mol_b induced by the dummy atoms
2. Augments the induced subgraph with extra edges connecting atoms that are distance 2 apart. I.e. if (i, j) and (j, k) are edges in the induced subgraph, also adds (i, k)
3. Identifies connected components of the augmented induced subgraph with dummy groups

The motivation for step 2 is to allow dummy groups to be merged if they share an anchor atom, even if the original dummy groups do not have bond interactions.

However, this can lead to disconnected dummy atoms in some cases where we have 3 or more disconnected components of the induced subgraph that are connected in the augmented induced subgraph (i.e. by step 2) through 2 or more different anchor atoms (see the example in #1016).

This PR modifies the heuristic to

1. Build a subgraph of mol_b induced by the dummy atoms (same as before)
2. Find connected components of the (non-augmented) induced subgraph
3. Arbitrarily choose an anchor for each connected component
4. Merge components with identical anchors

This is similar to the existing heuristic with the important difference that it cannot result in disconnected dummy atoms (by construction).

Like the existing heuristic, we make an arbitrary choice of anchor atom for a given dummy group when there are several possibilities.

Unlike the existing heuristic, the approach here does not necessarily merge dummy groups that are separated by a single core atom. If this is desirable, we should be able to implement it in the present approach by ranking candidates in order of increasing number of dummy groups before making an arbitrary selection.

Fixes #1016 