### PR TITLE
Faster ERFC and minor NB all pairs clean up

### DIFF
--- a/timemachine/cpp/src/gpu_utils.cuh
+++ b/timemachine/cpp/src/gpu_utils.cuh
@@ -83,3 +83,21 @@ double __device__ __forceinline__ rmul_rn(double a, double b) { return __dmul_rn
 float __device__ __forceinline__ radd_rn(float a, float b) { return __fadd_rn(a, b); }
 
 double __device__ __forceinline__ radd_rn(double a, double b) { return __dadd_rn(a, b); }
+
+// Faster ERFC approximation courtesy of Norbert Juffa. NVIDIA Corporation
+static __forceinline__ __device__ float fasterfc(float a) {
+    /* approximate log(erfc(a)) with rel. error < 7e-9 */
+    float t, x = a;
+    t = (float)-1.6488499458192755E-006;
+    t = __fmaf_rn(t, x, (float)2.9524665006554534E-005);
+    t = __fmaf_rn(t, x, (float)-2.3341951153749626E-004);
+    t = __fmaf_rn(t, x, (float)1.0424943374047289E-003);
+    t = __fmaf_rn(t, x, (float)-2.5501426008983853E-003);
+    t = __fmaf_rn(t, x, (float)3.1979939710877236E-004);
+    t = __fmaf_rn(t, x, (float)2.7605379075746249E-002);
+    t = __fmaf_rn(t, x, (float)-1.4827402067461906E-001);
+    t = __fmaf_rn(t, x, (float)-9.1844764013203406E-001);
+    t = __fmaf_rn(t, x, (float)-1.6279070384382459E+000);
+    t = t * x;
+    return exp2f(t);
+}

--- a/timemachine/cpp/src/kernels/k_nonbonded_common.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_common.cuh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../gpu_utils.cuh"
 #include "k_fixed_point.cuh"
 
 // each atom parameterized by a 4-tuple: charge, lj sigma, lj epsilon, 4D coordinate w
@@ -23,11 +24,7 @@ float __device__ __forceinline__ real_es_factor(float real_beta, float dij, floa
     float beta_dij = real_beta * dij;
     // max ulp error is: 2 + floor(abs(1.16 * x))
     float exp_beta_dij_2 = __expf(-beta_dij * beta_dij);
-    // 5th order gaussian polynomial approximation, we need the exp(-x^2) anyways for the chain rule
-    // so we use last variant in https://en.wikipedia.org/wiki/Error_function#Approximation_with_elementary_functions
-    float t = 1.0f / (1.0f + 0.3275911f * beta_dij);
-    erfc_beta_dij = (0.254829592f + (-0.284496736f + (1.421413741f + (-1.453152027f + 1.061405429f * t) * t) * t) * t) *
-                    t * exp_beta_dij_2;
+    erfc_beta_dij = fasterfc(beta_dij);
     return -inv_d2ij * (static_cast<float>(TWO_OVER_SQRT_PI) * beta_dij * exp_beta_dij_2 + erfc_beta_dij);
 }
 


### PR DESCRIPTION
* Uses a faster erfc which gets ~1% speed up
* Avoids using as many registers in nonbonded potentials, no performance impact, but a nice to have going forward as we refine the nonbonded potentials

# Benchmarks
A10, Cuda Arch 8.6

# Current
```
dhfr-apo: N=23558 speed: 691.25ns/day dt: 2.5fs (ran 10000 steps in 3.13s)
dhfr-apo-barostat-interval-25: N=23558 speed: 631.88ns/day dt: 2.5fs (ran 10000 steps in 3.42s)
hif2a-apo: N=8805 speed: 1176.71ns/day dt: 2.5fs (ran 10000 steps in 1.84s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1028.24ns/day dt: 2.5fs (ran 10000 steps in 2.10s)
hif2a-rbfe: N=8840 speed: 907.28ns/day dt: 2.5fs (ran 10000 steps in 2.38s)
hif2a-rbfe-local: N=8840 speed: 1283.75ns/day dt: 2.5fs (ran 10000 steps in 1.69s)
solvent-apo: N=6282 speed: 1460.84ns/day dt: 2.5fs (ran 10000 steps in 1.48s)
solvent-apo-barostat-interval-25: N=6282 speed: 1287.59ns/day dt: 2.5fs (ran 10000 steps in 1.68s)
solvent-rbfe: N=6317 speed: 1165.96ns/day dt: 2.5fs (ran 10000 steps in 1.86s)
solvent-rbfe-local: N=6317 speed: 1387.95ns/day dt: 2.5fs (ran 10000 steps in 1.56s)
```

# PR
```
dhfr-apo: N=23558 speed: 699.28ns/day dt: 2.5fs (ran 10000 steps in 3.09s)
dhfr-apo-barostat-interval-25: N=23558 speed: 638.05ns/day dt: 2.5fs (ran 10000 steps in 3.39s)
hif2a-apo: N=8805 speed: 1189.40ns/day dt: 2.5fs (ran 10000 steps in 1.82s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1038.08ns/day dt: 2.5fs (ran 10000 steps in 2.08s)
hif2a-rbfe: N=8840 speed: 920.71ns/day dt: 2.5fs (ran 10000 steps in 2.35s)
hif2a-rbfe-local: N=8840 speed: 1325.67ns/day dt: 2.5fs (ran 10000 steps in 1.63s)
solvent-apo: N=6282 speed: 1455.16ns/day dt: 2.5fs (ran 10000 steps in 1.49s)
solvent-apo-barostat-interval-25: N=6282 speed: 1327.64ns/day dt: 2.5fs (ran 10000 steps in 1.63s)
solvent-rbfe: N=6317 speed: 1169.75ns/day dt: 2.5fs (ran 10000 steps in 1.85s)
solvent-rbfe-local: N=6317 speed: 1396.92ns/day dt: 2.5fs (ran 10000 steps in 1.55s)
```