### PR TITLE
[wip] Utilities for per-atom decoupling

### DIFF
--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -1,0 +1,42 @@
+import numpy as np
+from jax import vmap
+
+from timemachine.datasets import fetch_freesolv
+from timemachine.fe.experimental import DecoupleByAtomRank, rank_atoms_by_path_length_to_src
+
+
+def test_decouple_by_atom_rank():
+    """for a few random molecules, make basic assertions about per-atom decoupling schedule"""
+
+    mols = fetch_freesolv()
+
+    num_test_mols = 10
+    np.random.seed(1234)
+    lambdas = np.linspace(0, 1, 100)
+    for mol in mols[:num_test_mols]:
+        n_atoms = mol.GetNumAtoms()
+        n_src_idxs = np.random.randint(1, min(5, n_atoms))  # arbitrary threshold: between 1 and 5 src_idxs
+        src_idxs = list(set(np.random.randint(0, n_atoms, n_src_idxs)))
+
+        atom_idxs = np.arange(n_atoms)
+        atom_ranks = rank_atoms_by_path_length_to_src(mol, src_idxs)
+        assert atom_ranks.shape == atom_idxs.shape
+
+        decoupler = DecoupleByAtomRank(atom_idxs, atom_ranks)
+        atom_lams = vmap(decoupler.atom_lams_from_global_lam)(lambdas)
+
+        assert atom_lams.shape == (len(lambdas), n_atoms), "wrong shape"
+        assert (atom_lams >= 0).all() and (atom_lams <= 1).all(), "wrong range"
+
+        diffs = np.diff(atom_lams, axis=0)
+        assert (diffs >= 0).all(), "not monotonic"
+
+        started = atom_lams > 0
+        finished = atom_lams == 1
+        assert not started[0].any(), "should start at 0"
+        assert finished[-1].all(), "should end at 1"
+
+        # check somewhere in the middle of the first stage -- could check other stages too
+        fractional_t = 0.25 * (1.0 / len(set(atom_ranks)))
+        t = int(fractional_t * len(lambdas))
+        assert (started[t] == (atom_ranks == 0)).all(), "didn't start with atom_rank 0"

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -12,7 +12,7 @@ def test_decouple_by_atom_rank():
 
     num_test_mols = 10
     np.random.seed(1234)
-    lambdas = np.linspace(0, 1, 100)
+    lambdas = np.linspace(0, 1, 1000)
     for mol in mols[:num_test_mols]:
         n_atoms = mol.GetNumAtoms()
         n_src_idxs = np.random.randint(1, min(5, n_atoms))  # arbitrary threshold: between 1 and 5 src_idxs

--- a/timemachine/fe/experimental.py
+++ b/timemachine/fe/experimental.py
@@ -57,8 +57,6 @@ class DecoupleByAtomRank:
 
     def atom_lams_from_global_lam(self, global_lam):
         """each stage goes from 0 to 1 in turn"""
-        if not (0 <= global_lam <= 1):
-            raise ValueError(f"global_lam={global_lam}, not in expected interval [0,1]")
 
         num_atoms = len(self.atom_idxs)
 

--- a/timemachine/fe/experimental.py
+++ b/timemachine/fe/experimental.py
@@ -66,8 +66,7 @@ class DecoupleByAtomRank:
         upper_boundaries = fractional_ranks
         lower_boundaries = upper_boundaries - bin_width
 
-        slope = 1.0 / bin_width  # == self.num_stages
-        atom_lams = jnp.clip(slope * (global_lam - lower_boundaries), 0, 1)
+        atom_lams = jnp.clip(self.num_stages * (global_lam - lower_boundaries), 0, 1)
 
         # patch special case: ensure exactly 1.0 at endpoint
         # (since in jax default float32 mode, atom_lams can be 0.99999994 != 1.0 at global_lam = 1.0)

