### PR TITLE
Make test deadline setting consistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MKFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 CPP_DIR := $(MKFILE_DIR)timemachine/cpp/
 INSTALL_PREFIX := $(MKFILE_DIR)timemachine/
 # Conditionally set pytest args, to be able to override in CI
-PYTEST_CI_ARGS ?= --color=yes --cov=. --cov-report=html:coverage/ --cov-append --durations=100 --hypothesis-profile ci
+PYTEST_CI_ARGS ?= --color=yes --cov=. --cov-report=html:coverage/ --cov-append --durations=100
 
 NOGPU_MARKER := nogpu
 MEMCHECK_MARKER := memcheck

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -svx
+addopts = -svx --hypothesis-profile=no-deadline
 testpaths =
     tests/
 markers =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ from timemachine.lib import custom_ops
 
 # disable deadline in CI to avoid "Flaky" errors if the first example times out
 hypothesis.settings.register_profile("ci", deadline=None)
+hypothesis.settings.register_profile("no-deadline", deadline=None)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,7 @@ import pytest
 
 from timemachine.lib import custom_ops
 
-# disable deadline in CI to avoid "Flaky" errors if the first example times out
-hypothesis.settings.register_profile("ci", deadline=None)
+# disable deadlines avoid "Flaky" errors if the first example times out
 hypothesis.settings.register_profile("no-deadline", deadline=None)
 
 

--- a/tests/test_jax_utils.py
+++ b/tests/test_jax_utils.py
@@ -3,7 +3,7 @@ from functools import partial
 import hypothesis.strategies as st
 import numpy as np
 import pytest
-from hypothesis import example, given, seed, settings
+from hypothesis import example, given, seed
 from hypothesis.extra.numpy import array_shapes, arrays
 from jax import jit
 from jax import numpy as jnp
@@ -156,7 +156,6 @@ def coords_box_w_triples(draw):
 
 
 @given(coords_box_w_triples())
-@settings(deadline=400)
 @example((np.array([[0, 0], [0.5, 0]]), np.array([[1, 1]]), None))
 @example((np.array([[0, 0], [1.5, 0]]), np.array([[1, 1]]), None))
 @seed(2022)


### PR DESCRIPTION
We currently set a custom test timeout deadline for `test_pairwise_distances_periodic`, which overrides the default setting of `None` in CI.

We should probably either remove this and run tests locally with `--hypothesis-profile=ci`, or override this specific test with a value of `None` for consistency.

(This is causing failures due to timeout locally when running tests in parallel.)