### PR TITLE
Fixes for equilibration with HREX

### DIFF
--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -44,7 +44,7 @@ def assert_shapes_consistent(U, coords, sys_params, box):
     # can call grad(U) and get right shape
     du_dx, du_dp = grad(U, argnums=(0, 1))(coords, sys_params, box)
     assert du_dx.shape == coords.shape
-    for (p, p_prime) in zip(sys_params, du_dp):
+    for p, p_prime in zip(sys_params, du_dp):
         assert p.shape == p_prime.shape
 
 
@@ -326,7 +326,7 @@ def test_run_sims_bisection_early_stopping():
     )
 
     # runs all n_bisections iterations by default
-    results, _, _ = run_sims_bisection_early_stopping()
+    results = run_sims_bisection_early_stopping()[0]
     assert len(results) == 1 + n_bisections  # initial result + bisection iterations
 
     def result_with_overlap(overlap):
@@ -336,24 +336,24 @@ def test_run_sims_bisection_early_stopping():
         # overlap does not improve; should run all n_bisections iterations
         mock_estimate_free_energy_bar.return_value = result_with_overlap(0.0)
         with pytest.warns(MinOverlapWarning):
-            results, _, _ = run_sims_bisection_early_stopping(min_overlap=0.4)
+            results = run_sims_bisection_early_stopping(min_overlap=0.4)[0]
         assert len(results) == 1 + n_bisections
 
         # min_overlap satisfied by initial states
         mock_estimate_free_energy_bar.return_value = result_with_overlap(0.5)
-        results, _, _ = run_sims_bisection_early_stopping(min_overlap=0.4)
+        results = run_sims_bisection_early_stopping(min_overlap=0.4)[0]
         assert len(results) == 1
 
         # min_overlap achieved after 1 iteration
         mock_estimate_free_energy_bar.side_effect = [result_with_overlap(overlap) for overlap in [0.0, 0.5, 0.5]]
-        results, _, _ = run_sims_bisection_early_stopping(min_overlap=0.4)
+        results = run_sims_bisection_early_stopping(min_overlap=0.4)[0]
         assert len(results) == 1 + 1
 
         # min_overlap achieved after 2 iterations
         mock_estimate_free_energy_bar.side_effect = [
             result_with_overlap(overlap) for overlap in [0.0, 0.5, 0.3, 0.5, 0.6]
         ]
-        results, _, _ = run_sims_bisection_early_stopping(min_overlap=0.4)
+        results = run_sims_bisection_early_stopping(min_overlap=0.4)[0]
         assert len(results) == 1 + 2
 
 

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -794,8 +794,6 @@ def run_sims_hrex(
     warn(f"Setting numpy global random state using seed {md_params.seed}")
     np.random.seed(md_params.seed)
 
-    initial_replicas = [CoordsVelBox(s.x0, s.v0, s.box0) for s in initial_states]
-
     bps = initial_states[0].potentials  # TODO: assert initial states have compatible potentials?
     sp = SummedPotential([bp.potential for bp in bps], [bp.params for bp in bps])
     ubp = sp.to_gpu(np.float32)
@@ -826,8 +824,6 @@ def run_sims_hrex(
         # Add an identity move to the mixture to ensure aperiodicity
         neighbor_pairs = [(StateIdx(0), StateIdx(0))] + neighbor_pairs
 
-    hrex = HREX.from_replicas(initial_replicas)
-
     def get_equilibrated_initial_state(initial_state: InitialState) -> InitialState:
         if md_params.n_eq_steps == 0:
             return initial_state
@@ -843,6 +839,9 @@ def run_sims_hrex(
         return equilibrated_initial_state
 
     initial_states = [get_equilibrated_initial_state(initial_state) for initial_state in initial_states]
+
+    initial_replicas = [CoordsVelBox(s.x0, s.v0, s.box0) for s in initial_states]
+    hrex = HREX.from_replicas(initial_replicas)
 
     samples_by_state_by_iter: List[List[Tuple[StoredArrays, NDArray]]] = []
     replica_idx_by_state_by_iter: List[List[ReplicaIdx]] = []

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -735,8 +735,8 @@ def run_sims_bisection(
                 MinOverlapWarning,
             )
 
-    frames = [get_state(lamb).frames for lamb in lambdas]
-    boxes = [get_state(lamb).boxes for lamb in lambdas]
+    frames = [get_samples(lamb)[0] for lamb in lambdas]
+    boxes = [get_samples(lamb)[1] for lamb in lambdas]
     final_velocities = [get_samples(lamb)[2] for lamb in lambdas]
 
     return results, frames, boxes, final_velocities

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -838,8 +838,9 @@ def run_sims_hrex(
         assert len(xs) == len(boxes) == 1
         x0 = xs[0]
         box0 = boxes[0]
+        v0 = ctxt.get_v_t()
 
-        equilibrated_initial_state = replace(initial_state, x0=x0, box0=box0)
+        equilibrated_initial_state = replace(initial_state, x0=x0, v0=v0, box0=box0)
         return equilibrated_initial_state
 
     initial_states = [get_equilibrated_initial_state(initial_state) for initial_state in initial_states]

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -794,7 +794,6 @@ def run_sims_hrex(
     warn(f"Setting numpy global random state using seed {md_params.seed}")
     np.random.seed(md_params.seed)
 
-    lambdas = [s.lamb for s in initial_states]
     initial_replicas = [CoordsVelBox(s.x0, s.v0, s.box0) for s in initial_states]
 
     bps = initial_states[0].potentials  # TODO: assert initial states have compatible potentials?
@@ -903,8 +902,8 @@ def run_sims_hrex(
             print()
 
     # Concatenate frames and boxes from all iterations
-    frames_by_state: List[StoredArrays] = [StoredArrays() for _ in lambdas]
-    boxes_by_state_: List[List[NDArray]] = [[] for _ in lambdas]
+    frames_by_state: List[StoredArrays] = [StoredArrays() for _ in initial_states]
+    boxes_by_state_: List[List[NDArray]] = [[] for _ in initial_states]
     for samples_by_state in samples_by_state_by_iter:
         for samples, frames, boxes in zip(samples_by_state, frames_by_state, boxes_by_state_):
             frames_i, boxes_i = samples

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -837,8 +837,9 @@ def run_sims_hrex(
         xs, boxes = ctxt.multiple_steps(md_params.n_eq_steps, store_x_interval=0)
         assert len(xs) == len(boxes) == 1
         x0 = xs[0]
-        box0 = boxes[0]
+        assert np.all(x0 == ctxt.get_x_t())
         v0 = ctxt.get_v_t()
+        box0 = boxes[0]
 
         equilibrated_initial_state = replace(initial_state, x0=x0, v0=v0, box0=box0)
         return equilibrated_initial_state


### PR DESCRIPTION
- Fixes a bug where configurations equilibrated at the start of HREX were not used, so `md_params.n_eq_steps` was effectively zero in `run_sims_hrex` (https://github.com/proteneer/timemachine/commit/59957d7c91d6af36b443b9d043ad8a0dcfc5785d)
- Uses equilibrated samples from bisection to initialize states for HREX in `estimate_relative_free_energy_bisection_hrex` (https://github.com/proteneer/timemachine/commit/6fd6a287ecc69bbe8d0bfebdcec5b128f3be320e). This eliminates expensive and redundant equilibration.
- Fixes a bug where we discarded equilibrated velocities (https://github.com/proteneer/timemachine/pull/1148/commits/49a6053e0faf5693d10a9e813e00bd1050ff5eb1)