### PR TITLE
Skips custom ops for nightly no-gpu tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -130,7 +130,7 @@ nightly-tests-nogpu:
   rules:
     - if: $NIGHTLY_TESTS
   script:
-    - pip install .[test]
+    - SKIP_CUSTOM_OPS=1 pip install .[test]
     - make nogpu_nightly_tests
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-nogpu-nightly-tests"


### PR DESCRIPTION
* Shouldn't build the custom ops for the no-gpu tests. Flag was not correctly added for tests

Nightly pipeline failed to run the no-gpu tests due to no GPU to detect the cuda arch: https://gitlab.com/relaytx/physics-platform/timemachine/-/pipelines/909329867

Re-running just the nightly no-gpu tests here: https://gitlab.com/relaytx/physics-platform/timemachine/-/jobs/4530485804