### PR TITLE
Refactor and organize interface for Monte Carlo moves

### DIFF
--- a/tests/test_md_moves.py
+++ b/tests/test_md_moves.py
@@ -32,13 +32,13 @@ def test_random_walk_metropolis_hastings(dist, seed):
     tau = round(1 / dx ** 2)
     n_independent_samples = n_samples // tau - 1
 
-    d_log_q = np.random.uniform(-1.0, 1.0)  # arbitrary offset added to log_q
+    log_q_offset = np.random.uniform(-1.0, 1.0)  # arbitrary offset added to log_q
 
     if dist == "normal":
-        log_q = lambda x: -(x ** 2) / 2 + d_log_q
+        log_q = lambda x: -(x ** 2) / 2 + log_q_offset
         target_samples = np.random.normal(0, 1, size=(n_independent_samples,))
     else:
-        log_q = lambda x: d_log_q if -1 < x < 1 else -float("inf")
+        log_q = lambda x: log_q_offset if -1 < x < 1 else -float("inf")
         target_samples = np.random.uniform(-1, 1, size=(n_independent_samples,))
 
     sampler = RWMH1D(log_q, dx)

--- a/tests/test_md_moves.py
+++ b/tests/test_md_moves.py
@@ -1,37 +1,50 @@
-from typing import Tuple
+from typing import Callable, Tuple
 
 import numpy as np
+import pytest
 from scipy.stats import ks_2samp
 
 from timemachine.md.moves import MetropolisHastingsMove
 
 
-def test_random_walk_metropolis_hastings():
+class RWMH1D(MetropolisHastingsMove[float]):
+    def __init__(self, log_q: Callable[[float], float], proposal_radius: float):
+        super().__init__()
+        self.log_q = log_q
+        self.proposal_radius = proposal_radius
+
+    def propose_with_log_q_diff(self, x: float) -> Tuple[float, float]:
+        dx = self.proposal_radius
+        x_prop = x + np.random.uniform(-dx, dx)
+        log_q_diff = self.log_q(x_prop) - self.log_q(x)
+        return x_prop, log_q_diff
+
+
+@pytest.mark.parametrize("dist", ["normal", "uniform"])
+@pytest.mark.parametrize("seed", [2023, 2024, 2025])
+def test_random_walk_metropolis_hastings(dist, seed):
     """Test sampling from a 1-d normal distribution using Random Walk Metropolis-Hastings"""
 
-    np.random.seed(2023)
-    n_samples = 100_000
+    np.random.seed(seed)
+    n_samples = 200_000
     dx = 0.1
 
-    class RWMH1D(MetropolisHastingsMove[float]):
-        def propose_with_log_q_diff(self, x: float) -> Tuple[float, float]:
-            x_prop = x + np.random.uniform(-dx, dx)
+    if dist == "normal":
+        log_q = lambda x: -(x ** 2) / 2
+        sample_target = lambda n: np.random.normal(0, 1, size=(n,))
+    else:
+        log_q = lambda x: 0.0 if -1 < x < 1 else -float("inf")
+        sample_target = lambda n: np.random.uniform(-1, 1, size=(n,))
 
-            def log_q(x):
-                return -(x ** 2) / 2
-
-            log_q_diff = log_q(x_prop) - log_q(x)
-
-            return x_prop, log_q_diff
-
-    rwmh = RWMH1D()
+    sampler = RWMH1D(log_q, dx)
     x_0 = np.random.uniform(-1.0, 1.0)
-    rw_samples = rwmh.sample_chain(x_0, n_samples)
+
+    rw_samples = sampler.sample_chain(x_0, n_samples)
 
     tau = round(2 / dx ** 2)
     decorrelated_rw_samples = rw_samples[tau::tau]
 
-    target_samples = np.random.normal(0, 1, size=(len(decorrelated_rw_samples),))
+    target_samples = sample_target(len(decorrelated_rw_samples))
 
     _, pvalue = ks_2samp(decorrelated_rw_samples, target_samples)
 