--- a/timemachine/fe/experimental.py
+++ b/timemachine/fe/experimental.py
@@ -1,0 +1,79 @@
+# alternatives to decoupling all atoms at once
+# adapted from:
+#   https://github.com/proteneer/timemachine/blob/acccb46c3ed7eaf614fd79b42e42db597a546891/examples/sifting.py#L212-L328
+
+import numpy as np
+from jax import numpy as jnp
+from networkx import shortest_path_length
+
+from timemachine.graph_utils import convert_to_nx
+
+
+def rank_atoms_by_path_length_to_src(mol, source_idxs):
+    """rank(i) = min_{s in source_idxs} shortest_path_length(i, s)
+
+    Usage suggestion:
+    * source_idxs might contain a single central atom, a list of anchor atoms, or a list of peripheral atoms
+    """
+
+    graph = convert_to_nx(mol)
+    n_atoms = graph.number_of_nodes()
+    min_dist = np.inf * np.ones(n_atoms, dtype=int)
+
+    for source in source_idxs:
+        _distance_dict = shortest_path_length(graph, source=source)
+        _distances = np.array([_distance_dict[i] for i in range(n_atoms)])
+        min_dist = np.minimum(min_dist, _distances)
+
+    if not (min_dist < np.inf).all():
+        raise ValueError("didn't expect mol graph to be disconnected")
+
+    return min_dist.astype(int)
+
+
+# TODO: add utilities to get atom ranks using other heuristics,
+#   e.g. by distance from periphery, or by distance from center, or looking at conformer rather than only graph?
+
+
+class DecoupleByAtomRank:
+    def __init__(self, atom_idxs, atom_ranks):
+        """Interpolate atom_lams[i] from 0 to 1 in stages, with stages defined by atom_ranks.
+
+        Notes
+        -----
+        this function doesn't attempt to handle
+            (1) indexing properly into a system's collection of nb_params,
+            (2) converting atom lams into w_offsets or other parameters.
+
+        TODO: modify to accept an "overlap" parameter?
+            when "overlap" == 0, stage i completes before stage i+1 begins (as in current implementation)
+            when "overlap" == 1, all stages run at once (aka atom_lams[i] = global_lam for all i)
+            and get maybe useful intermediate behaviors for 0 < overlap < 1
+        """
+        self.atom_idxs = atom_idxs
+        self.atom_ranks = atom_ranks
+        self.num_stages = len(set(atom_ranks))
+        assert set(atom_ranks) == set(range(self.num_stages))
+
+    def atom_lams_from_global_lam(self, global_lam):
+        """each stage goes from 0 to 1 in turn"""
+        if not (0 <= global_lam <= 1):
+            raise ValueError(f"global_lam={global_lam}, not in expected interval [0,1]")
+
+        num_atoms = len(self.atom_idxs)
+
+        bin_width = 1 / self.num_stages
+        fractional_ranks = (self.atom_ranks + 1) / self.num_stages
+
+        upper_boundaries = fractional_ranks
+        lower_boundaries = upper_boundaries - bin_width
+
+        slope = 1.0 / bin_width  # == self.num_stages
+        atom_lams = jnp.clip(slope * (global_lam - lower_boundaries), 0, 1)
+
+        # patch special case: ensure exactly 1.0 at endpoint
+        # (since in jax default float32 mode, atom_lams can be 0.99999994 != 1.0 at global_lam = 1.0)
+        _ones = jnp.ones(num_atoms)
+        atom_lams = jnp.where(global_lam == _ones, _ones, atom_lams)
+
+        return atom_lams

--- a/timemachine/fe/experimental.py
+++ b/timemachine/fe/experimental.py
@@ -36,7 +36,7 @@ def rank_atoms_by_path_length_to_src(mol, source_idxs):
     if not (min_dist < np.inf).all():
         raise ValueError("didn't expect mol graph to be disconnected")
 
-    ranks = np.argsort(min_dist)
+    ranks = np.argsort(min_dist, kind="stable")
     return ranks
 
 


### PR DESCRIPTION
Adds and tests basic utilities for per-atom decoupling:
* extracting atom ranks based on shortest path lengths to selected atoms
* decoupling all atoms with `(rank == i)` before decoupling all atoms with `(rank == (i+1))`

(A similar goal was considered here in https://github.com/proteneer/timemachine/pull/420 , and these utilities derived from the `sifting.py` file in @proteneer 's branch https://github.com/proteneer/timemachine/blob/acccb46c3ed7eaf614fd79b42e42db597a546891/examples/sifting.py#L212-L328 (One notable difference relative to `sifting.py` is that this PR considers the ranks in the opposite order, i.e. decoupling of rank i precedes decoupling of rank i+1, but it might make sense to reverse this.)))

The implementation is currently only applicable to the "absolute" case (i.e. "deletions only"), but see also related functions in transformato for scheduling one-atom-at-a-time mutations that might involve both additions and deletions https://github.com/wiederm/transformato/blob/77d5f0fd2e3e9a0d67c0ecc817bfe8389295a3aa/transformato/annihilation.py#L10 .