### PR TITLE
Perf/remove stride in kernels

### DIFF
--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -92,11 +92,11 @@ void __global__ k_scatter_accum(
     if (idx >= N) {
         return;
     }
-    const unsigned int atom_idx = unique_idxs[idx];
+    const unsigned int dest_idx = unique_idxs[idx];
 
 #pragma unroll D
     for (int i = 0; i < D; i++) {
-        atomicAdd(array + (atom_idx * D + i), gathered_array[idx * D + i]);
+        atomicAdd(array + (dest_idx * D + i), gathered_array[idx * D + i]);
     }
 }
 

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -86,7 +86,7 @@ void __global__ k_scatter_accum(
     const unsigned int *__restrict__ unique_idxs, // NOTE: race condition possible if there are repeated indices
     const T *__restrict__ gathered_array,
     T *__restrict__ array) {
-    static_assert(D <= PARAMS_PER_ATOM);
+    static_assert(D <= 5, "More loop unrolling than expected");
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
     if (idx >= N) {

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -52,7 +52,7 @@ void __global__ k_check_rebuild_coords_and_box_gather(
     }
 }
 
-template <typename RealType>
+template <typename RealType, int COORDS_DIM, int PARAMS_DIM>
 void __global__ k_gather_coords_and_params(
     const int N,
     const unsigned int *__restrict__ idxs,
@@ -60,20 +60,24 @@ void __global__ k_gather_coords_and_params(
     const RealType *__restrict__ params,
     RealType *__restrict__ gathered_coords,
     RealType *__restrict__ gathered_params) {
-
+    static_assert(COORDS_DIM == 3);
+    static_assert(PARAMS_DIM == PARAMS_PER_ATOM);
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    int stride = gridDim.y;
-    int stride_idx = blockIdx.y;
-
     if (idx >= N) {
         return;
     }
 
+    const unsigned int atom_idx = idxs[idx];
+
     // Coords have 3 dimensions, params have 4
-    if (stride_idx < 3) {
-        gathered_coords[idx * 3 + stride_idx] = coords[idxs[idx] * 3 + stride_idx];
+#pragma unroll COORDS_DIM
+    for (int i = 0; i < COORDS_DIM; i++) {
+        gathered_coords[idx * COORDS_DIM + i] = coords[atom_idx * COORDS_DIM + i];
     }
-    gathered_params[idx * stride + stride_idx] = params[idxs[idx] * stride + stride_idx];
+#pragma unroll PARAMS_DIM
+    for (int i = 0; i < PARAMS_DIM; i++) {
+        gathered_params[idx * PARAMS_DIM + i] = params[atom_idx * PARAMS_DIM + i];
+    }
 }
 
 template <typename T, int D>

--- a/timemachine/cpp/src/nonbonded_all_pairs.cu
+++ b/timemachine/cpp/src/nonbonded_all_pairs.cu
@@ -213,8 +213,8 @@ void NonbondedAllPairs<RealType>::execute_device(
         gpuErrchk(cudaEventRecord(nblist_flag_sync_event_, stream));
     }
     // compute new coordinates/params
-    k_gather_coords_and_params<<<dim3(ceil_divide(K_, tpb), PARAMS_PER_ATOM, 1), tpb, 0, stream>>>(
-        K_, d_sorted_atom_idxs_, d_x, d_p, d_gathered_x_, d_gathered_p_);
+    k_gather_coords_and_params<double, 3, PARAMS_PER_ATOM>
+        <<<ceil_divide(K_, tpb), tpb, 0, stream>>>(K_, d_sorted_atom_idxs_, d_x, d_p, d_gathered_x_, d_gathered_p_);
     gpuErrchk(cudaPeekAtLastError());
 
     // reset buffers and sorted accumulators

--- a/timemachine/cpp/src/nonbonded_all_pairs.cu
+++ b/timemachine/cpp/src/nonbonded_all_pairs.cu
@@ -262,16 +262,16 @@ void NonbondedAllPairs<RealType>::execute_device(
 
     // coords are N,3
     if (d_du_dx) {
-        k_scatter_accum<<<dim3(ceil_divide(K_, tpb), 3, 1), tpb, 0, stream>>>(
-            K_, d_sorted_atom_idxs_, d_gathered_du_dx_, d_du_dx);
+        k_scatter_accum<unsigned long long, 3>
+            <<<ceil_divide(K_, tpb), tpb, 0, stream>>>(K_, d_sorted_atom_idxs_, d_gathered_du_dx_, d_du_dx);
         gpuErrchk(cudaPeekAtLastError());
     }
 
     // params are N, PARAMS_PER_ATOM
     // this needs to be an accumulated permute
     if (d_du_dp) {
-        k_scatter_accum<<<dim3(ceil_divide(K_, tpb), PARAMS_PER_ATOM, 1), tpb, 0, stream>>>(
-            K_, d_sorted_atom_idxs_, d_gathered_du_dp_, d_du_dp);
+        k_scatter_accum<unsigned long long, PARAMS_PER_ATOM>
+            <<<ceil_divide(K_, tpb), tpb, 0, stream>>>(K_, d_sorted_atom_idxs_, d_gathered_du_dp_, d_du_dp);
         gpuErrchk(cudaPeekAtLastError());
     }
 

--- a/timemachine/cpp/src/nonbonded_interaction_group.cu
+++ b/timemachine/cpp/src/nonbonded_interaction_group.cu
@@ -186,8 +186,8 @@ void NonbondedInteractionGroup<RealType>::execute_device(
     }
 
     // compute new coordinates/params
-    k_gather_coords_and_params<<<dim3(ceil_divide(K, tpb), PARAMS_PER_ATOM, 1), tpb, 0, stream>>>(
-        K, d_perm_, d_x, d_p, d_sorted_x_, d_sorted_p_);
+    k_gather_coords_and_params<double, 3, PARAMS_PER_ATOM>
+        <<<ceil_divide(K, tpb), tpb, 0, stream>>>(K, d_perm_, d_x, d_p, d_sorted_x_, d_sorted_p_);
     gpuErrchk(cudaPeekAtLastError());
     // reset buffers and sorted accumulators
     if (d_du_dx) {

--- a/timemachine/cpp/src/nonbonded_interaction_group.cu
+++ b/timemachine/cpp/src/nonbonded_interaction_group.cu
@@ -236,14 +236,15 @@ void NonbondedInteractionGroup<RealType>::execute_device(
 
     // coords are N,3
     if (d_du_dx) {
-        k_scatter_accum<<<dim3(B_K, 3, 1), tpb, 0, stream>>>(K, d_perm_, d_sorted_du_dx_, d_du_dx);
+        k_scatter_accum<unsigned long long, 3><<<B_K, tpb, 0, stream>>>(K, d_perm_, d_sorted_du_dx_, d_du_dx);
         gpuErrchk(cudaPeekAtLastError());
     }
 
     // params are N, PARAMS_PER_ATOM
     // this needs to be an accumulated permute
     if (d_du_dp) {
-        k_scatter_accum<<<dim3(B_K, PARAMS_PER_ATOM, 1), tpb, 0, stream>>>(K, d_perm_, d_sorted_du_dp_, d_du_dp);
+        k_scatter_accum<unsigned long long, PARAMS_PER_ATOM>
+            <<<B_K, tpb, 0, stream>>>(K, d_perm_, d_sorted_du_dp_, d_du_dp);
         gpuErrchk(cudaPeekAtLastError());
     }
     if (d_u) {


### PR DESCRIPTION
* Remove striding, which limits memory locality. Makes minor difference for DHFR
* Only significant where we don't have atomic operations

# Benchmarks
A10 
Cuda Arch 8.6

Performance difference of hif2a/solvent is within noise

## Current
```
dhfr-apo: N=23558 speed: 705.74ns/day dt: 2.5fs (ran 100000 steps in 30.61s)
dhfr-apo-barostat-interval-25: N=23558 speed: 633.97ns/day dt: 2.5fs (ran 100000 steps in 34.07s)
hif2a-apo: N=8805 speed: 1230.63ns/day dt: 2.5fs (ran 100000 steps in 17.56s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1045.14ns/day dt: 2.5fs (ran 100000 steps in 20.67s)
hif2a-rbfe-barostat-interval-15: N=8840 speed: 780.08ns/day dt: 2.5fs (ran 100000 steps in 27.69s)
hif2a-rbfe-local: N=8840 speed: 1382.17ns/day dt: 2.5fs (ran 100000 steps in 15.63s)
solvent-apo: N=6282 speed: 1485.00ns/day dt: 2.5fs (ran 100000 steps in 14.55s)
solvent-apo-barostat-interval-25: N=6282 speed: 1332.47ns/day dt: 2.5fs (ran 100000 steps in 16.21s)
solvent-rbfe-barostat-interval-15: N=6317 speed: 1028.12ns/day dt: 2.5fs (ran 100000 steps in 21.01s)
solvent-rbfe-local: N=6317 speed: 1472.67ns/day dt: 2.5fs (ran 100000 steps in 14.67s)
```

## Remove striding from kernels
```
dhfr-apo: N=23558 speed: 709.69ns/day dt: 2.5fs (ran 100000 steps in 30.44s)
dhfr-apo-barostat-interval-25: N=23558 speed: 638.78ns/day dt: 2.5fs (ran 100000 steps in 33.82s)
hif2a-apo: N=8805 speed: 1236.75ns/day dt: 2.5fs (ran 100000 steps in 17.47s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1049.33ns/day dt: 2.5fs (ran 100000 steps in 20.59s)
hif2a-rbfe-barostat-interval-15: N=8840 speed: 777.49ns/day dt: 2.5fs (ran 100000 steps in 27.78s)
hif2a-rbfe-local: N=8840 speed: 1394.16ns/day dt: 2.5fs (ran 100000 steps in 15.50s)
solvent-apo: N=6282 speed: 1515.47ns/day dt: 2.5fs (ran 100000 steps in 14.26s)
solvent-apo-barostat-interval-25: N=6282 speed: 1330.37ns/day dt: 2.5fs (ran 100000 steps in 16.24s)
solvent-rbfe-barostat-interval-15: N=6317 speed: 1031.44ns/day dt: 2.5fs (ran 100000 steps in 20.94s)
solvent-rbfe-local: N=6317 speed: 1474.96ns/day dt: 2.5fs (ran 100000 steps in 14.65s)
```

# Kernel Timings
A4000 GPU

Only showing the DHFR benchmarks kernel statistics, for Hif2a/solvent it is 3.4kns vs 3.2kns. 

* 30% faster for k_gather_coords_and_params for DHFR, 5% faster for hif2a/solvent
* Not really faster for k_scatter_accum, but for consistency removed


## Current
```
CUDA Kernel Statistics:

 Time (%)  Total Time (ns)  Instances  Avg (ns)   Med (ns)   Min (ns)  Max (ns)  StdDev (ns)                                                  Name                                                
 --------  ---------------  ---------  ---------  ---------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
     63.3   77,948,168,455    202,000  385,882.0  378,593.0   326,785   443,871     26,426.1  void k_nonbonded_unified<float, (int)256, (bool)0, (bool)1, (bool)0>(int, int, const unsigned int *…
      9.6   11,804,186,275     41,075  287,381.3  283,041.0   229,056   338,912     20,643.1  void k_find_blocks_with_ixns<float, (bool)1>(int, int, int, const unsigned int *, const unsigned in…
      5.2    6,399,632,590     20,200  316,813.5  310,561.0   271,361   359,168     22,570.5  void gen_sequenced<curandStateXORWOW, double2, normal_args_double_st, &curand_normal_scaled2_double…
      3.2    3,948,854,896    210,080   18,796.9   19,072.0     8,672    74,977      3,324.8  void k_nonbonded_pair_list<float, (bool)1>(int, const double *, const double *, const double *, con…
      3.1    3,871,543,391    210,080   18,428.9   18,400.0     4,832    76,097      3,211.2  void k_harmonic_angle<float, (int)3>(int, const double *, const double *, const int *, unsigned lon…
      3.0    3,699,114,944    210,080   17,608.1   17,920.0     5,536    76,385      2,642.4  void k_periodic_torsion<float, (int)3>(int, const double *, const double *, const int *, unsigned l…
      2.7    3,302,280,894      8,080  408,698.1  418,496.0   339,105   445,632     21,628.8  void k_nonbonded_unified<float, (int)256, (bool)1, (bool)0, (bool)0>(int, int, const unsigned int *…
      2.4    3,013,041,985    210,080   14,342.4   15,264.0     3,808    56,224      4,067.3  void k_harmonic_bond<float>(int, const double *, const double *, const int *, unsigned long long *,…
      1.8    2,230,433,868    210,080   10,617.1   10,272.0     8,160    62,944      1,307.1  void k_gather_coords_and_params<double>(int, const unsigned int *, const T1 *, const T1 *, T1 *, T1…
      1.7    2,125,073,983    207,979   10,217.7    8,225.0     4,064    51,776      3,609.1  void k_check_rebuild_coords_and_box_gather<float>(int, const unsigned int *, const double *, const …
      1.6    1,973,127,758    202,000    9,768.0    9,440.0     8,256    35,680      1,039.1  void k_update_forward_baoab<double, (int)3>(int, T1, const unsigned int *, const T1 *, const T1 *, …
      0.9    1,152,454,589    202,000    5,705.2    5,632.0     4,736    36,128        517.7  void k_scatter_accum<unsigned long long>(int, const unsigned int *, const T1 *, T1 *)      
```

## Removing Stride
```
CUDA Kernel Statistics:

 Time (%)  Total Time (ns)  Instances  Avg (ns)   Med (ns)   Min (ns)  Max (ns)  StdDev (ns)                                                  Name                                                
 --------  ---------------  ---------  ---------  ---------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
     63.2   75,664,012,220    202,000  374,574.3  371,586.0   312,257   435,136     19,509.0  void k_nonbonded_unified<float, (int)256, (bool)0, (bool)1, (bool)0>(int, int, const unsigned int *…
      9.6   11,519,517,280     41,075  280,450.8  278,017.0   223,489   330,816     15,833.8  void k_find_blocks_with_ixns<float, (bool)1>(int, int, int, const unsigned int *, const unsigned in…
      5.2    6,251,166,458     20,200  309,463.7  306,785.0   254,881   354,495     16,856.6  void gen_sequenced<curandStateXORWOW, double2, normal_args_double_st, &curand_normal_scaled2_double…
      3.8    4,551,746,052    210,080   21,666.7   22,176.0     8,799    37,216      2,690.1  void k_nonbonded_pair_list<float, (bool)1>(int, const double *, const double *, const double *, con…
      3.1    3,733,470,112    210,080   17,771.7   17,985.0     4,640    35,904      2,781.1  void k_harmonic_angle<float, (int)3>(int, const double *, const double *, const int *, unsigned lon…
      3.0    3,576,821,763    210,080   17,026.0   17,248.0     5,248    36,672      2,631.6  void k_periodic_torsion<float, (int)3>(int, const double *, const double *, const int *, unsigned l…
      2.7    3,181,617,224      8,080  393,764.5  384,737.0   313,889   434,848     18,250.7  void k_nonbonded_unified<float, (int)256, (bool)1, (bool)0, (bool)0>(int, int, const unsigned int *…
      2.4    2,908,558,513    210,080   13,845.0   14,400.0     3,648    32,320      3,664.2  void k_harmonic_bond<float>(int, const double *, const double *, const int *, unsigned long long *,…
      1.8    2,107,694,508    207,979   10,134.2    8,480.0     4,096    24,576      3,650.0  void k_check_rebuild_coords_and_box_gather<float>(int, const unsigned int *, const double *, const …
      1.7    1,988,803,700    202,000    9,845.6    9,568.0     8,192    21,536      1,012.0  void k_update_forward_baoab<double, (int)3>(int, T1, const unsigned int *, const T1 *, const T1 *, …
      1.2    1,443,332,277    210,080    6,870.4    6,624.0     4,416    21,856      1,308.2  void k_gather_coords_and_params<double, (int)3, (int)4>(int, const unsigned int *, const T1 *, cons…
      1.0    1,148,886,105    202,000    5,687.6    5,664.0     4,704    28,769        385.2  void k_scatter_accum<unsigned long long, (int)3>(int, const unsigned int *, const T1 *, T1 *)
```