### PR TITLE
Optimizes Langevin Kernel and Generate Noise in Batches

### DIFF
--- a/timemachine/cpp/src/kernels/k_integrator.cuh
+++ b/timemachine/cpp/src/kernels/k_integrator.cuh
@@ -12,7 +12,7 @@ __global__ void update_forward_baoab(
     RealType *__restrict__ x_t,
     RealType *__restrict__ v_t,
     const unsigned long long *__restrict__ du_dx,
-    const RealType dt) {
+    const RealType half_dt) {
 
     int kernel_idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (kernel_idx >= N * D) {

--- a/timemachine/cpp/src/langevin_integrator.cu
+++ b/timemachine/cpp/src/langevin_integrator.cu
@@ -69,11 +69,12 @@ void LangevinIntegrator::step_fwd(
     curandErrchk(templateCurandNormal(cr_rng_, d_noise_, round_up_even(N_ * D), 0.0, 1.0));
 
     size_t tpb = default_threads_per_block;
-    size_t n_blocks = ceil_divide(N_, tpb);
-    dim3 dimGrid_dx(n_blocks, D);
+    // Run in blocks so as to ensure that neighboring threads are modifying the same atom
+    // which allows more efficient memory accesses/writes
+    size_t n_blocks = ceil_divide(N_ * D, tpb);
 
     update_forward_baoab<double>
-        <<<dimGrid_dx, tpb, 0, stream>>>(N_, D, ca_, d_idxs, d_cbs_, d_ccs_, d_noise_, d_x_t, d_v_t, d_du_dx_, dt_);
+        <<<n_blocks, tpb, 0, stream>>>(N_, D, ca_, d_idxs, d_cbs_, d_ccs_, d_noise_, d_x_t, d_v_t, d_du_dx_, dt_);
 
     gpuErrchk(cudaPeekAtLastError());
 }

--- a/timemachine/cpp/src/langevin_integrator.cu
+++ b/timemachine/cpp/src/langevin_integrator.cu
@@ -74,7 +74,7 @@ void LangevinIntegrator::step_fwd(
     size_t n_blocks = ceil_divide(N_ * D, tpb);
 
     update_forward_baoab<double>
-        <<<n_blocks, tpb, 0, stream>>>(N_, D, ca_, d_idxs, d_cbs_, d_ccs_, d_noise_, d_x_t, d_v_t, d_du_dx_, dt_);
+        <<<n_blocks, tpb, 0, stream>>>(N_, D, ca_, d_idxs, d_cbs_, d_ccs_, d_noise_, d_x_t, d_v_t, d_du_dx_, 0.5 * dt_);
 
     gpuErrchk(cudaPeekAtLastError());
 }

--- a/timemachine/cpp/src/langevin_integrator.hpp
+++ b/timemachine/cpp/src/langevin_integrator.hpp
@@ -16,13 +16,15 @@ private:
     const double dt_;
     const double friction_;
     double ca_;
+
+    // The iteration of the noise, will be between 0 and noise_batch_size_ - 1
+    int noise_iteration_;
+    int noise_batch_size_; // Number of batches of noise to generate at one time.
+
     double *d_cbs_;
     double *d_ccs_;
-    double *d_noise_;
+    double *d_noise_; // [N_ * 3 * noise_batch_size_]
     unsigned long long *d_du_dx_;
-
-    std::vector<cudaStream_t> pot_streams_;
-    std::vector<cudaEvent_t> stream_events_;
 
     curandGenerator_t cr_rng_;
 


### PR DESCRIPTION
# Changes
- Optimizes the langevin kernel to have neighboring threads acting on the same particle, reduces kernel runtime by ~15-20% for Hif2a and only ~5% for DHFR. Only ~1% impact on overall runtimes but only for Hif2a. Happy to drop this change as was wanting to verify that I understood the Cuda model by trying it.
- Batch noise generation in the Langevin Integrator. ~2% performance improvement. Tried larger batches of 10 and didn't notice any further improvement.

# Benchmarks

# Current
```
dhfr-apo: N=23558 speed: 409.74ns/day dt: 1.5fs (ran 100000 steps in 31.63s)
dhfr-apo-barostat-interval-25: N=23558 speed: 378.29ns/day dt: 1.5fs (ran 100000 steps in 34.26s)
dhfr-apo-hmr-barostat-interval-25: N=23558 speed: 631.65ns/day dt: 2.5fs (ran 100000 steps in 34.20s)
building a protein system with 1758 protein atoms and 7047 water atoms
hif2a-apo: N=8805 speed: 702.99ns/day dt: 1.5fs (ran 100000 steps in 18.44s)
hif2a-apo-barostat-interval-25: N=8805 speed: 606.07ns/day dt: 1.5fs (ran 100000 steps in 21.39s)
hif2a-rbfe: N=8840 speed: 729.96ns/day dt: 1.5fs (ran 100000 steps in 17.76s)
hif2a-rbfe-local: N=8840 speed: 1124.07ns/day dt: 1.5fs (ran 100000 steps in 11.53s)
solvent-apo: N=6282 speed: 861.12ns/day dt: 1.5fs (ran 100000 steps in 15.05s)
solvent-apo-barostat-interval-25: N=6282 speed: 776.32ns/day dt: 1.5fs (ran 100000 steps in 16.70s)
solvent-rbfe: N=6317 speed: 905.01ns/day dt: 1.5fs (ran 100000 steps in 14.32s)
solvent-rbfe-local: N=6317 speed: 1081.10ns/day dt: 1.5fs (ran 100000 steps in 11.99s)
```

# Integrator - batch size 5
```
dhfr-apo: N=23558 speed: 417.06ns/day dt: 1.5fs (ran 100000 steps in 31.08s)
dhfr-apo-barostat-interval-25: N=23558 speed: 383.87ns/day dt: 1.5fs (ran 100000 steps in 33.76s)
dhfr-apo-hmr-barostat-interval-25: N=23558 speed: 640.14ns/day dt: 2.5fs (ran 100000 steps in 33.75s)
hif2a-apo: N=8805 speed: 723.56ns/day dt: 1.5fs (ran 100000 steps in 17.91s)
hif2a-apo-barostat-interval-25: N=8805 speed: 623.83ns/day dt: 1.5fs (ran 100000 steps in 20.78s)
hif2a-rbfe: N=8840 speed: 752.96ns/day dt: 1.5fs (ran 100000 steps in 17.22s)
hif2a-rbfe-local: N=8840 speed: 1160.53ns/day dt: 1.5fs (ran 100000 steps in 11.17s)
solvent-apo: N=6282 speed: 882.90ns/day dt: 1.5fs (ran 100000 steps in 14.68s)
solvent-apo-barostat-interval-25: N=6282 speed: 795.39ns/day dt: 1.5fs (ran 100000 steps in 16.30s)
solvent-rbfe: N=6317 speed: 928.68ns/day dt: 1.5fs (ran 100000 steps in 13.96s)
solvent-rbfe-local: N=6317 speed: 1138.37ns/day dt: 1.5fs (ran 100000 steps in 11.39s)
```