### PR TITLE
Parallelize Box Bounds calculation

### DIFF
--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -119,9 +119,10 @@ Neighborlist<RealType>::get_nblist_host(int N, const double *h_coords, const dou
     gpuErrchk(cudaMemcpy(&h_ixn_count, d_ixn_count_, 1 * sizeof(*d_ixn_count_), cudaMemcpyDeviceToHost));
     std::vector<int> h_ixn_tiles(MAX_TILE_BUFFER);
     std::vector<unsigned int> h_ixn_atoms(MAX_ATOM_BUFFER);
-    gpuErrchk(cudaMemcpy(&h_ixn_tiles[0], d_ixn_tiles_, MAX_TILE_BUFFER * sizeof(int), cudaMemcpyDeviceToHost));
     gpuErrchk(
-        cudaMemcpy(&h_ixn_atoms[0], d_ixn_atoms_, MAX_ATOM_BUFFER * sizeof(unsigned int), cudaMemcpyDeviceToHost));
+        cudaMemcpy(&h_ixn_tiles[0], d_ixn_tiles_, MAX_TILE_BUFFER * sizeof(*d_ixn_tiles_), cudaMemcpyDeviceToHost));
+    gpuErrchk(
+        cudaMemcpy(&h_ixn_atoms[0], d_ixn_atoms_, MAX_ATOM_BUFFER * sizeof(*d_ixn_atoms_), cudaMemcpyDeviceToHost));
 
     std::vector<std::vector<int>> ixn_list(row_blocks, std::vector<int>());
     for (int i = 0; i < h_ixn_count; i++) {

--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -76,12 +76,12 @@ void Neighborlist<RealType>::compute_block_bounds_host(
     gpuErrchk(cudaMemcpy(
         &h_block_bounds_centers[0],
         d_column_block_bounds_ctr_,
-        this->num_column_blocks() * 3 * sizeof(*d_column_block_bounds_ctr_),
+        h_block_bounds_centers.size() * sizeof(*d_column_block_bounds_ctr_),
         cudaMemcpyDeviceToHost));
     gpuErrchk(cudaMemcpy(
         &h_block_bounds_extents[0],
         d_column_block_bounds_ext_,
-        this->num_column_blocks() * 3 * sizeof(*d_column_block_bounds_ext_),
+        h_block_bounds_extents.size() * sizeof(*d_column_block_bounds_ext_),
         cudaMemcpyDeviceToHost));
 
     // Handle the float -> double, doing a direct copy from a double buffer to a float buffer results in garbage values


### PR DESCRIPTION
* Adopt the pytest style of tests in neighborlist tests with parameterize, which made testing easier
* Parallelizes the bounding box calculation to reduce the number of shuffle syncs, which results in different centers/extents from the reference. The volumes are identical, which is the important measure.

## Plots of volume similarity for DHFR

### Hilbert Sorted Blocks
![dhfr_sorted_1_precision_32](https://github.com/proteneer/timemachine/assets/5840832/b40f01ea-06cf-42c9-88bf-dc931a53c51c)

### Unsorted Blocks
![dhfr_sorted_0_precision_32](https://github.com/proteneer/timemachine/assets/5840832/b708eebb-967a-4857-a484-8bccf8bedd17)


# Benchmarks
A10 GPU
8.6 Cuda Arch

Less than a 0.5% percent difference across all cases, was for pedagogical reasons that this was implemented.

## Current
```
dhfr-apo: N=23558 speed: 705.04ns/day dt: 2.5fs (ran 100000 steps in 30.64s)
dhfr-apo-barostat-interval-25: N=23558 speed: 634.01ns/day dt: 2.5fs (ran 100000 steps in 34.07s)
hif2a-apo: N=8805 speed: 1232.37ns/day dt: 2.5fs (ran 100000 steps in 17.53s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1046.24ns/day dt: 2.5fs (ran 100000 steps in 20.65s)
hif2a-rbfe-barostat-interval-15: N=8840 speed: 780.38ns/day dt: 2.5fs (ran 100000 steps in 27.68s)
hif2a-rbfe-local: N=8840 speed: 1390.09ns/day dt: 2.5fs (ran 100000 steps in 15.54s)
solvent-apo: N=6282 speed: 1484.49ns/day dt: 2.5fs (ran 100000 steps in 14.55s)
solvent-apo-barostat-interval-25: N=6282 speed: 1327.31ns/day dt: 2.5fs (ran 100000 steps in 16.28s)
solvent-rbfe-barostat-interval-15: N=6317 speed: 1027.46ns/day dt: 2.5fs (ran 100000 steps in 21.03s)
solvent-rbfe-local: N=6317 speed: 1471.52ns/day dt: 2.5fs (ran 100000 steps in 14.68s)
```

## Parallel Bounding Blocks
```
dhfr-apo: N=23558 speed: 705.90ns/day dt: 2.5fs (ran 100000 steps in 30.60s)
dhfr-apo-barostat-interval-25: N=23558 speed: 635.53ns/day dt: 2.5fs (ran 100000 steps in 33.99s)
hif2a-apo: N=8805 speed: 1233.35ns/day dt: 2.5fs (ran 100000 steps in 17.52s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1047.54ns/day dt: 2.5fs (ran 100000 steps in 20.62s)
hif2a-rbfe-barostat-interval-15: N=8840 speed: 783.32ns/day dt: 2.5fs (ran 100000 steps in 27.58s)
hif2a-rbfe-local: N=8840 speed: 1395.57ns/day dt: 2.5fs (ran 100000 steps in 15.48s)
solvent-apo: N=6282 speed: 1510.37ns/day dt: 2.5fs (ran 100000 steps in 14.30s)
solvent-apo-barostat-interval-25: N=6282 speed: 1323.21ns/day dt: 2.5fs (ran 100000 steps in 16.33s)
solvent-rbfe-barostat-interval-15: N=6317 speed: 1029.71ns/day dt: 2.5fs (ran 100000 steps in 20.98s)
solvent-rbfe-local: N=6317 speed: 1480.62ns/day dt: 2.5fs (ran 100000 steps in 14.59s)
```

# Kernel Timings
A4000 GPU
8.6 Cuda Arch

Important to note that the `k_find_blocks_with_ixn` timings don't change. If the bounding blocks are larger than
previously, the time it takes to compute the ixn pairs can grow.

## Current
```
CUDA Kernel Statistics:

 Time (%)  Total Time (ns)  Instances  Avg (ns)   Med (ns)   Min (ns)  Max (ns)  StdDev (ns)                                                  Name                                                
 --------  ---------------  ---------  ---------  ---------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
     63.5   80,267,365,603    202,000  397,363.2  386,274.0   315,233   452,607     29,018.4  void k_nonbonded_unified<float, (int)256, (bool)0, (bool)1, (bool)0>(int, int, const unsigned int *…
      9.6   12,182,376,631     41,075  296,588.6  296,672.0   225,056   348,960     22,013.6  void k_find_blocks_with_ixns<float, (bool)1>(int, int, int, const unsigned int *, const unsigned in…
      5.2    6,598,803,226     20,200  326,673.4  314,785.0   257,825   367,392     25,059.1  void gen_sequenced<curandStateXORWOW, double2, normal_args_double_st, &curand_normal_scaled2_double…
      3.1    3,936,454,522    210,080   18,737.9   18,592.0     4,800    40,352      3,232.1  void k_harmonic_angle<float, (int)3>(int, const double *, const double *, const int *, unsigned lon…
      3.0    3,845,004,450    210,080   18,302.6   18,593.0     8,672    35,393      3,202.8  void k_nonbonded_pair_list<float, (bool)1>(int, const double *, const double *, const double *, con…
      3.0    3,763,729,942    210,080   17,915.7   18,175.0     5,248    37,600      2,690.4  void k_periodic_torsion<float, (int)3>(int, const double *, const double *, const int *, unsigned l…
      2.7    3,447,137,585      8,080  426,625.9  431,296.0   316,800   453,503     15,779.7  void k_nonbonded_unified<float, (int)256, (bool)1, (bool)0, (bool)0>(int, int, const unsigned int *…
      2.4    3,041,692,406    210,080   14,478.7   15,520.0     3,776    34,208      4,031.9  void k_harmonic_bond<float>(int, const double *, const double *, const int *, unsigned long long *,…
      1.8    2,285,381,466    210,080   10,878.6   10,656.0     8,288    30,464      1,398.2  void k_gather_coords_and_params<double>(int, const unsigned int *, const T1 *, const T1 *, T1 *, T1…
      1.6    2,060,896,296    207,979    9,909.2    8,128.0     4,256    24,576      3,479.8  void k_check_rebuild_coords_and_box_gather<float>(int, const unsigned int *, const double *, const …
      1.6    1,979,776,210    202,000    9,800.9    9,504.0     8,224    17,921      1,055.7  void k_update_forward_baoab<double, (int)3>(int, T1, const unsigned int *, const T1 *, const T1 *, …
      0.9    1,177,663,595    202,000    5,830.0    5,760.0     4,704    17,696        512.9  void k_scatter_accum<unsigned long long>(int, const unsigned int *, const T1 *, T1 *)               
      0.5      661,181,164     41,075   16,096.9   16,224.0    12,448    28,736        837.7  k_compact_trim_atoms(int, int, unsigned int *, unsigned int *, int *, unsigned int *)               
      0.3      440,644,681     56,560    7,790.7    6,784.0     3,200    27,072      4,427.5  void k_accumulate_energy<(unsigned int)512>(int, const __int128 *, __int128 *)                      
      0.3      347,538,443     41,075    8,461.1    8,480.0     6,624    19,808        559.3  void k_find_block_bounds<float>(int, int, const unsigned int *, const double *, const double *, T1 …
```

## Parallel Bounding Blocks
```
CUDA Kernel Statistics:

 Time (%)  Total Time (ns)  Instances  Avg (ns)   Med (ns)   Min (ns)  Max (ns)  StdDev (ns)                                                  Name                                                
 --------  ---------------  ---------  ---------  ---------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
     63.6   80,230,869,362    202,000  397,182.5  385,408.0   314,529   452,800     29,135.9  void k_nonbonded_unified<float, (int)256, (bool)0, (bool)1, (bool)0>(int, int, const unsigned int *…
      9.6   12,168,731,758     41,075  296,256.4  295,296.0   225,888   346,592     22,167.1  void k_find_blocks_with_ixns<float, (bool)1>(int, int, int, const unsigned int *, const unsigned in…
      5.2    6,591,807,440     20,200  326,327.1  314,560.0   257,281   367,136     25,127.1  void gen_sequenced<curandStateXORWOW, double2, normal_args_double_st, &curand_normal_scaled2_double…
      3.2    3,994,884,887    210,080   19,016.0   18,944.0     4,608    56,896      3,323.1  void k_harmonic_angle<float, (int)3>(int, const double *, const double *, const int *, unsigned lon…
      3.0    3,825,344,938    210,080   18,209.0   18,528.0     8,736    36,256      3,115.6  void k_nonbonded_pair_list<float, (bool)1>(int, const double *, const double *, const double *, con…
      3.0    3,800,911,443    210,080   18,092.7   18,336.0     5,344    57,152      2,655.7  void k_periodic_torsion<float, (int)3>(int, const double *, const double *, const int *, unsigned l…
      2.7    3,444,765,659      8,080  426,332.4  431,551.0   317,344   453,727     16,472.5  void k_nonbonded_unified<float, (int)256, (bool)1, (bool)0, (bool)0>(int, int, const unsigned int *…
      2.4    3,065,313,491    210,080   14,591.2   15,680.0     3,840    56,000      4,151.8  void k_harmonic_bond<float>(int, const double *, const double *, const int *, unsigned long long *,…
      1.8    2,272,257,525    210,080   10,816.2   10,592.0     7,680    28,928      1,373.2  void k_gather_coords_and_params<double>(int, const unsigned int *, const T1 *, const T1 *, T1 *, T1…
      1.6    2,066,414,207    207,979    9,935.7    8,096.0     4,288    55,360      3,526.3  void k_check_rebuild_coords_and_box_gather<float>(int, const unsigned int *, const double *, const …
      1.5    1,937,484,830    202,000    9,591.5    9,248.0     8,416    21,056      1,093.3  void k_update_forward_baoab<double, (int)3>(int, T1, const unsigned int *, const T1 *, const T1 *, …
      0.9    1,179,446,728    202,000    5,838.8    5,728.0     4,608    22,752        526.1  void k_scatter_accum<unsigned long long>(int, const unsigned int *, const T1 *, T1 *)               
      0.5      665,847,580     41,075   16,210.5   16,320.0    12,608    27,871        886.6  k_compact_trim_atoms(int, int, unsigned int *, unsigned int *, int *, unsigned int *)               
      0.3      441,562,012     56,560    7,807.0    6,752.0     3,232    25,664      4,440.9  void k_accumulate_energy<(unsigned int)512>(int, const __int128 *, __int128 *)                      
      0.2      210,811,713     41,075    5,132.4    5,120.0     4,161    17,408        431.8  void k_find_block_bounds<float>(int, int, const unsigned int *, const double *, const double *, T1 …
```