### PR TITLE
Remove MetropolisHastingsMove

### DIFF
--- a/tests/test_md_moves.py
+++ b/tests/test_md_moves.py
@@ -4,19 +4,20 @@ import numpy as np
 import pytest
 from scipy.stats import ks_2samp
 
-from timemachine.md.moves import MetropolisHastingsMove
+from timemachine.md.moves import MonteCarloMove
 
 
-class RWMH1D(MetropolisHastingsMove[float]):
+class RWMH1D(MonteCarloMove[float]):
     def __init__(self, log_q: Callable[[float], float], proposal_radius: float):
         super().__init__()
         self.log_q = log_q
         self.proposal_radius = proposal_radius
 
-    def propose_with_log_q_diff(self, x: float) -> Tuple[float, float]:
+    def propose(self, x: float) -> Tuple[float, float]:
         x_prop = np.random.normal(x, self.proposal_radius)
         log_q_diff = self.log_q(x_prop) - self.log_q(x)
-        return x_prop, log_q_diff
+        log_acceptance_probability = np.minimum(log_q_diff, 0.0)
+        return x_prop, log_acceptance_probability
 
 
 @pytest.mark.parametrize("seed", [2023, 2024, 2025])

--- a/timemachine/md/exchange/exchange_mover.py
+++ b/timemachine/md/exchange/exchange_mover.py
@@ -39,7 +39,7 @@ def randomly_translate(coords, new_loc):
     return centered_coords + new_loc
 
 
-class BDExchangeMove(moves.MetropolisHastingsMove):
+class BDExchangeMove(moves.MonteCarloMove):
     """
     Untargetted, biased deletion move where we selectively prefer certain waters over others.
     """
@@ -157,7 +157,7 @@ class BDExchangeMove(moves.MetropolisHastingsMove):
         self.batch_log_weights_incremental = batch_log_weights_incremental
         self.batch_log_weights = batch_log_weights
 
-    def propose_with_log_q_diff(self, x: CoordsVelBox) -> Tuple[CoordsVelBox, float]:
+    def propose(self, x: CoordsVelBox) -> Tuple[CoordsVelBox, float]:
         coords = x.coords
         box = x.box
         log_weights_before = self.batch_log_weights(coords, box)
@@ -184,10 +184,10 @@ class BDExchangeMove(moves.MetropolisHastingsMove):
         # trial_coords[chosen_water_atoms] = moved_coords
         # log_weights_after = self.batch_log_weights(trial_coords, box)
 
-        log_q_diff = logsumexp(log_weights_before) - logsumexp(log_weights_after)
+        log_acceptance_probability = np.minimum(logsumexp(log_weights_before) - logsumexp(log_weights_after), 0.0)
         new_state = CoordsVelBox(trial_coords, x.velocities, x.box)
 
-        return new_state, log_q_diff
+        return new_state, log_acceptance_probability
 
 
 # numpy version of delta_r

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -4,7 +4,7 @@ from typing import Callable, Generic, List, NewType, Optional, Sequence, Tuple, 
 import numpy as np
 from numpy.typing import NDArray
 
-from timemachine.md.moves import MetropolisHastingsMove, MixtureOfMoves
+from timemachine.md.moves import MixtureOfMoves, MonteCarloMove
 from timemachine.utils import batches
 
 Replica = TypeVar("Replica")
@@ -13,14 +13,14 @@ StateIdx = NewType("StateIdx", int)
 ReplicaIdx = NewType("ReplicaIdx", int)
 
 
-class NeighborSwapMove(MetropolisHastingsMove[List[Replica]]):
+class NeighborSwapMove(MonteCarloMove[List[Replica]]):
     def __init__(self, log_q: Callable[[Replica, StateIdx], float], s_a: StateIdx, s_b: StateIdx):
         super().__init__()
         self.log_q = log_q
         self.s_a = s_a
         self.s_b = s_b
 
-    def propose_with_log_q_diff(self, state: List[Replica]) -> Tuple[List[Replica], float]:
+    def propose(self, state: List[Replica]) -> Tuple[List[Replica], float]:
         s_a = self.s_a
         s_b = self.s_b
         state_ = list(state)
@@ -31,7 +31,9 @@ class NeighborSwapMove(MetropolisHastingsMove[List[Replica]]):
         r_b = state[s_b]
         log_q_diff = self.log_q(r_a, s_b) + self.log_q(r_b, s_a) - self.log_q(r_a, s_a) - self.log_q(r_b, s_b)
 
-        return proposed_state, log_q_diff
+        log_acceptance_probability = np.minimum(log_q_diff, 0.0)
+
+        return proposed_state, log_acceptance_probability
 
 
 Samples = TypeVar("Samples")

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -69,20 +69,6 @@ class MonteCarloMove(Move[_State], ABC):
         return self._n_accepted / self._n_proposed if self._n_proposed else np.nan
 
 
-class MetropolisHastingsMove(MonteCarloMove[_State], ABC):
-    @abstractmethod
-    def propose_with_log_q_diff(self, x: _State) -> Tuple[_State, float]:
-        """Return proposed state and the difference in log unnormalized probability, i.e.
-
-        log_q_diff = log(q(x_proposed)) - log(q(x))
-        """
-
-    def propose(self, x: _State) -> Tuple[_State, float]:
-        proposal, log_q_diff = self.propose_with_log_q_diff(x)
-        log_acceptance_probability = np.minimum(log_q_diff, 0.0)
-        return proposal, log_acceptance_probability
-
-
 class CompoundMove(Move[_State]):
     def __init__(self, moves: Sequence[MonteCarloMove[_State]]):
         self.moves = moves


### PR DESCRIPTION
This is a flawed abstraction since it assumes a symmetric proposal distribution. It seems simpler to just remove this than rename to `SymmetricMetropolisHastingsMove` or attempt to generalize the naming to apply to asymmetric cases.