### PR TITLE
Fixes Local MD when n_frames > max_buffer_size

### DIFF
--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -255,15 +255,13 @@ def hif2a_ligand_pair_single_topology_lam0_state():
     return state
 
 
-@given(integers(1, 100), integers(1, 100), integers(0, 5))
+@given(integers(1, 100), integers(1, 100))
 @seed(2023)
-@example(10, 3, 0)
-@example(10, 1, 1)
-@example(1, 10, 5)
-def test_sample_max_buffer_frames(
-    hif2a_ligand_pair_single_topology_lam0_state, n_frames, max_buffer_frames, local_steps
-):
-    md_params = MDParams(n_frames, 1, 1, 2023, local_steps=local_steps)
+@example(10, 3)
+@example(10, 1)
+@example(1, 10)
+def test_sample_max_buffer_frames(hif2a_ligand_pair_single_topology_lam0_state, n_frames, max_buffer_frames):
+    md_params = MDParams(n_frames, 1, 1, 2023)
     frames_ref, _ = sample(hif2a_ligand_pair_single_topology_lam0_state, md_params)
     frames_test, _ = sample(
         hif2a_ligand_pair_single_topology_lam0_state, md_params, max_buffer_frames=max_buffer_frames

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -10,8 +10,16 @@ from scipy.optimize import check_grad, minimize
 
 from timemachine.constants import DEFAULT_TEMP
 from timemachine.fe import free_energy, topology, utils
-from timemachine.fe.free_energy import BarResult, MDParams, PairBarResult, batches, make_pair_bar_plots, sample
-from timemachine.fe.rbfe import setup_initial_states
+from timemachine.fe.free_energy import (
+    BarResult,
+    HostConfig,
+    MDParams,
+    PairBarResult,
+    batches,
+    make_pair_bar_plots,
+    sample,
+)
+from timemachine.fe.rbfe import setup_initial_states, setup_optimized_host
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.stored_arrays import StoredArrays
 from timemachine.ff import Forcefield
@@ -189,6 +197,40 @@ def test_vacuum_and_solvent_edge_types():
     assert type(vacuum_masses) == type(solvent_masses)
 
 
+@pytest.fixture(scope="module")
+def solvent_hif2a_ligand_pair_single_topology_lam0_state():
+    mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
+    forcefield = Forcefield.load_default()
+    st = SingleTopology(mol_a, mol_b, core, forcefield)
+
+    solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(3.0, forcefield.water_ff)
+    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box)
+    solvent_host = setup_optimized_host(st, solvent_host_config)
+    state = setup_initial_states(st, solvent_host, DEFAULT_TEMP, [0.0], 2023)[0]
+    return state
+
+
+@pytest.mark.parametrize("n_frames", [1, 10])
+@pytest.mark.parametrize("local_steps", [0, 1])
+@pytest.mark.parametrize("max_buffer_frames", [1])
+def test_sample_max_buffer_frames_with_local_md(
+    solvent_hif2a_ligand_pair_single_topology_lam0_state, n_frames, local_steps, max_buffer_frames
+):
+    """Ensure that if sample is called with max_buffer_frames combined with local MD it works. This failed previously
+    due to trying to configure local md on the same context repeatedly. This was due to max_buffer_frames < n_frames which
+    resulted in caling ctxt.setup_local_md multiple times.
+    """
+    steps_per_frame = 1
+    n_eq_steps = 1
+
+    md_params = MDParams(n_frames, n_eq_steps, steps_per_frame, 2023, local_steps=local_steps)
+    frames, _ = sample(
+        solvent_hif2a_ligand_pair_single_topology_lam0_state, md_params, max_buffer_frames=max_buffer_frames
+    )
+    assert isinstance(frames, StoredArrays)
+    assert len(frames) == n_frames
+
+
 @given(integers(min_value=1))
 @seed(2023)
 def test_batches_of_nothing(batch_size):
@@ -213,13 +255,15 @@ def hif2a_ligand_pair_single_topology_lam0_state():
     return state
 
 
-@given(integers(1, 100), integers(1, 100))
+@given(integers(1, 100), integers(1, 100), integers(0, 5))
 @seed(2023)
-@example(10, 3)
-@example(10, 1)
-@example(1, 10)
-def test_sample_max_buffer_frames(hif2a_ligand_pair_single_topology_lam0_state, n_frames, max_buffer_frames):
-    md_params = MDParams(n_frames, 1, 1, 2023)
+@example(10, 3, 0)
+@example(10, 1, 1)
+@example(1, 10, 5)
+def test_sample_max_buffer_frames(
+    hif2a_ligand_pair_single_topology_lam0_state, n_frames, max_buffer_frames, local_steps
+):
+    md_params = MDParams(n_frames, 1, 1, 2023, local_steps=local_steps)
     frames_ref, _ = sample(hif2a_ligand_pair_single_topology_lam0_state, md_params)
     frames_test, _ = sample(
         hif2a_ligand_pair_single_topology_lam0_state, md_params, max_buffer_frames=max_buffer_frames

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -357,6 +357,9 @@ def sample(initial_state: InitialState, md_params: MDParams, max_buffer_frames: 
 
     rng = np.random.default_rng(md_params.seed)
 
+    if md_params.local_steps > 0:
+        ctxt.setup_local_md(initial_state.integrator.temperature, md_params.freeze_reference)
+
     assert np.all(np.isfinite(ctxt.get_x_t())), "Equilibration resulted in a nan"
 
     def run_production_steps(n_steps: int) -> Tuple[NDArray, NDArray]:
@@ -371,7 +374,6 @@ def sample(initial_state: InitialState, md_params: MDParams, max_buffer_frames: 
     def run_production_local_steps(n_steps: int) -> Tuple[NDArray, NDArray]:
         coords = None
         boxes = None
-        ctxt.setup_local_md(initial_state.integrator.temperature, md_params.freeze_reference)
         for steps in batches(n_steps, md_params.steps_per_frame):
             if steps < md_params.steps_per_frame:
                 warn(


### PR DESCRIPTION
Local MD caused `sample` calls to fail due to configuring the context multiple times. Only happens if max_buffer_frames < n_frames which is not a case we run in the tests for speed reasons. 