### PR TITLE
Adds Nsys profile files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ oe_license.txt
 build/
 *.egg-info/
 .coverage*
+
+# Nsys profiling files
+*.sqlite
+*.nsys-rep


### PR DESCRIPTION
*  Been generating a lot of nsys profiles using `nsys profile --stats=true -t nvtx,cuda` and seems best to avoid these ending up in the repo. 
* `.sqlite` files only get generated with `--stats=true` flag