### PR TITLE
Clean up Kernels

### DIFF
--- a/timemachine/cpp/src/kernels/k_nonbonded.cu
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cu
@@ -30,6 +30,9 @@ void __global__ k_coords_to_kv_gather(
     float y = coords[atom_idx * 3 + 1];
     float z = coords[atom_idx * 3 + 2];
 
+    // floor is used in place of nearbyint here to ensure all particles are imaged into the home box. This differs
+    // from distances calculations where the nearest possible image is calculated rather than imaging into
+    // the home box.
     x -= bx * floor(x / bx);
     y -= by * floor(y / by);
     z -= bz * floor(z / bz);

--- a/timemachine/cpp/src/kernels/k_nonbonded_pair_list.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_pair_list.cuh
@@ -91,8 +91,6 @@ void __global__ k_nonbonded_pair_list(
     unsigned long long g_epsj = 0;
     unsigned long long g_wj = 0;
 
-    RealType real_beta = static_cast<RealType>(beta);
-
     RealType real_cutoff = static_cast<RealType>(cutoff);
     RealType cutoff_squared = real_cutoff * real_cutoff;
 
@@ -123,14 +121,13 @@ void __global__ k_nonbonded_pair_list(
     if (d2ij < cutoff_squared) {
 
         RealType ebd;
-        RealType es_prefactor;
+        RealType delta_prefactor;
         RealType dij;
         RealType inv_dij;
         RealType inv_d2ij;
         compute_electrostatics<RealType, true>(
-            charge_scale, qi, qj, d2ij, beta, dij, inv_dij, inv_d2ij, ebd, es_prefactor, u);
+            charge_scale, qi, qj, d2ij, static_cast<RealType>(beta), dij, inv_dij, inv_d2ij, ebd, delta_prefactor, u);
 
-        RealType delta_prefactor = es_prefactor;
         // lennard jones force
         if (eps_i != 0 && eps_j != 0) {
             RealType sig_grad;

--- a/timemachine/cpp/src/kernels/k_nonbonded_precomputed.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_precomputed.cuh
@@ -55,7 +55,6 @@ void __global__ k_nonbonded_precomputed(
     unsigned long long gj_y = 0;
     unsigned long long gj_z = 0;
 
-    RealType real_beta = static_cast<RealType>(beta);
     RealType real_cutoff = static_cast<RealType>(cutoff);
     RealType cutoff_squared = real_cutoff * real_cutoff;
 
@@ -88,7 +87,7 @@ void __global__ k_nonbonded_precomputed(
         if (q_ij != 0) {
 
             RealType erfc_beta;
-            RealType es_factor = real_es_factor(real_beta, d_ij, inv_dij * inv_dij, erfc_beta);
+            RealType es_factor = real_es_factor(static_cast<RealType>(beta), d_ij, inv_dij * inv_dij, erfc_beta);
 
             if (u_buffer) {
                 // energies

--- a/timemachine/cpp/src/nonbonded_all_pairs.cu
+++ b/timemachine/cpp/src/nonbonded_all_pairs.cu
@@ -68,8 +68,8 @@ NonbondedAllPairs<RealType>::NonbondedAllPairs(
 
     cudaSafeMalloc(&d_nblist_x_, N_ * 3 * sizeof(*d_nblist_x_));
     gpuErrchk(cudaMemset(d_nblist_x_, 0, N_ * 3 * sizeof(*d_nblist_x_))); // set non-sensical positions
-    cudaSafeMalloc(&d_nblist_box_, 3 * 3 * sizeof(*d_nblist_x_));
-    gpuErrchk(cudaMemset(d_nblist_box_, 0, 3 * 3 * sizeof(*d_nblist_x_)));
+    cudaSafeMalloc(&d_nblist_box_, 3 * 3 * sizeof(*d_nblist_box_));
+    gpuErrchk(cudaMemset(d_nblist_box_, 0, 3 * 3 * sizeof(*d_nblist_box_)));
     cudaSafeMalloc(&d_rebuild_nblist_, 1 * sizeof(*d_rebuild_nblist_));
     gpuErrchk(cudaMallocHost(&p_rebuild_nblist_, 1 * sizeof(*p_rebuild_nblist_)));
 

--- a/timemachine/cpp/src/nonbonded_interaction_group.cu
+++ b/timemachine/cpp/src/nonbonded_interaction_group.cu
@@ -65,8 +65,8 @@ NonbondedInteractionGroup<RealType>::NonbondedInteractionGroup(
 
     cudaSafeMalloc(&d_nblist_x_, N_ * 3 * sizeof(*d_nblist_x_));
     gpuErrchk(cudaMemset(d_nblist_x_, 0, N_ * 3 * sizeof(*d_nblist_x_))); // set non-sensical positions
-    cudaSafeMalloc(&d_nblist_box_, 3 * 3 * sizeof(*d_nblist_x_));
-    gpuErrchk(cudaMemset(d_nblist_box_, 0, 3 * 3 * sizeof(*d_nblist_x_)));
+    cudaSafeMalloc(&d_nblist_box_, 3 * 3 * sizeof(*d_nblist_box_));
+    gpuErrchk(cudaMemset(d_nblist_box_, 0, 3 * 3 * sizeof(*d_nblist_box_)));
     cudaSafeMalloc(&d_rebuild_nblist_, 1 * sizeof(*d_rebuild_nblist_));
     gpuErrchk(cudaMallocHost(&p_rebuild_nblist_, 1 * sizeof(*p_rebuild_nblist_)));
 


### PR DESCRIPTION
- Remove some redundant variables in nonbonded kernels
- Adds a comment clarifying why the imaging is slightly different in the k_coords_to_kv_gather kernel as compared to other places where we image for distances
- Fixes up using the incorrect variable for sizeof in nonbonded potentials