### PR TITLE
Fix nightly test

### DIFF
--- a/tests/hrex/test_hrex_rbfe.py
+++ b/tests/hrex/test_hrex_rbfe.py
@@ -48,7 +48,7 @@ def hif2a_single_topology_leg(request):
 @pytest.mark.nightly(reason="Slow")
 def test_hrex_rbfe_hif2a(hif2a_single_topology_leg):
     mol_a, mol_b, core, forcefield, host_config = hif2a_single_topology_leg
-    md_params = MDParams(n_frames=200, n_eq_steps=10_000, steps_per_frame=400, seed=2023)
+    md_params = MDParams(n_frames=200, n_eq_steps=10_000, steps_per_frame=400, seed=2024)
     n_windows = 5
 
     result = estimate_relative_free_energy_bisection_hrex(


### PR DESCRIPTION
Changes the seed for a stochastic nightly test. Does not change the acceptance threshold, as it passes ~80% of seeds tried (so it seems we were just unlucky). This was missed in local development because I'm using `numpy==1.25.1`, which apparently does not produce identical pseudorandom number streams as the pinned version (`1.23.5`) for a given seed.

- [x] Verify nightly tests pass in CI