### PR TITLE
Removes support for resizing BoundPotential parameter vectors

### DIFF
--- a/timemachine/cpp/src/bound_potential.hpp
+++ b/timemachine/cpp/src/bound_potential.hpp
@@ -20,6 +20,7 @@ struct BoundPotential {
     std::vector<int> shape;
     std::unique_ptr<DeviceBuffer<double>> d_p;
     std::shared_ptr<Potential> potential;
+    const int max_size_;
 
     int size() const;
 

--- a/timemachine/cpp/src/local_md_potentials.cu
+++ b/timemachine/cpp/src/local_md_potentials.cu
@@ -51,10 +51,11 @@ LocalMDPotentials::LocalMDPotentials(
         default_bonds[i * 2 + 0] = 0;
         default_bonds[i * 2 + 1] = i + 1;
     }
+    std::vector<double> default_params(N_ * 3);
     free_restraint_ = std::shared_ptr<FlatBottomBond<double>>(new FlatBottomBond<double>(default_bonds));
     // Construct a bound potential with 0 params
-    bound_free_restraint_ =
-        std::shared_ptr<BoundPotential>(new BoundPotential(free_restraint_, std::vector<int>({0}), nullptr));
+    bound_free_restraint_ = std::shared_ptr<BoundPotential>(
+        new BoundPotential(free_restraint_, std::vector<int>({N_, 3}), &default_params[0]));
 
     // Ensure that the refence idxs start out as all N_
     k_initialize_array<unsigned int><<<ceil_divide(N_, WARP_SIZE), WARP_SIZE>>>(N_, d_all_pairs_idxs_.data, N_);
@@ -70,8 +71,8 @@ LocalMDPotentials::LocalMDPotentials(
     if (!freeze_reference_) {
         frozen_restraint_ = std::shared_ptr<LogFlatBottomBond<double>>(
             new LogFlatBottomBond<double>(default_bonds, 1 / (temperature_ * BOLTZ)));
-        bound_frozen_restraint_ =
-            std::shared_ptr<BoundPotential>(new BoundPotential(frozen_restraint_, std::vector<int>({0}), nullptr));
+        bound_frozen_restraint_ = std::shared_ptr<BoundPotential>(
+            new BoundPotential(frozen_restraint_, std::vector<int>({N_, 3}), &default_params[0]));
         all_potentials_.push_back(bound_frozen_restraint_);
     }
 


### PR DESCRIPTION
* Makes debugging more complicated, now it behaves like the neighborlist
* In a future PR we should remove the `shape` of BoundPotentials