### PR TITLE
Revert "Upgrade to pymbar 4 (#1043)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.23.5
 scipy==1.10.1
-pymbar==4.0.1
+pymbar==3.0.5
 pyyaml==5.4.1
 networkx==2.8.8
 matplotlib==3.7.1

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         "jaxlib>0.4.1",
         "networkx",
         "numpy",
-        "pymbar>=4",
+        "pymbar>3.0.4,<4",
         "pyyaml",
         "rdkit",
         "scipy",

--- a/tests/test_bar.py
+++ b/tests/test_bar.py
@@ -21,13 +21,12 @@ def test_bootstrap_bar():
         w_F, w_R = gaussian_work_example(2000, 2000, sigma_F=sigma_F, seed=0)
 
         # estimate 3 times
-        bar = pymbar.bar(w_F, w_R)
-        df_ref, ddf_ref = bar["Delta_f"], bar["dDelta_f"]
+        df_ref, ddf_ref = pymbar.BAR(w_F, w_R)
         df_0, bootstrap_samples = bootstrap_bar(w_F, w_R, n_bootstrap=n_bootstrap)
         df_1, bootstrap_sigma = bar_with_bootstrapped_uncertainty(w_F, w_R)
 
         # assert estimates identical, uncertainties comparable
-        print(f"stddev(w_F) = {sigma_F}, bootstrap uncertainty = {bootstrap_sigma}, pymbar.bar uncertainty = {ddf_ref}")
+        print(f"stddev(w_F) = {sigma_F}, bootstrap uncertainty = {bootstrap_sigma}, pymbar.BAR uncertainty = {ddf_ref}")
         assert df_0 == df_ref
         assert df_1 == df_ref
         assert len(bootstrap_samples) == n_bootstrap, "timed out on default problem size!"

--- a/tests/test_interpolate_fe.py
+++ b/tests/test_interpolate_fe.py
@@ -88,8 +88,7 @@ def test_hif2a_free_energy_estimates():
             plt.legend()
             plt.savefig(f"lambda_{lambda_idx-1}_{lambda_idx}.png")
 
-            bar = pymbar.bar(fwd_delta_u, rev_delta_u)
-            dG_exact, exact_bar_err = bar["Delta_f"], bar["dDelta_f"]
+            dG_exact, exact_bar_err = pymbar.BAR(fwd_delta_u, rev_delta_u)
             dG_exact /= beta
             exact_bar_err /= beta
 

--- a/tests/test_mapped_estimators.py
+++ b/tests/test_mapped_estimators.py
@@ -5,7 +5,7 @@ Assert accurate estimates for free energy differences between 1D Gaussians using
 from dataclasses import dataclass
 
 import numpy as np
-import pymbar
+from pymbar import BAR, EXP, MBAR
 
 from timemachine.maps.estimators import compute_mapped_reduced_work, compute_mapped_u_kn
 
@@ -75,7 +75,7 @@ def test_one_sided_estimates():
         assert np.std(mapped_w_F) < eps
 
         # ... and estimated_delta_f should be == exact_delta_f
-        estimated_delta_f = pymbar.exp(mapped_w_F)["Delta_f"]
+        estimated_delta_f = EXP(mapped_w_F)[0]
         exact_delta_f = dst_state.reduced_free_energy - src_state.reduced_free_energy
 
         np.testing.assert_allclose(estimated_delta_f, exact_delta_f)
@@ -100,9 +100,8 @@ def test_two_sided_estimates():
         w_F = compute_mapped_reduced_work(x_a, u_a, u_b, map_fxn)
         w_R = compute_mapped_reduced_work(x_b, u_b, u_a, inv_map_fxn)
 
-        # estimated_delta_f = pymbar.bar(w_F, w_R)["Delta_f"] #  default solver -> BoundsError: Cannot determine bound on free energy
-        bar_settings = dict(method="self-consistent-iteration", compute_uncertainty=False)
-        estimated_delta_f = pymbar.bar(w_F, w_R, **bar_settings)["Delta_f"]
+        # estimated_delta_f = BAR(w_F, w_R)[0] #  default solver -> BoundsError: Cannot determine bound on free energy
+        estimated_delta_f = BAR(w_F, w_R, method="self-consistent-iteration", compute_uncertainty=False)
 
         exact_delta_f = state_b.reduced_free_energy - state_a.reduced_free_energy
 
