### PR TITLE
Skip nightly condensed mtm test

### DIFF
--- a/tests/test_mtm_condensed.py
+++ b/tests/test_mtm_condensed.py
@@ -19,13 +19,14 @@ from timemachine.md.states import CoordsVelBox
 from timemachine.potentials import NonbondedInteractionGroup, bonded, nonbonded
 
 
+@pytest.mark.skip("Has shown to be flaky, needs further investigation. Condensed MTM not currently used")
 @pytest.mark.nightly(reason="Takes a long time to run")
-def test_condensed_phase_mtm():
+@pytest.mark.parametrize("seed", [2021])
+def test_condensed_phase_mtm(seed):
     """
     Tests multiple-try metropolis in the condensed phase.
     """
 
-    seed = 2021
     np.random.seed(seed)
 
     mol, torsion_idxs = testsystems.ligands.get_biphenyl()
@@ -41,12 +42,13 @@ def test_condensed_phase_mtm():
 
     proposal_U = state.U_decharged
 
-    cache_path = "mtm_condensed_cache.pkl"
+    num_workers = 4
+    weighted_batches = 400000
+    cache_path = f"mtm_condensed_cache_seed_{seed}_workers_{num_workers}_batches_{weighted_batches}.pkl"
     if not os.path.exists(cache_path):
         print("Generating cache")
-        num_batches = 400000
         vacuum_samples, vacuum_log_weights = enhanced.generate_log_weighted_samples(
-            mol, temperature, state.U_easy, proposal_U, num_batches=num_batches, seed=seed
+            mol, temperature, state.U_easy, proposal_U, num_batches=weighted_batches, seed=seed, num_workers=num_workers
         )
         # Discard velocities
         vacuum_samples = vacuum_samples[:, 0, :]


### PR DESCRIPTION
* Modified to make it easier to test multiple seeds for variation
* Modifies the cache to write out files based on the parameters to avoid reuse when changing parameters
* Fixes num workers to 4 to be consistent across CI and other machines