### PR TITLE
Clean up Benchmarks script

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -20,7 +20,7 @@ from timemachine.fe.single_topology import SingleTopology
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, custom_ops
-from timemachine.md import builders, minimizer
+from timemachine.md import builders
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.potentials import (
     BoundPotential,
@@ -337,9 +337,9 @@ def run_single_topology_benchmarks(
 ):
     host_fns, host_masses = openmm_deserializer.deserialize_system(host_config.omm_system, cutoff=1.2)
 
-    # resolve host clashes
-    min_host_coords = minimizer.minimize_host_4d([st.mol_a, st.mol_b], host_config, st.ff)
-    x0 = min_host_coords
+    # RBFE
+    initial_state = prepare_hif2a_initial_state(st, host_config)
+    x0 = initial_state.x0[: len(host_config.conf)]
     v0 = np.zeros_like(x0)
 
     for barostat_interval in [0, 25]:
@@ -353,9 +353,6 @@ def run_single_topology_benchmarks(
             host_fns,
             barostat_interval=barostat_interval,
         )
-
-    # RBFE
-    initial_state = prepare_hif2a_initial_state(st, host_config)
 
     barostat_interval = initial_state.barostat.interval
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -4,10 +4,13 @@ relative binding free energy edge from the HIF2A test system"""
 
 import time
 from argparse import ArgumentParser
+from dataclasses import dataclass
 from importlib import resources
+from typing import List
 
 import numpy as np
 import pytest
+from numpy.typing import NDArray
 
 from timemachine import constants
 from timemachine.fe import rbfe
@@ -19,11 +22,18 @@ from timemachine.ff.handlers import openmm_deserializer
 from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, custom_ops
 from timemachine.md import builders, minimizer
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
-from timemachine.potentials import HarmonicBond, Nonbonded, NonbondedInteractionGroup, Potential
+from timemachine.potentials import BoundPotential, HarmonicBond, Nonbonded, NonbondedInteractionGroup, Potential
 from timemachine.testsystems.dhfr import setup_dhfr
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
 
 SECONDS_PER_DAY = 24 * 60 * 60
+
+
+@dataclass
+class BenchmarkConfig:
+    num_batches: int
+    steps_per_batch: int
+    verbose: bool
 
 
 @pytest.fixture(scope="module")
@@ -95,14 +105,13 @@ def generate_hif2a_frames(n_frames: int, frame_interval: int, seed=None, barosta
 
 
 def benchmark_potential(
+    config: BenchmarkConfig,
     label: str,
     potential: Potential,
     precision,
-    params,
-    coords,
-    boxes,
-    verbose: bool = True,
-    num_batches: int = 5,
+    params: NDArray,
+    coords: NDArray,
+    boxes: NDArray,
     compute_du_dx: bool = True,
     compute_du_dp: bool = True,
     compute_u: bool = True,
@@ -117,7 +126,7 @@ def benchmark_potential(
     frames = coords.shape[0]
     param_batches = params.shape[0]
     runs_per_batch = frames * param_batches
-    for _ in range(num_batches):
+    for _ in range(config.num_batches):
         batch_start = time.time()
         _, _, _ = unbound.execute_selective_batch(
             coords,
@@ -133,30 +142,25 @@ def benchmark_potential(
         batch_times.append(delta)
         runs_per_second = runs_per_batch / np.mean(batch_times)
 
-        if verbose:
+        if config.verbose:
             print(f"executions per second: {runs_per_second:.3f}")
     print(
-        f"{label}: N={coords.shape[1]} Frames={frames} Params={param_batches} speed: {runs_per_second:.2f} executions/seconds (ran {runs_per_batch * num_batches} potentials in {(time.time() - start):.2f}s)",
+        f"{label}: N={coords.shape[1]} Frames={frames} Params={param_batches} speed: {runs_per_second:.2f} executions/seconds (ran {runs_per_batch * config.num_batches} potentials in {(time.time() - start):.2f}s)",
         f"du_dp={compute_du_dp}, du_dx={compute_du_dx}, u={compute_u}",
     )
 
 
 def benchmark(
+    config: BenchmarkConfig,
     label: str,
-    masses,
-    x0,
-    v0,
-    box,
-    bound_potentials,
+    masses: NDArray,
+    x0: NDArray,
+    v0: NDArray,
+    box: NDArray,
+    bound_potentials: List[BoundPotential],
     hmr: bool = True,
-    verbose: bool = True,
-    num_batches: int = 100,
-    steps_per_batch: int = 1000,
     barostat_interval: int = 0,
 ):
-    """
-    TODO: configuration blob containing num_batches, steps_per_batch, and any other options
-    """
 
     if barostat_interval > 0:
         label += f"-barostat-interval-{barostat_interval}"
@@ -201,6 +205,9 @@ def benchmark(
 
     batch_times = []
 
+    steps_per_batch = config.steps_per_batch
+    num_batches = config.num_batches
+
     # run once before timer starts
     ctxt.multiple_steps(steps_per_batch)
 
@@ -223,7 +230,7 @@ def benchmark(
         ps_per_day = dt * steps_per_day
         ns_per_day = ps_per_day * 1e-3
 
-        if verbose:
+        if config.verbose:
             print(f"steps per second: {steps_per_second:.3f}")
             print(f"ns per day: {ns_per_day:.3f}")
 
@@ -235,21 +242,16 @@ def benchmark(
 
 
 def benchmark_local(
+    config: BenchmarkConfig,
     label: str,
-    masses,
-    x0,
-    v0,
-    box,
-    bound_potentials,
-    ligand_idxs,
+    masses: NDArray,
+    x0: NDArray,
+    v0: NDArray,
+    box: NDArray,
+    bound_potentials: List[BoundPotential],
+    ligand_idxs: NDArray,
     hmr: bool = True,
-    verbose: bool = True,
-    num_batches: int = 100,
-    steps_per_batch: int = 1000,
 ):
-    """
-    TODO: configuration blob containing num_batches, steps_per_batch, and any other options
-    """
 
     seed = 1234
     dt = 1.5e-3
@@ -280,6 +282,9 @@ def benchmark_local(
 
     batch_times = []
 
+    steps_per_batch = config.steps_per_batch
+    num_batches = config.num_batches
+
     ligand_idxs = ligand_idxs.astype(np.int32)
 
     local_seed = rng.integers(np.iinfo(np.int32).max)
@@ -306,7 +311,7 @@ def benchmark_local(
         ps_per_day = dt * steps_per_day
         ns_per_day = ps_per_day * 1e-3
 
-        if verbose:
+        if config.verbose:
             print(f"steps per second: {steps_per_second:.3f}")
             print(f"ns per day: {ns_per_day:.3f}")
 
@@ -318,12 +323,10 @@ def benchmark_local(
 
 
 def run_single_topology_benchmarks(
+    config: BenchmarkConfig,
     stage: str,
     st: SingleTopology,
     host_config: HostConfig,
-    verbose: bool = False,
-    num_batches: int = 100,
-    steps_per_batch: int = 1000,
 ):
     host_fns, host_masses = openmm_deserializer.deserialize_system(host_config.omm_system, cutoff=1.2)
 
@@ -334,15 +337,13 @@ def run_single_topology_benchmarks(
 
     for barostat_interval in [0, 25]:
         benchmark(
+            config,
             f"{stage}-apo",
             host_masses,
             x0,
             v0,
             host_config.box,
             host_fns,
-            verbose=verbose,
-            num_batches=num_batches,
-            steps_per_batch=steps_per_batch,
             barostat_interval=barostat_interval,
         )
 
@@ -352,19 +353,18 @@ def run_single_topology_benchmarks(
     barostat_interval = initial_state.barostat.interval
 
     benchmark(
+        config,
         f"{stage}-rbfe",
         initial_state.integrator.masses,
         initial_state.x0,
         initial_state.v0,
         host_config.box,
         initial_state.potentials,
-        verbose=verbose,
-        num_batches=num_batches,
-        steps_per_batch=steps_per_batch,
         barostat_interval=barostat_interval,
     )
 
     benchmark_local(
+        config,
         f"{stage}-rbfe-local",
         initial_state.integrator.masses,
         initial_state.x0,
@@ -372,13 +372,10 @@ def run_single_topology_benchmarks(
         host_config.box,
         initial_state.potentials,
         initial_state.ligand_idxs,
-        verbose=verbose,
-        num_batches=num_batches,
-        steps_per_batch=steps_per_batch,
     )
 
 
-def benchmark_dhfr(verbose: bool = False, num_batches: int = 100, steps_per_batch: int = 1000):
+def benchmark_dhfr(config: BenchmarkConfig):
     host_fns, host_masses, host_conf, box = setup_dhfr()
 
     x0 = host_conf
@@ -386,23 +383,19 @@ def benchmark_dhfr(verbose: bool = False, num_batches: int = 100, steps_per_batc
 
     for barostat_interval in [0, 25]:
         benchmark(
+            config,
             "dhfr-apo",
             host_masses,
             x0,
             v0,
             box,
             host_fns,
-            verbose=verbose,
-            num_batches=num_batches,
-            steps_per_batch=steps_per_batch,
             barostat_interval=barostat_interval,
         )
 
 
-def prepare_hif2a_initial_state(st, host_config):
-    st = rbfe.SingleTopology(st.mol_a, st.mol_b, st.core, st.ff)
+def prepare_hif2a_initial_state(st: SingleTopology, host_config: HostConfig, lamb: float = 0.1):
     temperature = constants.DEFAULT_TEMP
-    lamb = 0.1
     host = rbfe.setup_optimized_host(st, host_config)
     initial_state = rbfe.setup_initial_states(st, host, temperature, [lamb], seed=2022)[0]
     free_idxs = rbfe.get_free_idxs(initial_state)
@@ -416,7 +409,7 @@ def prepare_hif2a_initial_state(st, host_config):
     return initial_state
 
 
-def benchmark_hif2a(verbose: bool = False, num_batches: int = 100, steps_per_batch: int = 1000):
+def benchmark_hif2a(config: BenchmarkConfig):
     # we use simple charge "sc" to be able to run on machines that don't have openeye licenses.
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     forcefield = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
@@ -431,12 +424,10 @@ def benchmark_hif2a(verbose: bool = False, num_batches: int = 100, steps_per_bat
     # resolve host clashes
     host_config = HostConfig(host_system, host_coords, host_box, host_num_waters)
 
-    run_single_topology_benchmarks(
-        "hif2a", st, host_config, num_batches=num_batches, steps_per_batch=steps_per_batch, verbose=verbose
-    )
+    run_single_topology_benchmarks(config, "hif2a", st, host_config)
 
 
-def benchmark_solvent(verbose: bool = False, num_batches: int = 100, steps_per_batch: int = 1000):
+def benchmark_solvent(config: BenchmarkConfig):
     # we use simple charge "sc" to be able to run on machines that don't have openeye licenses.
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     forcefield = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
@@ -448,21 +439,19 @@ def benchmark_solvent(verbose: bool = False, num_batches: int = 100, steps_per_b
 
     # resolve host clashes
     host_config = HostConfig(host_system, host_coords, host_box, num_water_atoms)
-    run_single_topology_benchmarks(
-        "solvent", st, host_config, num_batches=num_batches, steps_per_batch=steps_per_batch, verbose=verbose
-    )
+    run_single_topology_benchmarks(config, "solvent", st, host_config)
 
 
 def test_dhfr():
-    benchmark_dhfr(verbose=True, num_batches=2, steps_per_batch=100)
+    benchmark_dhfr(BenchmarkConfig(verbose=True, num_batches=2, steps_per_batch=100))
 
 
 def test_hif2a():
-    benchmark_hif2a(verbose=True, num_batches=2, steps_per_batch=100)
+    benchmark_hif2a(BenchmarkConfig(verbose=True, num_batches=2, steps_per_batch=100))
 
 
 def test_solvent():
-    benchmark_solvent(verbose=True, num_batches=2, steps_per_batch=100)
+    benchmark_solvent(BenchmarkConfig(verbose=True, num_batches=2, steps_per_batch=100))
 
 
 def get_nonbonded_pot_params(bps):
@@ -476,6 +465,8 @@ def get_nonbonded_pot_params(bps):
 def test_nonbonded_interaction_group_potential(hi2fa_test_frames):
     bps, frames, boxes, ligand_idxs = hi2fa_test_frames
     nonbonded_potential, nonbonded_params = get_nonbonded_pot_params(bps)
+
+    config = BenchmarkConfig(num_batches=2, steps_per_batch=0, verbose=False)
 
     num_param_batches = 5
     beta = 1 / (constants.BOLTZ * constants.DEFAULT_TEMP)
@@ -493,13 +484,13 @@ def test_nonbonded_interaction_group_potential(hi2fa_test_frames):
     class_name = potential.__class__.__name__
     for precision in precisions:
         benchmark_potential(
+            config,
             class_name,
             potential,
             precision,
             nonbonded_params,
             frames,
             boxes,
-            verbose=False,
         )
 
 
@@ -507,6 +498,8 @@ def test_nonbonded_potential(hi2fa_test_frames):
     bps, frames, boxes, _ = hi2fa_test_frames
 
     nonbonded_pot, nonbonded_params = get_nonbonded_pot_params(bps)
+
+    config = BenchmarkConfig(num_batches=2, steps_per_batch=0, verbose=False)
 
     num_param_batches = 5
 
@@ -525,18 +518,20 @@ def test_nonbonded_potential(hi2fa_test_frames):
     class_name = potential.__class__.__name__
     for precision in precisions:
         benchmark_potential(
+            config,
             class_name,
             potential,
             precision,
             nonbonded_params,
             frames,
             boxes,
-            verbose=False,
         )
 
 
 def test_bonded_potentials(hi2fa_test_frames):
     bps, frames, boxes, _ = hi2fa_test_frames
+
+    config = BenchmarkConfig(num_batches=2, steps_per_batch=0, verbose=False)
 
     num_param_batches = 5
 
@@ -546,13 +541,13 @@ def test_bonded_potentials(hi2fa_test_frames):
         params = np.stack([bp.params] * num_param_batches)
         for precision in [np.float32, np.float64]:
             benchmark_potential(
+                config,
                 class_name,
                 bp.potential,
                 precision,
                 params,
                 frames,
                 boxes,
-                verbose=False,
             )
 
 
@@ -567,12 +562,14 @@ if __name__ == "__main__":
     parser.add_argument("--verbose", action="store_true")
     args = parser.parse_args()
 
+    config = BenchmarkConfig(verbose=args.verbose, num_batches=args.num_batches, steps_per_batch=args.steps_per_batch)
+
     if not args.skip_dhfr:
-        benchmark_dhfr(verbose=args.verbose, num_batches=args.num_batches, steps_per_batch=args.steps_per_batch)
+        benchmark_dhfr(config)
     if not args.skip_hif2a:
-        benchmark_hif2a(verbose=args.verbose, num_batches=args.num_batches, steps_per_batch=args.steps_per_batch)
+        benchmark_hif2a(config)
     if not args.skip_solvent:
-        benchmark_solvent(verbose=args.verbose, num_batches=args.num_batches, steps_per_batch=args.steps_per_batch)
+        benchmark_solvent(config)
 
     if not args.skip_potentials:
         hif2a_frames = generate_hif2a_frames(1000, 20, seed=2022, barostat_interval=20)


### PR DESCRIPTION
- Separate out solvent for benchmarking as sometimes it isn't of interest
- Refactor the code to be less verbose
- Adds a configuration object which removes an old TODO
- Avoid minimizing host twice, which reduces the noise in the nvidia profiles we get out
- Avoids duplicate benchmarking case that had arisen when we did the FF split