### PR TITLE
Uses nearbyintf instead of nearbyint

### DIFF
--- a/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
@@ -38,9 +38,9 @@ void __global__ k_log_probability_selection(
     RealType atom_atom_dy = coords[idx * 3 + 1] - coords[reference_idx * 3 + 1];
     RealType atom_atom_dz = coords[idx * 3 + 2] - coords[reference_idx * 3 + 2];
 
-    atom_atom_dx -= bx * nearbyint(atom_atom_dx * inv_bx);
-    atom_atom_dy -= by * nearbyint(atom_atom_dy * inv_by);
-    atom_atom_dz -= bz * nearbyint(atom_atom_dz * inv_bz);
+    atom_atom_dx -= bx * nearbyintf(atom_atom_dx * inv_bx);
+    atom_atom_dy -= by * nearbyintf(atom_atom_dy * inv_by);
+    atom_atom_dz -= bz * nearbyintf(atom_atom_dz * inv_bz);
 
     const RealType distance_sq =
         atom_atom_dx * atom_atom_dx + atom_atom_dy * atom_atom_dy + atom_atom_dz * atom_atom_dz;
@@ -98,7 +98,7 @@ void __global__ k_flat_bottom_bond(
     RealType r2 = 0;
     for (int d = 0; d < 3; d++) {
         double delta = coords[src_idx * 3 + d] - coords[dst_idx * 3 + d];
-        delta -= box[d * 3 + d] * nearbyint(delta / box[d * 3 + d]);
+        delta -= box[d * 3 + d] * nearbyintf(delta / box[d * 3 + d]);
         dx[d] = delta;
         r2 += delta * delta;
     }

--- a/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
@@ -47,7 +47,7 @@ void __global__ k_log_flat_bottom_bond(
     RealType r2 = 0;
     for (int d = 0; d < 3; d++) {
         double delta = coords[src_idx * 3 + d] - coords[dst_idx * 3 + d];
-        delta -= box[d * 3 + d] * nearbyint(delta / box[d * 3 + d]);
+        delta -= box[d * 3 + d] * nearbyintf(delta / box[d * 3 + d]);
         dx[d] = delta;
         r2 += delta * delta;
     }

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -64,9 +64,9 @@ void __global__ k_find_block_bounds(
         RealType center_x = static_cast<RealType>(0.5) * (maxPos_x + minPos_x);
         RealType center_y = static_cast<RealType>(0.5) * (maxPos_y + minPos_y);
         RealType center_z = static_cast<RealType>(0.5) * (maxPos_z + minPos_z);
-        pos_x -= bx * nearbyint((pos_x - center_x) * inv_bx);
-        pos_y -= by * nearbyint((pos_y - center_y) * inv_by);
-        pos_z -= bz * nearbyint((pos_z - center_z) * inv_bz);
+        pos_x -= bx * nearbyintf((pos_x - center_x) * inv_bx);
+        pos_y -= by * nearbyintf((pos_y - center_y) * inv_by);
+        pos_z -= bz * nearbyintf((pos_z - center_z) * inv_bz);
         minPos_x = min(minPos_x, pos_x);
         minPos_y = min(minPos_y, pos_y);
         minPos_z = min(minPos_z, pos_z);
@@ -246,9 +246,9 @@ void __global__ k_find_blocks_with_ixns(
          static_cast<RealType>(0.5) * bz - row_bb_ext_z >= cutoff);
 
     if (single_periodic_box) {
-        pos_i_x -= bx * nearbyint((pos_i_x - row_bb_ctr_x) * inv_bx);
-        pos_i_y -= by * nearbyint((pos_i_y - row_bb_ctr_y) * inv_by);
-        pos_i_z -= bz * nearbyint((pos_i_z - row_bb_ctr_z) * inv_bz);
+        pos_i_x -= bx * nearbyintf((pos_i_x - row_bb_ctr_x) * inv_bx);
+        pos_i_y -= by * nearbyintf((pos_i_y - row_bb_ctr_y) * inv_by);
+        pos_i_z -= bz * nearbyintf((pos_i_z - row_bb_ctr_z) * inv_bz);
 
         non_periodic_dist_i = static_cast<RealType>(0.5) * (pos_i_x * pos_i_x + pos_i_y * pos_i_y + pos_i_z * pos_i_z);
     }
@@ -277,9 +277,9 @@ void __global__ k_find_blocks_with_ixns(
         RealType box_box_dz = row_bb_ctr_z - col_bb_ctr_z;
 
         // Recenter delta box
-        box_box_dx -= bx * nearbyint(box_box_dx * inv_bx);
-        box_box_dy -= by * nearbyint(box_box_dy * inv_by);
-        box_box_dz -= bz * nearbyint(box_box_dz * inv_bz);
+        box_box_dx -= bx * nearbyintf(box_box_dx * inv_bx);
+        box_box_dy -= by * nearbyintf(box_box_dy * inv_by);
+        box_box_dz -= bz * nearbyintf(box_box_dz * inv_bz);
 
         // If boxes overlap, treat distance as 0
         box_box_dx = max(static_cast<RealType>(0.0), fabs(box_box_dx) - row_bb_ext_x - col_bb_ext_x);
@@ -326,9 +326,9 @@ void __global__ k_find_blocks_with_ixns(
         RealType atom_box_dy = (atom_i_idx < N ? coords[atom_i_idx * 3 + 1] : 0) - col_bb_ctr_y;
         RealType atom_box_dz = (atom_i_idx < N ? coords[atom_i_idx * 3 + 2] : 0) - col_bb_ctr_z;
 
-        atom_box_dx -= bx * nearbyint(atom_box_dx * inv_bx);
-        atom_box_dy -= by * nearbyint(atom_box_dy * inv_by);
-        atom_box_dz -= bz * nearbyint(atom_box_dz * inv_bz);
+        atom_box_dx -= bx * nearbyintf(atom_box_dx * inv_bx);
+        atom_box_dy -= by * nearbyintf(atom_box_dy * inv_by);
+        atom_box_dz -= bz * nearbyintf(atom_box_dz * inv_bz);
 
         atom_box_dx = max(static_cast<RealType>(0.0), fabs(atom_box_dx) - col_bb_ext_x);
         atom_box_dy = max(static_cast<RealType>(0.0), fabs(atom_box_dy) - col_bb_ext_y);
@@ -361,9 +361,9 @@ void __global__ k_find_blocks_with_ixns(
 
         if (single_periodic_box) {
             // Recenter using **row** box center
-            pos_j_x -= bx * nearbyint((pos_j_x - row_bb_ctr_x) * inv_bx);
-            pos_j_y -= by * nearbyint((pos_j_y - row_bb_ctr_y) * inv_by);
-            pos_j_z -= bz * nearbyint((pos_j_z - row_bb_ctr_z) * inv_bz);
+            pos_j_x -= bx * nearbyintf((pos_j_x - row_bb_ctr_x) * inv_bx);
+            pos_j_y -= by * nearbyintf((pos_j_y - row_bb_ctr_y) * inv_by);
+            pos_j_z -= bz * nearbyintf((pos_j_z - row_bb_ctr_z) * inv_bz);
 
             non_periodic_dist_j =
                 static_cast<RealType>(0.5) * (pos_j_x * pos_j_x + pos_j_y * pos_j_y + pos_j_z * pos_j_z);
@@ -382,9 +382,9 @@ void __global__ k_find_blocks_with_ixns(
                 RealType atom_atom_dy = row_i_y - pos_j_y;
                 RealType atom_atom_dz = row_i_z - pos_j_z;
 
-                atom_atom_dx -= bx * nearbyint(atom_atom_dx * inv_bx);
-                atom_atom_dy -= by * nearbyint(atom_atom_dy * inv_by);
-                atom_atom_dz -= bz * nearbyint(atom_atom_dz * inv_bz);
+                atom_atom_dx -= bx * nearbyintf(atom_atom_dx * inv_bx);
+                atom_atom_dy -= by * nearbyintf(atom_atom_dy * inv_by);
+                atom_atom_dz -= bz * nearbyintf(atom_atom_dz * inv_bz);
 
                 interacts |= (atom_atom_dx * atom_atom_dx + atom_atom_dy * atom_atom_dy + atom_atom_dz * atom_atom_dz) <
                              cutoff_squared;

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -133,14 +133,6 @@ void __device__ v_nonbonded_unified(
     unsigned long long *__restrict__ du_dp,
     unsigned long long *__restrict__ u_buffer) {
 
-    RealType box_x = shared_box.x;
-    RealType box_y = shared_box.y;
-    RealType box_z = shared_box.z;
-
-    RealType inv_box_x = shared_box.inv_x;
-    RealType inv_box_y = shared_box.inv_y;
-    RealType inv_box_z = shared_box.inv_z;
-
     int row_block_idx = ixn_tiles[tile_idx];
 
     const int warp_idx = threadIdx.x % warp_size;

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -214,9 +214,9 @@ void __device__ v_nonbonded_unified(
         RealType delta_y = ci_y - cj_y;
         RealType delta_z = ci_z - cj_z;
 
-        delta_x -= box_x * nearbyint(delta_x * inv_box_x);
-        delta_y -= box_y * nearbyint(delta_y * inv_box_y);
-        delta_z -= box_z * nearbyint(delta_z * inv_box_z);
+        delta_x -= shared_box.x * nearbyintf(delta_x * shared_box.inv_x);
+        delta_y -= shared_box.y * nearbyintf(delta_y * shared_box.inv_y);
+        delta_z -= shared_box.z * nearbyintf(delta_z * shared_box.inv_z);
 
         RealType d2ij = delta_x * delta_x + delta_y * delta_y + delta_z * delta_z;
         RealType delta_w;

--- a/timemachine/cpp/src/kernels/k_nonbonded_pair_list.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_pair_list.cuh
@@ -111,9 +111,9 @@ void __global__ k_nonbonded_pair_list(
     RealType delta_y = ci_y - cj_y;
     RealType delta_z = ci_z - cj_z;
 
-    delta_x -= box_x * nearbyint(delta_x * inv_box_x);
-    delta_y -= box_y * nearbyint(delta_y * inv_box_y);
-    delta_z -= box_z * nearbyint(delta_z * inv_box_z);
+    delta_x -= box_x * nearbyintf(delta_x * inv_box_x);
+    delta_y -= box_y * nearbyintf(delta_y * inv_box_y);
+    delta_z -= box_z * nearbyintf(delta_z * inv_box_z);
 
     RealType delta_w = w_i - w_j;
     RealType d2ij = delta_x * delta_x + delta_y * delta_y + delta_z * delta_z + delta_w * delta_w;

--- a/timemachine/cpp/src/kernels/k_nonbonded_precomputed.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_precomputed.cuh
@@ -71,9 +71,9 @@ void __global__ k_nonbonded_precomputed(
     RealType delta_y = ci_y - cj_y;
     RealType delta_z = ci_z - cj_z;
 
-    delta_x -= box_x * nearbyint(delta_x * inv_box_x);
-    delta_y -= box_y * nearbyint(delta_y * inv_box_y);
-    delta_z -= box_z * nearbyint(delta_z * inv_box_z);
+    delta_x -= box_x * nearbyintf(delta_x * inv_box_x);
+    delta_y -= box_y * nearbyintf(delta_y * inv_box_y);
+    delta_z -= box_z * nearbyintf(delta_z * inv_box_z);
 
     unsigned long long energy = 0;
 


### PR DESCRIPTION
* Slightly faster version of nearbyint that reduces fp64 operations
* Using shared box struct directly reduces usage of 6 registers which improves occupancy
* More important for subsequent PR, but some simple changes that provided a minor speed up

# Benchmark
Nvidia A10 Cuda arch 8.6

## Current
```
dhfr-apo: N=23558 speed: 412.06ns/day dt: 1.5fs (ran 100000 steps in 31.46s)
dhfr-apo-barostat-interval-25: N=23558 speed: 378.96ns/day dt: 1.5fs (ran 100000 steps in 34.20s)
dhfr-apo-hmr-barostat-interval-25: N=23558 speed: 632.83ns/day dt: 2.5fs (ran 100000 steps in 34.14s)
building a protein system with 1758 protein atoms and 7047 water atoms
hif2a-apo: N=8805 speed: 703.61ns/day dt: 1.5fs (ran 100000 steps in 18.42s)
hif2a-apo-barostat-interval-25: N=8805 speed: 606.01ns/day dt: 1.5fs (ran 100000 steps in 21.39s)
hif2a-rbfe: N=8840 speed: 729.92ns/day dt: 1.5fs (ran 100000 steps in 17.76s)
hif2a-rbfe-local: N=8840 speed: 1116.33ns/day dt: 1.5fs (ran 100000 steps in 11.61s)
solvent-apo: N=6282 speed: 861.06ns/day dt: 1.5fs (ran 100000 steps in 15.05s)
solvent-apo-barostat-interval-25: N=6282 speed: 776.06ns/day dt: 1.5fs (ran 100000 steps in 16.70s)
solvent-rbfe: N=6317 speed: 904.13ns/day dt: 1.5fs (ran 100000 steps in 14.34s)
solvent-rbfe-local: N=6317 speed: 1078.32ns/day dt: 1.5fs (ran 100000 steps in 12.02s)
```

## With `nearbyintf`
```
dhfr-apo: N=23558 speed: 416.08ns/day dt: 1.5fs (ran 100000 steps in 31.15s)
dhfr-apo-barostat-interval-25: N=23558 speed: 383.45ns/day dt: 1.5fs (ran 100000 steps in 33.80s)
dhfr-apo-hmr-barostat-interval-25: N=23558 speed: 639.67ns/day dt: 2.5fs (ran 100000 steps in 33.77s)
hif2a-apo: N=8805 speed: 710.72ns/day dt: 1.5fs (ran 100000 steps in 18.24s)
hif2a-apo-barostat-interval-25: N=8805 speed: 610.16ns/day dt: 1.5fs (ran 100000 steps in 21.24s)
hif2a-rbfe: N=8840 speed: 738.52ns/day dt: 1.5fs (ran 100000 steps in 17.55s)
hif2a-rbfe-local: N=8840 speed: 1126.74ns/day dt: 1.5fs (ran 100000 steps in 11.51s)
solvent-apo: N=6282 speed: 872.06ns/day dt: 1.5fs (ran 100000 steps in 14.86s)
solvent-apo-barostat-interval-25: N=6282 speed: 790.21ns/day dt: 1.5fs (ran 100000 steps in 16.40s)
solvent-rbfe: N=6317 speed: 906.81ns/day dt: 1.5fs (ran 100000 steps in 14.29s)
solvent-rbfe-local: N=6317 speed: 1086.87ns/day dt: 1.5fs (ran 100000 steps in 11.93s)
```