### PR TITLE
Add `nocuda` mark for tests that should run without CUDA available

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,6 +47,27 @@ lint:
   script:
     - make verify
 
+nocuda-tests:
+  stage: test
+  image: $DOCKER_TAG
+  needs: ["lint"]
+  tags:
+    - timemachine
+    - cpu
+  rules:
+    - if: $CI_EXTERNAL_PULL_REQUEST_IID
+  variables:
+    CMAKE_ARGS: -DCUDA_ARCH=75
+  script:
+    - SKIP_CUSTOM_OPS=1 pip install .[test]
+    - make nocuda_tests
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-nocuda-tests"
+    paths:
+        - coverage/
+    when: on_success
+    expire_in: 1 week
+
 nogpu-tests:
   stage: test
   image: $DOCKER_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,8 +56,6 @@ nocuda-tests:
     - cpu
   rules:
     - if: $CI_EXTERNAL_PULL_REQUEST_IID
-  variables:
-    CMAKE_ARGS: -DCUDA_ARCH=75
   script:
     - SKIP_CUSTOM_OPS=1 pip install .[test]
     - make nocuda_tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,6 +144,25 @@ nightly-tests:
     when: on_success
     expire_in: 1 week
 
+nightly-tests-nocuda:
+  stage: test
+  image: $DOCKER_TAG
+  needs: ["lint"]
+  tags:
+    - timemachine
+    - cpu
+  rules:
+    - if: $NIGHTLY_TESTS
+  script:
+    - SKIP_CUSTOM_OPS=1 pip install .[test]
+    - make nocuda_nightly_tests
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-nocuda-nightly-tests"
+    paths:
+        - coverage/
+    when: on_success
+    expire_in: 1 week
+
 nightly-tests-nogpu:
   stage: test
   image: $DOCKER_TAG

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ unit_tests:
 nightly_tests:
 	pytest -m '$(NIGHTLY_MARKER) and not $(NOCUDA_MARKER) and not $(NOGPU_MARKER)' $(PYTEST_CI_ARGS)
 