--- a/tests/test_md_moves.py
+++ b/tests/test_md_moves.py
@@ -14,15 +14,15 @@ def test_rwmh():
     dx = 0.1
 
     class RWMH1D(MetropolisHastingsMove[float]):
-        def propose_with_dlogq(self, x: float) -> Tuple[float, float]:
+        def propose_with_log_q_diff(self, x: float) -> Tuple[float, float]:
             x_prop = x + np.random.uniform(-dx, dx)
 
             def log_q(x):
                 return -(x ** 2) / 2
 
-            dlogq = log_q(x_prop) - log_q(x)
+            log_q_diff = log_q(x_prop) - log_q(x)
 
-            return x_prop, dlogq
+            return x_prop, log_q_diff
 
     rwmh = RWMH1D()
     x_0 = np.random.uniform(-1.0, 1.0)

--- a/tests/test_md_moves.py
+++ b/tests/test_md_moves.py
@@ -14,38 +14,39 @@ class RWMH1D(MetropolisHastingsMove[float]):
         self.proposal_radius = proposal_radius
 
     def propose_with_log_q_diff(self, x: float) -> Tuple[float, float]:
-        dx = self.proposal_radius
-        x_prop = x + np.random.uniform(-dx, dx)
+        x_prop = np.random.normal(x, self.proposal_radius)
         log_q_diff = self.log_q(x_prop) - self.log_q(x)
         return x_prop, log_q_diff
 
 
-@pytest.mark.parametrize("dist", ["normal", "uniform"])
 @pytest.mark.parametrize("seed", [2023, 2024, 2025])
+@pytest.mark.parametrize("dist", ["uniform", "normal"])
 def test_random_walk_metropolis_hastings(dist, seed):
     """Test sampling from a 1-d normal distribution using Random Walk Metropolis-Hastings"""
 
     np.random.seed(seed)
-    n_samples = 200_000
+    n_samples = 100_000
     dx = 0.1
 
     # estimate autocorrelation time, number of independent samples
-    tau = round(2 / dx ** 2)
-    n_independent_samples = n_samples // tau
+    tau = round(1 / dx ** 2)
+    n_independent_samples = n_samples // tau - 1
+
+    d_log_q = np.random.uniform(-1.0, 1.0)  # arbitrary offset added to log_q
 
     if dist == "normal":
-        log_q = lambda x: -(x ** 2) / 2
+        log_q = lambda x: -(x ** 2) / 2 + d_log_q
         target_samples = np.random.normal(0, 1, size=(n_independent_samples,))
     else:
-        log_q = lambda x: 0.0 if -1 < x < 1 else -float("inf")
+        log_q = lambda x: d_log_q if -1 < x < 1 else -float("inf")
         target_samples = np.random.uniform(-1, 1, size=(n_independent_samples,))
 
     sampler = RWMH1D(log_q, dx)
     x_0 = np.random.uniform(-1.0, 1.0)
     rw_samples = sampler.sample_chain(x_0, n_samples)
 
-    decorrelated_rw_samples = rw_samples[::tau]
+    decorrelated_rw_samples = rw_samples[tau::tau]
 
     _, pvalue = ks_2samp(decorrelated_rw_samples, target_samples)
 
-    assert pvalue >= 0.05
+    assert pvalue >= 0.01

--- a/tests/test_md_moves.py
+++ b/tests/test_md_moves.py
@@ -16,11 +16,16 @@ def test_rwmh():
     class RWMH1D(MetropolisHastingsMove[float]):
         def propose_with_dlogq(self, x: float) -> Tuple[float, float]:
             x_prop = x + np.random.uniform(-dx, dx)
-            log_q = -(x_prop ** 2) / 2
-            return x_prop, log_q
+
+            def log_q(x):
+                return -(x ** 2) / 2
+
+            dlogq = log_q(x_prop) - log_q(x)
+
+            return x_prop, dlogq
 
     rwmh = RWMH1D()
