### PR TITLE
Refactor Barostat

### DIFF
--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -543,5 +543,5 @@ def test_get_group_indices():
     assert_group_idxs_are_equal(ref_idxs, test_idxs)
 
     with pytest.raises(AssertionError):
-        # num_atoms <  an atom's indx in bond_idxs
+        # num_atoms <  an atom's index in bond_idxs
         get_group_indices([[0, 3]], num_atoms=3)

--- a/timemachine/cpp/src/barostat.cu
+++ b/timemachine/cpp/src/barostat.cu
@@ -5,11 +5,10 @@
 #include "gpu_utils.cuh"
 #include "math_utils.cuh"
 #include <algorithm>
-#include <cub/cub.cuh>
 #include <set>
 #include <stdio.h>
 
-#include "kernels/k_fixed_point.cuh"
+#include "kernels/k_barostat.cuh"
 
 namespace timemachine {
 
@@ -126,152 +125,6 @@ MonteCarloBarostat::~MonteCarloBarostat() {
     gpuErrchk(cudaFree(d_num_attempted_));
     curandErrchk(curandDestroyGenerator(cr_rng_));
 };
-
-void __global__ rescale_positions(
-    const int N,                                     // Number of atoms to shift
-    double *__restrict__ coords,                     // Coordinates
-    const double *__restrict__ length_scale,         // [1]
-    const double *__restrict__ box,                  // [9]
-    double *__restrict__ scaled_box,                 // [9]
-    const int *__restrict__ atom_idxs,               // [N]
-    const int *__restrict__ mol_idxs,                // [N]
-    const int *__restrict__ mol_offsets,             // [N]
-    const unsigned long long *__restrict__ centroids // [N*3]
-) {
-    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx >= N) {
-        return;
-    }
-    const int atom_idx = atom_idxs[idx];
-    const int mol_idx = mol_idxs[idx];
-
-    const double center_x = box[0 * 3 + 0] * 0.5;
-    const double center_y = box[1 * 3 + 1] * 0.5;
-    const double center_z = box[2 * 3 + 2] * 0.5;
-
-    const double num_atoms = static_cast<double>(mol_offsets[mol_idx + 1] - mol_offsets[mol_idx]);
-
-    const double centroid_x = FIXED_TO_FLOAT<double>(centroids[mol_idx * 3 + 0]) / num_atoms;
-    const double centroid_y = FIXED_TO_FLOAT<double>(centroids[mol_idx * 3 + 1]) / num_atoms;
-    const double centroid_z = FIXED_TO_FLOAT<double>(centroids[mol_idx * 3 + 2]) / num_atoms;
-
-    const double displacement_x = ((centroid_x - center_x) * length_scale[0]) + center_x - centroid_x;
-    const double displacement_y = ((centroid_y - center_y) * length_scale[0]) + center_y - centroid_y;
-    const double displacement_z = ((centroid_z - center_z) * length_scale[0]) + center_z - centroid_z;
-
-    coords[atom_idx * 3 + 0] += displacement_x;
-    coords[atom_idx * 3 + 1] += displacement_y;
-    coords[atom_idx * 3 + 2] += displacement_z;
-    if (idx == 0) {
-        scaled_box[0 * 3 + 0] *= length_scale[0];
-        scaled_box[1 * 3 + 1] *= length_scale[0];
-        scaled_box[2 * 3 + 2] *= length_scale[0];
-    }
-}
-
-void __global__ find_group_centroids(
-    const int N,                               // Number of atoms to shift
-    const double *__restrict__ coords,         // Coordinates
-    const int *__restrict__ atom_idxs,         // [N]
-    const int *__restrict__ mol_idxs,          // [N]
-    unsigned long long *__restrict__ centroids // [num_molecules * 3]
-) {
-    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx >= N) {
-        return;
-    }
-    const int atom_idx = atom_idxs[idx];
-    const int mol_idx = mol_idxs[idx];
-    atomicAdd(centroids + mol_idx * 3 + 0, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 0]));
-    atomicAdd(centroids + mol_idx * 3 + 1, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 1]));
-    atomicAdd(centroids + mol_idx * 3 + 2, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 2]));
-}
-
-void __global__ k_setup_barostat_move(
-    const double *__restrict__ rand,     // [2], use first value, second value is metropolis condition
-    double *__restrict__ d_box,          // [3*3]
-    double *__restrict__ d_volume_delta, // [1]
-    double *__restrict__ d_volume_scale, // [1]
-    double *__restrict__ d_length_scale  // [1]
-) {
-    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx >= 1) {
-        return; // Only a single thread needs to perform this operation
-    }
-    const double volume = d_box[0 * 3 + 0] * d_box[1 * 3 + 1] * d_box[2 * 3 + 2];
-    if (d_volume_scale[0] == 0) {
-        d_volume_scale[0] = 0.01 * volume;
-    }
-    const double delta_volume = d_volume_scale[0] * 2 * (rand[0] - 0.5);
-    const double new_volume = volume + delta_volume;
-    d_volume_delta[0] = delta_volume;
-    d_length_scale[0] = cbrt(new_volume / volume);
-}
-
-void __global__ k_decide_move(
-    const int N,
-    const int num_molecules,
-    const double kt,
-    const double pressure,
-    const double *__restrict__ rand, // [2] Use second value
-    double *__restrict__ d_volume_delta,
-    double *__restrict__ d_volume_scale,
-    const __int128 *__restrict__ d_init_u,
-    const __int128 *__restrict__ d_final_u,
-    double *__restrict__ d_box,
-    const double *__restrict__ d_box_output,
-    double *__restrict__ d_x,
-    const double *__restrict__ d_x_output,
-    int *__restrict__ num_accepted,
-    int *__restrict__ num_attempted) {
-    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx >= N) {
-        return;
-    }
-
-    const double volume = d_box[0 * 3 + 0] * d_box[1 * 3 + 1] * d_box[2 * 3 + 2];
-    const double new_volume = volume + d_volume_delta[0];
-    double energy_delta = INFINITY;
-    if (!fixed_point_overflow(d_final_u[0]) && !fixed_point_overflow(d_init_u[0])) {
-        energy_delta = FIXED_ENERGY_TO_FLOAT<double>(d_final_u[0] - d_init_u[0]);
-    }
-
-    const double w = energy_delta + pressure * d_volume_delta[0] - num_molecules * kt * std::log(new_volume / volume);
-
-    const bool rejected = w > 0 && rand[1] > std::exp(-w / kt);
-    if (idx == 0) {
-        if (!rejected) {
-            num_accepted[0]++;
-        }
-        num_attempted[0]++;
-        if (num_attempted[0] >= 10) {
-            if (num_accepted[0] < 0.25 * num_attempted[0]) {
-                d_volume_scale[0] /= 1.1;
-                // Reset the counters
-                num_attempted[0] = 0;
-                num_accepted[0] = 0;
-            } else if (num_accepted[0] > 0.75 * num_attempted[0]) {
-                d_volume_scale[0] = min(d_volume_scale[0] * 1.1, volume * 0.3);
-                // Reset the counters
-                num_attempted[0] = 0;
-                num_accepted[0] = 0;
-            }
-        }
-    }
-    if (rejected) {
-        return;
-    }
-    // If the mc move was accepted copy all of the data into place
-
-    if (idx < 9) {
-        d_box[idx] = d_box_output[idx];
-    }
-
-#pragma unroll
-    for (int i = 0; i < 3; i++) {
-        d_x[idx * 3 + i] = d_x_output[idx * 3 + i];
-    }
-}
 
 void MonteCarloBarostat::reset_counters() {
     gpuErrchk(cudaMemset(d_num_accepted_, 0, sizeof(*d_num_accepted_)));

--- a/timemachine/cpp/src/barostat.cu
+++ b/timemachine/cpp/src/barostat.cu
@@ -145,7 +145,9 @@ void MonteCarloBarostat::inplace_move(
     // Get offset into the d_rand_ array
     int random_offset = (((step_ / interval_) * 2) - 2) % (RANDOM_BATCH_SIZE * 2);
 
-    // Generate the scaling and metropolis conditions in batches then offset on each move
+    // Generate random values batches then offset on each move
+    // Each move requires two random values, the first is used to adjust the scaling of box in k_setup_barostat_move
+    // and the second is used to accept or reject in the metropolis hasting check performed in k_decide_move.
     if (random_offset == 0) {
         curandErrchk(curandSetStream(cr_rng_, stream));
         curandErrchk(curandGenerateUniformDouble(cr_rng_, d_rand_, RANDOM_BATCH_SIZE * 2));

--- a/timemachine/cpp/src/barostat.cu
+++ b/timemachine/cpp/src/barostat.cu
@@ -173,6 +173,9 @@ void MonteCarloBarostat<RealType>::inplace_move(
     gpuErrchk(cudaMemcpyAsync(d_box_after_, d_box, 3 * 3 * sizeof(*d_box_after_), cudaMemcpyDeviceToDevice, stream));
 
     const int tpb = DEFAULT_THREADS_PER_BLOCK;
+    // TBD: For larger systems (20k >) may be better to reduce the number of blocks, rather than
+    // matching the number of blocks to be ceil_divide(units_of_work, tpb). The kernels already support this, but
+    // at the moment we match the blocks * tpb to equal units_of_work
     const int blocks = ceil_divide(num_grouped_atoms_, tpb);
 
     k_find_group_centroids<RealType>

--- a/timemachine/cpp/src/barostat.cu
+++ b/timemachine/cpp/src/barostat.cu
@@ -165,12 +165,12 @@ void MonteCarloBarostat::inplace_move(
     const int tpb = DEFAULT_THREADS_PER_BLOCK;
     const int blocks = ceil_divide(num_grouped_atoms_, tpb);
 
-    find_group_centroids<<<blocks, tpb, 0, stream>>>(
+    k_find_group_centroids<<<blocks, tpb, 0, stream>>>(
         num_grouped_atoms_, d_x_after_, d_atom_idxs_, d_mol_idxs_, d_centroids_);
     gpuErrchk(cudaPeekAtLastError());
 
     // Scale centroids
-    rescale_positions<<<blocks, tpb, 0, stream>>>(
+    k_rescale_positions<<<blocks, tpb, 0, stream>>>(
         num_grouped_atoms_,
         d_x_after_,
         d_length_scale_,

--- a/timemachine/cpp/src/barostat.hpp
+++ b/timemachine/cpp/src/barostat.hpp
@@ -9,7 +9,7 @@
 
 namespace timemachine {
 
-class MonteCarloBarostat {
+template <typename RealType> class MonteCarloBarostat {
 
 public:
     MonteCarloBarostat(
@@ -39,14 +39,14 @@ private:
 
     std::vector<std::shared_ptr<BoundPotential>> bps_;
 
-    double pressure_;
-    const double temperature_;
+    RealType pressure_;
+    const RealType temperature_;
     int interval_;
     const int seed_;
     const std::vector<std::vector<int>> group_idxs_;
 
     // stuff that deals with RNG
-    double *d_rand_;
+    RealType *d_rand_;
     curandGenerator_t cr_rng_;
 
     // internals
@@ -62,10 +62,10 @@ private:
     __int128 *d_init_u_;
     __int128 *d_final_u_;
 
-    double *d_volume_;
-    double *d_volume_delta_;
-    double *d_length_scale_;
-    double *d_volume_scale_;
+    RealType *d_volume_;
+    RealType *d_volume_delta_;
+    RealType *d_length_scale_;
+    RealType *d_volume_scale_;
 
     double *d_x_after_;
     double *d_box_after_;
@@ -78,5 +78,8 @@ private:
 
     StreamedPotentialRunner runner_;
 };
+
+template class MonteCarloBarostat<float>;
+template class MonteCarloBarostat<double>;
 
 } // namespace timemachine

--- a/timemachine/cpp/src/context.cu
+++ b/timemachine/cpp/src/context.cu
@@ -23,7 +23,7 @@ Context::Context(
     const double *box_0,
     std::shared_ptr<Integrator> intg,
     std::vector<std::shared_ptr<BoundPotential>> bps,
-    std::shared_ptr<MonteCarloBarostat> barostat)
+    std::shared_ptr<MonteCarloBarostat<float>> barostat)
     : N_(N), barostat_(barostat), step_(0), intg_(intg), bps_(bps), nonbonded_pots_(0) {
 
     d_x_t_ = gpuErrchkCudaMallocAndCopy(x_0, N * 3);

--- a/timemachine/cpp/src/context.hpp
+++ b/timemachine/cpp/src/context.hpp
@@ -17,7 +17,7 @@ public:
         const double *box_0,
         std::shared_ptr<Integrator> intg,
         std::vector<std::shared_ptr<BoundPotential>> bps,
-        std::shared_ptr<MonteCarloBarostat> barostat = nullptr);
+        std::shared_ptr<MonteCarloBarostat<float>> barostat = nullptr);
 
     ~Context();
 
@@ -64,7 +64,7 @@ public:
 private:
     int N_; // number of particles
 
-    std::shared_ptr<MonteCarloBarostat> barostat_;
+    std::shared_ptr<MonteCarloBarostat<float>> barostat_;
 
     void _step(std::vector<std::shared_ptr<BoundPotential>> &bps, unsigned int *d_atom_idxs, const cudaStream_t stream);
 

--- a/timemachine/cpp/src/kernels/k_barostat.cuh
+++ b/timemachine/cpp/src/kernels/k_barostat.cuh
@@ -1,0 +1,149 @@
+#pragma once
+
+#include "k_fixed_point.cuh"
+
+void __global__ rescale_positions(
+    const int N,                                     // Number of atoms to shift
+    double *__restrict__ coords,                     // Coordinates
+    const double *__restrict__ length_scale,         // [1]
+    const double *__restrict__ box,                  // [9]
+    double *__restrict__ scaled_box,                 // [9]
+    const int *__restrict__ atom_idxs,               // [N]
+    const int *__restrict__ mol_idxs,                // [N]
+    const int *__restrict__ mol_offsets,             // [N]
+    const unsigned long long *__restrict__ centroids // [N*3]
+) {
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= N) {
+        return;
+    }
+    const int atom_idx = atom_idxs[idx];
+    const int mol_idx = mol_idxs[idx];
+
+    const double center_x = box[0 * 3 + 0] * 0.5;
+    const double center_y = box[1 * 3 + 1] * 0.5;
+    const double center_z = box[2 * 3 + 2] * 0.5;
+
+    const double num_atoms = static_cast<double>(mol_offsets[mol_idx + 1] - mol_offsets[mol_idx]);
+
+    const double centroid_x = FIXED_TO_FLOAT<double>(centroids[mol_idx * 3 + 0]) / num_atoms;
+    const double centroid_y = FIXED_TO_FLOAT<double>(centroids[mol_idx * 3 + 1]) / num_atoms;
+    const double centroid_z = FIXED_TO_FLOAT<double>(centroids[mol_idx * 3 + 2]) / num_atoms;
+
+    const double displacement_x = ((centroid_x - center_x) * length_scale[0]) + center_x - centroid_x;
+    const double displacement_y = ((centroid_y - center_y) * length_scale[0]) + center_y - centroid_y;
+    const double displacement_z = ((centroid_z - center_z) * length_scale[0]) + center_z - centroid_z;
+
+    coords[atom_idx * 3 + 0] += displacement_x;
+    coords[atom_idx * 3 + 1] += displacement_y;
+    coords[atom_idx * 3 + 2] += displacement_z;
+    if (idx == 0) {
+        scaled_box[0 * 3 + 0] *= length_scale[0];
+        scaled_box[1 * 3 + 1] *= length_scale[0];
+        scaled_box[2 * 3 + 2] *= length_scale[0];
+    }
+}
+
+void __global__ find_group_centroids(
+    const int N,                               // Number of atoms to shift
+    const double *__restrict__ coords,         // Coordinates
+    const int *__restrict__ atom_idxs,         // [N]
+    const int *__restrict__ mol_idxs,          // [N]
+    unsigned long long *__restrict__ centroids // [num_molecules * 3]
+) {
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= N) {
+        return;
+    }
+    const int atom_idx = atom_idxs[idx];
+    const int mol_idx = mol_idxs[idx];
+    atomicAdd(centroids + mol_idx * 3 + 0, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 0]));
+    atomicAdd(centroids + mol_idx * 3 + 1, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 1]));
+    atomicAdd(centroids + mol_idx * 3 + 2, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 2]));
+}
+
+void __global__ k_setup_barostat_move(
+    const double *__restrict__ rand,     // [2], use first value, second value is metropolis condition
+    double *__restrict__ d_box,          // [3*3]
+    double *__restrict__ d_volume_delta, // [1]
+    double *__restrict__ d_volume_scale, // [1]
+    double *__restrict__ d_length_scale  // [1]
+) {
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= 1) {
+        return; // Only a single thread needs to perform this operation
+    }
+    const double volume = d_box[0 * 3 + 0] * d_box[1 * 3 + 1] * d_box[2 * 3 + 2];
+    if (d_volume_scale[0] == 0) {
+        d_volume_scale[0] = 0.01 * volume;
+    }
+    const double delta_volume = d_volume_scale[0] * 2 * (rand[0] - 0.5);
+    const double new_volume = volume + delta_volume;
+    d_volume_delta[0] = delta_volume;
+    d_length_scale[0] = cbrt(new_volume / volume);
+}
+
+void __global__ k_decide_move(
+    const int N,
+    const int num_molecules,
+    const double kt,
+    const double pressure,
+    const double *__restrict__ rand, // [2] Use second value
+    double *__restrict__ d_volume_delta,
+    double *__restrict__ d_volume_scale,
+    const __int128 *__restrict__ d_init_u,
+    const __int128 *__restrict__ d_final_u,
+    double *__restrict__ d_box,
+    const double *__restrict__ d_box_output,
+    double *__restrict__ d_x,
+    const double *__restrict__ d_x_output,
+    int *__restrict__ num_accepted,
+    int *__restrict__ num_attempted) {
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= N) {
+        return;
+    }
+
+    const double volume = d_box[0 * 3 + 0] * d_box[1 * 3 + 1] * d_box[2 * 3 + 2];
+    const double new_volume = volume + d_volume_delta[0];
+    double energy_delta = INFINITY;
+    if (!fixed_point_overflow(d_final_u[0]) && !fixed_point_overflow(d_init_u[0])) {
+        energy_delta = FIXED_ENERGY_TO_FLOAT<double>(d_final_u[0] - d_init_u[0]);
+    }
+
+    const double w = energy_delta + pressure * d_volume_delta[0] - num_molecules * kt * std::log(new_volume / volume);
+
+    const bool rejected = w > 0 && rand[1] > std::exp(-w / kt);
+    if (idx == 0) {
+        if (!rejected) {
+            num_accepted[0]++;
+        }
+        num_attempted[0]++;
+        if (num_attempted[0] >= 10) {
+            if (num_accepted[0] < 0.25 * num_attempted[0]) {
+                d_volume_scale[0] /= 1.1;
+                // Reset the counters
+                num_attempted[0] = 0;
+                num_accepted[0] = 0;
+            } else if (num_accepted[0] > 0.75 * num_attempted[0]) {
+                d_volume_scale[0] = min(d_volume_scale[0] * 1.1, volume * 0.3);
+                // Reset the counters
+                num_attempted[0] = 0;
+                num_accepted[0] = 0;
+            }
+        }
+    }
+    if (rejected) {
+        return;
+    }
+    // If the mc move was accepted copy all of the data into place
+
+    if (idx < 9) {
+        d_box[idx] = d_box_output[idx];
+    }
+
+#pragma unroll
+    for (int i = 0; i < 3; i++) {
+        d_x[idx * 3 + i] = d_x_output[idx * 3 + i];
+    }
+}

