### PR TITLE
Modify infer_node_vals_and_errs_networkx to support nx.MultiDiGraph

### DIFF
--- a/timemachine/fe/mle.py
+++ b/timemachine/fe/mle.py
@@ -8,6 +8,8 @@ from jax import value_and_grad
 from jax.scipy.stats import norm
 from scipy.optimize import minimize
 
+_NX_G = TypeVar("_NX_G", bound=nx.DiGraph | nx.MultiGraph)
+
 
 def make_stddevs_finite(stddevs, min_stddev=1e-3):
     """Ignore claims that stddev < min_stddev"""
@@ -214,9 +216,6 @@ def infer_node_vals_and_errs(
     dg_err = bootstrap_estimates.std(0)
 
     return dg, dg_err
-
-
-_NX_G = TypeVar("_NX_G", bound=nx.DiGraph | nx.MultiGraph)
 
 
 def infer_node_vals_and_errs_networkx(

--- a/timemachine/fe/mle.py
+++ b/timemachine/fe/mle.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import TypeVar
 
 import networkx as nx
 import numpy as np
@@ -216,8 +216,11 @@ def infer_node_vals_and_errs(
     return dg, dg_err
 
 
+_NX_G = TypeVar("_NX_G", bound=nx.DiGraph | nx.MultiGraph)
+
+
 def infer_node_vals_and_errs_networkx(
-    graph: Union[nx.DiGraph, nx.MultiDiGraph],
+    graph: _NX_G,
     edge_diff_prop: str,
     edge_stddev_prop: str,
     ref_node_val_prop: str,
@@ -226,7 +229,7 @@ def infer_node_vals_and_errs_networkx(
     node_stddev_prop: str = "inferred_dg_stddev",
     n_bootstrap: int = 100,
     seed: int = 0,
-) -> Union[nx.DiGraph, nx.MultiDiGraph]:
+) -> _NX_G:
     """Version of :py:func:`timemachine.fe.mle.infer_node_vals_and_errs` that accepts a directed networkx graph.
 
     Parameters

--- a/timemachine/fe/mle.py
+++ b/timemachine/fe/mle.py
@@ -1,4 +1,4 @@
-from typing import TypeVar
+from typing import Union
 
 import networkx as nx
 import numpy as np
@@ -7,8 +7,6 @@ from jax import numpy as jnp
 from jax import value_and_grad
 from jax.scipy.stats import norm
 from scipy.optimize import minimize
-
-_NX_G = TypeVar("_NX_G", bound=nx.DiGraph | nx.MultiGraph)
 
 
 def make_stddevs_finite(stddevs, min_stddev=1e-3):
@@ -219,7 +217,7 @@ def infer_node_vals_and_errs(
 
 
 def infer_node_vals_and_errs_networkx(
-    graph: _NX_G,
+    graph: Union[nx.DiGraph, nx.MultiDiGraph],
     edge_diff_prop: str,
     edge_stddev_prop: str,
     ref_node_val_prop: str,
@@ -228,7 +226,7 @@ def infer_node_vals_and_errs_networkx(
     node_stddev_prop: str = "inferred_dg_stddev",
     n_bootstrap: int = 100,
     seed: int = 0,
-) -> _NX_G:
+) -> Union[nx.DiGraph, nx.MultiDiGraph]:
     """Version of :py:func:`timemachine.fe.mle.infer_node_vals_and_errs` that accepts a directed networkx graph.
 
     Parameters

--- a/timemachine/fe/mle.py
+++ b/timemachine/fe/mle.py
@@ -230,10 +230,11 @@ def infer_node_vals_and_errs_networkx(
     seed: int = 0,
 ) -> NxDiGraph:
     """Version of :py:func:`timemachine.fe.mle.infer_node_vals_and_errs` that accepts a directed networkx graph.
+    This will also accept a MultiDiGraph which represents multiple replicates of the same graph.
 
     Parameters
     ----------
-    nx_graph: networkx.DiGraph
+    nx_graph: networkx.DiGraph or networkx.MultiDiGraph
         Directed Networkx graph
     edge_diff_prop: str
         Edge property to use for differences
@@ -252,7 +253,7 @@ def infer_node_vals_and_errs_networkx(
 
     Returns
     -------
-    networkx.DiGraph
+    networkx.DiGraph/networkx.MultiDiGraph
         Subgraph limited to edges with defined edge_diff_prop and edge_stddev_prop, where nodes have been labeled with
         the inferred values of `node_val_prop` and `node_stddev_prop`.
     """
@@ -283,7 +284,7 @@ def infer_node_vals_and_errs_networkx(
     edge_idxs = np.array(sg_relabeled.edges)
 
     dgs, dg_errs = infer_node_vals_and_errs(
-        np.array([e[:2] for e in edge_idxs]),
+        np.array([e[:2] for e in edge_idxs]),  # remove edge key in MultiDiGraph if present
         np.array([sg_relabeled.edges[e][edge_diff_prop] for e in edge_idxs]),
         np.array([sg_relabeled.edges[e][edge_stddev_prop] for e in edge_idxs]),
         ref_node_idxs,

--- a/timemachine/fe/mle.py
+++ b/timemachine/fe/mle.py
@@ -282,7 +282,7 @@ def infer_node_vals_and_errs_networkx(
             ref_node_stddevs.append(d.get(ref_node_stddev_prop, 0.0))
 
     edges = np.array(sg_relabeled.edges)
-    edge_idxs = np.array([e[:2] for e in edges])  # remove edge key in MultiDiGraph if present
+    edge_idxs = edges[:, :2]  # remove edge key in MultiDiGraph if present
     dgs, dg_errs = infer_node_vals_and_errs(
         edge_idxs,
         np.array([sg_relabeled.edges[e][edge_diff_prop] for e in edges]),

--- a/timemachine/fe/mle.py
+++ b/timemachine/fe/mle.py
@@ -8,6 +8,8 @@ from jax import value_and_grad
 from jax.scipy.stats import norm
 from scipy.optimize import minimize
 
+NxDiGraph = Union[nx.DiGraph, nx.MultiDiGraph]
+
 
 def make_stddevs_finite(stddevs, min_stddev=1e-3):
     """Ignore claims that stddev < min_stddev"""
@@ -217,7 +219,7 @@ def infer_node_vals_and_errs(
 
 
 def infer_node_vals_and_errs_networkx(
-    graph: Union[nx.DiGraph, nx.MultiDiGraph],
+    graph: NxDiGraph,
     edge_diff_prop: str,
     edge_stddev_prop: str,
     ref_node_val_prop: str,
@@ -226,7 +228,7 @@ def infer_node_vals_and_errs_networkx(
     node_stddev_prop: str = "inferred_dg_stddev",
     n_bootstrap: int = 100,
     seed: int = 0,
-) -> Union[nx.DiGraph, nx.MultiDiGraph]:
+) -> NxDiGraph:
     """Version of :py:func:`timemachine.fe.mle.infer_node_vals_and_errs` that accepts a directed networkx graph.
 
     Parameters

--- a/timemachine/fe/mle.py
+++ b/timemachine/fe/mle.py
@@ -281,12 +281,12 @@ def infer_node_vals_and_errs_networkx(
             ref_node_vals.append(d[ref_node_val_prop])
             ref_node_stddevs.append(d.get(ref_node_stddev_prop, 0.0))
 
-    edge_idxs = np.array(sg_relabeled.edges)
-
+    edges = np.array(sg_relabeled.edges)
+    edge_idxs = np.array([e[:2] for e in edges])  # remove edge key in MultiDiGraph if present
     dgs, dg_errs = infer_node_vals_and_errs(
-        np.array([e[:2] for e in edge_idxs]),  # remove edge key in MultiDiGraph if present
-        np.array([sg_relabeled.edges[e][edge_diff_prop] for e in edge_idxs]),
-        np.array([sg_relabeled.edges[e][edge_stddev_prop] for e in edge_idxs]),
+        edge_idxs,
+        np.array([sg_relabeled.edges[e][edge_diff_prop] for e in edges]),
+        np.array([sg_relabeled.edges[e][edge_stddev_prop] for e in edges]),
         ref_node_idxs,
         ref_node_vals,
         ref_node_stddevs,

--- a/timemachine/fe/mle.py
+++ b/timemachine/fe/mle.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import networkx as nx
 import numpy as np
 from jax import jit
@@ -215,7 +217,7 @@ def infer_node_vals_and_errs(
 
 
 def infer_node_vals_and_errs_networkx(
-    graph: nx.DiGraph,
+    graph: Union[nx.DiGraph, nx.MultiDiGraph],
     edge_diff_prop: str,
     edge_stddev_prop: str,
     ref_node_val_prop: str,
@@ -224,7 +226,7 @@ def infer_node_vals_and_errs_networkx(
     node_stddev_prop: str = "inferred_dg_stddev",
     n_bootstrap: int = 100,
     seed: int = 0,
-) -> nx.DiGraph:
+) -> Union[nx.DiGraph, nx.MultiDiGraph]:
     """Version of :py:func:`timemachine.fe.mle.infer_node_vals_and_errs` that accepts a directed networkx graph.
 
     Parameters
@@ -252,7 +254,7 @@ def infer_node_vals_and_errs_networkx(
         Subgraph limited to edges with defined edge_diff_prop and edge_stddev_prop, where nodes have been labeled with
         the inferred values of `node_val_prop` and `node_stddev_prop`.
     """
-    assert isinstance(graph, nx.DiGraph), "Graph must be a DiGraph"
+    assert isinstance(graph, (nx.DiGraph, nx.MultiDiGraph)), "Graph must be a DiGraph or MultiDiGraph"
     edges_with_props = [
         e for e, d in graph.edges.items() if d.get(edge_diff_prop) is not None and d.get(edge_stddev_prop) is not None
     ]
@@ -279,7 +281,7 @@ def infer_node_vals_and_errs_networkx(
     edge_idxs = np.array(sg_relabeled.edges)
 
     dgs, dg_errs = infer_node_vals_and_errs(
-        edge_idxs,
+        np.array([e[:2] for e in edge_idxs]),
         np.array([sg_relabeled.edges[e][edge_diff_prop] for e in edge_idxs]),
         np.array([sg_relabeled.edges[e][edge_stddev_prop] for e in edge_idxs]),
         ref_node_idxs,


### PR DESCRIPTION
- Update infer_node_vals_and_errs_networkx to allow a MultiDiGraph to be passed
- Can be used to infer dgs across replicates (where the replicates have the same nodes, but multiple edges with different pred_ddgs)
- Update test