### PR TITLE
Use StoredArrays for frames in SimulationResult

### DIFF
--- a/tests/test_stored_arrays.py
+++ b/tests/test_stored_arrays.py
@@ -139,8 +139,8 @@ def test_stored_arrays_store_raises_on_file_collision():
         sa.store(fc, prefix=Path("subdir"))  # no collision
 
 
-def test_stored_arrays_raises_on_pickling_attempt():
-    sa = StoredArrays()
-    with pytest.raises(NotImplementedError) as e:
-        _ = pickle.dumps(sa)
-    assert "pickling not implemented" in str(e)
+@given(stored_arrays_instances)
+@seed(2023)
+def test_stored_arrays_pickle_roundtrip(sa_ref):
+    sa_test = pickle.loads(pickle.dumps(sa_ref))
+    assert sa_ref == sa_test

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -16,9 +16,7 @@ from timemachine.fe.free_energy import (
     HostConfig,
     InitialState,
     MDParams,
-    PairBarResult,
     SimulationResult,
-    estimate_free_energy_bar,
     make_pair_bar_plots,
     run_sims_sequential,
 )
@@ -239,25 +237,9 @@ def estimate_absolute_free_energy(
 
     combined_prefix = get_mol_name(mol) + "_" + prefix
     try:
-        u_kln_by_component_by_lambda, stored_frames, stored_boxes = run_sims_sequential(
-            initial_states, md_params, temperature, keep_idxs
-        )
-        bar_results = [
-            estimate_free_energy_bar(u_kln_by_component, temperature)
-            for u_kln_by_component in u_kln_by_component_by_lambda
-        ]
-
-        result = PairBarResult(initial_states, bar_results)
+        result, stored_frames, stored_boxes = run_sims_sequential(initial_states, md_params, temperature, keep_idxs)
         plots = make_pair_bar_plots(result, temperature, combined_prefix)
-
-        return SimulationResult(
-            result,
-            plots,
-            stored_frames,
-            stored_boxes,
-            md_params,
-            [],
-        )
+        return SimulationResult(result, plots, stored_frames, stored_boxes, md_params, [])
     except Exception as err:
         with open(f"failed_ahfe_result_{combined_prefix}.pkl", "wb") as fh:
             pickle.dump((initial_states, md_params, err), fh)

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -135,7 +135,7 @@ class PairBarResult:
 class SimulationResult:
     final_result: PairBarResult
     plots: PairBarPlots
-    frames: List[NDArray]  # (len(keep_idxs), n_frames, N, 3)
+    frames: List[StoredArrays]  # (len(keep_idxs), n_frames, N, 3)
     boxes: List[NDArray]
     md_params: MDParams
     intermediate_results: List[PairBarResult]
@@ -519,7 +519,7 @@ def run_sims_sequential(
     md_params: MDParams,
     temperature: float,
     keep_idxs: List[int],
-) -> Tuple[PairBarResult, List[NDArray], List[NDArray]]:
+) -> Tuple[PairBarResult, List[StoredArrays], List[NDArray]]:
     """Sequentially run simulations at each state in initial_states,
     returning summaries that can be used for pair BAR, energy decomposition, and other diagnostics
 
@@ -557,7 +557,7 @@ def run_sims_sequential(
     for lamb_idx, initial_state in enumerate(initial_states):
 
         # run simulation
-        cur_frames, cur_boxes = sample(initial_state, md_params)
+        cur_frames, cur_boxes = sample(initial_state, md_params, max_buffer_frames=100)
         print(f"completed simulation at lambda={initial_state.lamb}!")
 
         # keep samples from any requested states in memory

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -519,13 +519,13 @@ def run_sims_sequential(
     md_params: MDParams,
     temperature: float,
     keep_idxs: List[int],
-) -> Tuple[NDArray, List[NDArray], List[NDArray]]:
+) -> Tuple[PairBarResult, List[NDArray], List[NDArray]]:
     """Sequentially run simulations at each state in initial_states,
     returning summaries that can be used for pair BAR, energy decomposition, and other diagnostics
 
     Returns
     -------
-    decomposed_u_klns: [n_lams - 1, n_components, 2, 2, n_frames] array
+    pair_bar_result: PairBarResult
     stored_frames: coord trajectories, one for each state in keep_idxs
     stored_boxes: box trajectories, one for each state in keep_idxs
 
@@ -578,7 +578,11 @@ def run_sims_sequential(
 
         prev_state = state
 
-    return np.array(u_kln_by_component_by_lambda), stored_frames, stored_boxes
+    bar_results = [
+        estimate_free_energy_bar(u_kln_by_component, temperature) for u_kln_by_component in u_kln_by_component_by_lambda
+    ]
+
+    return PairBarResult(list(initial_states), bar_results), stored_frames, stored_boxes
 
 
 def make_batch_u_fns(initial_state: InitialState, temperature: float) -> List[Batch_u_fn]:

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -565,7 +565,7 @@ def estimate_relative_free_energy_bisection(
         stored_boxes = []
         for i in keep_idxs:
             try:
-                stored_frames.append(np.array(frames[i]))
+                stored_frames.append(frames[i])
                 stored_boxes.append(boxes[i])
             except IndexError:
                 warnings.warn(f"Invalid index in keep_idxs: {i}. Bisection terminated with only {len(frames)} windows.")

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -16,9 +16,7 @@ from timemachine.fe.free_energy import (
     HostConfig,
     InitialState,
     MDParams,
-    PairBarResult,
     SimulationResult,
-    estimate_free_energy_bar,
     make_pair_bar_plots,
     run_sims_bisection,
     run_sims_sequential,
@@ -434,24 +432,9 @@ def estimate_relative_free_energy(
     # TODO: rename prefix to postfix, or move to beginning of combined_prefix?
     combined_prefix = get_mol_name(mol_a) + "_" + get_mol_name(mol_b) + "_" + prefix
     try:
-        u_kln_by_component_by_lambda, stored_frames, stored_boxes = run_sims_sequential(
-            initial_states, md_params, temperature, keep_idxs
-        )
-        bar_results = [
-            estimate_free_energy_bar(u_kln_by_component, temperature)
-            for u_kln_by_component in u_kln_by_component_by_lambda
-        ]
-        result = PairBarResult(initial_states, bar_results)
+        result, stored_frames, stored_boxes = run_sims_sequential(initial_states, md_params, temperature, keep_idxs)
         plots = make_pair_bar_plots(result, temperature, combined_prefix)
-
-        return SimulationResult(
-            result,
-            plots,
-            stored_frames,
-            stored_boxes,
-            md_params,
-            [],
-        )
+        return SimulationResult(result, plots, stored_frames, stored_boxes, md_params, [])
     except Exception as err:
         with open(f"failed_rbfe_result_{combined_prefix}.pkl", "wb") as fh:
             pickle.dump((initial_states, md_params, err), fh)


### PR DESCRIPTION
We currently load stored frames into memory to construct `SimulationResult` objects. This is unnecessary; loading can be deferred until we're ready to save the frames to disk or analyze them; at that point, we can process individual chunks separately to avoid using too much memory.

This PR:

* Modifies `SimulationResult` to store frames as `StoredArrays` instead of `NDArray`, avoiding the need to load the frames into memory to construct the result object
* Makes some minor modifications to make the interface of `run_sims_sequential` more consistent with `run_sims_bisection`
* Adds support for pickling `StoredArrays` objects. This allows existing code that pickles `SimulationResult` objects (e.g. `examples/rbfe_edge_list.py`) to continue working without changes.