### PR TITLE
Misc fixes and improvements to RBFE code

### DIFF
--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -302,7 +302,7 @@ def test_make_pair_bar_plots(mock_fig, hif2a_ligand_pair_single_topology_lam0_st
     )
 
 
-def test_run_sims_with_greedy_bisection_early_stopping():
+def test_run_sims_bisection_early_stopping():
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     forcefield = Forcefield.load_default()
     st = SingleTopology(mol_a, mol_b, core, forcefield)
@@ -315,7 +315,7 @@ def test_run_sims_with_greedy_bisection_early_stopping():
 
     n_bisections = 3
 
-    run_sims_with_greedy_bisection_partial = partial(
+    run_sims_bisection_early_stopping = partial(
         run_sims_bisection,
         [0.0, 1.0],
         make_initial_state,
@@ -326,7 +326,7 @@ def test_run_sims_with_greedy_bisection_early_stopping():
     )
 
     # runs all n_bisections iterations by default
-    results, _, _ = run_sims_with_greedy_bisection_partial()
+    results, _, _ = run_sims_bisection_early_stopping()
     assert len(results) == 1 + n_bisections  # initial result + bisection iterations
 
     def result_with_overlap(overlap):
@@ -336,24 +336,24 @@ def test_run_sims_with_greedy_bisection_early_stopping():
         # overlap does not improve; should run all n_bisections iterations
         mock_estimate_free_energy_bar.return_value = result_with_overlap(0.0)
         with pytest.warns(MinOverlapWarning):
-            results, _, _ = run_sims_with_greedy_bisection_partial(min_overlap=0.4)
+            results, _, _ = run_sims_bisection_early_stopping(min_overlap=0.4)
         assert len(results) == 1 + n_bisections
 
         # min_overlap satisfied by initial states
         mock_estimate_free_energy_bar.return_value = result_with_overlap(0.5)
-        results, _, _ = run_sims_with_greedy_bisection_partial(min_overlap=0.4)
+        results, _, _ = run_sims_bisection_early_stopping(min_overlap=0.4)
         assert len(results) == 1
 
         # min_overlap achieved after 1 iteration
         mock_estimate_free_energy_bar.side_effect = [result_with_overlap(overlap) for overlap in [0.0, 0.5, 0.5]]
-        results, _, _ = run_sims_with_greedy_bisection_partial(min_overlap=0.4)
+        results, _, _ = run_sims_bisection_early_stopping(min_overlap=0.4)
         assert len(results) == 1 + 1
 
         # min_overlap achieved after 2 iterations
         mock_estimate_free_energy_bar.side_effect = [
             result_with_overlap(overlap) for overlap in [0.0, 0.5, 0.3, 0.5, 0.6]
         ]
-        results, _, _ = run_sims_with_greedy_bisection_partial(min_overlap=0.4)
+        results, _, _ = run_sims_bisection_early_stopping(min_overlap=0.4)
         assert len(results) == 1 + 2
 
 

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -23,7 +23,7 @@ from timemachine.fe.free_energy import (
     batches,
     estimate_free_energy_bar,
     make_pair_bar_plots,
-    run_sims_with_greedy_bisection,
+    run_sims_bisection,
     sample,
 )
 from timemachine.fe.rbfe import setup_initial_state, setup_initial_states, setup_optimized_host
@@ -316,7 +316,7 @@ def test_run_sims_with_greedy_bisection_early_stopping():
     n_bisections = 3
 
     run_sims_with_greedy_bisection_partial = partial(
-        run_sims_with_greedy_bisection,
+        run_sims_bisection,
         [0.0, 1.0],
         make_initial_state,
         md_params,

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -241,6 +241,7 @@ def test_local_md_parameters(freeze_reference):
         local_steps=steps_per_frame,
         min_radius=0.1,
         max_radius=0.5,
+        freeze_reference=freeze_reference,
     )
 
     # Local MD not supported by vacuum, will reset local_steps to 0

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -1,5 +1,6 @@
 # test that we can run relative free energy simulations in complex and in solvent
 # this doesn't test for accuracy, just that everything mechanically runs.
+from dataclasses import replace
 from importlib import resources
 from warnings import catch_warnings
 
@@ -8,6 +9,7 @@ import pytest
 
 from timemachine.fe.free_energy import HostConfig, MDParams, PairBarResult, SimulationResult, image_frames, sample
 from timemachine.fe.rbfe import (
+    DEFAULT_MD_PARAMS,
     estimate_relative_free_energy,
     estimate_relative_free_energy_bisection,
     run_solvent,
@@ -368,17 +370,20 @@ def test_rbfe_with_1_window(estimate_relative_free_energy_fn):
 
 def test_estimate_free_energy_bisection_invalid_args():
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
-    with pytest.raises(ValueError, match="keep_idxs"):
+    with catch_warnings(record=True) as ws:
         estimate_relative_free_energy_bisection(
             mol_a,
             mol_b,
             core,
             Forcefield.load_default(),
             host_config=None,
-            n_windows=3,
-            min_overlap=0.4,
-            keep_idxs=[0, 2],  # invalid with min_overlap not None
+            md_params=replace(DEFAULT_MD_PARAMS, n_frames=1, n_eq_steps=1, steps_per_frame=1),
+            n_windows=10,
+            min_overlap=0.0,  # causes immediate termination with 2 windows
+            keep_idxs=[0, 9],
         )
+
+    assert "Invalid index in keep_idxs: 9. Bisection terminated with only 2 windows." in {w.message.args[0] for w in ws}
 
 
 if __name__ == "__main__":

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -9,7 +9,7 @@ import pytest
 from timemachine.fe.free_energy import HostConfig, MDParams, PairBarResult, SimulationResult, image_frames, sample
 from timemachine.fe.rbfe import (
     estimate_relative_free_energy,
-    estimate_relative_free_energy_via_greedy_bisection,
+    estimate_relative_free_energy_bisection,
     run_solvent,
     run_vacuum,
 )
@@ -148,7 +148,7 @@ def run_triple(mol_a, mol_b, core, forcefield, md_params, protein_path, estimate
 @pytest.mark.nightly(reason="Slow!")
 @pytest.mark.parametrize(
     "estimate_relative_free_energy_fn",
-    [estimate_relative_free_energy, estimate_relative_free_energy_via_greedy_bisection],
+    [estimate_relative_free_energy, estimate_relative_free_energy_bisection],
 )
 def test_run_hif2a_test_system(estimate_relative_free_energy_fn):
 
@@ -344,7 +344,7 @@ def test_imaging_frames():
 
 @pytest.mark.parametrize(
     "estimate_relative_free_energy_fn",
-    [estimate_relative_free_energy, estimate_relative_free_energy_via_greedy_bisection],
+    [estimate_relative_free_energy, estimate_relative_free_energy_bisection],
 )
 def test_rbfe_with_1_window(estimate_relative_free_energy_fn):
     """Should not be able to run a relative free energy calculation with a single window"""
@@ -365,10 +365,10 @@ def test_rbfe_with_1_window(estimate_relative_free_energy_fn):
         )
 
 
-def test_estimate_free_energy_via_greedy_bisection_invalid_args():
+def test_estimate_free_energy_bisection_invalid_args():
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     with pytest.raises(ValueError, match="keep_idxs"):
-        estimate_relative_free_energy_via_greedy_bisection(
+        estimate_relative_free_energy_bisection(
             mol_a,
             mol_b,
             core,
@@ -384,4 +384,4 @@ if __name__ == "__main__":
     # convenience: so we can run this directly from python tests/test_relative_free_energy.py without
     # toggling the pytest marker
     test_run_hif2a_test_system(estimate_relative_free_energy)
-    test_run_hif2a_test_system(estimate_relative_free_energy_via_greedy_bisection)
+    test_run_hif2a_test_system(estimate_relative_free_energy_bisection)

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -406,7 +406,7 @@ def sample(initial_state: InitialState, md_params: MDParams, max_buffer_frames: 
             )
             coords.append(x_t)
             boxes.append(box_t)
-        return np.array(coords), np.array(boxes)
+        return np.concatenate(coords), np.concatenate(boxes)
 
     all_coords: Union[NDArray, StoredArrays]
 

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -599,7 +599,7 @@ class MinOverlapWarning(UserWarning):
     pass
 
 
-def run_sims_with_greedy_bisection(
+def run_sims_bisection(
     initial_lambdas: Sequence[float],
     make_initial_state: Callable[[float], InitialState],
     md_params: MDParams,

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -385,8 +385,8 @@ def sample(initial_state: InitialState, md_params: MDParams, max_buffer_frames: 
         return coords, boxes
 
     def run_production_local_steps(n_steps: int) -> Tuple[NDArray, NDArray]:
-        coords = None
-        boxes = None
+        coords = []
+        boxes = []
         for steps in batches(n_steps, md_params.steps_per_frame):
             if steps < md_params.steps_per_frame:
                 warn(
@@ -396,9 +396,7 @@ def sample(initial_state: InitialState, md_params: MDParams, max_buffer_frames: 
             global_steps = steps - md_params.local_steps
             local_steps = md_params.local_steps
             if global_steps > 0:
-                ctxt.multiple_steps(
-                    n_steps=global_steps,
-                )
+                ctxt.multiple_steps(n_steps=global_steps)
             x_t, box_t = ctxt.multiple_steps_local(
                 local_steps,
                 initial_state.ligand_idxs.astype(np.int32),
@@ -406,15 +404,9 @@ def sample(initial_state: InitialState, md_params: MDParams, max_buffer_frames: 
                 radius=rng.uniform(md_params.min_radius, md_params.max_radius),
                 seed=rng.integers(np.iinfo(np.int32).max),
             )
-
-            if coords is None:
-                coords = np.array(x_t)
-                boxes = np.array(box_t)
-            else:
-                coords = np.concatenate([coords, x_t])
-                boxes = np.concatenate([boxes, box_t])
-        assert coords is not None and boxes is not None
-        return coords, boxes
+            coords.append(x_t)
+            boxes.append(box_t)
+        return np.array(coords), np.array(boxes)
 
     all_coords: Union[NDArray, StoredArrays]
 

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -609,7 +609,7 @@ def run_sims_with_greedy_bisection(
     verbose: bool = True,
 ) -> Tuple[List[PairBarResult], List[StoredArrays], List[NDArray]]:
     r"""Starting from a specified lambda schedule, successively bisect the lambda interval between the pair of states
-    with the largest BAR :math:`\Delta G` error and sample the new state with MD.
+    with the lowest BAR overlap and sample the new state with MD.
 
     Parameters
     ----------

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -585,9 +585,7 @@ def estimate_relative_free_energy_bisection(
                 stored_frames.append(np.array(frames[i]))
                 stored_boxes.append(boxes[i])
             except IndexError:
-                warnings.warn(
-                    f"Invalid index in keep_idxs: {i}. Bisection terminated with only {len(results)} windows."
-                )
+                warnings.warn(f"Invalid index in keep_idxs: {i}. Bisection terminated with only {len(frames)} windows.")
 
         return SimulationResult(
             final_result,

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -537,10 +537,8 @@ def estimate_relative_free_energy_bisection(
 
     assert len(keep_idxs) <= n_windows
 
-    if min_overlap is not None and keep_idxs not in [None, [0, -1], list(range(n_windows))]:
-        raise ValueError(
-            "when min_overlap is not None, keep_idxs must be equal to one of None, [0, -1], or list(range(n_windows))"
-        )
+    if min_overlap is not None and keep_idxs is not None and not all(i in {0, -1} for i in keep_idxs):
+        raise ValueError("when min_overlap is not None, keep_idxs must be None or a list with all elements in {0, -1}")
 
     single_topology = SingleTopology(mol_a, mol_b, core, ff)
 

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -20,8 +20,8 @@ from timemachine.fe.free_energy import (
     SimulationResult,
     estimate_free_energy_bar,
     make_pair_bar_plots,
+    run_sims_bisection,
     run_sims_sequential,
-    run_sims_with_greedy_bisection,
 )
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.system import VacuumSystem, convert_omm_system
@@ -458,7 +458,7 @@ def estimate_relative_free_energy(
         raise err
 
 
-def estimate_relative_free_energy_via_greedy_bisection(
+def estimate_relative_free_energy_bisection(
     mol_a: Chem.rdchem.Mol,
     mol_b: Chem.rdchem.Mol,
     core: NDArray,
@@ -568,7 +568,7 @@ def estimate_relative_free_energy_via_greedy_bisection(
     combined_prefix = get_mol_name(mol_a) + "_" + get_mol_name(mol_b) + "_" + prefix
 
     try:
-        results, frames, boxes = run_sims_with_greedy_bisection(
+        results, frames, boxes = run_sims_bisection(
             [lambda_min, lambda_max],
             make_optimized_initial_state,
             md_params,
@@ -615,7 +615,7 @@ def run_vacuum(
         md_params = replace(md_params, local_steps=0)
         warnings.warn("Vacuum simulations don't support local steps, will use all global steps")
     # min_cutoff defaults to None since there is no environment to prevent conformational changes in the ligand
-    return estimate_relative_free_energy_via_greedy_bisection(
+    return estimate_relative_free_energy_bisection(
         mol_a,
         mol_b,
         core,
@@ -646,7 +646,7 @@ def run_solvent(
     solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(box_width, forcefield.water_ff)
     solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes, deboggle later
     solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
-    solvent_res = estimate_relative_free_energy_via_greedy_bisection(
+    solvent_res = estimate_relative_free_energy_bisection(
         mol_a,
         mol_b,
         core,
@@ -679,7 +679,7 @@ def run_complex(
     )
     complex_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes, deboggle later
     complex_host_config = HostConfig(complex_sys, complex_conf, complex_box, nwa)
-    complex_res = estimate_relative_free_energy_via_greedy_bisection(
+    complex_res = estimate_relative_free_energy_bisection(
         mol_a,
         mol_b,
         core,

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -536,7 +536,7 @@ def estimate_relative_free_energy_bisection(
         keep_idxs = [0, -1]  # keep frames from first and last windows
 
     assert len(set(keep_idxs)) == len(keep_idxs)
-    assert len(keep_idxs) < n_windows
+    assert len(keep_idxs) <= n_windows
 
     single_topology = SingleTopology(mol_a, mol_b, core, ff)
 

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -537,7 +537,7 @@ def estimate_relative_free_energy_bisection(
 
     assert len(keep_idxs) <= n_windows
 
-    if min_overlap is not None and keep_idxs is not None and not all(i in {0, -1} for i in keep_idxs):
+    if min_overlap is not None and not all(i in {0, -1} for i in keep_idxs):
         raise ValueError("when min_overlap is not None, keep_idxs must be None or a list with all elements in {0, -1}")
 
     single_topology = SingleTopology(mol_a, mol_b, core, ff)

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -577,7 +577,7 @@ def estimate_relative_free_energy_bisection(
 
         plots = make_pair_bar_plots(final_result, temperature, combined_prefix)
 
-        assert len(results) == len(frames) == len(boxes)
+        assert len(frames) == len(boxes) == len(results) + 1
         stored_frames = []
         stored_boxes = []
         for i in keep_idxs:

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -97,7 +97,7 @@ class NVTMove(MonteCarloMove[CoordsVelBox]):
         ctxt = custom_ops.Context(x.coords, x.velocities, x.box, self.integrator_impl, self.bound_impls)
         return self._steps(ctxt)
 
-    def _steps(self, ctxt: custom_ops.Context) -> CoordsVelBox:
+    def _steps(self, ctxt: "custom_ops.Context") -> CoordsVelBox:
         xs, boxes = ctxt.multiple_steps(self.n_steps, 0)
         x_t = xs[0]
         v_t = ctxt.get_v_t()

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from functools import partial
-from typing import Any, List, Tuple
+from typing import Any, Generic, List, Tuple, TypeVar
 
 import jax
 import jax.numpy as jnp
@@ -16,16 +16,18 @@ from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.md.states import CoordsVelBox
 from timemachine.potentials import BoundPotential, HarmonicBond
 
+_State = TypeVar("_State")
 
-class MonteCarloMove:
+
+class MonteCarloMove(Generic[_State]):
     n_proposed: int = 0
     n_accepted: int = 0
 
-    def propose(self, x: CoordsVelBox) -> Tuple[CoordsVelBox, float]:
+    def propose(self, x: _State) -> Tuple[_State, float]:
         """return proposed state and log acceptance probability"""
         raise NotImplementedError
 
-    def move(self, x: CoordsVelBox) -> CoordsVelBox:
+    def move(self, x: _State) -> _State:
         proposal, log_acceptance_probability = self.propose(x)
         self.n_proposed += 1
 
@@ -45,12 +47,12 @@ class MonteCarloMove:
             return 0.0
 
 
-class CompoundMove(MonteCarloMove):
+class CompoundMove(MonteCarloMove[_State]):
     def __init__(self, moves: List[MonteCarloMove]):
         """Apply each of a list of moves in sequence"""
         self.moves = moves
 
-    def move(self, x: CoordsVelBox) -> CoordsVelBox:
+    def move(self, x: _State) -> _State:
         for individual_move in self.moves:
             x = individual_move.move(x)
         return x
@@ -72,7 +74,7 @@ class CompoundMove(MonteCarloMove):
         return np.sum(self.n_proposed_by_move)
 
 
-class NVTMove(MonteCarloMove):
+class NVTMove(MonteCarloMove[CoordsVelBox]):
     def __init__(
         self,
         bps: List[BoundPotential],
@@ -95,7 +97,7 @@ class NVTMove(MonteCarloMove):
         ctxt = custom_ops.Context(x.coords, x.velocities, x.box, self.integrator_impl, self.bound_impls)
         return self._steps(ctxt)
 
-    def _steps(self, ctxt: "custom_ops.Context") -> CoordsVelBox:
+    def _steps(self, ctxt: custom_ops.Context) -> CoordsVelBox:
         xs, boxes = ctxt.multiple_steps(self.n_steps, 0)
         x_t = xs[0]
         v_t = ctxt.get_v_t()


### PR DESCRIPTION
This PR collects some miscellaneous fixes and improvements, spun out of the HREX development branch to simplify review of the latter:

- Renames some internal RBFE methods that previously had unwieldy names, e.g. `estimate_relative_free_energy_via_greedy_bisection` -> `estimate_relative_free_energy_bisection` (https://github.com/proteneer/timemachine/pull/1115/commits/d5cbe0a36f9f6c29452ab45876e6f7a8738a37b8)
- Fixes overly-restrictive argument validation in `estimate_relative_free_energy_bisection`. E.g. should allow empty `keep_idxs`. (https://github.com/proteneer/timemachine/pull/1115/commits/c5b48fabcec270018a5de3f05e2626052ae43477)
- Simplifies trajectory accumulation in `run_production_local_steps`, avoids copying current coordinates and boxes after each batch (https://github.com/proteneer/timemachine/pull/1115/commits/82c7cbe2c7f00d9f368ee455fd698dcb50ca2b69)
- Makes `MonteCarloMove` generic in the state type, so it can be used with types other than `CoordsVelBox`. This enables reusing this code for HREX, where the state type is a mapping from states to replicas. (https://github.com/proteneer/timemachine/pull/1115/commits/355b9835a1b01245e214122fb32af697e6853d3a)