### PR TITLE
Handle inhomogenous parameter dimensions in reference SummedPotential

### DIFF
--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -115,6 +115,18 @@ def test_summed_potential_invalid_parameters_size(harmonic_bond):
     )
 
 
+def test_summed_potential_nested(harmonic_bond):
+    nested_sp = SummedPotential([harmonic_bond.potential], [harmonic_bond.params])
+    nested_sp_params = harmonic_bond.params.flatten()
+    sp = SummedPotential([nested_sp, harmonic_bond.potential], [nested_sp_params, harmonic_bond.params])
+    sp_params = np.concatenate([nested_sp_params, harmonic_bond.params.flatten()])
+    bp = sp.bind(sp_params)
+    execute_bound_impl(bp.to_gpu(np.float32).bound_impl)
+
+    # test reference potential
+    _ = bp(np.ones((3, 3)), np.eye(3))
+
+
 def reference_execute_over_batch(unbound, coords, boxes, params):
     coord_batches = coords.shape[0]
     param_batches = params.shape[0]

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -124,7 +124,14 @@ def test_summed_potential_nested(harmonic_bond):
     execute_bound_impl(bp.to_gpu(np.float32).bound_impl)
 
     # test reference potential
-    _ = bp(np.ones((3, 3)), np.eye(3))
+    x, box = np.ones((3, 3)), np.eye(3)
+    _ = bp(x, box)
+
+    # another level of nesting is fine, too
+    sp_prime = SummedPotential([sp, nested_sp, harmonic_bond.potential], [sp_params, nested_sp_params, harmonic_bond.params])
+    sp_prime_params = np.concatenate([sp_params, nested_sp_params, harmonic_bond.params.flatten()])
+    bp_prime = sp_prime.bind(sp_prime_params)
+    _ = bp_prime(x, box)
 
 
 def reference_execute_over_batch(unbound, coords, boxes, params):

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -114,6 +114,22 @@ def test_summed_potential_invalid_parameters_size(harmonic_bond):
         in str(e)
     )
 
+    # test reference potential
+    x, box = np.ones((3, 3)), np.eye(3)
+
+    bp = sp.bind(np.empty(0))
+    with pytest.raises(AssertionError):
+        _ = bp(x, box)
+
+    bp = sp.bind(np.ones(harmonic_bond.params.size + 1))
+    with pytest.raises(AssertionError):
+        _ = bp(x, box)
+
+    # should assert flattened params
+    bp = sp.bind(harmonic_bond.params)
+    with pytest.raises(AssertionError):
+        _ = bp(x, box)
+
 
 def test_summed_potential_nested(harmonic_bond):
     nested_sp = SummedPotential([harmonic_bond.potential], [harmonic_bond.params])
@@ -128,7 +144,9 @@ def test_summed_potential_nested(harmonic_bond):
     _ = bp(x, box)
 
     # another level of nesting is fine, too
-    sp_prime = SummedPotential([sp, nested_sp, harmonic_bond.potential], [sp_params, nested_sp_params, harmonic_bond.params])
+    sp_prime = SummedPotential(
+        [sp, nested_sp, harmonic_bond.potential], [sp_params, nested_sp_params, harmonic_bond.params]
+    )
     sp_prime_params = np.concatenate([sp_params, nested_sp_params, harmonic_bond.params.flatten()])
     bp_prime = sp_prime.bind(sp_prime_params)
     _ = bp_prime(x, box)

