### PR TITLE
Fixes CIFWriter

### DIFF
--- a/examples/relative_free_energy.py
+++ b/examples/relative_free_energy.py
@@ -14,7 +14,7 @@ from timemachine.md import builders
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
 
 
-def write_trajectory_as_pdb(mol_a, mol_b, core, all_frames, host_topology, prefix):
+def write_trajectory_as_cif(mol_a, mol_b, core, all_frames, host_topology, prefix):
 
     atom_map_mixin = AtomMapMixin(mol_a, mol_b, core)
     for window_idx, window_frames in enumerate(all_frames):
@@ -25,6 +25,7 @@ def write_trajectory_as_pdb(mol_a, mol_b, core, all_frames, host_topology, prefi
             ligand_frame = frame[host_topology.getNumAtoms() :]
             mol_ab_frame = cif_writer.convert_single_topology_mols(ligand_frame, atom_map_mixin)
             writer.write_frame(np.concatenate([host_frame, mol_ab_frame]) * 10)
+        writer.close()
 
 
 def run_pair(mol_a, mol_b, core, forcefield, md_params, protein_path):
@@ -42,7 +43,7 @@ def run_pair(mol_a, mol_b, core, forcefield, md_params, protein_path):
         fh.write(solvent_res.plots.overlap_detail_png)
 
     # this st is only needed to deal with visualization jank
-    write_trajectory_as_pdb(mol_a, mol_b, core, solvent_res.frames, solvent_top, "solvent_traj")
+    write_trajectory_as_cif(mol_a, mol_b, core, solvent_res.frames, solvent_top, "solvent_traj")
 
     print(
         f"solvent dG: {np.sum(solvent_res.result.all_dGs):.3f} +- {np.linalg.norm(solvent_res.result.all_errs):.3f} kJ/mol"
@@ -58,7 +59,7 @@ def run_pair(mol_a, mol_b, core, forcefield, md_params, protein_path):
     )
     with open("complex_overlap.png", "wb") as fh:
         fh.write(complex_res.plots.overlap_detail_png)
-    write_trajectory_as_pdb(mol_a, mol_b, core, complex_res.frames, complex_top, "complex_traj")
+    write_trajectory_as_cif(mol_a, mol_b, core, complex_res.frames, complex_top, "complex_traj")
 
     print(
         f"complex dG: {np.sum(complex_res.result.all_dGs):.3f} +- {np.linalg.norm(complex_res.result.all_errs):.3f} kJ/mol"

--- a/tests/test_chiral_restraints.py
+++ b/tests/test_chiral_restraints.py
@@ -597,6 +597,7 @@ $$$$""",
     # for f in traj:
     #     f = f - np.mean(f, axis=0)
     #     writer.write_frame(f*10)
+    # writer.close()
 
     frames = simulate_system(U_fn, x0_inverted, num_samples=1000)
 

--- a/tests/test_cif_writer.py
+++ b/tests/test_cif_writer.py
@@ -76,6 +76,7 @@ def test_cif_writer(n_frames):
         cif = PDBxFile(temp.name)
         assert cif.getNumFrames() == n_frames
         assert cif.getPositions(asNumpy=True).shape == good_coords.shape
+        np.testing.assert_allclose(cif.getPositions(asNumpy=True), good_coords)
 
     _, solvent_coords, _, solvent_top = builders.build_water_system(4.0, ff.water_ff)
 
@@ -89,6 +90,7 @@ def test_cif_writer(n_frames):
         cif = PDBxFile(temp.name)
         assert cif.getNumFrames() == n_frames
         assert cif.getPositions(asNumpy=True).shape == good_coords.shape
+        np.testing.assert_allclose(cif.getPositions(asNumpy=True), good_coords)
 
     # test complex
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as path_to_pdb:
@@ -103,3 +105,4 @@ def test_cif_writer(n_frames):
             cif = PDBxFile(temp.name)
             assert cif.getNumFrames() == n_frames
             assert cif.getPositions(asNumpy=True).shape == good_coords.shape
+            np.testing.assert_allclose(cif.getPositions(asNumpy=True), good_coords)

--- a/tests/test_cif_writer.py
+++ b/tests/test_cif_writer.py
@@ -3,6 +3,7 @@ from tempfile import NamedTemporaryFile
 
 import numpy as np
 import pytest
+from openmm.app import PDBxFile
 
 from timemachine.fe.cif_writer import CIFWriter, convert_single_topology_mols
 from timemachine.fe.single_topology import SingleTopology
@@ -35,34 +36,71 @@ def test_write_single_topology_frame():
 
         # tbd replace with atom map mixin
         writer.write_frame(good_coords * 10)
+        writer.close()
+        cif = PDBxFile(temp.name)
+        assert cif.getNumFrames() == 1
+        assert cif.getPositions(asNumpy=True).shape == good_coords.shape
 
 
+@pytest.mark.parametrize("n_frames", [1, 4, 5])
 @pytest.mark.nogpu
-def test_cif_writer():
+def test_cif_writer_context(n_frames):
+    mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
+
+    # test vacuum
+    with NamedTemporaryFile(suffix=".cif") as temp:
+        good_coords = np.concatenate([get_romol_conf(mol_a), get_romol_conf(mol_b)], axis=0)
+        with CIFWriter([mol_a, mol_b], temp.name) as writer:
+            for _ in range(n_frames):
+                writer.write_frame(good_coords * 10)
+        cif = PDBxFile(temp.name)
+        assert cif.getNumFrames() == n_frames
+        assert cif.getPositions(asNumpy=True).shape == good_coords.shape
+
+
+@pytest.mark.parametrize("n_frames", [1, 4, 5])
+@pytest.mark.nogpu
+def test_cif_writer(n_frames):
 
     ff = Forcefield.load_default()
 
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
 
     # test vacuum
-    with NamedTemporaryFile() as temp:
+    with NamedTemporaryFile(suffix=".cif") as temp:
         writer = CIFWriter([mol_a, mol_b], temp.name)
         good_coords = np.concatenate([get_romol_conf(mol_a), get_romol_conf(mol_b)], axis=0)
-        writer.write_frame(good_coords * 10)
+        for _ in range(n_frames):
+            writer.write_frame(good_coords * 10)
+        writer.close()
+        print(temp.name)
+        cif = PDBxFile(temp.name)
+        assert cif.getNumFrames() == n_frames
+        assert cif.getPositions(asNumpy=True).shape == good_coords.shape
 
     _, solvent_coords, _, solvent_top = builders.build_water_system(4.0, ff.water_ff)
 
     # test solvent
-    with NamedTemporaryFile() as temp:
+    with NamedTemporaryFile(suffix=".cif") as temp:
         writer = CIFWriter([solvent_top, mol_a, mol_b], temp.name)
         good_coords = np.concatenate([solvent_coords, get_romol_conf(mol_a), get_romol_conf(mol_b)], axis=0)
-        writer.write_frame(good_coords * 10)
+        for _ in range(n_frames):
+            writer.write_frame(good_coords * 10)
+        writer.close()
+        cif = PDBxFile(temp.name)
+        assert cif.getNumFrames() == n_frames
+        assert cif.getPositions(asNumpy=True).shape == good_coords.shape
 
     # test complex
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as path_to_pdb:
         _, complex_coords, _, complex_top = builders.build_protein_system(str(path_to_pdb), ff.protein_ff, ff.water_ff)
 
-        with NamedTemporaryFile() as temp:
+        with NamedTemporaryFile(suffix=".cif") as temp:
             writer = CIFWriter([complex_top, mol_a, mol_b], temp.name)
             good_coords = np.concatenate([complex_coords, get_romol_conf(mol_a), get_romol_conf(mol_b)], axis=0)
-            writer.write_frame(good_coords * 10)
+            for _ in range(n_frames):
+                writer.write_frame(good_coords * 10)
+            writer.close()
+            cif = PDBxFile(temp.name)
+            assert cif.getNumFrames() == n_frames
+            assert cif.getPositions(asNumpy=True).shape == good_coords.shape

--- a/tests/test_cif_writer.py
+++ b/tests/test_cif_writer.py
@@ -73,7 +73,6 @@ def test_cif_writer(n_frames):
         for _ in range(n_frames):
             writer.write_frame(good_coords * 10)
         writer.close()
-        print(temp.name)
         cif = PDBxFile(temp.name)
         assert cif.getNumFrames() == n_frames
         assert cif.getPositions(asNumpy=True).shape == good_coords.shape

--- a/tests/test_interpolate_fe.py
+++ b/tests/test_interpolate_fe.py
@@ -68,6 +68,7 @@ def test_hif2a_free_energy_estimates():
             fc = cif_writer.convert_single_topology_mols(f, st)
             fc = fc - np.mean(fc, axis=0)
             writer.write_frame(fc * 10)
+        writer.close()
 
         if lambda_idx > 0:
 

--- a/tests/test_jax_nonbonded.py
+++ b/tests/test_jax_nonbonded.py
@@ -10,7 +10,6 @@ import pytest
 from jax import jit
 from jax import numpy as jnp
 from jax import value_and_grad, vmap
-from openmm import unit
 from scipy.optimize import minimize
 
 from timemachine.constants import BOLTZ, DEFAULT_TEMP
@@ -112,12 +111,10 @@ difficult_instance_flags = {key: True for key in easy_instance_flags}
 
 def generate_waterbox_nb_args() -> NonbondedArgs:
     ff = Forcefield.load_default()
-    system, positions, box, _ = builders.build_water_system(3.0, ff.water_ff)
+    system, conf, box, _ = builders.build_water_system(3.0, ff.water_ff)
     bps, masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     nb = bps[-1]
     params = nb.params
-
-    conf = positions.value_in_unit(unit.nanometer)
 
     N = conf.shape[0]
     beta = nb.potential.beta
@@ -307,12 +304,10 @@ def test_vmap():
 def test_jax_nonbonded_block():
     """Assert that nonbonded_block and nonbonded_on_specific_pairs agree"""
     ff = Forcefield.load_default()
-    system, positions, box, _ = builders.build_water_system(3.0, ff.water_ff)
+    system, conf, box, _ = builders.build_water_system(3.0, ff.water_ff)
     bps, masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     nb = bps[-1]
     params = nb.params
-
-    conf = positions.value_in_unit(unit.nanometer)
 
     N = conf.shape[0]
     beta = nb.potential.beta
@@ -375,12 +370,10 @@ def test_lj_basis():
 def test_precomputation():
     """Assert that nonbonded interaction groups using precomputation agree with reference nonbonded_on_specific_pairs"""
     ff = Forcefield.load_default()
-    system, positions, box, _ = builders.build_water_system(3.0, ff.water_ff)
+    system, conf, box, _ = builders.build_water_system(3.0, ff.water_ff)
     bps, masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     nb = bps[-1]
     params = nb.params
-
-    conf = positions.value_in_unit(unit.nanometer)
 
     n_atoms = conf.shape[0]
     beta = nb.potential.beta

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -96,7 +96,6 @@ def test_local_minimize_water_box():
     ff = Forcefield.load_default()
 
     system, x0, box0, _ = builders.build_water_system(4.0, ff.water_ff)
-    x0 = np.array(builders.strip_units(x0))
     host_fns, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     box0 += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes at the boundary
 

--- a/tests/test_nonbonded.py
+++ b/tests/test_nonbonded.py
@@ -271,7 +271,6 @@ class TestNonbonded(GradientTest):
         ff = Forcefield.load_default()
 
         _, all_coords, box, _ = builders.build_water_system(3.0, ff.water_ff)
-        all_coords = all_coords / all_coords.unit
         for size in [33, 231, 1050]:
 
             coords = all_coords[:size]
@@ -297,7 +296,6 @@ class TestNonbonded(GradientTest):
         ff = Forcefield.load_default()
 
         _, coords, box, _ = builders.build_water_system(3.0, ff.water_ff)
-        coords = coords / coords.unit
         coords = coords[:size]
 
         # Down shift box size to be only a portion of the cutoff

--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -18,7 +18,7 @@ def get_mol_by_name(mols, name):
     assert 0, "Mol not found"
 
 
-def write_trajectory_as_pdb(mol_a, mol_b, core, all_frames, host_topology, out_path):
+def write_trajectory_as_cif(mol_a, mol_b, core, all_frames, host_topology, out_path):
     atom_map_mixin = AtomMapMixin(mol_a, mol_b, core)
     writer = cif_writer.CIFWriter([host_topology, mol_a, mol_b], out_path)
     for frame in all_frames:
@@ -26,6 +26,7 @@ def write_trajectory_as_pdb(mol_a, mol_b, core, all_frames, host_topology, out_p
         ligand_frame = frame[host_topology.getNumAtoms() :]
         mol_ab_frame = cif_writer.convert_single_topology_mols(ligand_frame, atom_map_mixin)
         writer.write_frame(np.concatenate([host_frame, mol_ab_frame]) * 10)
+    writer.close()
 
 
 def run_edge(mol_a, mol_b, protein_path, n_windows):
@@ -62,13 +63,13 @@ def run_edge(mol_a, mol_b, protein_path, n_windows):
     solvent_host = setup_optimized_host(st, solvent_host_config)
     initial_states = setup_initial_states(st, solvent_host, DEFAULT_TEMP, lambda_schedule, seed)
     all_frames = [state.x0 for state in initial_states]
-    write_trajectory_as_pdb(
+    write_trajectory_as_cif(
         mol_a,
         mol_b,
         core,
         all_frames,
         solvent_top,
-        f"solvent_{get_mol_name(mol_a)}_{get_mol_name(mol_b)}.pdb",
+        f"solvent_{get_mol_name(mol_a)}_{get_mol_name(mol_b)}.cif",
     )
 
     # complex
@@ -81,13 +82,13 @@ def run_edge(mol_a, mol_b, protein_path, n_windows):
     initial_states = setup_initial_states(st, complex_host, DEFAULT_TEMP, lambda_schedule, seed)
 
     all_frames = [state.x0 for state in initial_states]
-    write_trajectory_as_pdb(
+    write_trajectory_as_cif(
         mol_a,
         mol_b,
         core,
         all_frames,
         complex_top,
-        f"complex_{get_mol_name(mol_a)}_{get_mol_name(mol_b)}.pdb",
+        f"complex_{get_mol_name(mol_a)}_{get_mol_name(mol_b)}.cif",
     )
 
 

--- a/timemachine/fe/cif_writer.py
+++ b/timemachine/fe/cif_writer.py
@@ -23,6 +23,7 @@ def convert_single_topology_mols(coords: np.ndarray, atom_map: AtomMapMixin) -> 
         >>> lig_coords = convert_single_topology_mols(x0[num_host_coords:], atom_map)
         >>> new_coords = np.concatenate((x0[:num_host_coords], lig_coords), axis=0)
         >>> writer.write_frame(new_coords*10)
+        >>> writer.close()
 
     """
     xa = np.zeros((atom_map.mol_a.GetNumAtoms(), 3))
@@ -54,7 +55,7 @@ class CIFWriter:
 
         writer = CIFWriter([topol, mol_a, mol_b], out.cif) # writer header
         writer.write_frame(coords) # coords must be in units of angstroms
-        writer.close() # writes footer
+        writer.close() # writes a hashtag
         ```
 
         Parameters
@@ -137,3 +138,14 @@ class CIFWriter:
         """
         self.frame_idx += 1
         PDBxFile.writeModel(self.topology, x, self.out_handle, self.frame_idx)
+
+    def close(self):
+        # Need this final #
+        self.out_handle.write("#")
+        self.out_handle.flush()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, tb):
+        self.close()

--- a/timemachine/md/builders.py
+++ b/timemachine/md/builders.py
@@ -8,7 +8,7 @@ from timemachine.ff import sanitize_water_ff
 
 
 def strip_units(coords):
-    return unit.Quantity(np.array(coords / coords.unit), coords.unit)
+    return np.array(coords.value_in_unit_system(unit.md_unit_system))
 
 
 def build_protein_system(host_pdbfile: Union[app.PDBFile, str], protein_ff: str, water_ff: str):
@@ -36,7 +36,6 @@ def build_protein_system(host_pdbfile: Union[app.PDBFile, str], protein_ff: str,
 
     padding = 1.0
     box_lengths = np.amax(host_coords, axis=0) - np.amin(host_coords, axis=0)
-    box_lengths = box_lengths.value_in_unit_system(unit.md_unit_system)
 
     box_lengths = box_lengths + padding
     box = np.eye(3, dtype=np.float64) * box_lengths
@@ -71,7 +70,7 @@ def build_water_system(box_width, water_ff: str):
     system = ff.createSystem(m.getTopology(), nonbondedMethod=app.NoCutoff, constraints=None, rigidWater=False)
 
     positions = m.getPositions()
-    positions = unit.Quantity(np.array(positions / positions.unit), positions.unit)
+    positions = strip_units(positions)
 
     assert m.getTopology().getNumAtoms() == positions.shape[0]
 


### PR DESCRIPTION
- OpenMM doesn't write an ending # that is needed to be read
- Adds back the close method, also makes the writer a context
- Correctly strip out units, as the PDBxFile writer is units away