### PR TITLE
Task/reenable custom ops for cpu tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,8 +56,11 @@ nogpu-tests:
     - cpu
   rules:
     - if: $CI_EXTERNAL_PULL_REQUEST_IID
+  # Build custom ops with fixed cuda arch, to test C++ that is CPU only
+  variables:
+    CMAKE_ARGS: -DCUDA_ARCH=75
   script:
-    - SKIP_CUSTOM_OPS=1 pip install .[test]
+    - pip install .[test]
     - make nogpu_tests
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-nogpu-tests"
@@ -129,8 +132,11 @@ nightly-tests-nogpu:
     - cpu
   rules:
     - if: $NIGHTLY_TESTS
+  # Build custom ops with fixed cuda arch, to test C++ that is CPU only
+  variables:
+    CMAKE_ARGS: -DCUDA_ARCH=75
   script:
-    - SKIP_CUSTOM_OPS=1 pip install .[test]
+    - pip install .[test]
     - make nogpu_nightly_tests
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-nogpu-nightly-tests"

--- a/tests/test_rmsd_align.py
+++ b/tests/test_rmsd_align.py
@@ -1,10 +1,12 @@
 # test the custom_op for rmsd alignment
-
 import numpy as np
+import pytest
 from scipy.stats import ortho_group, special_ortho_group
 
 from timemachine.lib import custom_ops
 from timemachine.potentials import rmsd
+
+pytestmark = [pytest.mark.nogpu]
 
 
 def test_rmsd_align_proper():


### PR DESCRIPTION
In #1048 I skipped building custom ops due to the use of `native` as the default cuda arch, which fails when you have no GPU. This reenables building custom ops so that we can test C++ code on the CPU instances.

Moves the rmsd alignment tests to the nogpu marker. 