### PR TITLE
Switches noise in langevin integrator to float

### DIFF
--- a/timemachine/cpp/src/kernels/k_integrator.cuh
+++ b/timemachine/cpp/src/kernels/k_integrator.cuh
@@ -7,7 +7,7 @@ __global__ void k_update_forward_baoab(
     const unsigned int *__restrict__ idxs,        // N
     const RealType *__restrict__ cbs,             // N
     const RealType *__restrict__ ccs,             // N
-    const RealType *__restrict__ noise,           // N x 3
+    const float *__restrict__ noise,              // N x 3
     RealType *__restrict__ x_t,                   // N x 3
     RealType *__restrict__ v_t,                   // N x 3
     const unsigned long long *__restrict__ du_dx, // N x 3

--- a/timemachine/cpp/src/langevin_integrator.hpp
+++ b/timemachine/cpp/src/langevin_integrator.hpp
@@ -22,7 +22,7 @@ private:
 
     double *d_cbs_;
     double *d_ccs_;
-    double *d_noise_;
+    float *d_noise_;
     unsigned long long *d_du_dx_;
 
     curandGenerator_t cr_rng_;


### PR DESCRIPTION
* Goes from ~5% of the time down to <1% of the total time

# Benchmarks
Cuda Arch 8.6
A10

Between a 2-5% speed up.
```
# Double noise in LangevinIntegrator
dhfr-apo: N=23558 speed: 710.41ns/day dt: 2.5fs (ran 100000 steps in 30.41s)
dhfr-apo-barostat-interval-25: N=23558 speed: 639.87ns/day dt: 2.5fs (ran 100000 steps in 33.76s)
hif2a-apo: N=8805 speed: 1237.61ns/day dt: 2.5fs (ran 100000 steps in 17.46s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1050.70ns/day dt: 2.5fs (ran 100000 steps in 20.56s)
hif2a-rbfe-barostat-interval-15: N=8840 speed: 779.97ns/day dt: 2.5fs (ran 100000 steps in 27.70s)
hif2a-rbfe-local: N=8840 speed: 1384.30ns/day dt: 2.5fs (ran 100000 steps in 15.61s)
solvent-apo: N=6282 speed: 1502.48ns/day dt: 2.5fs (ran 100000 steps in 14.38s)
solvent-apo-barostat-interval-25: N=6282 speed: 1328.45ns/day dt: 2.5fs (ran 100000 steps in 16.26s)
solvent-rbfe-barostat-interval-15: N=6317 speed: 1031.83ns/day dt: 2.5fs (ran 100000 steps in 20.94s)
solvent-rbfe-local: N=6317 speed: 1468.23ns/day dt: 2.5fs (ran 100000 steps in 14.72s)

# Float noise in LangevinIntegrator
dhfr-apo: N=23558 speed: 741.43ns/day dt: 2.5fs (ran 100000 steps in 29.14s)
dhfr-apo-barostat-interval-25: N=23558 speed: 664.94ns/day dt: 2.5fs (ran 100000 steps in 32.49s)
hif2a-apo: N=8805 speed: 1278.21ns/day dt: 2.5fs (ran 100000 steps in 16.90s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1082.91ns/day dt: 2.5fs (ran 100000 steps in 19.95s)
hif2a-rbfe-barostat-interval-15: N=8840 speed: 793.95ns/day dt: 2.5fs (ran 100000 steps in 27.21s)
hif2a-rbfe-local: N=8840 speed: 1436.60ns/day dt: 2.5fs (ran 100000 steps in 15.04s)
solvent-apo: N=6282 speed: 1569.91ns/day dt: 2.5fs (ran 100000 steps in 13.76s)
solvent-apo-barostat-interval-25: N=6282 speed: 1366.51ns/day dt: 2.5fs (ran 100000 steps in 15.81s)
solvent-rbfe-barostat-interval-15: N=6317 speed: 1054.18ns/day dt: 2.5fs (ran 100000 steps in 20.49s)
solvent-rbfe-local: N=6317 speed: 1510.87ns/day dt: 2.5fs (ran 100000 steps in 14.30s)
```