### PR TITLE
Fix spurious truncation of HREX swap stats

### DIFF
--- a/tests/hrex/test_hrex_rbfe.py
+++ b/tests/hrex/test_hrex_rbfe.py
@@ -49,6 +49,7 @@ def hif2a_single_topology_leg(request):
 def test_hrex_rbfe_hif2a(hif2a_single_topology_leg):
     mol_a, mol_b, core, forcefield, host_config = hif2a_single_topology_leg
     md_params = MDParams(n_frames=200, n_eq_steps=10_000, steps_per_frame=400, seed=2023)
+    n_windows = 5
 
     result = estimate_relative_free_energy_bisection_hrex(
         mol_a,
@@ -58,7 +59,7 @@ def test_hrex_rbfe_hif2a(hif2a_single_topology_leg):
         host_config,
         md_params,
         lambda_interval=(0.0, 0.15),
-        n_windows=5,
+        n_windows=n_windows,
         n_frames_bisection=100,
         n_frames_per_iter=5,
     )
@@ -67,6 +68,8 @@ def test_hrex_rbfe_hif2a(hif2a_single_topology_leg):
         plot_hrex_rbfe_hif2a(result)
 
     assert result.hrex_diagnostics
+
+    assert result.hrex_diagnostics.cumulative_swap_acceptance_rates.shape[1] == n_windows - 1
 
     # Swap acceptance rates for all neighboring pairs should be >~ 20%
     final_swap_acceptance_rates = result.hrex_diagnostics.cumulative_swap_acceptance_rates[-1]

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -857,7 +857,9 @@ def run_sims_hrex(
         hrex, samples_by_state = hrex.sample_replicas(sample_replica, replica_from_samples)
         log_q = get_log_q_fn(hrex.replicas)
         hrex, fraction_accepted_by_pair = hrex.attempt_neighbor_swaps(neighbor_pairs, log_q, n_swap_attempts_per_iter)
-        fraction_accepted_by_pair = fraction_accepted_by_pair[1:]  # remove stats for (0, 0) pair
+
+        if len(initial_states) == 2:
+            fraction_accepted_by_pair = fraction_accepted_by_pair[1:]  # remove stats for identity move
 
         samples_by_state_by_iter.append(samples_by_state)
         replica_idx_by_state_by_iter.append(hrex.replica_idx_by_state)


### PR DESCRIPTION
When there is just a pair of states (K = 2), we add an identity move to the mixture of neighbor swap moves in HREX to prevent periodicity when the swap acceptance probability is close to 1.

Originally, the identity move was added regardless of the value of K, but we changed the logic in #1128 to only add it when K = 2, because the mechanism for periodicity that it's intended to work around can't occur for K > 2. But we neglected to wrap the corresponding truncation to remove the acceptance stats for the identity move in the same conditional, resulting in truncating acceptance stats for the first neighbor swap move when K > 2.

This PR fixes the issue and adds a test.