### PR TITLE
Remove shape information from BoundPotential

### DIFF
--- a/timemachine/cpp/src/bound_potential.cu
+++ b/timemachine/cpp/src/bound_potential.cu
@@ -46,17 +46,15 @@ void BoundPotential::execute_host(
     }
 };
 
-void BoundPotential::set_params_device(const int device_size, const double *d_new_params, const cudaStream_t stream) {
-    int updated_size = device_size;
-    if (updated_size > 0) {
-        if (updated_size > max_size_) {
+void BoundPotential::set_params_device(const int size, const double *d_new_params, const cudaStream_t stream) {
+    if (size > 0) {
+        if (size > max_size_) {
             throw std::runtime_error(
-                "parameter size is greater than max size: " + std::to_string(updated_size) + " > " +
-                std::to_string(max_size_));
+                "parameter size is greater than max size: " + std::to_string(size) + " > " + std::to_string(max_size_));
         }
-        gpuErrchk(cudaMemcpyAsync(
-            d_p->data, d_new_params, updated_size * sizeof(*d_p->data), cudaMemcpyDeviceToDevice, stream));
+        gpuErrchk(
+            cudaMemcpyAsync(d_p->data, d_new_params, size * sizeof(*d_p->data), cudaMemcpyDeviceToDevice, stream));
     }
-    this->size = device_size;
+    this->size = size;
 }
 } // namespace timemachine

--- a/timemachine/cpp/src/bound_potential.cu
+++ b/timemachine/cpp/src/bound_potential.cu
@@ -46,16 +46,16 @@ void BoundPotential::execute_host(
     }
 };
 
-void BoundPotential::set_params_device(const int updated_size, const double *d_new_params, const cudaStream_t stream) {
-    if (updated_size > 0) {
-        if (updated_size > max_size_) {
+void BoundPotential::set_params_device(const int new_size, const double *d_new_params, const cudaStream_t stream) {
+    if (new_size > 0) {
+        if (new_size > max_size_) {
             throw std::runtime_error(
-                "parameter size is greater than max size: " + std::to_string(updated_size) + " > " +
+                "parameter size is greater than max size: " + std::to_string(new_size) + " > " +
                 std::to_string(max_size_));
         }
-        gpuErrchk(cudaMemcpyAsync(
-            d_p->data, d_new_params, updated_size * sizeof(*d_p->data), cudaMemcpyDeviceToDevice, stream));
+        gpuErrchk(
+            cudaMemcpyAsync(d_p->data, d_new_params, new_size * sizeof(*d_p->data), cudaMemcpyDeviceToDevice, stream));
     }
-    this->size = updated_size;
+    this->size = new_size;
 }
 } // namespace timemachine

--- a/timemachine/cpp/src/bound_potential.cu
+++ b/timemachine/cpp/src/bound_potential.cu
@@ -46,15 +46,16 @@ void BoundPotential::execute_host(
     }
 };
 
-void BoundPotential::set_params_device(const int size, const double *d_new_params, const cudaStream_t stream) {
-    if (size > 0) {
-        if (size > max_size_) {
+void BoundPotential::set_params_device(const int updated_size, const double *d_new_params, const cudaStream_t stream) {
+    if (updated_size > 0) {
+        if (updated_size > max_size_) {
             throw std::runtime_error(
-                "parameter size is greater than max size: " + std::to_string(size) + " > " + std::to_string(max_size_));
+                "parameter size is greater than max size: " + std::to_string(updated_size) + " > " +
+                std::to_string(max_size_));
         }
-        gpuErrchk(
-            cudaMemcpyAsync(d_p->data, d_new_params, size * sizeof(*d_p->data), cudaMemcpyDeviceToDevice, stream));
+        gpuErrchk(cudaMemcpyAsync(
+            d_p->data, d_new_params, updated_size * sizeof(*d_p->data), cudaMemcpyDeviceToDevice, stream));
     }
-    this->size = size;
+    this->size = updated_size;
 }
 } // namespace timemachine

--- a/timemachine/cpp/src/bound_potential.cu
+++ b/timemachine/cpp/src/bound_potential.cu
@@ -11,6 +11,18 @@ BoundPotential::BoundPotential(std::shared_ptr<Potential> potential, const int s
     }
 }
 
+void BoundPotential::execute_device(
+    const int N,
+    const double *d_x,
+    const double *d_box,
+    unsigned long long *d_du_dx,
+    unsigned long long *d_du_dp,
+    __int128 *d_u,
+    cudaStream_t stream) {
+    this->potential->execute_device(
+        N, this->size, d_x, this->size > 0 ? this->d_p->data : nullptr, d_box, d_du_dx, d_du_dp, d_u, stream);
+}
+
 void BoundPotential::execute_host(
     const int N,
     const double *h_x,           // [N,3]

--- a/timemachine/cpp/src/bound_potential.hpp
+++ b/timemachine/cpp/src/bound_potential.hpp
@@ -29,10 +29,7 @@ struct BoundPotential {
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
         __int128 *d_u,
-        cudaStream_t stream) {
-        this->potential->execute_device(
-            N, this->size, d_x, this->size > 0 ? this->d_p->data : nullptr, d_box, d_du_dx, d_du_dp, d_u, stream);
-    }
+        cudaStream_t stream);
 };
 
 } // namespace timemachine

