### PR TITLE
Preserve velocities in HREX permutation moves

### DIFF
--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -229,7 +229,7 @@ def test_sample_max_buffer_frames_with_local_md(
     n_eq_steps = 1
 
     md_params = MDParams(n_frames, n_eq_steps, steps_per_frame, 2023, local_steps=local_steps)
-    frames, _ = sample(
+    frames, _, _ = sample(
         solvent_hif2a_ligand_pair_single_topology_lam0_state, md_params, max_buffer_frames=max_buffer_frames
     )
     assert isinstance(frames, StoredArrays)
@@ -267,8 +267,8 @@ def hif2a_ligand_pair_single_topology_lam0_state():
 @example(1, 10)
 def test_sample_max_buffer_frames(hif2a_ligand_pair_single_topology_lam0_state, n_frames, max_buffer_frames):
     md_params = MDParams(n_frames, 1, 1, 2023)
-    frames_ref, _ = sample(hif2a_ligand_pair_single_topology_lam0_state, md_params)
-    frames_test, _ = sample(
+    frames_ref, _, _ = sample(hif2a_ligand_pair_single_topology_lam0_state, md_params)
+    frames_test, _, _ = sample(
         hif2a_ligand_pair_single_topology_lam0_state, md_params, max_buffer_frames=max_buffer_frames
     )
 

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -357,7 +357,7 @@ def sample(
 
     boxes: NDArray with shape (n_frames, 3, 3)
 
-    final_velocities: NDArray with shape (N,)
+    final_velocities: NDArray with shape (N, 3)
 
     Notes
     -----

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -353,7 +353,9 @@ def sample(
 
     Returns
     -------
-    xs, boxes: NDArray with .shape[0] = md_params.n_frames
+    xs: NDArray with shape (n_frames, N, 3)
+
+    boxes: NDArray with shape (n_frames, 3, 3)
 
     final_velocities: NDArray with shape (N,)
 

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -385,6 +385,7 @@ def sample(
             n_steps=n_steps,
             store_x_interval=md_params.steps_per_frame,
         )
+        assert np.all(coords[-1] == ctxt.get_x_t())
         final_velocities = ctxt.get_v_t()
 
         return coords, boxes, final_velocities
@@ -412,6 +413,7 @@ def sample(
             coords.append(x_t)
             boxes.append(box_t)
 
+        assert np.all(coords[-1][-1] == ctxt.get_x_t())
         final_velocities = ctxt.get_v_t()
 
         return np.concatenate(coords), np.concatenate(boxes), final_velocities

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -808,12 +808,12 @@ def run_sims_hrex(
         log_q = -U / (BOLTZ * temperature)
         return log_q
 
-    def get_log_q_fn(xvb: List[CoordsVelBox]):
+    def get_log_q_fn(xvbs: List[CoordsVelBox]):
         def get_flattened_params(initial_state: InitialState) -> NDArray:
             return np.concatenate([bp.params.flatten() for bp in initial_state.potentials])
 
         params = [get_flattened_params(initial_state) for initial_state in initial_states]
-        log_q_kl = compute_log_q_matrix(xvb, params)
+        log_q_kl = compute_log_q_matrix(xvbs, params)
 
         def log_q_fn(replica_idx: ReplicaIdx, state_idx: StateIdx) -> float:
             return log_q_kl[replica_idx, state_idx]

--- a/timemachine/md/states.py
+++ b/timemachine/md/states.py
@@ -2,6 +2,4 @@
 
 from collections import namedtuple
 
-CoordsBox = namedtuple("CoordsBox", ["coords", "box"])
-
 CoordsVelBox = namedtuple("CoordsVelBox", ["coords", "velocities", "box"])


### PR DESCRIPTION
Currently velocities are lost after each MD propagation step in HREX, with the subsequent MD propagation step starting with zero velocity. This is effectively freezing the system every 5 ps with the current parameters.

This PR switches from using `CoordsBox` as the replica state type to `CoordsVelBox` to avoid dropping the velocities during HREX permutation moves.