+.PHONY: nocuda_nightly_tests
+nocuda_nightly_tests:
+	pytest -m '$(NIGHTLY_MARKER) and $(NOCUDA_MARKER)' $(PYTEST_CI_ARGS)
+
 .PHONY: nogpu_nightly_tests
 nogpu_nightly_tests:
 	pytest -m '$(NIGHTLY_MARKER) and $(NOGPU_MARKER)' $(PYTEST_CI_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,15 @@ INSTALL_PREFIX := $(MKFILE_DIR)timemachine/
 # Conditionally set pytest args, to be able to override in CI
 PYTEST_CI_ARGS ?= --color=yes --cov=. --cov-report=html:coverage/ --cov-append --durations=100
 
+# pytest mark to indicate tests that should be run in an environment without CUDA.
+# (e.g. no nvcc, so we can't build custom_ops)
+NOCUDA_MARKER := nocuda
+
+# pytest mark to indicate tests that should be run in an environment without a GPU
+# (but WITH build dependencies of # custom_ops, e.g. CUDA).
+# These tests can be run on cheaper CPU instances.
 NOGPU_MARKER := nogpu
+
 MEMCHECK_MARKER := memcheck
 NIGHTLY_MARKER := nightly
 
@@ -24,6 +32,10 @@ clean:
 verify:
 	pre-commit run --all-files --show-diff-on-failure --color=always
 
+.PHONY: nocuda_tests
+nocuda_tests:
+	pytest -m '$(NOCUDA_MARKER) and not $(NIGHTLY_MARKER)' $(PYTEST_CI_ARGS)
+
 .PHONY: nogpu_tests
 nogpu_tests:
 	pytest -m '$(NOGPU_MARKER) and not $(NIGHTLY_MARKER)' $(PYTEST_CI_ARGS)
@@ -34,11 +46,11 @@ memcheck_tests:
 
 .PHONY: unit_tests
 unit_tests:
-	pytest -m 'not $(NOGPU_MARKER) and not $(MEMCHECK_MARKER) and not $(NIGHTLY_MARKER)' $(PYTEST_CI_ARGS)
+	pytest -m 'not $(NOCUDA_MARKER) and not $(NOGPU_MARKER) and not $(MEMCHECK_MARKER) and not $(NIGHTLY_MARKER)' $(PYTEST_CI_ARGS)
 
 .PHONY: nightly_tests
 nightly_tests:
-	pytest -m '$(NIGHTLY_MARKER) and not $(NOGPU_MARKER)' $(PYTEST_CI_ARGS)
+	pytest -m '$(NIGHTLY_MARKER) and not $(NOCUDA_MARKER) and not $(NOGPU_MARKER)' $(PYTEST_CI_ARGS)
 
 .PHONY: nogpu_nightly_tests
 nogpu_nightly_tests:

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,5 +4,6 @@ testpaths =
     tests/
 markers =
     memcheck: marks tests to be run with cuda memory checks, triggers cuda device reset at end of marked tests (deselect with '-m "not memcheck"')
-    nogpu: marks tests that should run without the C++/CUDA extension module being built, e.g. tests that should run on platforms other than linux
+    nocuda: marks tests that should run without the C++/CUDA extension module being built, e.g. tests that should run on platforms other than linux
+    nogpu: marks tests that should be run without a GPU available
     nightly: marks tests that should run nightly, rather than regularly.

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -9,6 +9,8 @@ from timemachine.fe import atom_mapping
 from timemachine.fe.mcgregor import MaxVisitsWarning, NoMappingError
 from timemachine.fe.utils import plot_atom_mapping_grid
 
+pytestmark = [pytest.mark.nocuda]
+
 hif2a_set = "timemachine/datasets/fep_benchmark/hif2a/ligands.sdf"
 eg5_set = "timemachine/datasets/fep_benchmark/eg5/ligands.sdf"
 
@@ -18,7 +20,6 @@ datasets = [
 ]
 
 
-@pytest.mark.nogpu
 @pytest.mark.nightly(reason="Slow")
 def test_connected_core_and_complete_rings_with_large_numbers_of_cores():
     """The following tests that for two mols that have a large number of matching
@@ -370,7 +371,6 @@ def get_mol_name(mol) -> str:
 # CHEMBL1077227 -> CHEMBL1083836 has 14976 cores of size 48
 # CHEMBL1086410 -> CHEMBL1083836 has 10752 cores of size 52
 # CHEMBL1086410 -> CHEMBL1084935 has 6912 cores of size 60
-@pytest.mark.nogpu
 @pytest.mark.parametrize("filepath", datasets)
 @pytest.mark.nightly(reason="Slow")
 def test_all_pairs(filepath):
@@ -420,7 +420,6 @@ def get_mol_by_name(mols, name):
     assert 0, "Mol not found"
 
 
-@pytest.mark.nogpu
 def test_complete_rings_only():
     # this transformation has two ring changes:
     # a 6->5 member ring size change and a unicycle to bicycle change
@@ -502,7 +501,6 @@ def assert_core_sets_are_equal(core_set_a, core_set_b):
 
 
 # spot check
-@pytest.mark.nogpu
 def test_linker_map():
     # test that we can map a linker size change when connected_core=False, and enforce_core_core=False
     mol_a = Chem.MolFromMolBlock(
@@ -738,7 +736,6 @@ $$$$""",
     return mol_a, mol_b
 
 
-@pytest.mark.nogpu
 def test_hif2a_failure():
     # special failure with error message:
     # pred_sgg_a = a_cycles[a] == sg_a_cycles[a], KeyError: 18
@@ -799,7 +796,6 @@ def test_hif2a_failure():
     #         fh.write(res)
 
 
-@pytest.mark.nogpu
 def test_cyclohexane_stereo():
     # test that cyclohexane in two different conformations has a core alignment that is stereo correct. Note that this needs a
     # larger than typical cutoff.
@@ -857,7 +853,6 @@ def test_cyclohexane_stereo():
     assert len(all_cores) == 1
 
 
-@pytest.mark.nogpu
 def test_chiral_atom_map():
     mol_a = Chem.AddHs(Chem.MolFromSmiles("C"))
     mol_b = Chem.AddHs(Chem.MolFromSmiles("C"))
@@ -888,7 +883,6 @@ def test_chiral_atom_map():
     assert len(chiral_aware_cores[0]) == 5
 
 
-@pytest.mark.nogpu
 @pytest.mark.parametrize(
     "ring_matches_ring_only",
     [
@@ -928,7 +922,6 @@ def test_ring_matches_ring_only(ring_matches_ring_only):
     assert all(len([() for idx_a in core[:, 0] if mol_a.GetAtomWithIdx(int(idx_a)).IsInRing()]) == 4 for core in cores)
 
 
-@pytest.mark.nogpu
 def test_max_visits_warning():
     mol_a, mol_b = get_cyclohexanes_different_confs()
     core_kwargs = dict(
@@ -950,7 +943,6 @@ def test_max_visits_warning():
             atom_mapping.get_cores(mol_a, mol_b, **core_kwargs, max_visits=1)
 
 
-@pytest.mark.nogpu
 def test_max_cores_warning():
     mol_a, mol_b = get_cyclohexanes_different_confs()
     core_kwargs = dict(
@@ -968,7 +960,6 @@ def test_max_cores_warning():
         atom_mapping.get_cores(mol_a, mol_b, **core_kwargs, max_cores=1)
 
 
-@pytest.mark.nogpu
 def test_min_threshold():
     mol_a, mol_b = get_cyclohexanes_different_confs()
     core_kwargs = dict(

--- a/tests/test_bar.py
+++ b/tests/test_bar.py
@@ -18,7 +18,7 @@ from timemachine.fe.bar import (
     works_from_ukln,
 )
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def make_gaussian_ukln_example(

--- a/tests/test_barker.py
+++ b/tests/test_barker.py
@@ -19,8 +19,9 @@ from jax import numpy as jnp
 
 from timemachine.md.barker import BarkerProposal
 
+pytestmark = [pytest.mark.nocuda]
 
-@pytest.mark.nogpu
+
 def test_barker_shapes():
     def grad_log_q(x):
         return np.ones_like(x)
@@ -39,7 +40,6 @@ def test_barker_shapes():
         assert np.isscalar(logpdf)
 
 
-@pytest.mark.nogpu
 @pytest.mark.parametrize("x0", [-1, 0, +1])
 @pytest.mark.parametrize("proposal_sig", [0.1, 1.0])
 def test_proposal_normalization(x0, proposal_sig):
@@ -59,7 +59,6 @@ def test_proposal_normalization(x0, proposal_sig):
     assert Z == pytest.approx(1)
 
 
-@pytest.mark.nogpu
 def test_accurate_mcmc(threshold=1e-4):
     def log_q(x):
         return np.sum(-(x ** 4))
@@ -107,7 +106,6 @@ def test_accurate_mcmc(threshold=1e-4):
     assert histogram_mse < threshold
 
 
-@pytest.mark.nogpu
 @pytest.mark.parametrize("proposal_sig", [0.1, 1.0])
 @pytest.mark.parametrize("seed", range(5))
 def test_proposal_magnitude_independent_of_force_magnitude(proposal_sig, seed):

--- a/tests/test_centroid_rescaler.py
+++ b/tests/test_centroid_rescaler.py
@@ -6,7 +6,7 @@ from timemachine.md.barostat.utils import compute_intramolecular_distances
 
 np.random.seed(2021)
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def _generate_random_instance():

--- a/tests/test_chiral_utils.py
+++ b/tests/test_chiral_utils.py
@@ -7,7 +7,7 @@ from timemachine.fe import chiral_utils, utils
 from timemachine.fe.chiral_utils import ChiralCheckMode, ChiralRestrIdxSet, find_atom_map_chiral_conflicts
 from timemachine.potentials.chiral_restraints import U_chiral_atom_batch, U_chiral_bond_batch
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def test_setup_chiral_atom_restraints():

--- a/tests/test_cif_writer.py
+++ b/tests/test_cif_writer.py
@@ -12,8 +12,9 @@ from timemachine.ff import Forcefield
 from timemachine.md import builders
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
 
+pytestmark = [pytest.mark.nocuda]
 
-@pytest.mark.nogpu
+
 def test_write_single_topology_frame():
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     forcefield = Forcefield.load_default()
@@ -43,7 +44,6 @@ def test_write_single_topology_frame():
 
 
 @pytest.mark.parametrize("n_frames", [1, 4, 5])
-@pytest.mark.nogpu
 def test_cif_writer_context(n_frames):
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
 
@@ -59,7 +59,6 @@ def test_cif_writer_context(n_frames):
 
 
 @pytest.mark.parametrize("n_frames", [1, 4, 5])
-@pytest.mark.nogpu
 def test_cif_writer(n_frames):
 
     ff = Forcefield.load_default()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -2,7 +2,7 @@ import pytest
 
 from timemachine.datasets import fetch_freesolv
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def test_fetch_freesolv():

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -18,7 +18,7 @@ from timemachine.fe.utils import get_romol_bonds
 # root-anchor - first atom in an anchor group, also the anchor atom that has direct 1-2 bonds to dummy atoms.
 # partition - only applies to dummy groups, as we require that dummy groups disjointly partition dummy atoms.
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def test_generate_dummy_group_assignments():

--- a/tests/test_fe_utils.py
+++ b/tests/test_fe_utils.py
@@ -8,7 +8,7 @@ from timemachine.fe import model_utils, utils
 from timemachine.fe.model_utils import image_frame, image_molecule
 from timemachine.ff import Forcefield
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def test_sanitize_energies():

--- a/tests/test_forcefields.py
+++ b/tests/test_forcefields.py
@@ -11,7 +11,7 @@ from timemachine import constants
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers.deserialize import deserialize_handlers
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def test_serialization_of_ffs():

--- a/tests/test_free_energy_restraints.py
+++ b/tests/test_free_energy_restraints.py
@@ -3,7 +3,7 @@ from rdkit import Chem
 
 from timemachine.fe.restraints import setup_relative_restraints_using_smarts
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def test_setting_up_restraints_using_smarts():

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -6,7 +6,7 @@ from rdkit import Chem
 from timemachine.fe import geometry, utils
 from timemachine.fe.geometry import LocalGeometry as LG
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def test_assign_aspirin():

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -13,7 +13,7 @@ from timemachine.ff import Forcefield
 from timemachine.ff.charges import AM1CCC_CHARGES
 from timemachine.ff.handlers import bonded, nonbonded
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def test_harmonic_bond():

--- a/tests/test_import_without_custom_ops.py
+++ b/tests/test_import_without_custom_ops.py
@@ -1,6 +1,6 @@
 import pytest
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def test_import_potentials_without_custom_ops():

--- a/tests/test_jax_nonbonded.py
+++ b/tests/test_jax_nonbonded.py
@@ -45,7 +45,7 @@ Energy = float
 NonbondedArgs = Tuple[Conf, Params, Box, ExclusionIdxs, ScaleFactors, Beta, Cutoff]
 NonbondedFxn = Callable[[Conf, Params, Box, ExclusionIdxs, ScaleFactors, Beta, Cutoff], Energy]
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def resolve_clashes(x0, box0, min_dist=0.1):

--- a/tests/test_jax_utils.py
+++ b/tests/test_jax_utils.py
@@ -22,7 +22,7 @@ from timemachine.potentials.jax_utils import (
     process_traj_in_chunks,
 )
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def test_delta_r():

--- a/tests/test_mle.py
+++ b/tests/test_mle.py
@@ -9,7 +9,7 @@ from scipy.stats import linregress
 
 from timemachine.fe.mle import infer_node_vals, infer_node_vals_and_errs, infer_node_vals_and_errs_networkx
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def generate_instance(g: nx.Graph, edge_noise_stddev=0.0):

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -14,7 +14,7 @@ from timemachine import parallel
 from timemachine.parallel import client
 from timemachine.parallel.utils import batch_list
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def jax_fn(x):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -3,8 +3,8 @@ import pytest
 
 from timemachine.fe.plots import plot_forward_and_reverse_ddg, plot_forward_and_reverse_dg
 
-# All plotting tests are to be tested without gpus
-pytestmark = [pytest.mark.nogpu]
+# Plotting code should not depend on CUDA
+pytestmark = [pytest.mark.nocuda]
 
 
 def test_forward_and_reverse_ddg_plot():

--- a/tests/test_protocol_optimization.py
+++ b/tests/test_protocol_optimization.py
@@ -13,7 +13,7 @@ from timemachine.optimize.protocol import (
 
 np.random.seed(2021)
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def test_rebalance_initial_protocol():

--- a/tests/test_reference_langevin_integrator.py
+++ b/tests/test_reference_langevin_integrator.py
@@ -14,7 +14,7 @@ from timemachine.integrator import LangevinIntegrator
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
 
 
-@pytest.mark.nogpu
+@pytest.mark.nocuda
 def test_reference_langevin_integrator(threshold=1e-4):
     """Assert approximately canonical sampling of e^{-x^4 / kBT},
     for various settings of temperature, friction, timestep, and mass"""
@@ -58,7 +58,7 @@ def test_reference_langevin_integrator(threshold=1e-4):
         assert histogram_mse < threshold
 
 
-@pytest.mark.nogpu
+@pytest.mark.nocuda
 def test_reference_langevin_integrator_deterministic():
     """Asserts that trajectories are deterministic given a seed value"""
     force_fxn = lambda x: -4 * x ** 3
@@ -82,7 +82,7 @@ def test_reference_langevin_integrator_deterministic():
     assert_deterministic(lambda seed: langevin.multiple_steps_lax(jax.random.PRNGKey(seed), x0, v0))
 
 
-@pytest.mark.nogpu
+@pytest.mark.nocuda
 def test_reference_langevin_integrator_consistent():
     """
     Asserts that the result of the implementation based on jax.lax

--- a/tests/test_reweighting.py
+++ b/tests/test_reweighting.py
@@ -18,6 +18,8 @@ from timemachine.md.enhanced import get_solvent_phase_system
 from timemachine.potentials import SummedPotential
 from timemachine.testsystems.gaussian1d import make_gaussian_testsystem
 
+pytestmark = [pytest.mark.nocuda]
+
 
 def assert_estimator_accurate(estimate_delta_f, analytical_delta_f, ref_params, n_random_trials, atol):
     """for many random parameter sets, assert that the reweighted estimates of
@@ -58,7 +60,6 @@ def assert_estimator_accurate(estimate_delta_f, analytical_delta_f, ref_params, 
         np.testing.assert_allclose(g_hat, g_ref, atol=atol)
 
 
-@pytest.mark.nogpu
 def test_endpoint_reweighting_1d():
     """assert that endpoint reweighting estimator for delta_f(params), grad(delta_f)(params) is accurate
     on tractable 1D system"""
@@ -89,7 +90,6 @@ def test_endpoint_reweighting_1d():
     assert_estimator_accurate(jit(estimate_delta_f), analytical_delta_f, ref_params, n_random_trials=10, atol=atol)
 
 
-@pytest.mark.nogpu
 def test_mixture_reweighting_1d():
     """using a variety of free energy estimates (MBAR, TI, analytical) to obtain reference mixture weights,
     assert that mixture reweighting estimator of delta_f(params), grad(delta_f)(params) is accurate
@@ -289,7 +289,6 @@ def test_mixture_reweighting_ahfe():
     assert np.isfinite(g_prime).all()
 
 
-@pytest.mark.nogpu
 def test_one_sided_exp():
     """assert consistency with pymbar.EXP on random instances + instances containing +inf work"""
 
@@ -316,7 +315,6 @@ def test_one_sided_exp():
     assert np.isclose(one_sided_exp(reduced_works), pymbar.EXP(reduced_works)[0])
 
 
-@pytest.mark.nogpu
 def test_interpret_as_mixture_potential():
     """assert approximate self-consistency a la https://arxiv.org/abs/1704.00891
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -5,7 +5,7 @@ from timemachine.ff.handlers import bonded, nonbonded
 from timemachine.ff.handlers.deserialize import deserialize_handlers
 from timemachine.ff.handlers.serialize import bin_to_str
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def test_harmonic_bond():

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -394,7 +394,7 @@ def test_combine_masses_hmr():
     np.testing.assert_almost_equal(test_masses, ref_masses)
 
 
-@pytest.mark.nogpu
+@pytest.mark.nocuda
 def test_jax_transform_intermediate_potential():
     def setup_arbitary_transformation():
         # NOTE: test system can probably be simplified; we just need

--- a/tests/test_smc.py
+++ b/tests/test_smc.py
@@ -15,7 +15,7 @@ from timemachine.md.smc import (
 )
 from timemachine.testsystems.gaussian1d import make_gaussian_testsystem
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def generate_log_weights(n):

--- a/tests/test_standard_state.py
+++ b/tests/test_standard_state.py
@@ -7,7 +7,7 @@ import scipy.integrate
 from timemachine.fe import standard_state
 from timemachine.potentials import rmsd
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 def test_translational_restraint():

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -6,7 +6,7 @@ import pytest
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
 from timemachine.training.dataset import Dataset
 
-pytestmark = [pytest.mark.nogpu]
+pytestmark = [pytest.mark.nocuda]
 
 
 class TestDataset(unittest.TestCase):

--- a/tests/test_vacuum_importance_sampling.py
+++ b/tests/test_vacuum_importance_sampling.py
@@ -15,7 +15,7 @@ def get_ff_am1ccc():
     return ff
 
 
-@pytest.mark.nogpu
+@pytest.mark.nocuda
 @pytest.mark.nightly(reason="This takes too long to run on CI")
 def test_vacuum_importance_sampling():
     """


### PR DESCRIPTION
The current `nogpu` mark is overloaded with at least 2 distinct intents:

1. Save cost by running tests that don't require GPU on cheaper CPU instances
2. Ensure that certain code runs without the CUDA extension module being built (e.g. on a macbook)

As of https://github.com/proteneer/timemachine/pull/1079, we build the extension module in CI before running `nogpu` tests, making this designation less effective for use (2).

This PR introduces a new mark, `nocuda`, intended for use with tests that should run without the extension module being built. The proposed intended meanings are then:

- `nocuda`: this should run without the CUDA extension module available, e.g. on a user's macbook
- `nogpu`: this requires the CUDA extension module, but does not actually use the GPU (so we can run it on a CPU instance)