### PR TITLE
Perf/event sync and condense kernels

### DIFF
--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -11,6 +11,7 @@ void __global__ k_find_block_bounds(
     const int N,                               // Number of atoms
     const int num_tiles,                       // Number of tiles
     const int num_indices,                     // Number of indices
+    unsigned int *ixn_count,                   // [1]
     const unsigned int *__restrict__ row_idxs, // [num_indices]
     const double *__restrict__ coords,         // [N*3]
     const double *__restrict__ box,            // [3*3]
@@ -82,6 +83,11 @@ void __global__ k_find_block_bounds(
     block_bounds_ext[tile_idx * 3 + 0] = static_cast<RealType>(0.5) * (maxPos_x - minPos_x);
     block_bounds_ext[tile_idx * 3 + 1] = static_cast<RealType>(0.5) * (maxPos_y - minPos_y);
     block_bounds_ext[tile_idx * 3 + 2] = static_cast<RealType>(0.5) * (maxPos_z - minPos_z);
+
+    // Reset the ixn count
+    if (tile_idx == 0) {
+        ixn_count[0] = 0;
+    }
 }
 
 void __global__ k_compact_trim_atoms(

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -11,12 +11,12 @@ void __global__ k_find_block_bounds(
     const int N,                               // Number of atoms
     const int num_tiles,                       // Number of tiles
     const int num_indices,                     // Number of indices
-    unsigned int *ixn_count,                   // [1]
     const unsigned int *__restrict__ row_idxs, // [num_indices]
     const double *__restrict__ coords,         // [N*3]
     const double *__restrict__ box,            // [3*3]
     RealType *__restrict__ block_bounds_ctr,   // [num_tiles*3]
-    RealType *__restrict__ block_bounds_ext    // [num_tiles*3]
+    RealType *__restrict__ block_bounds_ext,   // [num_tiles*3]
+    unsigned int *ixn_count                    // [1]
 ) {
 
     // Algorithm taken from https://github.com/openmm/openmm/blob/master/platforms/cuda/src/kernels/findInteractingBlocks.cu#L7

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -14,8 +14,8 @@ void __global__ k_find_block_bounds(
     const unsigned int *__restrict__ row_idxs, // [num_indices]
     const double *__restrict__ coords,         // [N*3]
     const double *__restrict__ box,            // [3*3]
-    double *__restrict__ block_bounds_ctr,     // [num_tiles*3]
-    double *__restrict__ block_bounds_ext      // [num_tiles*3]
+    RealType *__restrict__ block_bounds_ctr,   // [num_tiles*3]
+    RealType *__restrict__ block_bounds_ext    // [num_tiles*3]
 ) {
 
     // Algorithm taken from https://github.com/openmm/openmm/blob/master/platforms/cuda/src/kernels/findInteractingBlocks.cu#L7
@@ -172,10 +172,10 @@ void __global__ k_find_blocks_with_ixns(
     const int NR,                                 // Number of rows idxs
     const unsigned int *__restrict__ column_idxs, // [NC]
     const unsigned int *__restrict__ row_idxs,    // [NR]
-    const double *__restrict__ column_bb_ctr,     // [N * 3] block centers
-    const double *__restrict__ column_bb_ext,     // [N * 3] block extents
-    const double *__restrict__ row_bb_ctr,        // [N * 3] block centers
-    const double *__restrict__ row_bb_ext,        // [N * 3] block extants
+    const RealType *__restrict__ column_bb_ctr,   // [N * 3] block centers
+    const RealType *__restrict__ column_bb_ext,   // [N * 3] block extents
+    const RealType *__restrict__ row_bb_ctr,      // [N * 3] block centers
+    const RealType *__restrict__ row_bb_ext,      // [N * 3] block extants
     const double *__restrict__ coords,            // [N * 3]
     const double *__restrict__ box,
     unsigned int *__restrict__ interactionCount, // number of tiles that have interactions

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -155,11 +155,13 @@ void __global__ k_copy_nblist_coords_and_box(
 }
 
 template <typename RealType>
-void __global__ k_gather(
+void __global__ k_gather_coords_and_params(
     const int N,
     const unsigned int *__restrict__ idxs,
-    const RealType *__restrict__ array,
-    RealType *__restrict__ gathered_array) {
+    const RealType *__restrict__ coords,
+    const RealType *__restrict__ params,
+    RealType *__restrict__ gathered_coords,
+    RealType *__restrict__ gathered_params) {
 
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int stride = gridDim.y;
@@ -169,7 +171,11 @@ void __global__ k_gather(
         return;
     }
 
-    gathered_array[idx * stride + stride_idx] = array[idxs[idx] * stride + stride_idx];
+    // Coords have 3 dimensions, params have 4
+    if (stride_idx < 3) {
+        gathered_coords[idx * 3 + stride_idx] = coords[idxs[idx] * 3 + stride_idx];
+    }
+    gathered_params[idx * stride + stride_idx] = params[idxs[idx] * stride + stride_idx];
 }
 
 template <typename RealType>

--- a/timemachine/cpp/src/kernels/k_nonbonded_common.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_common.cuh
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "k_fixed_point.cuh"
-#include <vector>
 
 // each atom parameterized by a 4-tuple: charge, lj sigma, lj epsilon, 4D coordinate w
 enum { PARAM_OFFSET_CHARGE = 0, PARAM_OFFSET_SIG, PARAM_OFFSET_EPS, PARAM_OFFSET_W, PARAMS_PER_ATOM };

--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -207,12 +207,12 @@ void Neighborlist<RealType>::compute_block_bounds_device(
         N,
         column_blocks,
         NC_,
-        d_ixn_count_,
         d_column_idxs_,
         d_coords,
         d_box,
         d_column_block_bounds_ctr_,
-        d_column_block_bounds_ext_);
+        d_column_block_bounds_ext_,
+        d_ixn_count_);
     gpuErrchk(cudaPeekAtLastError());
     // In the case of upper triangle of the matrix, the column and row indices are the same, so only compute block ixns for both
     // when they are different
@@ -222,12 +222,12 @@ void Neighborlist<RealType>::compute_block_bounds_device(
             N,
             row_blocks,
             NR_,
-            d_ixn_count_,
             d_row_idxs_,
             d_coords,
             d_box,
             d_row_block_bounds_ctr_,
-            d_row_block_bounds_ext_);
+            d_row_block_bounds_ext_,
+            d_ixn_count_);
         gpuErrchk(cudaPeekAtLastError());
     }
 };

--- a/timemachine/cpp/src/neighborlist.hpp
+++ b/timemachine/cpp/src/neighborlist.hpp
@@ -14,10 +14,10 @@ private:
     int NC_;             // Number of atoms in column, N_ by default
     int NR_;             // Number of atoms in row, N_ by default
 
-    double *d_row_block_bounds_ctr_;
-    double *d_row_block_bounds_ext_;
-    double *d_column_block_bounds_ctr_;
-    double *d_column_block_bounds_ext_;
+    RealType *d_row_block_bounds_ctr_;
+    RealType *d_row_block_bounds_ext_;
+    RealType *d_column_block_bounds_ctr_;
+    RealType *d_column_block_bounds_ext_;
 
     unsigned int *d_row_idxs_;
     unsigned int *d_column_idxs_;

--- a/timemachine/cpp/src/nonbonded_all_pairs.cu
+++ b/timemachine/cpp/src/nonbonded_all_pairs.cu
@@ -112,6 +112,9 @@ NonbondedAllPairs<RealType>::NonbondedAllPairs(
     cudaSafeMalloc(&d_sort_storage_, d_sort_storage_bytes_);
 
     this->set_atom_idxs(atom_idxs_h);
+
+    // Create event with timings disabled as timings slow down events
+    gpuErrchk(cudaEventCreateWithFlags(&rebuild_event_, cudaEventDisableTiming));
 };
 
 template <typename RealType> NonbondedAllPairs<RealType>::~NonbondedAllPairs() {
@@ -140,6 +143,8 @@ template <typename RealType> NonbondedAllPairs<RealType>::~NonbondedAllPairs() {
     gpuErrchk(cudaFree(d_nblist_box_));
     gpuErrchk(cudaFree(d_rebuild_nblist_));
     gpuErrchk(cudaFreeHost(p_rebuild_nblist_));
+
+    gpuErrchk(cudaEventDestroy(rebuild_event_));
 };
 
 // Set atom idxs upon which to compute the non-bonded potential. This will trigger a neighborlist rebuild.
@@ -277,12 +282,22 @@ void NonbondedAllPairs<RealType>::execute_device(
         // we can optimize this away by doing the check on the GPU directly.
         gpuErrchk(cudaMemcpyAsync(
             p_rebuild_nblist_, d_rebuild_nblist_, 1 * sizeof(*p_rebuild_nblist_), cudaMemcpyDeviceToHost, stream));
-        gpuErrchk(cudaStreamSynchronize(stream)); // slow!
+        gpuErrchk(cudaEventRecord(rebuild_event_, stream));
     }
     // compute new coordinates
     k_gather<<<dim3(ceil_divide(K_, tpb), 3, 1), tpb, 0, stream>>>(K_, d_sorted_atom_idxs_, d_x, d_gathered_x_);
     gpuErrchk(cudaPeekAtLastError());
 
+    // reset buffers and sorted accumulators
+    if (d_du_dx) {
+        gpuErrchk(cudaMemsetAsync(d_gathered_du_dx_, 0, K_ * COORDS_DIM * sizeof(*d_gathered_du_dx_), stream))
+    }
+    if (d_du_dp) {
+        gpuErrchk(cudaMemsetAsync(d_gathered_du_dp_, 0, K_ * PARAMS_PER_ATOM * sizeof(*d_gathered_du_dp_), stream))
+    }
+    // Syncing to an event allows having additional kernels run while we synchronize
+    // Note that if no event is recorded, this is effectively a no-op, such as in the case of sorting.
+    gpuErrchk(cudaEventSynchronize(rebuild_event_));
     if (p_rebuild_nblist_[0] > 0) {
 
         nblist_.build_nblist_device(K_, d_gathered_x_, d_box, cutoff_ + nblist_padding_, stream);
@@ -316,19 +331,6 @@ void NonbondedAllPairs<RealType>::execute_device(
         gpuErrchk(cudaMemcpyAsync(d_nblist_box_, d_box, 3 * 3 * sizeof(*d_box), cudaMemcpyDeviceToDevice, stream));
     }
 
-    // do parameter interpolation here
-    k_gather<<<dim3(ceil_divide(K_, tpb), PARAMS_PER_ATOM, 1), tpb, 0, stream>>>(
-        K_, d_sorted_atom_idxs_, d_p, d_gathered_p_);
-    gpuErrchk(cudaPeekAtLastError());
-
-    // reset buffers and sorted accumulators
-    if (d_du_dx) {
-        gpuErrchk(cudaMemsetAsync(d_gathered_du_dx_, 0, K_ * 3 * sizeof(*d_gathered_du_dx_), stream))
-    }
-    if (d_du_dp) {
-        gpuErrchk(cudaMemsetAsync(d_gathered_du_dp_, 0, K_ * PARAMS_PER_ATOM * sizeof(*d_gathered_du_dp_), stream))
-    }
-
     // look up which kernel we need for this computation
     int kernel_idx = 0;
     kernel_idx |= d_du_dp ? 1 << 0 : 0;
@@ -350,7 +352,6 @@ void NonbondedAllPairs<RealType>::execute_device(
         d_gathered_du_dp_,
         d_u // switch to nullptr if we don't request energies
     );
-
     gpuErrchk(cudaPeekAtLastError());
 
     // coords are N,3

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -56,7 +56,7 @@ private:
     unsigned int *d_sort_storage_;
     size_t d_sort_storage_bytes_;
 
-    cudaEvent_t rebuild_event_; // Event to synchronize on
+    cudaEvent_t nblist_flag_sync_event_; // Event to synchronize on
 
     const bool disable_hilbert_;
 

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -56,6 +56,8 @@ private:
     unsigned int *d_sort_storage_;
     size_t d_sort_storage_bytes_;
 
+    cudaEvent_t rebuild_event_; // Event to synchronize on
+
     const bool disable_hilbert_;
 
     std::array<k_nonbonded_fn, 8> kernel_ptrs_;

--- a/timemachine/cpp/src/nonbonded_interaction_group.hpp
+++ b/timemachine/cpp/src/nonbonded_interaction_group.hpp
@@ -58,6 +58,8 @@ private:
     unsigned int *d_sort_storage_;
     size_t d_sort_storage_bytes_;
 
+    cudaEvent_t rebuild_event_; // Event to synchronize rebuild flag on
+
     const bool disable_hilbert_;
 
     bool needs_sort();

--- a/timemachine/cpp/src/nonbonded_interaction_group.hpp
+++ b/timemachine/cpp/src/nonbonded_interaction_group.hpp
@@ -58,7 +58,7 @@ private:
     unsigned int *d_sort_storage_;
     size_t d_sort_storage_bytes_;
 
-    cudaEvent_t rebuild_event_; // Event to synchronize rebuild flag on
+    cudaEvent_t nblist_flag_sync_event_; // Event to synchronize rebuild flag on
 
     const bool disable_hilbert_;
 


### PR DESCRIPTION
This PR makes several minor changes for the continued goal of speeding things up

- Convert bounding box centers/extents to RealType for neighborlist: Reduces float64 operations in the bounding block kernel (~2% improvement)
- Merge the coords/param gather kernel: Avoids launching two kernels when one will suffice. (< 1% improvement)
- Reset the ixn count in the bounding block: Avoid launching a memset call (< 1% improvement)
- Perform an event sync rather than a stream sync: Avoid the amount of time the stream is doing no work (~2% improvement)

Gets about 4% speed up for Global MD and 10% for local MD

# Benchmarks

## Current Performance
```
dhfr-apo: N=23558 speed: 362.22ns/day dt: 1.5fs (ran 100000 steps in 35.78s)
dhfr-apo-barostat-interval-25: N=23558 speed: 333.55ns/day dt: 1.5fs (ran 100000 steps in 38.86s)
dhfr-apo-hmr-barostat-interval-25: N=23558 speed: 554.74ns/day dt: 2.5fs (ran 100000 steps in 38.94s)
building a protein system with 1758 protein atoms and 7047 water atoms
hif2a-apo: N=8805 speed: 639.16ns/day dt: 1.5fs (ran 100000 steps in 20.28s)
hif2a-apo-barostat-interval-25: N=8805 speed: 547.57ns/day dt: 1.5fs (ran 100000 steps in 23.67s)
hif2a-rbfe: N=8840 speed: 671.25ns/day dt: 1.5fs (ran 100000 steps in 19.31s)
hif2a-rbfe-local: N=8840 speed: 942.08ns/day dt: 1.5fs (ran 100000 steps in 13.76s)
solvent-apo: N=6282 speed: 800.01ns/day dt: 1.5fs (ran 100000 steps in 16.20s)
solvent-apo-barostat-interval-25: N=6282 speed: 706.27ns/day dt: 1.5fs (ran 100000 steps in 18.35s)
solvent-rbfe: N=6317 speed: 821.76ns/day dt: 1.5fs (ran 100000 steps in 15.77s)
solvent-rbfe-local: N=6317 speed: 898.41ns/day dt: 1.5fs (ran 100000 steps in 14.43s)

NonbondedInteractionGroup_f32: N=8840 Frames=1000 Params=5 speed: 1151.44 executions/seconds (ran 25000 potentials in 21.71s)
NonbondedInteractionGroup_f64: N=8840 Frames=1000 Params=5 speed: 989.78 executions/seconds (ran 25000 potentials in 25.26s)
Nonbonded_f32: N=8840 Frames=1000 Params=5 speed: 937.20 executions/seconds (ran 25000 potentials in 26.68s)
Nonbonded_f64: N=8840 Frames=1000 Params=5 speed: 134.98 executions/seconds (ran 25000 potentials in 185.21s)
HarmonicBond_f32: N=8840 Frames=1000 Params=5 speed: 1453.91 executions/seconds (ran 25000 potentials in 17.20s)
HarmonicBond_f64: N=8840 Frames=1000 Params=5 speed: 1450.21 executions/seconds (ran 25000 potentials in 17.24s)
HarmonicAngleStable_f32: N=8840 Frames=1000 Params=5 speed: 1411.45 executions/seconds (ran 25000 potentials in 17.71s)
HarmonicAngleStable_f64: N=8840 Frames=1000 Params=5 speed: 1403.30 executions/seconds (ran 25000 potentials in 17.82s)
PeriodicTorsion_f32: N=8840 Frames=1000 Params=5 speed: 1410.21 executions/seconds (ran 25000 potentials in 17.73s)
PeriodicTorsion_f64: N=8840 Frames=1000 Params=5 speed: 1396.22 executions/seconds (ran 25000 potentials in 17.91s)
NonbondedPairListPrecomputed_f32: N=8840 Frames=1000 Params=5 speed: 1557.66 executions/seconds (ran 25000 potentials in 16.05s)
NonbondedPairListPrecomputed_f64: N=8840 Frames=1000 Params=5 speed: 1549.71 executions/seconds (ran 25000 potentials in 16.13s)
```

## Modifications
```
dhfr-apo: N=23558 speed: 378.51ns/day dt: 1.5fs (ran 100000 steps in 34.24s)
dhfr-apo-barostat-interval-25: N=23558 speed: 348.86ns/day dt: 1.5fs (ran 100000 steps in 37.15s)
dhfr-apo-hmr-barostat-interval-25: N=23558 speed: 582.50ns/day dt: 2.5fs (ran 100000 steps in 37.08s)
hif2a-apo: N=8805 speed: 658.98ns/day dt: 1.5fs (ran 100000 steps in 19.67s)
hif2a-apo-barostat-interval-25: N=8805 speed: 569.63ns/day dt: 1.5fs (ran 100000 steps in 22.75s)
hif2a-rbfe: N=8840 speed: 689.49ns/day dt: 1.5fs (ran 100000 steps in 18.80s)
hif2a-rbfe-local: N=8840 speed: 1044.49ns/day dt: 1.5fs (ran 100000 steps in 12.41s)
solvent-apo: N=6282 speed: 829.60ns/day dt: 1.5fs (ran 100000 steps in 15.62s)
solvent-apo-barostat-interval-25: N=6282 speed: 743.66ns/day dt: 1.5fs (ran 100000 steps in 17.43s)
solvent-rbfe: N=6317 speed: 856.90ns/day dt: 1.5fs (ran 100000 steps in 15.13s)
solvent-rbfe-local: N=6317 speed: 1000.22ns/day dt: 1.5fs (ran 100000 steps in 12.96s)

NonbondedInteractionGroup_f32: N=8840 Frames=1000 Params=5 speed: 1180.08 executions/seconds (ran 25000 potentials in 21.19s)
NonbondedInteractionGroup_f64: N=8840 Frames=1000 Params=5 speed: 1015.75 executions/seconds (ran 25000 potentials in 24.61s)
Nonbonded_f32: N=8840 Frames=1000 Params=5 speed: 964.16 executions/seconds (ran 25000 potentials in 25.93s)
Nonbonded_f64: N=8840 Frames=1000 Params=5 speed: 135.40 executions/seconds (ran 25000 potentials in 184.64s)
HarmonicBond_f32: N=8840 Frames=1000 Params=5 speed: 1486.46 executions/seconds (ran 25000 potentials in 16.82s)
HarmonicBond_f64: N=8840 Frames=1000 Params=5 speed: 1486.91 executions/seconds (ran 25000 potentials in 16.81s)
HarmonicAngleStable_f32: N=8840 Frames=1000 Params=5 speed: 1449.15 executions/seconds (ran 25000 potentials in 17.25s)
HarmonicAngleStable_f64: N=8840 Frames=1000 Params=5 speed: 1442.11 executions/seconds (ran 25000 potentials in 17.34s)
PeriodicTorsion_f32: N=8840 Frames=1000 Params=5 speed: 1454.51 executions/seconds (ran 25000 potentials in 17.19s)
PeriodicTorsion_f64: N=8840 Frames=1000 Params=5 speed: 1431.92 executions/seconds (ran 25000 potentials in 17.46s)
NonbondedPairListPrecomputed_f32: N=8840 Frames=1000 Params=5 speed: 1605.27 executions/seconds (ran 25000 potentials in 15.57s)
NonbondedPairListPrecomputed_f64: N=8840 Frames=1000 Params=5 speed: 1592.64 executions/seconds (ran 25000 potentials in 15.70s)
```