### PR TITLE
Handle pymbar convergence failure during bisection

### DIFF
--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -322,5 +322,5 @@ def test_bisection_handles_mbar_convergence_error(mock_MBAR):
     assert all(
         bar_result is None
         for pair_bar_result in result.intermediate_results
-        for bar_result in pair_bar_result.bar_results
+        for _, bar_result in pair_bar_result.bar_results
     )

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -300,18 +300,19 @@ def test_make_pair_bar_plots(mock_fig, hif2a_ligand_pair_single_topology_lam0_st
     )
 
 
-@patch("pymbar.MBAR")
-def test_bisection_handles_mbar_convergence_error(mock_MBAR):
-    """MBAR calculations may fail during early iterations of bisection, when there is typically insufficient overlap for
+@patch("pymbar.bar")
+def test_bisection_handles_mbar_convergence_error(mock_bar):
+    """BAR calculations may fail during early iterations of bisection, when there is typically insufficient overlap for
     convergence. Check that the bisection implementation intercepts convergence errors and handles them
     appropriately."""
 
-    mock_MBAR.side_effect = pymbar.utils.ConvergenceError("Mock convergence error")
+    mock_bar.side_effect = pymbar.utils.ConvergenceError("Mock convergence error")
 
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     ff = Forcefield.load_default()
     md_params = MDParams(1, 1, 1, seed=2023)
 
+    # should handle ConvergenceError raised by pymbar.bar
     result = estimate_relative_free_energy_via_greedy_bisection(
         mol_a, mol_b, core, ff, host_config=None, md_params=md_params, n_windows=3
     )

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -283,13 +283,15 @@ def test_make_pair_bar_plots(mock_fig, hif2a_ligand_pair_single_topology_lam0_st
     pair_result = PairBarResult(
         [hif2a_ligand_pair_single_topology_lam0_state] * 2,
         [
-            BarResult(
-                0.0,
-                0.0,
-                np.zeros(4),
-                0.0,
-                np.zeros(4),
+            (
                 np.zeros((4, 2, 2, 1)),
+                BarResult(
+                    0.0,
+                    0.0,
+                    np.zeros(4),
+                    0.0,
+                    np.zeros(4),
+                ),
             )
         ],
     )

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -2,10 +2,10 @@
 
 import pickle
 from functools import partial
-from typing import List, Sequence, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 import numpy as np
-from numpy.typing import NDArray as Array
+from numpy.typing import NDArray
 from openmm import app
 
 from timemachine import potentials
@@ -13,6 +13,7 @@ from timemachine.constants import BOLTZ, DEFAULT_TEMP
 from timemachine.fe import model_utils
 from timemachine.fe.free_energy import (
     AbsoluteFreeEnergy,
+    BarResult,
     HostConfig,
     InitialState,
     MDParams,
@@ -40,7 +41,7 @@ def generate_endstate_samples(
     num_samples: int,
     solvent_samples: Sequence[CoordsVelBox],
     ligand_samples: Sequence,
-    ligand_log_weights: Array,
+    ligand_log_weights: NDArray,
     num_ligand_atoms: int,
 ) -> List[CoordsVelBox]:
     """solvent + (noninteracting ligand) sample --> solvent + (vacuum ligand) sample
@@ -242,8 +243,8 @@ def estimate_absolute_free_energy(
         u_kln_by_component_by_lambda, stored_frames, stored_boxes = run_sims_sequential(
             initial_states, md_params, temperature, keep_idxs
         )
-        bar_results = [
-            estimate_free_energy_bar(u_kln_by_component, temperature)
+        bar_results: List[Tuple[NDArray, Optional[BarResult]]] = [
+            (u_kln_by_component, estimate_free_energy_bar(u_kln_by_component, temperature))
             for u_kln_by_component in u_kln_by_component_by_lambda
         ]
 
@@ -269,7 +270,7 @@ def setup_initial_states(
     ff: Forcefield,
     host_config: HostConfig,
     temperature: float,
-    lambda_schedule: Array,
+    lambda_schedule: NDArray,
     seed: int,
 ) -> List[InitialState]:
     """

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from functools import lru_cache
+from functools import cache
 from typing import Callable, Iterable, List, Optional, Sequence, Tuple, Union, overload
 from warnings import warn
 
@@ -601,8 +601,6 @@ def run_sims_with_greedy_bisection(
 
     assert len(initial_lambdas) >= 2
     assert np.all(np.diff(initial_lambdas) > 0), "initial lambda schedule must be monotonically increasing"
-
-    cache = lru_cache(maxsize=None)
 
     get_initial_state = cache(make_initial_state)
 

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -13,6 +13,7 @@ from rdkit import Chem
 from timemachine.constants import DEFAULT_PRESSURE, DEFAULT_TEMP
 from timemachine.fe import atom_mapping, model_utils
 from timemachine.fe.free_energy import (
+    BarResult,
     HostConfig,
     InitialState,
     MDParams,
@@ -438,8 +439,8 @@ def estimate_relative_free_energy(
         u_kln_by_component_by_lambda, stored_frames, stored_boxes = run_sims_sequential(
             initial_states, md_params, temperature, keep_idxs
         )
-        bar_results = [
-            estimate_free_energy_bar(u_kln_by_component, temperature)
+        bar_results: List[Tuple[NDArray, Optional[BarResult]]] = [
+            (u_kln_by_component, estimate_free_energy_bar(u_kln_by_component, temperature))
             for u_kln_by_component in u_kln_by_component_by_lambda
         ]
         result = PairBarResult(initial_states, bar_results)


### PR DESCRIPTION
#### Background
* During the initial iterations of bisection, we compute BAR $\Delta G$ estimates between states that typically have very little overlap
* pymbar 4.0.1 raises `ConvergenceError` exceptions when estimators fail to converge
  * pymbar <4.0.1 had a bug preventing `ConvergenceError`s from being raised, fixed in https://github.com/choderalab/pymbar/commit/66156f888a55a3c15b492e08fb91ae076784587a
* Since upgrading to pymbar 4.0.1 (#1043), we occasionally see failures due to unhandled `ConvergenceError` exceptions early in bisection

#### This PR
* Handles `ConvergenceError` exceptions raised by `pymbar.bar` during bisection
  * when convergence fails for a pair of states, the cost used for the next bisection decision (typically the BAR $\Delta G$ error estimate) is set to infinity
* **Modifies the result schema** to allow representing BAR computations that failed (as `None`), while retaining $u_{kln}$