--- a/timemachine/cpp/src/kernels/k_barostat.cuh
+++ b/timemachine/cpp/src/kernels/k_barostat.cuh
@@ -13,34 +13,36 @@ void __global__ rescale_positions(
     const int *__restrict__ mol_offsets,             // [N]
     const unsigned long long *__restrict__ centroids // [N*3]
 ) {
-    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx >= N) {
-        return;
-    }
-    const int atom_idx = atom_idxs[idx];
-    const int mol_idx = mol_idxs[idx];
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    float center_x = box[0 * 3 + 0] * 0.5f;
+    float center_y = box[1 * 3 + 1] * 0.5f;
+    float center_z = box[2 * 3 + 2] * 0.5f;
 
-    const double center_x = box[0 * 3 + 0] * 0.5;
-    const double center_y = box[1 * 3 + 1] * 0.5;
-    const double center_z = box[2 * 3 + 2] * 0.5;
-
-    const double num_atoms = static_cast<double>(mol_offsets[mol_idx + 1] - mol_offsets[mol_idx]);
-
-    const double centroid_x = FIXED_TO_FLOAT<double>(centroids[mol_idx * 3 + 0]) / num_atoms;
-    const double centroid_y = FIXED_TO_FLOAT<double>(centroids[mol_idx * 3 + 1]) / num_atoms;
-    const double centroid_z = FIXED_TO_FLOAT<double>(centroids[mol_idx * 3 + 2]) / num_atoms;
-
-    const double displacement_x = ((centroid_x - center_x) * length_scale[0]) + center_x - centroid_x;
-    const double displacement_y = ((centroid_y - center_y) * length_scale[0]) + center_y - centroid_y;
-    const double displacement_z = ((centroid_z - center_z) * length_scale[0]) + center_z - centroid_z;
-
-    coords[atom_idx * 3 + 0] += displacement_x;
-    coords[atom_idx * 3 + 1] += displacement_y;
-    coords[atom_idx * 3 + 2] += displacement_z;
+    double scale = length_scale[0];
     if (idx == 0) {
-        scaled_box[0 * 3 + 0] *= length_scale[0];
-        scaled_box[1 * 3 + 1] *= length_scale[0];
-        scaled_box[2 * 3 + 2] *= length_scale[0];
+        scaled_box[0 * 3 + 0] *= scale;
+        scaled_box[1 * 3 + 1] *= scale;
+        scaled_box[2 * 3 + 2] *= scale;
+    }
+    while (idx < N) {
+        int atom_idx = atom_idxs[idx];
+        int mol_idx = mol_idxs[idx];
+
+        float num_atoms = static_cast<float>(mol_offsets[mol_idx + 1] - mol_offsets[mol_idx]);
+
+        float centroid_x = FIXED_TO_FLOAT<float>(centroids[mol_idx * 3 + 0]) / num_atoms;
+        float centroid_y = FIXED_TO_FLOAT<float>(centroids[mol_idx * 3 + 1]) / num_atoms;
+        float centroid_z = FIXED_TO_FLOAT<float>(centroids[mol_idx * 3 + 2]) / num_atoms;
+
+        float displacement_x = ((centroid_x - center_x) * scale) + center_x - centroid_x;
+        float displacement_y = ((centroid_y - center_y) * scale) + center_y - centroid_y;
+        float displacement_z = ((centroid_z - center_z) * scale) + center_z - centroid_z;
+
+        coords[atom_idx * 3 + 0] += displacement_x;
+        coords[atom_idx * 3 + 1] += displacement_y;
+        coords[atom_idx * 3 + 2] += displacement_z;
+
+        idx += gridDim.x * blockDim.x;
     }
 }
 
