### PR TITLE
Allow passing empty list of cores

### DIFF
--- a/tests/test_fe_utils.py
+++ b/tests/test_fe_utils.py
@@ -173,6 +173,9 @@ def test_view_atom_mapping_3d():
     AllChem.EmbedMolecule(mol_a)
     AllChem.EmbedMolecule(mol_b)
 
+    view = utils.view_atom_mapping_3d(mol_a, mol_b)
+    assert isinstance(view, py3Dmol.view)
+
     core = [[2, 0], [3, 2], [0, 3], [1, 4]]
 
     view = utils.view_atom_mapping_3d(mol_a, mol_b, [core])

--- a/tests/test_fe_utils.py
+++ b/tests/test_fe_utils.py
@@ -176,6 +176,9 @@ def test_view_atom_mapping_3d():
     view = utils.view_atom_mapping_3d(mol_a, mol_b)
     assert isinstance(view, py3Dmol.view)
 
+    view = utils.view_atom_mapping_3d(mol_a, mol_b, [])
+    assert isinstance(view, py3Dmol.view)
+
     core = [[2, 0], [3, 2], [0, 3], [1, 4]]
 
     view = utils.view_atom_mapping_3d(mol_a, mol_b, [core])

--- a/tests/test_fe_utils.py
+++ b/tests/test_fe_utils.py
@@ -208,3 +208,12 @@ def test_view_atom_mapping_3d():
 
     view = utils.view_atom_mapping_3d(mol_a, mol_b, cores)
     assert isinstance(view, py3Dmol.view)
+
+    # multiple cores, different sizes, ndarray input
+    cores = [
+        np.array([[2, 0], [3, 2], [0, 3]]),
+        np.array([[2, 0], [3, 2], [0, 3], [1, 4]]),
+    ]
+
+    view = utils.view_atom_mapping_3d(mol_a, mol_b, cores)
+    assert isinstance(view, py3Dmol.view)

--- a/tests/test_fe_utils.py
+++ b/tests/test_fe_utils.py
@@ -173,12 +173,17 @@ def test_view_atom_mapping_3d():
     AllChem.EmbedMolecule(mol_a)
     AllChem.EmbedMolecule(mol_b)
 
+    # no core
     view = utils.view_atom_mapping_3d(mol_a, mol_b)
     assert isinstance(view, py3Dmol.view)
 
     view = utils.view_atom_mapping_3d(mol_a, mol_b, [])
     assert isinstance(view, py3Dmol.view)
 
+    view = utils.view_atom_mapping_3d(mol_a, mol_b, np.array([]))
+    assert isinstance(view, py3Dmol.view)
+
+    # single core
     core = [[2, 0], [3, 2], [0, 3], [1, 4]]
 
     view = utils.view_atom_mapping_3d(mol_a, mol_b, [core])
@@ -186,3 +191,20 @@ def test_view_atom_mapping_3d():
 
     with pytest.raises(AssertionError, match="expect a list of cores"):
         utils.view_atom_mapping_3d(mol_a, mol_b, core)
+
+    # multiple cores
+    view = utils.view_atom_mapping_3d(mol_a, mol_b, [core, core])
+    assert isinstance(view, py3Dmol.view)
+
+    # multiple cores, ndarray input
+    view = utils.view_atom_mapping_3d(mol_a, mol_b, np.array([core, core]))
+    assert isinstance(view, py3Dmol.view)
+
+    # multiple cores, different sizes
+    cores = [
+        [[2, 0], [3, 2], [0, 3]],
+        [[2, 0], [3, 2], [0, 3], [1, 4]],
+    ]
+
+    view = utils.view_atom_mapping_3d(mol_a, mol_b, cores)
+    assert isinstance(view, py3Dmol.view)

--- a/timemachine/fe/utils.py
+++ b/timemachine/fe/utils.py
@@ -287,8 +287,8 @@ def view_atom_mapping_3d(
     except ImportError as e:
         raise RuntimeError("requires py3Dmol to be installed") from e
 
-    if len(cores) > 0:
-        assert np.asarray(cores[0]).ndim == 2, "expect a list of cores"
+    for core in cores:
+        assert np.asarray(core).ndim == 2, "expect a list of cores"
 
     make_style = lambda props: {"stick": props}
     atom_style = lambda color: make_style({"color": color})

--- a/timemachine/fe/utils.py
+++ b/timemachine/fe/utils.py
@@ -287,9 +287,10 @@ def view_atom_mapping_3d(
     except ImportError as e:
         raise RuntimeError("requires py3Dmol to be installed") from e
 
-    cores_ = np.asarray(cores)
-    assert cores_.ndim == 3, "expect a list of cores"
-    cores = cores_.tolist()
+    if cores:
+        cores_ = np.asarray(cores)
+        assert cores_.ndim == 3, "expect a list of cores"
+        cores = cores_.tolist()
 
     make_style = lambda props: {"stick": props}
     atom_style = lambda color: make_style({"color": color})


### PR DESCRIPTION
Fixes regressions in `view_atom_mapping_3d` introduced by #1028: 

- omitting the `cores` argument (or passing an empty list) results in `AssertionError`
- passing list of cores with different sizes results in runtime error
- passing list of ndarrays results in runtime error