@@ -129,7 +128,7 @@ def test_multistate_estimates():
 
     # compute MBAR estimate
     u_kn = compute_mapped_u_kn(samples, u_fxns, map_fxns)
-    mbar = pymbar.MBAR(u_kn, N_k)
+    mbar = MBAR(u_kn, N_k)
 
     exact_f_k = np.array([state.reduced_free_energy for state in states])
     exact_f_k -= exact_f_k[0]

--- a/tests/test_reweighting.py
+++ b/tests/test_reweighting.py
@@ -291,7 +291,7 @@ def test_mixture_reweighting_ahfe():
 
 @pytest.mark.nogpu
 def test_one_sided_exp():
-    """assert consistency with pymbar.exp on random instances + instances containing +inf work"""
+    """assert consistency with pymbar.EXP on random instances + instances containing +inf work"""
 
     np.random.seed(2022)
     num_instances = 100
@@ -306,14 +306,14 @@ def test_one_sided_exp():
         reduced_works = np.random.randn(num_works) * stddev + mean
 
         # compare estimates
-        pymbar_estimate = pymbar.exp(reduced_works)["Delta_f"]
+        pymbar_estimate, _ = pymbar.EXP(reduced_works)
         tm_estimate = one_sided_exp(reduced_works)
 
         assert np.isclose(tm_estimate, pymbar_estimate)
 
     # also check +inf
     reduced_works = jnp.array([+np.inf, 0])
-    assert np.isclose(one_sided_exp(reduced_works), pymbar.exp(reduced_works)["Delta_f"])
+    assert np.isclose(one_sided_exp(reduced_works), pymbar.EXP(reduced_works)[0])
 
 
 @pytest.mark.nogpu

--- a/tests/test_terminal_bond_maps.py
+++ b/tests/test_terminal_bond_maps.py
@@ -10,7 +10,7 @@ config.update("jax_enable_x64", True)
 
 from functools import partial
 
-import pymbar
+from pymbar import BAR, EXP, MBAR
 from rdkit import Chem
 from rdkit.Chem import AllChem
 
@@ -132,10 +132,10 @@ def test_on_methane():
 
     assert np.std(mapped_w_R) < 1.0
 
-    estimated_delta_f_forward = pymbar.exp(mapped_w_F)["Delta_f"]
+    estimated_delta_f_forward = EXP(mapped_w_F)[0]
 
-    estimated_delta_f_reverse = -pymbar.exp(mapped_w_R)["Delta_f"]
-    estimated_delta_f_bar = pymbar.bar(mapped_w_F, mapped_w_R)["Delta_f"]
+    estimated_delta_f_reverse = -EXP(mapped_w_R)[0]
+    estimated_delta_f_bar = BAR(mapped_w_F, mapped_w_R)[0]
 
     # also plug into MBAR
     K = 2
@@ -159,7 +159,7 @@ def test_on_methane():
 
     u_kn = compute_mapped_u_kn(samples, u_fxns, map_fxns)
 
-    mbar = pymbar.MBAR(u_kn, N_k)
+    mbar = MBAR(u_kn, N_k)
     estimated_delta_f_mbar = mbar.f_k[1]
 
     estimates = np.array(

--- a/timemachine/fe/loss.py
+++ b/timemachine/fe/loss.py
@@ -11,7 +11,7 @@ from timemachine.fe import bar as tmbar
 # https://github.com/google/jax/issues/1142
 # courtesy of mattjj
 def mybar_impl(w):
-    A = pymbar.bar(w[0], w[1])["Delta_f"]
+    A, _ = pymbar.BAR(w[0], w[1])
     return A
 
 


### PR DESCRIPTION
pymbar 4.0.1 fixed a bug that prevented `ConvergenceErrors` from being raised by `pymbar.bar` (fixed in this [commit](https://github.com/choderalab/pymbar/commit/66156f888a55a3c15b492e08fb91ae076784587a); see #1054 for more context). As a result, there is currently no way to implement our preferred behavior of returning the final iterate (vs. raising an error) if we reach `maximum_iterations` without convergence.

This PR temporarily rolls back to pymbar 3. In the long run, we'll probably want to either

1. upgrade to pymbar 4 if an option is added to skip the convergence check, or
2. use `iterated_solution=False` if we determine that the "self-consistent iteration" solution method is acceptable for our use case

This reverts commit 5bb97e9955a55a8fad5e00b40dd81d8f950b4c7a.