--- a/timemachine/potentials/summed.py
+++ b/timemachine/potentials/summed.py
@@ -34,6 +34,9 @@ def summed_potential(
     """
     assert len(U_fns) == len(shapes)
     sizes = [np.prod(shape) for shape in shapes]
+    assert params.ndim == 1
+    (num_params,) = params.shape
+    assert sum(sizes) == num_params
     # np.split expects indices, must increment sizes to be indices
     split_indices = np.cumsum(sizes)
     paramss = [ps.reshape(shape) for ps, shape in zip(np.split(params, split_indices[:-1]), shapes)]

--- a/timemachine/potentials/summed.py
+++ b/timemachine/potentials/summed.py
@@ -1,4 +1,3 @@
-from functools import reduce
 from typing import Optional, Sequence, Tuple
 
 import jax.numpy as jnp
@@ -34,7 +33,7 @@ def summed_potential(
         shapes of the parameter array input for each potential term (must be same length as U_fns)
     """
     assert len(U_fns) == len(shapes)
-    sizes = [reduce(lambda x, y: x * y, shape) for shape in shapes]
+    sizes = [np.product(shape) for shape in shapes]
     # np.split expects indices, must increment sizes to be indices
     split_indices = np.cumsum(sizes)
     paramss = [ps.reshape(shape) for ps, shape in zip(np.split(params, split_indices[:-1]), shapes)]

--- a/timemachine/potentials/summed.py
+++ b/timemachine/potentials/summed.py
@@ -35,8 +35,7 @@ def summed_potential(
     assert len(U_fns) == len(shapes)
     sizes = [np.prod(shape) for shape in shapes]
     assert params.ndim == 1
-    (num_params,) = params.shape
-    assert sum(sizes) == num_params
+    assert sum(sizes) == params.shape[0]
     # np.split expects indices, must increment sizes to be indices
     split_indices = np.cumsum(sizes)
     paramss = [ps.reshape(shape) for ps, shape in zip(np.split(params, split_indices[:-1]), shapes)]

--- a/timemachine/potentials/summed.py
+++ b/timemachine/potentials/summed.py
@@ -34,8 +34,7 @@ def summed_potential(
     """
     assert len(U_fns) == len(shapes)
     sizes = [np.prod(shape) for shape in shapes]
-    assert params.ndim == 1
-    assert sum(sizes) == params.shape[0]
+    assert params.shape == (sum(sizes),)
     # np.split expects indices, must increment sizes to be indices
     split_indices = np.cumsum(sizes)
     paramss = [ps.reshape(shape) for ps, shape in zip(np.split(params, split_indices[:-1]), shapes)]

--- a/timemachine/potentials/summed.py
+++ b/timemachine/potentials/summed.py
@@ -1,3 +1,4 @@
+from functools import reduce
 from typing import Optional, Sequence, Tuple
 
 import jax.numpy as jnp
@@ -33,7 +34,7 @@ def summed_potential(
         shapes of the parameter array input for each potential term (must be same length as U_fns)
     """
     assert len(U_fns) == len(shapes)
-    sizes = np.prod(shapes, axis=1)
+    sizes = [reduce(lambda x, y: x * y, shape) for shape in shapes]
     # np.split expects indices, must increment sizes to be indices
     split_indices = np.cumsum(sizes)
     paramss = [ps.reshape(shape) for ps, shape in zip(np.split(params, split_indices[:-1]), shapes)]

--- a/timemachine/potentials/summed.py
+++ b/timemachine/potentials/summed.py
@@ -33,7 +33,7 @@ def summed_potential(
         shapes of the parameter array input for each potential term (must be same length as U_fns)
     """
     assert len(U_fns) == len(shapes)
-    sizes = [np.product(shape) for shape in shapes]
+    sizes = [np.prod(shape) for shape in shapes]
     # np.split expects indices, must increment sizes to be indices
     split_indices = np.cumsum(sizes)
     paramss = [ps.reshape(shape) for ps, shape in zip(np.split(params, split_indices[:-1]), shapes)]


### PR DESCRIPTION
The reference summed potential currently fails when the component potentials have parameters with different numbers of dimensions. For example, in

```python
 nested_sp = SummedPotential([harmonic_bond.potential], [harmonic_bond.params])
 nested_sp_params = harmonic_bond.params.flatten()
 sp = SummedPotential([nested_sp, harmonic_bond.potential], [nested_sp_params, harmonic_bond.params])
```

(where `nested_sp_params.ndim == 1` and `harmonic_bond.params.ndim == 2`), `sp` will fail when called, raising

> ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (2,) + inhomogeneous part.

This PR adds a test for the above case, and modifies the reference summed potential implementation to handle inhomogenous numbers of dimensions.