-    x_0 = np.random.uniform(-0.3, 0.3)
+    x_0 = np.random.uniform(-1.0, 1.0)
     rw_samples = rwmh.sample_chain(x_0, n_samples)
 
     tau = round(2 / dx ** 2)

--- a/tests/test_md_moves.py
+++ b/tests/test_md_moves.py
@@ -6,7 +6,7 @@ from scipy.stats import ks_2samp
 from timemachine.md.moves import MetropolisHastingsMove
 
 
-def test_rwmh():
+def test_random_walk_metropolis_hastings():
     """Test sampling from a 1-d normal distribution using Random Walk Metropolis-Hastings"""
 
     np.random.seed(2023)

--- a/tests/test_md_moves.py
+++ b/tests/test_md_moves.py
@@ -29,22 +29,22 @@ def test_random_walk_metropolis_hastings(dist, seed):
     n_samples = 200_000
     dx = 0.1
 
+    # estimate autocorrelation time, number of independent samples
+    tau = round(2 / dx ** 2)
+    n_independent_samples = n_samples // tau
+
     if dist == "normal":
         log_q = lambda x: -(x ** 2) / 2
-        sample_target = lambda n: np.random.normal(0, 1, size=(n,))
+        target_samples = np.random.normal(0, 1, size=(n_independent_samples,))
     else:
         log_q = lambda x: 0.0 if -1 < x < 1 else -float("inf")
-        sample_target = lambda n: np.random.uniform(-1, 1, size=(n,))
+        target_samples = np.random.uniform(-1, 1, size=(n_independent_samples,))
 
     sampler = RWMH1D(log_q, dx)
     x_0 = np.random.uniform(-1.0, 1.0)
-
     rw_samples = sampler.sample_chain(x_0, n_samples)
 
-    tau = round(2 / dx ** 2)
-    decorrelated_rw_samples = rw_samples[tau::tau]
-
-    target_samples = sample_target(len(decorrelated_rw_samples))
+    decorrelated_rw_samples = rw_samples[::tau]
 
     _, pvalue = ks_2samp(decorrelated_rw_samples, target_samples)
 

--- a/tests/test_md_moves.py
+++ b/tests/test_md_moves.py
@@ -1,0 +1,33 @@
+from typing import Tuple
+
+import numpy as np
+from scipy.stats import ks_2samp
+
+from timemachine.md.moves import MetropolisHastingsMove
+
+
+def test_rwmh():
+    """Test sampling from a 1-d normal distribution using Random Walk Metropolis-Hastings"""
+
+    np.random.seed(2023)
+    n_samples = 100_000
+    dx = 0.1
+
+    class RWMH1D(MetropolisHastingsMove[float]):
+        def propose_with_dlogq(self, x: float) -> Tuple[float, float]:
+            x_prop = x + np.random.uniform(-dx, dx)
+            log_q = -(x_prop ** 2) / 2
+            return x_prop, log_q
+
+    rwmh = RWMH1D()
+    x_0 = np.random.uniform(-0.3, 0.3)
+    rw_samples = rwmh.sample_chain(x_0, n_samples)
+
+    tau = round(2 / dx ** 2)
+    decorrelated_rw_samples = rw_samples[tau::tau]
+
+    target_samples = np.random.normal(0, 1, size=(len(decorrelated_rw_samples),))
+
+    _, pvalue = ks_2samp(decorrelated_rw_samples, target_samples)
+
+    assert pvalue >= 0.05

--- a/tests/test_mtm.py
+++ b/tests/test_mtm.py
@@ -11,7 +11,8 @@ from timemachine import testsystems
 from timemachine.constants import BOLTZ
 from timemachine.ff import Forcefield
 from timemachine.md import enhanced
-from timemachine.md.moves import NPTMove, OptimizedMTMMove, ReferenceMTMMove
+from timemachine.md.barostat.moves import NPTMove
+from timemachine.md.moves import OptimizedMTMMove, ReferenceMTMMove
 from timemachine.md.states import CoordsVelBox
 from timemachine.potentials import NonbondedInteractionGroup, nonbonded
 