--- a/timemachine/cpp/src/bound_potential.hpp
+++ b/timemachine/cpp/src/bound_potential.hpp
@@ -11,20 +11,14 @@ namespace timemachine {
 // a potential bounded to a set of parameters with some shape
 struct BoundPotential {
 
-    BoundPotential(
-        // Potential *potential,
-        std::shared_ptr<Potential> potential,
-        std::vector<int> shape,
-        const double *h_p);
+    BoundPotential(std::shared_ptr<Potential> potential, const int size, const double *h_p);
 
-    std::vector<int> shape;
+    int size;
     std::unique_ptr<DeviceBuffer<double>> d_p;
     std::shared_ptr<Potential> potential;
     const int max_size_;
 
-    int size() const;
-
-    void set_params_device(const std::vector<int> shape, const double *d_p, const cudaStream_t stream);
+    void set_params_device(const int size, const double *d_p, const cudaStream_t stream);
 
     void execute_host(const int N, const double *h_x, const double *h_box, unsigned long long *h_du_dx, __int128 *h_u);
 
@@ -37,7 +31,7 @@ struct BoundPotential {
         __int128 *d_u,
         cudaStream_t stream) {
         this->potential->execute_device(
-            N, this->size(), d_x, this->size() > 0 ? this->d_p->data : nullptr, d_box, d_du_dx, d_du_dp, d_u, stream);
+            N, this->size, d_x, this->size > 0 ? this->d_p->data : nullptr, d_box, d_du_dx, d_du_dp, d_u, stream);
     }
 };
 

