### PR TITLE
Preserve MD context in HREX simulations

### DIFF
--- a/tests/hrex/test_hrex_rbfe.py
+++ b/tests/hrex/test_hrex_rbfe.py
@@ -61,7 +61,7 @@ def test_hrex_rbfe_hif2a(hif2a_single_topology_leg):
         lambda_interval=(0.0, 0.15),
         n_windows=n_windows,
         n_frames_bisection=100,
-        n_frames_per_iter=5,
+        n_frames_per_iter=1,
     )
 
     if DEBUG:

--- a/tests/test_benchmark_free_energy.py
+++ b/tests/test_benchmark_free_energy.py
@@ -77,7 +77,7 @@ def test_benchmark_hif2a_single_topology(hif2a_single_topology_leg, enable_hrex)
             run_sims_hrex,
             initial_states,
             md_params,
-            n_frames_per_iter=5,
+            n_frames_per_iter=1,
             temperature=temperature,
             print_diagnostics_interval=None,
         )

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -597,7 +597,7 @@ def estimate_relative_free_energy_bisection_hrex(
     keep_idxs: Optional[List[int]] = None,
     min_cutoff: Optional[float] = 0.7,
     n_frames_bisection: int = 100,
-    n_frames_per_iter: int = 5,
+    n_frames_per_iter: int = 1,
 ) -> SimulationResult:
     """
     Estimate relative free energy between mol_a and mol_b using Hamiltonian Replica EXchange (HREX) sampling of a


### PR DESCRIPTION
Currently, we reinitialize the MD context for each state after each iteration of HREX. Thus, with the current defaults, we reinitialize the GPU potentials and context from scratch after every 5 ps of MD when running with HREX. This is already a significant overhead, but becomes extreme (~2x) when the amount of MD between HREX moves is reduced to 1 ps.

This PR eliminates a major source of overhead by preserving `Context` objects for each state across HREX iterations. Note that this does increase GPU memory usage by a factor of the number of windows, but this should still be well within reasonable bounds.

Further improvement might be achieved by avoiding copies to GPU memory when updating the context state to account for the current replica permutation. This should only require updating pointers to GPU memory, with no copying necessary.

Benchmarks (`test_benchmark_hif2a_single_topology`, solvent phase, 20 windows):

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-right" />

<col  class="org-right" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">&#xa0;</th>
<th scope="col" class="org-right">ns/day (before)</th>
<th scope="col" class="org-right">ns/day (after)</th>
<th scope="col" class="org-left">notes</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">no HREX</td>
<td class="org-right">370.2</td>
<td class="org-right">370.3</td>
<td class="org-left">(no difference expected)</td>
</tr>


<tr>
<td class="org-left">HREX, 5ps/move</td>
<td class="org-right">299.2</td>
<td class="org-right">361.7</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">HREX, 1ps/move</td>
<td class="org-right">168.5</td>
<td class="org-right">307.8</td>
<td class="org-left">&#xa0;</td>
</tr>
</tbody>
</table>
