### PR TITLE
Fix keep_idxs with adaptive bisection

### DIFF
--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -363,6 +363,21 @@ def test_rbfe_with_1_window(estimate_relative_free_energy_fn):
         )
 
 
+def test_estimate_free_energy_via_greedy_bisection_invalid_args():
+    mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
+    with pytest.raises(ValueError, match="keep_idxs"):
+        estimate_relative_free_energy_via_greedy_bisection(
+            mol_a,
+            mol_b,
+            core,
+            Forcefield.load_default(),
+            host_config=None,
+            n_windows=3,
+            min_overlap=0.4,
+            keep_idxs=[0, 2],  # invalid with min_overlap not None
+        )
+
+
 if __name__ == "__main__":
     # convenience: so we can run this directly from python tests/test_relative_free_energy.py without
     # toggling the pytest marker

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -313,7 +313,7 @@ def test_imaging_frames():
         md_params=md_params,
         n_windows=windows,
     )
-    keep_idxs = [0, len(res.final_result.initial_states) - 1]
+    keep_idxs = [0, -1]
     assert len(keep_idxs) == len(res.frames)
 
     # A buffer, as imaging doesn't ensure everything is perfectly in the box

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -234,7 +234,7 @@ def estimate_absolute_free_energy(
     initial_states = setup_initial_states(afe, ff, host_config, temperature, lambda_schedule, md_params.seed)
 
     if keep_idxs is None:
-        keep_idxs = [0, len(initial_states) - 1]  # keep first and last windows
+        keep_idxs = [0, -1]  # keep first and last windows
     assert len(keep_idxs) <= len(lambda_schedule)
 
     combined_prefix = get_mol_name(mol) + "_" + prefix

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -525,8 +525,8 @@ def run_sims_sequential(
     u_kln_by_component_by_lambda = []
 
     keep_idxs = keep_idxs or []
-    if keep_idxs:
-        assert all(np.array(keep_idxs) >= 0)
+    keep_idxs = [range(len(initial_states))[i] for i in keep_idxs]  # ensure all indices > 0
+    assert np.all(np.array(keep_idxs) >= 0)
 
     for lamb_idx, initial_state in enumerate(initial_states):
 

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -510,8 +510,9 @@ def estimate_relative_free_energy_via_greedy_bisection(
         value
 
     keep_idxs: list of int or None, optional
-        If None, return only the end-state frames. Otherwise if not None, use only for debugging, and this
-        will return the frames corresponding to the idxs of interest.
+        If None, return only the end-state frames. Otherwise if not None (typically for debugging), return frames from
+        windows corresponding to the specified indices. When min_overlap is not None, i.e. when adaptive bisection is
+        enabled, keep_idxs must equal one of None, [0, -1], or list(range(n_windows)).
 
     md_params: MDParams
         Parameters for the equilibration and production MD. Defaults to 400 global steps per frame, 1000 frames and 10k
@@ -554,8 +555,14 @@ def estimate_relative_free_energy_via_greedy_bisection(
     )
 
     if keep_idxs is None:
-        keep_idxs = [0, len(initial_states) - 1]  # keep frames from first and last windows
+        keep_idxs = [0, -1]  # keep frames from first and last windows
+
     assert len(keep_idxs) <= n_windows
+
+    if min_overlap is not None and keep_idxs not in [None, [0, -1], list(range(n_windows))]:
+        raise ValueError(
+            "when min_overlap is not None, keep_idxs must be equal to one of None, [0, -1], or list(range(n_windows))"
+        )
 
     # TODO: rename prefix to postfix, or move to beginning of combined_prefix?
     combined_prefix = get_mol_name(mol_a) + "_" + get_mol_name(mol_b) + "_" + prefix

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -428,7 +428,7 @@ def estimate_relative_free_energy(
     )
 
     if keep_idxs is None:
-        keep_idxs = [0, len(initial_states) - 1]  # keep frames from first and last windows
+        keep_idxs = [0, -1]  # keep frames from first and last windows
     assert len(keep_idxs) <= len(lambda_schedule)
 
     # TODO: rename prefix to postfix, or move to beginning of combined_prefix?

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -532,6 +532,16 @@ def estimate_relative_free_energy_via_greedy_bisection(
         n_windows = DEFAULT_NUM_WINDOWS
     assert n_windows >= 2
 
+    if keep_idxs is None:
+        keep_idxs = [0, -1]  # keep frames from first and last windows
+
+    assert len(keep_idxs) <= n_windows
+
+    if min_overlap is not None and keep_idxs not in [None, [0, -1], list(range(n_windows))]:
+        raise ValueError(
+            "when min_overlap is not None, keep_idxs must be equal to one of None, [0, -1], or list(range(n_windows))"
+        )
+
     single_topology = SingleTopology(mol_a, mol_b, core, ff)
 
     lambda_min, lambda_max = lambda_interval or (0.0, 1.0)
@@ -553,16 +563,6 @@ def estimate_relative_free_energy_via_greedy_bisection(
         temperature=temperature,
         seed=md_params.seed,
     )
-
-    if keep_idxs is None:
-        keep_idxs = [0, -1]  # keep frames from first and last windows
-
-    assert len(keep_idxs) <= n_windows
-
-    if min_overlap is not None and keep_idxs not in [None, [0, -1], list(range(n_windows))]:
-        raise ValueError(
-            "when min_overlap is not None, keep_idxs must be equal to one of None, [0, -1], or list(range(n_windows))"
-        )
 
     # TODO: rename prefix to postfix, or move to beginning of combined_prefix?
     combined_prefix = get_mol_name(mol_a) + "_" + get_mol_name(mol_b) + "_" + prefix


### PR DESCRIPTION
Fixes a bug where the default value of `keep_idxs` can result in out-of-bounds indexing when adaptive bisection is enabled (`min_overlap not None`)