@@ -51,15 +53,15 @@ void __global__ find_group_centroids(
     const int *__restrict__ mol_idxs,          // [N]
     unsigned long long *__restrict__ centroids // [num_molecules * 3]
 ) {
-    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx >= N) {
-        return;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    while (idx < N) {
+        int atom_idx = atom_idxs[idx];
+        int mol_idx = mol_idxs[idx];
+        atomicAdd(centroids + mol_idx * 3 + 0, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 0]));
+        atomicAdd(centroids + mol_idx * 3 + 1, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 1]));
+        atomicAdd(centroids + mol_idx * 3 + 2, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 2]));
+        idx += gridDim.x * blockDim.x;
     }
-    const int atom_idx = atom_idxs[idx];
-    const int mol_idx = mol_idxs[idx];
-    atomicAdd(centroids + mol_idx * 3 + 0, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 0]));
-    atomicAdd(centroids + mol_idx * 3 + 1, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 1]));
-    atomicAdd(centroids + mol_idx * 3 + 2, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 2]));
 }
 
 void __global__ k_setup_barostat_move(
@@ -73,12 +75,12 @@ void __global__ k_setup_barostat_move(
     if (idx >= 1) {
         return; // Only a single thread needs to perform this operation
     }
-    const double volume = d_box[0 * 3 + 0] * d_box[1 * 3 + 1] * d_box[2 * 3 + 2];
+    const float volume = d_box[0 * 3 + 0] * d_box[1 * 3 + 1] * d_box[2 * 3 + 2];
     if (d_volume_scale[0] == 0) {
         d_volume_scale[0] = 0.01 * volume;
     }
-    const double delta_volume = d_volume_scale[0] * 2 * (rand[0] - 0.5);
-    const double new_volume = volume + delta_volume;
+    const float delta_volume = d_volume_scale[0] * 2 * (rand[0] - 0.5);
+    const float new_volume = volume + delta_volume;
     d_volume_delta[0] = delta_volume;
     d_length_scale[0] = cbrt(new_volume / volume);
 }
@@ -99,51 +101,53 @@ void __global__ k_decide_move(
     const double *__restrict__ d_x_output,
     int *__restrict__ num_accepted,
     int *__restrict__ num_attempted) {
-    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx >= N) {
-        return;
-    }
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
     const double volume = d_box[0 * 3 + 0] * d_box[1 * 3 + 1] * d_box[2 * 3 + 2];
-    const double new_volume = volume + d_volume_delta[0];
+    const double volume_delta = d_volume_delta[0];
+    const double new_volume = volume + volume_delta;
     double energy_delta = INFINITY;
     if (!fixed_point_overflow(d_final_u[0]) && !fixed_point_overflow(d_init_u[0])) {
         energy_delta = FIXED_ENERGY_TO_FLOAT<double>(d_final_u[0] - d_init_u[0]);
     }
 
-    const double w = energy_delta + pressure * d_volume_delta[0] - num_molecules * kt * std::log(new_volume / volume);
+    const double w = energy_delta + pressure * volume_delta - num_molecules * kt * std::log(new_volume / volume);
 
     const bool rejected = w > 0 && rand[1] > std::exp(-w / kt);
-    if (idx == 0) {
-        if (!rejected) {
-            num_accepted[0]++;
-        }
-        num_attempted[0]++;
-        if (num_attempted[0] >= 10) {
-            if (num_accepted[0] < 0.25 * num_attempted[0]) {
-                d_volume_scale[0] /= 1.1;
-                // Reset the counters
-                num_attempted[0] = 0;
-                num_accepted[0] = 0;
-            } else if (num_accepted[0] > 0.75 * num_attempted[0]) {
-                d_volume_scale[0] = min(d_volume_scale[0] * 1.1, volume * 0.3);
-                // Reset the counters
-                num_attempted[0] = 0;
-                num_accepted[0] = 0;
+
+    while (idx < N) {
+        if (idx == 0) {
+            if (!rejected) {
+                num_accepted[0]++;
+            }
+            num_attempted[0]++;
+            if (num_attempted[0] >= 10) {
+                if (num_accepted[0] < 0.25 * num_attempted[0]) {
+                    d_volume_scale[0] /= 1.1;
+                    // Reset the counters
+                    num_attempted[0] = 0;
+                    num_accepted[0] = 0;
+                } else if (num_accepted[0] > 0.75 * num_attempted[0]) {
+                    d_volume_scale[0] = min(d_volume_scale[0] * 1.1, volume * 0.3);
+                    // Reset the counters
+                    num_attempted[0] = 0;
+                    num_accepted[0] = 0;
+                }
             }
         }
-    }
-    if (rejected) {
-        return;
-    }
-    // If the mc move was accepted copy all of the data into place
+        if (rejected) {
+            return;
+        }
+        // If the mc move was accepted copy all of the data into place
 
-    if (idx < 9) {
-        d_box[idx] = d_box_output[idx];
-    }
+        if (idx < 9) {
+            d_box[idx] = d_box_output[idx];
+        }
 
-#pragma unroll
-    for (int i = 0; i < 3; i++) {
-        d_x[idx * 3 + i] = d_x_output[idx * 3 + i];
+#pragma unroll 3
+        for (int i = 0; i < 3; i++) {
+            d_x[idx * 3 + i] = d_x_output[idx * 3 + i];
+        }
+        idx += gridDim.x * blockDim.x;
     }
 }

--- a/timemachine/cpp/src/kernels/k_barostat.cuh
+++ b/timemachine/cpp/src/kernels/k_barostat.cuh
@@ -4,10 +4,11 @@
 
 // k_rescale_positions scales the box and the centroids of groups to evaluate a potential
 // barostat move
+template <typename RealType>
 void __global__ k_rescale_positions(
     const int N,                                     // Number of atoms to shift
     double *__restrict__ coords,                     // Coordinates
-    const double *__restrict__ length_scale,         // [1]
+    const RealType *__restrict__ length_scale,       // [1]
     const double *__restrict__ box,                  // [9]
     double *__restrict__ scaled_box,                 // [9]
     const int *__restrict__ atom_idxs,               // [N]
@@ -16,11 +17,11 @@ void __global__ k_rescale_positions(
     const unsigned long long *__restrict__ centroids // [N*3]
 ) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    float center_x = box[0 * 3 + 0] * 0.5f;
-    float center_y = box[1 * 3 + 1] * 0.5f;
-    float center_z = box[2 * 3 + 2] * 0.5f;
+    RealType center_x = box[0 * 3 + 0] * 0.5f;
+    RealType center_y = box[1 * 3 + 1] * 0.5f;
+    RealType center_z = box[2 * 3 + 2] * 0.5f;
 
-    double scale = length_scale[0];
+    RealType scale = length_scale[0];
     if (idx == 0) {
         scaled_box[0 * 3 + 0] *= scale;
         scaled_box[1 * 3 + 1] *= scale;
@@ -30,15 +31,15 @@ void __global__ k_rescale_positions(
         int atom_idx = atom_idxs[idx];
         int mol_idx = mol_idxs[idx];
 
-        float num_atoms = static_cast<float>(mol_offsets[mol_idx + 1] - mol_offsets[mol_idx]);
+        RealType num_atoms = static_cast<RealType>(mol_offsets[mol_idx + 1] - mol_offsets[mol_idx]);
 
-        float centroid_x = FIXED_TO_FLOAT<float>(centroids[mol_idx * 3 + 0]) / num_atoms;
-        float centroid_y = FIXED_TO_FLOAT<float>(centroids[mol_idx * 3 + 1]) / num_atoms;
-        float centroid_z = FIXED_TO_FLOAT<float>(centroids[mol_idx * 3 + 2]) / num_atoms;
+        RealType centroid_x = FIXED_TO_FLOAT<RealType>(centroids[mol_idx * 3 + 0]) / num_atoms;
+        RealType centroid_y = FIXED_TO_FLOAT<RealType>(centroids[mol_idx * 3 + 1]) / num_atoms;
+        RealType centroid_z = FIXED_TO_FLOAT<RealType>(centroids[mol_idx * 3 + 2]) / num_atoms;
 
-        float displacement_x = ((centroid_x - center_x) * scale) + center_x - centroid_x;
-        float displacement_y = ((centroid_y - center_y) * scale) + center_y - centroid_y;
-        float displacement_z = ((centroid_z - center_z) * scale) + center_z - centroid_z;
+        RealType displacement_x = ((centroid_x - center_x) * scale) + center_x - centroid_x;
+        RealType displacement_y = ((centroid_y - center_y) * scale) + center_y - centroid_y;
+        RealType displacement_z = ((centroid_z - center_z) * scale) + center_z - centroid_z;
 
         coords[atom_idx * 3 + 0] += displacement_x;
         coords[atom_idx * 3 + 1] += displacement_y;
@@ -49,6 +50,7 @@ void __global__ k_rescale_positions(
 }
 
 // k_find_group_centroids computes the centroids of a group of atoms.
+template <typename RealType>
 void __global__ k_find_group_centroids(
     const int N,                               // Number of atoms to shift
     const double *__restrict__ coords,         // Coordinates [N * 3]
@@ -60,32 +62,33 @@ void __global__ k_find_group_centroids(
     while (idx < N) {
         int atom_idx = atom_idxs[idx];
         int mol_idx = mol_idxs[idx];
-        atomicAdd(centroids + mol_idx * 3 + 0, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 0]));
-        atomicAdd(centroids + mol_idx * 3 + 1, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 1]));
-        atomicAdd(centroids + mol_idx * 3 + 2, FLOAT_TO_FIXED<double>(coords[atom_idx * 3 + 2]));
+        atomicAdd(centroids + mol_idx * 3 + 0, FLOAT_TO_FIXED<RealType>(coords[atom_idx * 3 + 0]));
+        atomicAdd(centroids + mol_idx * 3 + 1, FLOAT_TO_FIXED<RealType>(coords[atom_idx * 3 + 1]));
+        atomicAdd(centroids + mol_idx * 3 + 2, FLOAT_TO_FIXED<RealType>(coords[atom_idx * 3 + 2]));
         idx += gridDim.x * blockDim.x;
     }
 }
 
 // k_setup_barostat_move performs the initialization for a barostat move. It determines what the the proposed
 // volume will be and sets up d_length_scale and d_volume_delta for use in k_decide_move.
+template <typename RealType>
 void __global__ k_setup_barostat_move(
-    const double *__restrict__ rand,     // [2], use first value, second value is metropolis condition
-    double *__restrict__ d_box,          // [3*3]
-    double *__restrict__ d_volume_delta, // [1]
-    double *__restrict__ d_volume_scale, // [1]
-    double *__restrict__ d_length_scale  // [1]
+    const RealType *__restrict__ rand,     // [2], use first value, second value is metropolis condition
+    double *__restrict__ d_box,            // [3*3]
+    RealType *__restrict__ d_volume_delta, // [1]
+    RealType *__restrict__ d_volume_scale, // [1]
+    RealType *__restrict__ d_length_scale  // [1]
 ) {
     const int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= 1) {
         return; // Only a single thread needs to perform this operation
     }
-    const float volume = d_box[0 * 3 + 0] * d_box[1 * 3 + 1] * d_box[2 * 3 + 2];
+    const RealType volume = d_box[0 * 3 + 0] * d_box[1 * 3 + 1] * d_box[2 * 3 + 2];
     if (d_volume_scale[0] == 0) {
         d_volume_scale[0] = 0.01 * volume;
     }
-    const float delta_volume = d_volume_scale[0] * 2 * (rand[0] - 0.5);
-    const float new_volume = volume + delta_volume;
+    const RealType delta_volume = d_volume_scale[0] * 2 * (rand[0] - 0.5);
+    const RealType new_volume = volume + delta_volume;
     d_volume_delta[0] = delta_volume;
     d_length_scale[0] = cbrt(new_volume / volume);
 }
@@ -93,14 +96,15 @@ void __global__ k_setup_barostat_move(
 // k_decide_move handles the metropolis check for whether or not to accept a barostat move that scales
 // the box volume. If the move is accepted then the box will be scaled as well as all of the coordinates.
 // It also handles the bookkeeping for the acceptance counters.
+template <typename RealType>
 void __global__ k_decide_move(
     const int N,
     const int num_molecules,
     const double kt,
     const double pressure,
-    const double *__restrict__ rand, // [2] Use second value
-    double *__restrict__ d_volume_delta,
-    double *__restrict__ d_volume_scale,
+    const RealType *__restrict__ rand, // [2] Use second value
+    RealType *__restrict__ d_volume_delta,
+    RealType *__restrict__ d_volume_scale,
     const __int128 *__restrict__ d_init_u,
     const __int128 *__restrict__ d_final_u,
     double *__restrict__ d_box,
@@ -111,15 +115,15 @@ void __global__ k_decide_move(
     int *__restrict__ num_attempted) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    const double volume = d_box[0 * 3 + 0] * d_box[1 * 3 + 1] * d_box[2 * 3 + 2];
-    const double volume_delta = d_volume_delta[0];
-    const double new_volume = volume + volume_delta;
-    double energy_delta = INFINITY;
+    const RealType volume = d_box[0 * 3 + 0] * d_box[1 * 3 + 1] * d_box[2 * 3 + 2];
+    const RealType volume_delta = d_volume_delta[0];
+    const RealType new_volume = volume + volume_delta;
+    RealType energy_delta = INFINITY;
     if (!fixed_point_overflow(d_final_u[0]) && !fixed_point_overflow(d_init_u[0])) {
-        energy_delta = FIXED_ENERGY_TO_FLOAT<double>(d_final_u[0] - d_init_u[0]);
+        energy_delta = FIXED_ENERGY_TO_FLOAT<RealType>(d_final_u[0] - d_init_u[0]);
     }
 
-    const double w = energy_delta + pressure * volume_delta - num_molecules * kt * std::log(new_volume / volume);
+    const RealType w = energy_delta + pressure * volume_delta - num_molecules * kt * std::log(new_volume / volume);
 
     const bool rejected = w > 0 && rand[1] > std::exp(-w / kt);
 

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -145,7 +145,7 @@ void declare_context(py::module &m) {
                         const py::array_t<double, py::array::c_style> &box0,
                         std::shared_ptr<timemachine::Integrator> intg,
                         std::vector<std::shared_ptr<timemachine::BoundPotential>> bps,
-                        std::optional<std::shared_ptr<timemachine::MonteCarloBarostat>> barostat) {
+                        std::optional<std::shared_ptr<timemachine::MonteCarloBarostat<float>>> barostat) {
                 int N = x0.shape()[0];
                 int D = x0.shape()[1];
                 verify_coords_and_box(x0, box0);
@@ -1188,19 +1188,18 @@ template <typename RealType, bool Negated> void declare_nonbonded_pair_list(py::
 
 void declare_barostat(py::module &m) {
 
-    using Class = timemachine::MonteCarloBarostat;
+    using Class = timemachine::MonteCarloBarostat<float>;
     std::string pyclass_name = std::string("MonteCarloBarostat");
     py::class_<Class, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
         .def(
-            py::init([](const int N,
-                        const double pressure,
-                        const double temperature,
-                        std::vector<std::vector<int>> group_idxs,
-                        const int frequency,
-                        std::vector<std::shared_ptr<timemachine::BoundPotential>> bps,
-                        const int seed) {
-                return new timemachine::MonteCarloBarostat(N, pressure, temperature, group_idxs, frequency, bps, seed);
-            }),
+            py::init(
+                [](const int N,
+                   const double pressure,
+                   const double temperature,
+                   std::vector<std::vector<int>> group_idxs,
+                   const int frequency,
+                   std::vector<std::shared_ptr<timemachine::BoundPotential>> bps,
+                   const int seed) { return new Class(N, pressure, temperature, group_idxs, frequency, bps, seed); }),
             py::arg("N"),
             py::arg("pressure"),
             py::arg("temperature"),
@@ -1208,9 +1207,9 @@ void declare_barostat(py::module &m) {
             py::arg("frequency"),
             py::arg("bps"),
             py::arg("seed"))
-        .def("set_interval", &timemachine::MonteCarloBarostat::set_interval, py::arg("interval"))
-        .def("get_interval", &timemachine::MonteCarloBarostat::get_interval)
-        .def("set_pressure", &timemachine::MonteCarloBarostat::set_pressure, py::arg("pressure"));
+        .def("set_interval", &Class::set_interval, py::arg("interval"))
+        .def("get_interval", &Class::get_interval)
+        .def("set_pressure", &Class::set_pressure, py::arg("pressure"));
 }
 
 void declare_summed_potential(py::module &m) {


### PR DESCRIPTION
# What Changed
- Refactors the barostat as I didn't know what I was doing when I wrote this originally
- Removes some unnecessary memsets introduced in #1090 that didn't need to be there
- Minor optimizations to the barostat that make no noticeable difference to the wall clock time

# Benchmarks
- Nvidia A10
- Cuda Arch 86

## Benchmarking
Using the `python tests/test_benchmark.py` we see minor differences. Multiple runs showed the differences to be noise.

### Current
```
dhfr-apo-barostat-interval-25: N=23558 speed: 622.98ns/day dt: 2.5fs (ran 100000 steps in 34.68s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1002.75ns/day dt: 2.5fs (ran 100000 steps in 21.54s)
solvent-apo-barostat-interval-25: N=6282 speed: 1278.64ns/day dt: 2.5fs (ran 100000 steps in 16.90s)
```
### Barostat changes
```
dhfr-apo-barostat-interval-25: N=23558 speed: 621.48ns/day dt: 2.5fs (ran 100000 steps in 34.76s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1006.45ns/day dt: 2.5fs (ran 100000 steps in 21.46s)
solvent-apo-barostat-interval-25: N=6282 speed: 1266.70ns/day dt: 2.5fs (ran 100000 steps in 17.06s)
```

## On a per kernel basis
- Nvidia A4000
- Cuda Arch 86


Looking at the nsys stats, there is slight improvement in some kernels. The most significant difference in total time is the `gen_sequenced` only being called once every 1000 moves. Computing energies is slow enough that this is negligible.

### Current

```
CUDA Kernel Statistics:

 Time (%)  Total Time (ns)  Instances  Avg (ns)   Med (ns)   Min (ns)  Max (ns)  StdDev (ns)                                                  Name                                                
 --------  ---------------  ---------  ---------  ---------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
      0.1        1,196,193         80   14,952.4   15,552.0    11,744    16,831      1,533.4  timemachine::k_decide_move(int, int, double, double, const double *, double *, double *, const __in…
      0.1          822,368         80   10,279.6   10,096.0     9,664    16,992        821.0  timemachine::rescale_positions(int, double *, const double *, const double *, double *, const int *…
      0.1          664,160         80    8,302.0    8,256.0     7,648     9,312        328.1  timemachine::find_group_centroids(int, const double *, const int *, const int *, unsigned long long…
      0.0          272,961         80    3,412.0    3,360.0     3,232     3,904        123.3  timemachine::k_setup_barostat_move(const double *, double *, double *, double *, double *)          
      0.0          184,833         80    2,310.4    2,272.0     2,144     2,816        120.9  void gen_sequenced<curandStateXORWOW, double, int, &curand_uniform_double_noargs<curandStateXORWOW>…

```


### Barostat Changes
```
CUDA Kernel Statistics:

 Time (%)  Total Time (ns)  Instances  Avg (ns)   Med (ns)   Min (ns)  Max (ns)  StdDev (ns)                                                  Name                                                
 --------  ---------------  ---------  ---------  ---------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
      0.1        1,205,501         80   15,068.8   15,616.0    12,031    17,824      1,501.8  k_decide_move(int, int, double, double, const double *, double *, double *, const __int128 *, const…
      0.1          676,253         80    8,453.2    8,352.0     7,936     9,152        296.0  rescale_positions(int, double *, const double *, const double *, double *, const int *, const int *…
      0.1          672,156         80    8,402.0    8,319.5     8,000     9,312        328.9  find_group_centroids(int, const double *, const int *, const int *, unsigned long long *)           
      0.0          248,100         80    3,101.3    3,103.5     2,592     3,713        280.8  k_setup_barostat_move(const double *, double *, double *, double *, double *)
      0.0            2,528          1    2,528.0    2,528.0     2,528     2,528          0.0  void gen_sequenced<curandStateXORWOW, double, int, &curand_uniform_double_noargs<curandStateXORWOW>
```