@@ -136,7 +137,7 @@ def test_optimized_MTM():
     bps = [ubp.bind(params) for ubp, params in zip(ubps, params)]
 
     # we should initialize new instances of this
-    npt_mover = NPTMove(bps, masses, temperature, pressure, n_steps=1000, seed=seed)
+    npt_mover = NPTMove(bps, masses, temperature, pressure=pressure, n_steps=1000, seed=seed)
 
     K = 100
     # note that these seeds aren't actually used, since we feed in explicit keys to acceptance_probability

--- a/tests/test_mtm.py
+++ b/tests/test_mtm.py
@@ -137,7 +137,7 @@ def test_optimized_MTM():
     bps = [ubp.bind(params) for ubp, params in zip(ubps, params)]
 
     # we should initialize new instances of this
-    npt_mover = NPTMove(bps, masses, temperature, pressure=pressure, n_steps=1000, seed=seed)
+    npt_mover = NPTMove(bps, masses, temperature, pressure, n_steps=1000, seed=seed)
 
     K = 100
     # note that these seeds aren't actually used, since we feed in explicit keys to acceptance_probability

--- a/tests/test_mtm_condensed.py
+++ b/tests/test_mtm_condensed.py
@@ -137,7 +137,7 @@ def test_condensed_phase_mtm(seed):
 
     bps = [ubp.bind(params) for ubp, params in zip(ubps, params)]
 
-    npt_mover = NPTMove(bps, masses, temperature, pressure=pressure, n_steps=md_steps_per_move, seed=seed)
+    npt_mover = NPTMove(bps, masses, temperature, pressure, n_steps=md_steps_per_move, seed=seed)
     mtm_mover = OptimizedMTMMove(K, batch_proposal_coords_fn, batch_log_weights_fn, seed=seed)
 
     enhanced_torsions = []
@@ -166,7 +166,7 @@ def test_condensed_phase_mtm(seed):
 
     vanilla_torsions = []
     xvb_t = copy.deepcopy(xvb0)
-    npt_mover = NPTMove(bps, masses, temperature, pressure=pressure, n_steps=500, seed=seed)
+    npt_mover = NPTMove(bps, masses, temperature, pressure, n_steps=500, seed=seed)
     for iteration in range(num_batches):
         solvent_torsion = get_torsion(xvb_t.coords[-num_ligand_atoms:])
         vanilla_torsions.append(solvent_torsion)

--- a/tests/test_mtm_condensed.py
+++ b/tests/test_mtm_condensed.py
@@ -14,7 +14,8 @@ from timemachine.constants import BOLTZ, DEFAULT_PRESSURE, DEFAULT_TEMP
 from timemachine.fe.utils import get_mol_masses
 from timemachine.ff import Forcefield
 from timemachine.md import enhanced
-from timemachine.md.moves import NPTMove, NVTMove, OptimizedMTMMove
+from timemachine.md.barostat.moves import NPTMove
+from timemachine.md.moves import NVTMove, OptimizedMTMMove
 from timemachine.md.states import CoordsVelBox
 from timemachine.potentials import NonbondedInteractionGroup, bonded, nonbonded
 
@@ -136,7 +137,7 @@ def test_condensed_phase_mtm(seed):
 
     bps = [ubp.bind(params) for ubp, params in zip(ubps, params)]
 
-    npt_mover = NPTMove(bps, masses, temperature, pressure, n_steps=md_steps_per_move, seed=seed)
+    npt_mover = NPTMove(bps, masses, temperature, pressure=pressure, n_steps=md_steps_per_move, seed=seed)
     mtm_mover = OptimizedMTMMove(K, batch_proposal_coords_fn, batch_log_weights_fn, seed=seed)
 
     enhanced_torsions = []
@@ -165,7 +166,7 @@ def test_condensed_phase_mtm(seed):
 
     vanilla_torsions = []
     xvb_t = copy.deepcopy(xvb0)
