### PR TITLE
[wip] Return inf not nan from jax potentials

### DIFF
--- a/tests/test_jax_nonbonded.py
+++ b/tests/test_jax_nonbonded.py
@@ -477,3 +477,15 @@ def test_precomputation():
 
         np.testing.assert_allclose(v_ref, v_test)
         np.testing.assert_allclose(gs_ref, gs_test)
+
+
+def test_lj_not_nan():
+    distances = [0.0, 0.00000001, 0.00001, 0.001, np.inf]
+
+    def U(r):
+        return lennard_jones(jnp.array(r), 0.3, 0.1)
+
+    for r in distances:
+        nrg = U(r)
+        assert not np.isnan(nrg)
+        assert np.sign(nrg) > 0

--- a/timemachine/potentials/jax_utils.py
+++ b/timemachine/potentials/jax_utils.py
@@ -12,6 +12,10 @@ Array: TypeAlias = NDArray
 DEFAULT_CHUNK_SIZE = 200
 
 
+def nan_to_inf(x):
+    return jnp.nan_to_num(x, nan=+jnp.inf)
+
+
 def get_all_pairs_indices(n: int) -> Array:
     """all indices i, j such that i < j < n"""
     n_interactions = n * (n - 1) / 2

--- a/timemachine/potentials/nonbonded.py
+++ b/timemachine/potentials/nonbonded.py
@@ -12,6 +12,7 @@ from timemachine.potentials.jax_utils import (
     DEFAULT_CHUNK_SIZE,
     delta_r,
     distance_on_pairs,
+    nan_to_inf,
     pairs_from_interaction_groups,
     pairwise_distances,
     process_traj_in_chunks,
@@ -48,7 +49,8 @@ def lennard_jones(dij, sig_ij, eps_ij):
     sig6 = (sig_ij / dij) ** 6
     sig12 = sig6 ** 2
 
-    return 4 * eps_ij * (sig12 - sig6)
+    nrg = 4 * eps_ij * (sig12 - sig6)  # +inf - +inf -> nan
+    return nan_to_inf(nrg)  # nrg can be nan if dij == 0
 
 
 def direct_space_pme(dij, qij, beta):


### PR DESCRIPTION
Possibly cleans up a case @proteneer encountered in https://github.com/proteneer/timemachine/pull/1083

Options: 
* convert nans to infs only in `lennard_jones`
* convert nans to infs in other jax potentials (unsure)
* convert nans to infs in downstream code (such as Metropolis checks https://github.com/proteneer/timemachine/pull/1083/commits/36d5d1fd0ac74054d9852c50302401439be1d60e )