### PR TITLE
Optimize graph MLE tests

### DIFF
--- a/tests/test_mle.py
+++ b/tests/test_mle.py
@@ -173,6 +173,7 @@ def test_infer_node_dgs_w_error():
             ref_node_idxs,
             ref_node_vals,
             ref_node_stddevs,
+            n_bootstrap=10,
             seed=np.random.randint(1000),
         )
         assert (dg_err > 0).all()
@@ -199,28 +200,20 @@ def test_infer_node_dgs_w_error_invariant_wrt_edge_order():
 
         seed = np.random.randint(1000)
 
-        dg_1, dg_err_1 = infer_node_vals_and_errs(
-            edge_idxs,
-            obs_edge_diffs,
-            edge_stddevs,
-            ref_node_idxs,
-            ref_node_vals,
-            ref_node_stddevs,
+        f = partial(
+            infer_node_vals_and_errs,
+            ref_node_idxs=ref_node_idxs,
+            ref_node_vals=ref_node_vals,
+            ref_node_stddevs=ref_node_stddevs,
+            n_bootstrap=10,
             seed=seed,
         )
+
+        dg_1, dg_err_1 = f(edge_idxs, obs_edge_diffs, edge_stddevs)
 
         p = np.random.permutation(len(edge_idxs))
         p = np.arange(len(edge_idxs))
-
-        dg_2, dg_err_2 = infer_node_vals_and_errs(
-            edge_idxs[p, :],
-            obs_edge_diffs[p],
-            edge_stddevs[p],
-            ref_node_idxs,
-            ref_node_vals,
-            ref_node_stddevs,
-            seed=seed,
-        )
+        dg_2, dg_err_2 = f(edge_idxs[p, :], obs_edge_diffs[p], edge_stddevs[p])
 
         np.testing.assert_allclose(dg_1, dg_2)  # expect convergence up to ~roundoff error
 
@@ -234,6 +227,7 @@ node_val_prop = "node_val"
 node_stddev_prop = "node_stddev"
 ref_node_val_prop = "ref_node_val"
 ref_node_stddev_prop = "ref_node_stddev"
+n_bootstrap = 10
 
 
 @pytest.fixture(scope="module", params=[0])
@@ -264,7 +258,7 @@ def _nx_graph_with_reference_mle_instance(request):
         g.add_node(n, **{ref_node_val_prop: ref_val, ref_node_stddev_prop: ref_stddev})
 
     dgs, dg_errs = infer_node_vals_and_errs(
-        edge_idxs, obs_edge_diffs, edge_stddevs, ref_node_idxs, ref_node_vals, ref_node_stddevs, seed=seed
+        edge_idxs, obs_edge_diffs, edge_stddevs, ref_node_idxs, ref_node_vals, ref_node_stddevs, n_bootstrap, seed
     )
 
     return g, seed, dgs, dg_errs
@@ -284,15 +278,14 @@ infer_node_vals_and_errs_networkx_partial = partial(
     ref_node_stddev_prop=ref_node_stddev_prop,
     node_val_prop=node_val_prop,
     node_stddev_prop=node_stddev_prop,
+    n_bootstrap=n_bootstrap,
 )
 
 
-def test_infer_node_vals_and_errs_networkx_requires_di_graph(nx_graph_with_reference_mle_instance):
-
-    g, seed, ref_dgs, ref_dg_errs = nx_graph_with_reference_mle_instance
-
+def test_infer_node_vals_and_errs_networkx_requires_digraph():
+    g = nx.Graph()
     with pytest.raises(AssertionError, match="Graph must be a DiGraph"):
-        infer_node_vals_and_errs_networkx_partial(g.to_undirected(), seed=seed)
+        infer_node_vals_and_errs_networkx_partial(g)
 
 
 def test_infer_node_vals_and_errs_networkx(nx_graph_with_reference_mle_instance):

--- a/tests/test_mle.py
+++ b/tests/test_mle.py
@@ -214,7 +214,7 @@ def test_infer_node_dgs_w_error_invariant_wrt_edge_order():
         p = np.random.permutation(len(edge_idxs))
         dg_2, dg_err_2 = f(edge_idxs[p, :], obs_edge_diffs[p], edge_stddevs[p])
 
-        np.testing.assert_allclose(dg_1, dg_2, rtol=1e-5)
+        np.testing.assert_allclose(dg_1, dg_2, rtol=1e-4)
 
         # TODO: errors are noisy; unclear how to test consistency
         # np.testing.assert_allclose(dg_err_1, dg_err_2) # fails

--- a/tests/test_mle.py
+++ b/tests/test_mle.py
@@ -386,6 +386,7 @@ def test_infer_node_vals_and_errs_networkx_raises_on_empty():
 
 def test_infer_node_vals_incorrect_sizes():
     """Verify that infer_node_vals correctly asserts that the length of arrays are the same"""
+    np.random.seed(2023)
     g = generate_random_valid_regular_graph()
     n_nodes = g.number_of_nodes()
 
@@ -413,6 +414,7 @@ def test_infer_node_vals_incorrect_sizes():
 
 def test_infer_node_vals_and_errs_incorrect_sizes():
     """Verify that infer_node_vals_and_errs correctly asserts that the length of arrays are the same"""
+    np.random.seed(2023)
     g = generate_random_valid_regular_graph()
     n_nodes = g.number_of_nodes()
 

--- a/tests/test_mle.py
+++ b/tests/test_mle.py
@@ -212,10 +212,9 @@ def test_infer_node_dgs_w_error_invariant_wrt_edge_order():
         dg_1, dg_err_1 = f(edge_idxs, obs_edge_diffs, edge_stddevs)
 
         p = np.random.permutation(len(edge_idxs))
-        p = np.arange(len(edge_idxs))
         dg_2, dg_err_2 = f(edge_idxs[p, :], obs_edge_diffs[p], edge_stddevs[p])
 
-        np.testing.assert_allclose(dg_1, dg_2)  # expect convergence up to ~roundoff error
+        np.testing.assert_allclose(dg_1, dg_2, rtol=1e-5)
 
         # TODO: errors are noisy; unclear how to test consistency
         # np.testing.assert_allclose(dg_err_1, dg_err_2) # fails


### PR DESCRIPTION
* Reduces number of bootstrap iterations: 100 -> 10
* Avoids generating instance for digraph assertion test
* Sets RNG seed in remaining tests using randomness
* Fixes typo leading to trivial assertion

Before:
```
148.30s call     tests/test_mle.py::test_infer_node_dgs_w_error_invariant_wrt_edge_order
65.64s call     tests/test_mle.py::test_infer_node_dgs_w_error
21.63s setup    tests/test_mle.py::test_infer_node_vals_and_errs_networkx_requires_di_graph[0]
21.40s call     tests/test_mle.py::test_infer_node_vals_and_errs_networkx[0]
```

After:
```
16.11s call     tests/test_mle.py::test_infer_node_dgs_w_error_invariant_wrt_edge_order
7.08s call     tests/test_mle.py::test_infer_node_dgs_w_error
5.10s call     tests/test_mle.py::test_infer_node_vals_and_errs_networkx[0]
```