### PR TITLE
Refactor using the existing MonteCarloMove class.

### DIFF
--- a/timemachine/exchange/exchange_mover.py
+++ b/timemachine/exchange/exchange_mover.py
@@ -135,9 +135,6 @@ class ExchangeMove(moves.MonteCarloMove):
         self.nb_params = jnp.array(nb_params)
         self.num_waters = len(water_idxs)
         self.water_idxs = water_idxs
-        # counters
-        self.a_count = 0  # accept count
-        self.t_count = 0  # trial count
         self.beta = 1 / DEFAULT_KT
 
         @jax.jit
@@ -185,7 +182,6 @@ class ExchangeMove(moves.MonteCarloMove):
             delta_U_total = np.inf
 
         log_p_accept = min(0, -self.beta * delta_U_total)
-        # print(-self.beta * delta_U_total, log_p_accept, np.exp(log_p_accept))
         new_state = CoordsVelBox(trial_coords, x.velocities, x.box)
 
         return new_state, log_p_accept

--- a/timemachine/exchange/exchange_mover.py
+++ b/timemachine/exchange/exchange_mover.py
@@ -276,7 +276,6 @@ def test_exchange():
 
     nb_cutoff = 1.2  # this has to be 1.2 since the builders hard code this in (should fix later)
     initial_state, nwm, topology = get_initial_state(args.water_pdb, mol, ff, seed, nb_cutoff)
-    # ctxt = initialize_ctxt(initial_state)
 
     # set up water indices, assumes that waters are placed at the front of the coordinates.
     water_idxs = []

--- a/timemachine/exchange/exchange_mover.py
+++ b/timemachine/exchange/exchange_mover.py
@@ -341,7 +341,7 @@ def test_exchange():
         print(
             f"{exc_mover.n_accepted} / {exc_mover.n_proposed} | density {density} | # of waters in bb {occ // 3} | md step: {idx * md_steps_per_batch}"
         )
-        if idx % 1 == 0:
+        if idx % 10 == 0:
             writer.write_frame(xvb_t.coords * 10)
 
         # run MC


### PR DESCRIPTION
Refactors the water_exchange branch to use existing movers:

1) Re-use existing CoordsVelBox structure to represent state. 
2) ExchangeMove now subclasses `MonteCarloMove` and implements the abstract `proposal` method
3) Propagate moves replaced by NPTMove.