-    npt_mover = NPTMove(bps, masses, temperature, pressure, n_steps=500, seed=seed)
+    npt_mover = NPTMove(bps, masses, temperature, pressure=pressure, n_steps=500, seed=seed)
     for iteration in range(num_batches):
         solvent_torsion = get_torsion(xvb_t.coords[-num_ligand_atoms:])
         vanilla_torsions.append(solvent_torsion)

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -26,7 +26,8 @@ from timemachine.fe.utils import get_mol_name, get_romol_conf
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.lib import LangevinIntegrator, MonteCarloBarostat
-from timemachine.md import builders, enhanced, minimizer, moves, smc
+from timemachine.md import builders, enhanced, minimizer, smc
+from timemachine.md.barostat.moves import NPTMove
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.md.states import CoordsVelBox
 from timemachine.potentials import SummedPotential
@@ -132,7 +133,7 @@ def setup_absolute_hydration_with_endpoint_samples(
     for U, p in zip(potentials, params):
         U.bind(p)
 
-    npt_mover = moves.NPTMove(potentials, None, masses, temperature, pressure, n_steps, seed)
+    npt_mover = NPTMove(potentials, None, masses, temperature, pressure=pressure, n_steps=n_steps, seed=seed)
 
     # combine solvent and ligand samples
     solvent_xvbs, ligand_samples, ligand_log_weights = enhanced.pregenerate_samples(

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -133,7 +133,7 @@ def setup_absolute_hydration_with_endpoint_samples(
     for U, p in zip(potentials, params):
         U.bind(p)
 
-    npt_mover = NPTMove(potentials, None, masses, temperature, pressure=pressure, n_steps=n_steps, seed=seed)
+    npt_mover = NPTMove(potentials, None, masses, temperature, pressure, n_steps=n_steps, seed=seed)
 
     # combine solvent and ligand samples
     solvent_xvbs, ligand_samples, ligand_log_weights = enhanced.pregenerate_samples(

--- a/timemachine/md/enhanced.py
+++ b/timemachine/md/enhanced.py
@@ -592,7 +592,7 @@ def generate_solvent_samples(
         potentials, params, masses, coords, box, temperature, pressure, num_equil_steps, seed
     )
 
-    npt_mover = NPTMove(potentials, masses, temperature, pressure=pressure, n_steps=md_steps_per_move, seed=seed)
+    npt_mover = NPTMove(potentials, masses, temperature, pressure, n_steps=md_steps_per_move, seed=seed)
 
     xvbs = [xvb0]
     for _ in range(n_samples):

--- a/timemachine/md/enhanced.py
+++ b/timemachine/md/enhanced.py
@@ -22,7 +22,8 @@ from timemachine.fe.free_energy import HostConfig
 from timemachine.fe.utils import get_romol_conf
 from timemachine.integrator import simulate
 from timemachine.lib import custom_ops
-from timemachine.md import builders, minimizer, moves
+from timemachine.md import builders, minimizer
+from timemachine.md.barostat.moves import NPTMove
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.md.states import CoordsVelBox
 from timemachine.potentials import bonded, rmsd
@@ -591,7 +592,7 @@ def generate_solvent_samples(
         potentials, params, masses, coords, box, temperature, pressure, num_equil_steps, seed
     )
 
-    npt_mover = moves.NPTMove(potentials, masses, temperature, pressure, n_steps=md_steps_per_move, seed=seed)
+    npt_mover = NPTMove(potentials, masses, temperature, pressure=pressure, n_steps=md_steps_per_move, seed=seed)
 
     xvbs = [xvb0]
     for _ in range(n_samples):

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Any, Generic, List, Sequence, Tuple, TypeVar
+from itertools import islice
+from typing import Any, Generic, Iterator, List, Sequence, Tuple, TypeVar
 
 import jax
 import jax.numpy as jnp
@@ -23,6 +24,14 @@ class Move(Generic[_State], ABC):
     @abstractmethod
     def move(self, _: _State) -> _State:
         ...
+
+    def sample_chain_iter(self, x: _State) -> Iterator[_State]:
+        while True:
+            x = self.move(x)
+            yield x
+
+    def sample_chain(self, x: _State, n_samples: int) -> List[_State]:
+        return list(islice(self.sample_chain_iter(x), n_samples))
 
 
 @dataclass

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -62,12 +62,15 @@ class MonteCarloMove(Move[_State], ABC):
 
 class MetropolisHastingsMove(MonteCarloMove[_State], ABC):
     @abstractmethod
-    def propose_with_dlogp(self, x: _State) -> Tuple[_State, float]:
-        "return proposed state and its unnormalized log probability"
+    def propose_with_dlogq(self, x: _State) -> Tuple[_State, float]:
+        """Return proposed state and the difference in log unnormalized probability, i.e.
+
+        dlogq = log(q(x_proposed)) - log(q(x))
+        """
 
     def propose(self, x: _State) -> Tuple[_State, float]:
-        proposal, dlogp = self.propose_with_dlogp(x)
-        log_acceptance_probability = np.minimum(dlogp, 0.0)
+        proposal, dlogq = self.propose_with_dlogq(x)
+        log_acceptance_probability = np.minimum(dlogq, 0.0)
         return proposal, log_acceptance_probability
 
 

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
 from functools import partial
 from itertools import islice
 from typing import Any, Generic, Iterator, List, Sequence, Tuple, TypeVar
@@ -36,11 +35,10 @@ class Move(Generic[_State], ABC):
         return list(islice(self.sample_chain_iter(x), n_samples))
 
 
-@dataclass
 class MonteCarloMove(Move[_State], ABC):
-
-    _n_proposed: int = field(default=0, init=False)
-    _n_accepted: int = field(default=0, init=False)
+    def __init__(self):
+        self._n_proposed = 0
+        self._n_accepted = 0
 
     @abstractmethod
     def propose(self, x: _State) -> Tuple[_State, float]:
@@ -85,11 +83,11 @@ class MetropolisHastingsMove(MonteCarloMove[_State], ABC):
         return proposal, log_acceptance_probability
 
 
-@dataclass
 class CompoundMove(Move[_State]):
     """Apply each of a list of moves in sequence"""
 
-    moves: Sequence[MonteCarloMove[_State]]
+    def __init__(self, moves: Sequence[MonteCarloMove[_State]]):
+        self.moves = moves
 
     def move(self, x: _State) -> _State:
         for individual_move in self.moves:

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -84,7 +84,7 @@ class MetropolisHastingsMove(MonteCarloMove[_State], ABC):
 
 
 class CompoundMove(Move[_State]):
-    """Apply each of a list of moves in sequence"""
+    """Apply each of a list of MonteCarloMoves in sequence"""
 
     def __init__(self, moves: Sequence[MonteCarloMove[_State]]):
         self.moves = moves

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -71,15 +71,15 @@ class MonteCarloMove(Move[_State], ABC):
 
 class MetropolisHastingsMove(MonteCarloMove[_State], ABC):
     @abstractmethod
-    def propose_with_dlogq(self, x: _State) -> Tuple[_State, float]:
+    def propose_with_log_q_diff(self, x: _State) -> Tuple[_State, float]:
         """Return proposed state and the difference in log unnormalized probability, i.e.
 
-        dlogq = log(q(x_proposed)) - log(q(x))
+        log_q_diff = log(q(x_proposed)) - log(q(x))
         """
 
     def propose(self, x: _State) -> Tuple[_State, float]:
-        proposal, dlogq = self.propose_with_dlogq(x)
-        log_acceptance_probability = np.minimum(dlogq, 0.0)
+        proposal, log_q_diff = self.propose_with_log_q_diff(x)
+        log_acceptance_probability = np.minimum(log_q_diff, 0.0)
         return proposal, log_acceptance_probability
 
 

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -41,10 +41,7 @@ class MonteCarloMove(Generic[_State]):
 
     @property
     def acceptance_fraction(self):
-        if self.n_proposed > 0:
-            return self.n_accepted / self.n_proposed
-        else:
-            return 0.0
+        return self.n_accepted / self.n_proposed if self.n_proposed else np.nan
 
 
 class CompoundMove(MonteCarloMove[_State]):

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -60,6 +60,17 @@ class MonteCarloMove(Move[_State], ABC):
         return self._n_accepted / self._n_proposed if self._n_proposed else np.nan
 
 
+class MetropolisHastingsMove(MonteCarloMove[_State], ABC):
+    @abstractmethod
+    def propose_with_dlogp(self, x: _State) -> Tuple[_State, float]:
+        "return proposed state and its unnormalized log probability"
+
+    def propose(self, x: _State) -> Tuple[_State, float]:
+        proposal, dlogp = self.propose_with_dlogp(x)
+        log_acceptance_probability = np.minimum(dlogp, 0.0)
+        return proposal, log_acceptance_probability
+
+
 @dataclass
 class CompoundMove(Move[_State]):
     """Apply each of a list of moves in sequence"""

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -20,8 +20,9 @@ _State = TypeVar("_State")
 
 
 class MonteCarloMove(Generic[_State]):
-    n_proposed: int = 0
-    n_accepted: int = 0
+    def __init__(self):
+        self.n_proposed = 0
+        self.n_accepted = 0
 
     def propose(self, x: _State) -> Tuple[_State, float]:
         """return proposed state and log acceptance probability"""

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -95,11 +95,11 @@ class CompoundMove(Move[_State]):
         return x
 
     @property
-    def n_accepted_by_move(self) -> List[float]:
+    def n_accepted_by_move(self) -> List[int]:
         return [m._n_accepted for m in self.moves]
 
     @property
-    def n_proposed_by_move(self) -> List[float]:
+    def n_proposed_by_move(self) -> List[int]:
         return [m._n_proposed for m in self.moves]
 
 

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -26,11 +26,13 @@ class Move(Generic[_State], ABC):
         ...
 
     def sample_chain_iter(self, x: _State) -> Iterator[_State]:
+        """Given an initial state, returns an iterator over an infinite sequence of samples"""
         while True:
             x = self.move(x)
             yield x
 
     def sample_chain(self, x: _State, n_samples: int) -> List[_State]:
+        """Given an initial state and number of samples, returns a finite sequence of samples"""
         return list(islice(self.sample_chain_iter(x), n_samples))
 
 

--- a/timemachine/md/thermostat/moves.py
+++ b/timemachine/md/thermostat/moves.py
@@ -1,9 +1,9 @@
 from timemachine.lib import custom_ops
-from timemachine.md.moves import MonteCarloMove
+from timemachine.md.moves import Move
 from timemachine.md.states import CoordsVelBox
 
 
-class UnadjustedLangevinMove(MonteCarloMove):
+class UnadjustedLangevinMove(Move):
     def __init__(self, integrator_impl, bound_impls, n_steps=5):
         self.integrator_impl = integrator_impl
         self.bound_impls = bound_impls
@@ -25,8 +25,5 @@ class UnadjustedLangevinMove(MonteCarloMove):
         v_t = ctxt.get_v_t()
 
         after_nvt = CoordsVelBox(x_t, v_t, x.box.copy())
-
-        self.n_proposed += 1
-        self.n_accepted += 1
 
         return after_nvt


### PR DESCRIPTION
Collection of miscellaneous improvements spun out of #1128. Highlights:

* Adds `MetropolisHastingsMove`, which extends `MonteCarloMove` to compute acceptance probabilities using the Metropolis convention
* Adds a base class `Move` to work around inconsistency between definition of `n_proposed`, `n_accepted` in `MonteCarloMove` vs. `CompoundMove`, and to clarify whether subclasses implement `propose` or `move`

Note: commits are mostly orthogonal changes