--- a/timemachine/cpp/src/local_md_utils.cu
+++ b/timemachine/cpp/src/local_md_utils.cu
@@ -75,7 +75,6 @@ construct_ixn_group_potential(const int N, std::shared_ptr<Potential> pot, const
     gpuErrchk(cudaMemcpy(&h_params[0], d_params, P * sizeof(*d_params), cudaMemcpyDeviceToHost));
     std::vector<int> row_dummy_idxs{0};
     std::vector<int> col_dummy_idxs{1};
-    std::vector<int> shape{P};
 
     if (N < 2) {
         throw std::runtime_error("N must be greater than 1");
@@ -85,13 +84,13 @@ construct_ixn_group_potential(const int N, std::shared_ptr<Potential> pot, const
         nb_pot) {
         std::shared_ptr<Potential> ixn_group(new NonbondedInteractionGroup<float>(
             N, row_dummy_idxs, col_dummy_idxs, nb_pot->get_beta(), nb_pot->get_cutoff()));
-        return std::shared_ptr<BoundPotential>(new BoundPotential(ixn_group, shape, &h_params[0]));
+        return std::shared_ptr<BoundPotential>(new BoundPotential(ixn_group, P, &h_params[0]));
     } else if (std::shared_ptr<NonbondedAllPairs<double>> nb_pot =
                    std::dynamic_pointer_cast<NonbondedAllPairs<double>>(pot);
                nb_pot) {
         std::shared_ptr<Potential> ixn_group(new NonbondedInteractionGroup<double>(
             N, row_dummy_idxs, col_dummy_idxs, nb_pot->get_beta(), nb_pot->get_cutoff()));
-        return std::shared_ptr<BoundPotential>(new BoundPotential(ixn_group, shape, &h_params[0]));
+        return std::shared_ptr<BoundPotential>(new BoundPotential(ixn_group, P, &h_params[0]));
     } else {
         throw std::runtime_error("unable to cast potential to NonbondedAllPairs");
     }

--- a/timemachine/cpp/src/nonbonded_common.cpp
+++ b/timemachine/cpp/src/nonbonded_common.cpp
@@ -80,16 +80,15 @@ void get_nonbonded_all_pair_potentials(
         if (std::shared_ptr<FanoutSummedPotential> fanned_potential =
                 std::dynamic_pointer_cast<FanoutSummedPotential>(pot->potential);
             fanned_potential != nullptr) {
-            std::vector<double> h_params(pot->size());
-            if (pot->size() > 0) {
+            std::vector<double> h_params(pot->size);
+            if (pot->size > 0) {
                 pot->d_p->copy_to(&h_params[0]);
             }
-            std::vector<int> shape{pot->size()};
             std::vector<std::shared_ptr<BoundPotential>> flattened_bps;
             for (auto summed_pot : fanned_potential->get_potentials()) {
                 if (is_summed_potential(summed_pot) || is_nonbonded_all_pairs_potential(summed_pot)) {
                     flattened_bps.push_back(
-                        std::shared_ptr<BoundPotential>(new BoundPotential(summed_pot, shape, &h_params[0])));
+                        std::shared_ptr<BoundPotential>(new BoundPotential(summed_pot, pot->size, &h_params[0])));
                 }
             }
             get_nonbonded_all_pair_potentials(flattened_bps, nb_pots);
@@ -97,13 +96,12 @@ void get_nonbonded_all_pair_potentials(
         } else if (std::shared_ptr<SummedPotential> summed_potential =
                        std::dynamic_pointer_cast<SummedPotential>(pot->potential);
                    summed_potential != nullptr) {
-            std::vector<double> h_params(pot->size());
+            std::vector<double> h_params(pot->size);
             int i = 0;
             int offset = 0;
-            if (pot->size() > 0) {
+            if (pot->size > 0) {
                 pot->d_p->copy_to(&h_params[0]);
             }
-            std::vector<int> shape(1);
 
             std::vector<std::shared_ptr<BoundPotential>> flattened_bps;
             std::vector<int> param_sizes = summed_potential->get_parameter_sizes();
@@ -111,9 +109,8 @@ void get_nonbonded_all_pair_potentials(
 
                 if (is_summed_potential(summed_pot) || is_nonbonded_all_pairs_potential(summed_pot)) {
                     std::vector<double> slice(h_params.begin() + offset, h_params.begin() + offset + param_sizes[i]);
-                    shape[0] = param_sizes[i];
                     flattened_bps.push_back(
-                        std::shared_ptr<BoundPotential>(new BoundPotential(summed_pot, shape, &slice[0])));
+                        std::shared_ptr<BoundPotential>(new BoundPotential(summed_pot, param_sizes[i], &slice[0])));
                 }
 
                 offset += param_sizes[i];

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -804,14 +804,12 @@ void declare_bound_potential(py::module &m) {
         .def(
             py::init([](std::shared_ptr<timemachine::Potential> potential,
                         const py::array_t<double, py::array::c_style> &params) {
-                std::vector<int> pshape(params.shape(), params.shape() + params.ndim());
-
-                return new timemachine::BoundPotential(potential, pshape, params.data());
+                return new timemachine::BoundPotential(potential, params.size(), params.data());
             }),
             py::arg("potential"),
             py::arg("params"))
         .def("get_potential", [](const timemachine::BoundPotential &bp) { return bp.potential; })
-        .def("size", &timemachine::BoundPotential::size)
+        .def("size", [](const timemachine::BoundPotential &bp) { return bp.size; })
         .def(
             "execute",
             [](timemachine::BoundPotential &bp,


### PR DESCRIPTION
`BoundPotential` currently stores the shape of the parameter array, but this information is unused. Storing just the size allows for modest simplification.