### PR TITLE
modify get_group_indices to require num_atoms

### DIFF
--- a/attic/scripts/test_barostat_water_density.py
+++ b/attic/scripts/test_barostat_water_density.py
@@ -61,7 +61,8 @@ if __name__ == "__main__":
     # get list of molecules for barostat by looking at bond table
     harmonic_bond_potential = unbound_potentials[0]
     bond_list = get_bond_list(harmonic_bond_potential)
-    group_indices = get_group_indices(bond_list)
+    num_atoms = len(masses)
+    group_indices = get_group_indices(bond_list, num_atoms)
 
     trajs = []
     volume_trajs = []

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -65,8 +65,9 @@ def generate_hif2a_frames(n_frames: int, frame_interval: int, seed=None, barosta
         bps.append(potential.to_gpu(precision=np.float32).bound_impl)  # get the bound implementation
 
     baro_impl = None
+
     if barostat_interval > 0:
-        group_idxs = get_group_indices(bond_list)
+        group_idxs = get_group_indices(bond_list, len(masses))
         baro = MonteCarloBarostat(
             initial_state.x0.shape[0],
             pressure,
@@ -175,7 +176,7 @@ def benchmark(
 
     baro_impl = None
     if barostat_interval > 0:
-        group_idxs = get_group_indices(bond_list)
+        group_idxs = get_group_indices(bond_list, len(masses))
         baro = MonteCarloBarostat(
             x0.shape[0],
             pressure,

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -39,7 +39,7 @@ def test_deterministic_energies():
 
     harmonic_bond_potential = host_fns[0]
     bond_list = get_bond_list(harmonic_bond_potential.potential)
-    group_idxs = get_group_indices(bond_list)
+    group_idxs = get_group_indices(bond_list, len(host_masses))
     baro = MonteCarloBarostat(
         x0.shape[0],
         pressure,

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -580,7 +580,7 @@ def test_multiple_steps_local_consistency(freeze_reference):
         np.testing.assert_equal(ref_u, test_u)
 
     # Verify that running with a barostat doesn't change the results
-    group_idxs = get_group_indices(get_bond_list(unbound_potentials[0]))
+    group_idxs = get_group_indices(get_bond_list(unbound_potentials[0]), len(masses))
 
     pressure = 1.0
 
@@ -870,7 +870,7 @@ def test_setup_context_with_references():
 
         barostat_impl = None
         if barostat_interval > 0:
-            group_idxs = get_group_indices(get_bond_list(unbound_potentials[0]))
+            group_idxs = get_group_indices(get_bond_list(unbound_potentials[0]), len(masses))
 
             barostat = MonteCarloBarostat(coords.shape[0], pressure, temperature, group_idxs, 1, seed)
             barostat_impl = barostat.impl(bps)

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -336,7 +336,7 @@ def setup_initial_states(
         bond_potential = ubps[0]
         assert isinstance(bond_potential, potentials.HarmonicBond)
         hmr_masses = model_utils.apply_hmr(masses, bond_potential.idxs)
-        group_idxs = get_group_indices(get_bond_list(bond_potential))
+        group_idxs = get_group_indices(get_bond_list(bond_potential), len(masses))
         baro = MonteCarloBarostat(len(hmr_masses), 1.0, temperature, group_idxs, 15, seed)
         box0 = host_config.box
 

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -146,7 +146,7 @@ def image_frames(initial_state: InitialState, frames: np.ndarray, boxes: np.ndar
     assert len(frames) == len(boxes), "Number of frames and boxes don't match"
 
     hb_potential = next(p.potential for p in initial_state.potentials if isinstance(p.potential, HarmonicBond))
-    group_indices = get_group_indices(get_bond_list(hb_potential))
+    group_indices = get_group_indices(get_bond_list(hb_potential), len(initial_state.integrator.masses))
     imaged_frames = np.empty_like(frames)
     for i, (frame, box) in enumerate(zip(frames, boxes)):
         assert frame.ndim == 2 and frame.shape[-1] == 3, "frames must have shape (N, 3)"

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -71,7 +71,7 @@ def setup_in_env(
     hmr_masses = np.concatenate([host_hmr_masses, st.combine_masses(use_hmr=True)])
 
     potentials = system.get_U_fns()
-    group_idxs = get_group_indices(get_bond_list(system.bond.potential))
+    group_idxs = get_group_indices(get_bond_list(system.bond.potential), len(hmr_masses))
     baro = MonteCarloBarostat(len(hmr_masses), DEFAULT_PRESSURE, temperature, group_idxs, 15, run_seed + 1)
 
     x0 = np.concatenate([host_conf, ligand_conf])

--- a/timemachine/md/barostat/utils.py
+++ b/timemachine/md/barostat/utils.py
@@ -39,11 +39,22 @@ def get_bond_list(harmonic_bond_potential: HarmonicBond) -> List[Tuple[int, int]
     return bond_list
 
 
-def get_group_indices(bond_list: List[Tuple[int, int]]) -> List[NDArray]:
+def get_group_indices(bond_list: List[Tuple[int, int]], num_atoms: int) -> List[NDArray]:
     """Connected components of bond graph"""
 
     topology = nx.Graph(bond_list)
     components = [np.array(list(c)) for c in nx.algorithms.connected_components(topology)]
+
+    found_set = set()
+    for grp in components:
+        for idx in grp:
+            assert idx < num_atoms
+            found_set.add(idx)
+
+    for atom_idx in range(num_atoms):
+        if atom_idx not in found_set:
+            components.append(np.array([atom_idx], dtype=np.int32))
+
     return components
 
 

--- a/timemachine/md/enhanced.py
+++ b/timemachine/md/enhanced.py
@@ -471,7 +471,7 @@ def equilibrate_solvent_phase(
     intg_equil_impl = intg_equil.impl()
 
     bond_list = get_bond_list(potentials[0])
-    group_idxs = get_group_indices(bond_list)
+    group_idxs = get_group_indices(bond_list, len(masses))
     barostat_interval = 5
 
     barostat = lib.MonteCarloBarostat(len(masses), pressure, temperature, group_idxs, barostat_interval, seed + 1)

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -399,7 +399,7 @@ def equilibrate_host(
 
     integrator = LangevinIntegrator(temperature, dt, friction, combined_masses, seed).impl()
 
-    group_indices = get_group_indices(bond_list)
+    group_indices = get_group_indices(bond_list, len(combined_masses))
 
     barostat_interval = 5
     u_impls = bind_potentials(parameterize_system(hgt, ff, 0.0))  # lambda=0

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -132,7 +132,7 @@ class NPTMove(NVTMove):
         assert isinstance(bps[0].potential, HarmonicBond), "First potential must be of type HarmonicBond"
 
         bond_list = get_bond_list(bps[0].potential)
-        group_idxs = get_group_indices(bond_list)
+        group_idxs = get_group_indices(bond_list, len(masses))
 
         barostat = lib.MonteCarloBarostat(len(masses), pressure, temperature, group_idxs, barostat_interval, seed + 1)
         barostat_impl = barostat.impl(self.bound_impls)


### PR DESCRIPTION
This PR modifies get_group_indices to properly support the presence of ions (or other atoms lacking bond information) by requiring `num_atoms` as an argument. This is both an improvement and a bugfix, since the get_group_indices will affect the `MonteCarloBarostat` as well.