### PR TITLE
Optimizes initial states using SummedPotential

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -368,8 +368,7 @@ def prepare_hif2a_initial_state(st, host_config):
     lamb = 0.1
     host = rbfe.setup_optimized_host(st, host_config)
     initial_state = rbfe.setup_initial_states(st, host, temperature, [lamb], seed=2022)[0]
-    bound_impls = [p.to_gpu(np.float32).bound_impl for p in initial_state.potentials]
-    val_and_grad_fn = minimizer.get_val_and_grad_fn(bound_impls, initial_state.box0)
+    val_and_grad_fn = minimizer.get_val_and_grad_fn(initial_state.potentials, initial_state.box0)
     assert np.all(np.isfinite(initial_state.x0)), "Initial coordinates contain nan or inf"
     ligand_coords = initial_state.x0[initial_state.ligand_idxs]
     d_ij = cdist(ligand_coords, initial_state.x0)

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -98,8 +98,7 @@ def test_local_minimize_water_box():
     host_fns, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     box0 += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes at the boundary
 
-    bound_impls = [p.to_gpu(np.float32).bound_impl for p in host_fns]
-    val_and_grad_fn = minimizer.get_val_and_grad_fn(bound_impls, box0)
+    val_and_grad_fn = minimizer.get_val_and_grad_fn(host_fns, box0)
 
     free_idxs = [0, 2, 3, 6, 7, 9, 15, 16]
     frozen_idxs = set(range(len(x0))).difference(set(free_idxs))

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -263,8 +263,7 @@ def optimize_coords_state(
     free_idxs: List[int],
     assert_energy_decreased: bool,
 ) -> NDArray:
-    bound_impls = [p.to_gpu(np.float32).bound_impl for p in potentials]
-    val_and_grad_fn = minimizer.get_val_and_grad_fn(bound_impls, box)
+    val_and_grad_fn = minimizer.get_val_and_grad_fn(potentials, box)
     assert np.all(np.isfinite(x0)), "Initial coordinates contain nan or inf"
     x_opt = minimizer.local_minimize(x0, val_and_grad_fn, free_idxs, assert_energy_decreased=assert_energy_decreased)
     assert np.all(np.isfinite(x_opt)), "Minimization resulted in a nan"

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -57,9 +57,10 @@ def parameterize_system(topo, ff: Forcefield, lamb: float):
 
 
 def bind_potentials(params_potential_pairs):
-    u_impls = [
-        potential.bind(params).to_gpu(precision=np.float32).bound_impl for params, potential in params_potential_pairs
-    ]
+    pots = [pot for _, pot in params_potential_pairs]
+    params = [p for p, _ in params_potential_pairs]
+    flat_params = np.concatenate([p.reshape(-1) for p in params])
+    u_impls = [SummedPotential(pots, params).bind(flat_params).to_gpu(precision=np.float32).bound_impl]
     return u_impls
 
 

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -406,7 +406,7 @@ def equilibrate_host(
     return ctxt.get_x_t(), ctxt.get_box()
 
 
-def get_val_and_grad_fn(bps: Iterable[BoundPotential], box: NDArray):
+def get_val_and_grad_fn(bps: Iterable[BoundPotential], box: NDArray, precision=np.float32):
     """
     Convert impls, box into a function that only takes in coords.
 
@@ -423,7 +423,7 @@ def get_val_and_grad_fn(bps: Iterable[BoundPotential], box: NDArray):
     """
     summed_pot = SummedPotential([bp.potential for bp in bps], [bp.params for bp in bps])
     params = np.concatenate([bp.params.reshape(-1) for bp in bps])
-    impl = summed_pot.to_gpu(np.float32).bind(params).bound_impl
+    impl = summed_pot.to_gpu(precision).bind(params).bound_impl
 
     def val_and_grad_fn(coords):
         g_bp, u_bp = impl.execute(coords, box)


### PR DESCRIPTION
* About 10% faster for some tests (locally, does not seem to be the case in CI)

Running the potentials previously shows to take 4ms vs 1ms using nsys, but doesn't seem to translate to the tests. Unsure whether or not we should merge this, but opening up for consideration.
# Current
Takes 4ms to run the bonded potentials plus the nonbonded potentials
![old_version](https://github.com/proteneer/timemachine/assets/5840832/c0ced096-478a-4a08-90e0-6a259d91f5b7)

# PR
Takes ~1ms to run all of the potentials
![new](https://github.com/proteneer/timemachine/assets/5840832/ce620956-a21a-4fdf-8aa6-e88955726cf8)
