### PR TITLE
Make setup_local_md idempotent

### DIFF
--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -632,7 +632,7 @@ def test_local_md_initialization(freeze_reference):
     ctxt = custom_ops.Context(coords, v0, box, intg.impl(), bps)
     ctxt.setup_local_md(constants.DEFAULT_TEMP, freeze_reference)
 
-    # setup_local_md is idempotent, and will warn if already setup already performed
+    # setup_local_md is idempotent if called with the same parameters
     ctxt.setup_local_md(constants.DEFAULT_TEMP, freeze_reference)
 
     # If the parameters change, will raise an exception

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -632,9 +632,14 @@ def test_local_md_initialization(freeze_reference):
     ctxt = custom_ops.Context(coords, v0, box, intg.impl(), bps)
     ctxt.setup_local_md(constants.DEFAULT_TEMP, freeze_reference)
 
-    # Can only configure local md once
-    with pytest.raises(RuntimeError, match="already configured"):
-        ctxt.setup_local_md(constants.DEFAULT_TEMP, freeze_reference)
+    # setup_local_md is idempotent, and will warn if already setup already performed
+    ctxt.setup_local_md(constants.DEFAULT_TEMP, freeze_reference)
+
+    # If the parameters change, will raise an exception
+    with pytest.raises(RuntimeError, match="local md configured with different parameters"):
+        ctxt.setup_local_md(constants.DEFAULT_TEMP + 1, freeze_reference)
+    with pytest.raises(RuntimeError, match="local md configured with different parameters"):
+        ctxt.setup_local_md(constants.DEFAULT_TEMP, not freeze_reference)
 
     ref_xs, ref_boxes = ctxt.multiple_steps(steps)
 

--- a/timemachine/cpp/src/context.cu
+++ b/timemachine/cpp/src/context.cu
@@ -71,7 +71,15 @@ double Context::_get_temperature() {
 
 void Context::setup_local_md(double temperature, bool freeze_reference) {
     if (this->local_md_pots_ != nullptr) {
-        throw std::runtime_error("local md already configured");
+        if (this->local_md_pots_->temperature != temperature ||
+            this->local_md_pots_->freeze_reference != freeze_reference) {
+            throw std::runtime_error(
+                "local md configured with different parameters, current parameters: Temperature " +
+                std::to_string(this->local_md_pots_->temperature) + " Freeze Reference " +
+                std::to_string(this->local_md_pots_->freeze_reference));
+        }
+        fprintf(stderr, "Context::setup_local_md: already setup local MD, skipping\n");
+        return;
     }
     this->local_md_pots_.reset(new LocalMDPotentials(N_, bps_, freeze_reference, temperature));
 }

--- a/timemachine/cpp/src/context.cu
+++ b/timemachine/cpp/src/context.cu
@@ -78,7 +78,6 @@ void Context::setup_local_md(double temperature, bool freeze_reference) {
                 std::to_string(this->local_md_pots_->temperature) + " Freeze Reference " +
                 std::to_string(this->local_md_pots_->freeze_reference));
         }
-        fprintf(stderr, "Context::setup_local_md: already setup local MD, skipping\n");
         return;
     }
     this->local_md_pots_.reset(new LocalMDPotentials(N_, bps_, freeze_reference, temperature));

--- a/timemachine/cpp/src/local_md_potentials.hpp
+++ b/timemachine/cpp/src/local_md_potentials.hpp
@@ -45,10 +45,11 @@ public:
 
     void reset_potentials(cudaStream_t stream);
 
+    const bool freeze_reference;
+    const double temperature;
+
 private:
     const int N_;
-    const bool freeze_reference_;
-    const double temperature_;
     std::size_t temp_storage_bytes_;
     int num_allpairs_idxs_;
 


### PR DESCRIPTION
* Would allow us to more generally share context's without having to know the prior state.
* Raise exception if setup has different parameters than previously setup
* Came up as part of HREX optimization (https://github.com/proteneer/timemachine/pull/1146#discussion_r1329427525)