### PR TITLE
Increase IxnGroup Neighborlist Padding

### DIFF
--- a/timemachine/potentials/potentials.py
+++ b/timemachine/potentials/potentials.py
@@ -160,7 +160,7 @@ class NonbondedInteractionGroup(Potential):
     cutoff: float
     col_atom_idxs: Optional[NDArray[np.int32]] = None
     disable_hilbert_sort: bool = False
-    nblist_padding: float = 0.1
+    nblist_padding: float = 0.2  # Greater padding than other NB potentials, performs better for RBFE
 
     def __call__(self, conf: Conf, params: Params, box: Optional[Box]) -> float | Array:
         num_atoms, _ = jnp.array(conf).shape


### PR DESCRIPTION
* Doubling Ixn group neighborlist padding increases performance by about 4% for RBFE
* May not be consistent for all uses of IxnGroup, helps primarily in RBFE where the row atoms are the ligands
* Also investigated changing the neighborlist padding of the AllPairs and 0.1 still seems ideal. 


# Plots of Solvent/Hif2a ns per day by padding
The following plots lack labels, but the x axis is the padding and the y axis is the ns per day
![hif2a_rbfe_15](https://github.com/proteneer/timemachine/assets/5840832/48b29e70-db88-4635-b0c6-7b6dedcf233f)
![solvent_rbfe_15](https://github.com/proteneer/timemachine/assets/5840832/de943f56-19bc-4f7e-bcd7-7a6affcd056c)

## Number of Neighborlist Rebuilds per Step
Taken looking at hif2a RBFE

We might be able to get a tiny bit more by going to 2.5, but on a percentage basis it didn't seem worth (~0.5%)

![rebuilds_per_step](https://github.com/proteneer/timemachine/assets/5840832/89e57969-afa5-40f6-8c18-f6c71725163c)

For comparison, AllPairs on Hif2a RBFE rebuilds the neighborlist on average every 4.6 steps with a std of 2.9.


# Benchmarks
Cuda Arch 8.6
Nvidia A10

Padding 0.1
```
dhfr-apo: N=23558 speed: 708.99ns/day dt: 2.5fs (ran 100000 steps in 30.47s)
dhfr-apo-barostat-interval-25: N=23558 speed: 637.04ns/day dt: 2.5fs (ran 100000 steps in 33.91s)
hif2a-apo: N=8805 speed: 1235.90ns/day dt: 2.5fs (ran 100000 steps in 17.48s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1050.07ns/day dt: 2.5fs (ran 100000 steps in 20.57s)
hif2a-rbfe-barostat-interval-15: N=8840 speed: 784.25ns/day dt: 2.5fs (ran 100000 steps in 27.55s)
hif2a-rbfe-local: N=8840 speed: 1376.63ns/day dt: 2.5fs (ran 100000 steps in 15.69s)
solvent-apo: N=6282 speed: 1510.94ns/day dt: 2.5fs (ran 100000 steps in 14.30s)
solvent-apo-barostat-interval-25: N=6282 speed: 1347.81ns/day dt: 2.5fs (ran 100000 steps in 16.03s)
solvent-rbfe-barostat-interval-15: N=6317 speed: 1027.39ns/day dt: 2.5fs (ran 100000 steps in 21.03s)
solvent-rbfe-local: N=6317 speed: 1470.29ns/day dt: 2.5fs (ran 100000 steps in 14.70s)
NonbondedInteractionGroup_f32: N=8840 Frames=1000 Params=5 speed: 1261.72 executions/seconds (ran 10000 potentials in 7.93s) du_dp=True, du_dx=True, u=True
NonbondedInteractionGroup_f64: N=8840 Frames=1000 Params=5 speed: 644.39 executions/seconds (ran 10000 potentials in 15.52s) du_dp=True, du_dx=True, u=True
HarmonicBond_f32: N=8840 Frames=1000 Params=5 speed: 1640.54 executions/seconds (ran 10000 potentials in 6.10s) du_dp=True, du_dx=True, u=True
HarmonicBond_f64: N=8840 Frames=1000 Params=5 speed: 1639.71 executions/seconds (ran 10000 potentials in 6.10s) du_dp=True, du_dx=True, u=True
HarmonicAngleStable_f32: N=8840 Frames=1000 Params=5 speed: 1588.09 executions/seconds (ran 10000 potentials in 6.30s) du_dp=True, du_dx=True, u=True
HarmonicAngleStable_f64: N=8840 Frames=1000 Params=5 speed: 1578.03 executions/seconds (ran 10000 potentials in 6.34s) du_dp=True, du_dx=True, u=True
PeriodicTorsion_f32: N=8840 Frames=1000 Params=5 speed: 1563.55 executions/seconds (ran 10000 potentials in 6.40s) du_dp=True, du_dx=True, u=True
PeriodicTorsion_f64: N=8840 Frames=1000 Params=5 speed: 1562.96 executions/seconds (ran 10000 potentials in 6.40s) du_dp=True, du_dx=True, u=True
NonbondedPairListPrecomputed_f32: N=8840 Frames=1000 Params=5 speed: 1737.28 executions/seconds (ran 10000 potentials in 5.76s) du_dp=True, du_dx=True, u=True
NonbondedPairListPrecomputed_f64: N=8840 Frames=1000 Params=5 speed: 1739.89 executions/seconds (ran 10000 potentials in 5.75s) du_dp=True, du_dx=True, u=True
Nonbonded_f32: N=8840 Frames=1000 Params=5 speed: 978.28 executions/seconds (ran 10000 potentials in 10.22s) du_dp=True, du_dx=True, u=True
Nonbonded_f64: N=8840 Frames=1000 Params=5 speed: 132.18 executions/seconds (ran 10000 potentials in 75.65s) du_dp=True, du_dx=True, u=True
SummedPotential(NonbondedInteractionGroup, NonbondedInteractionGroup)_f32: N=8840 Frames=1000 Params=5 speed: 981.17 executions/seconds (ran 10000 potentials in 10.19s) du_dp=True, du_dx=True, u=True
SummedPotential(NonbondedInteractionGroup, NonbondedInteractionGroup)_f64: N=8840 Frames=1000 Params=5 speed: 486.48 executions/seconds (ran 10000 potentials in 20.56s) du_dp=True, du_dx=True, u=True
```

Padding 0.2
~2-4% speed up for the RBFE simulations which contain a IxnGroup. 
```
dhfr-apo: N=23558 speed: 710.20ns/day dt: 2.5fs (ran 100000 steps in 30.42s)
dhfr-apo-barostat-interval-25: N=23558 speed: 638.87ns/day dt: 2.5fs (ran 100000 steps in 33.81s)
hif2a-apo: N=8805 speed: 1235.26ns/day dt: 2.5fs (ran 100000 steps in 17.49s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1048.07ns/day dt: 2.5fs (ran 100000 steps in 20.61s)
hif2a-rbfe-barostat-interval-15: N=8840 speed: 804.65ns/day dt: 2.5fs (ran 100000 steps in 26.85s)
hif2a-rbfe-local: N=8840 speed: 1440.23ns/day dt: 2.5fs (ran 100000 steps in 15.00s)
solvent-apo: N=6282 speed: 1513.62ns/day dt: 2.5fs (ran 100000 steps in 14.27s)
solvent-apo-barostat-interval-25: N=6282 speed: 1333.08ns/day dt: 2.5fs (ran 100000 steps in 16.21s)
solvent-rbfe-barostat-interval-15: N=6317 speed: 1062.26ns/day dt: 2.5fs (ran 100000 steps in 20.34s)
solvent-rbfe-local: N=6317 speed: 1502.78ns/day dt: 2.5fs (ran 100000 steps in 14.38s)
NonbondedInteractionGroup_f32: N=8840 Frames=1000 Params=5 speed: 1273.51 executions/seconds (ran 10000 potentials in 7.85s) du_dp=True, du_dx=True, u=True
NonbondedInteractionGroup_f64: N=8840 Frames=1000 Params=5 speed: 655.65 executions/seconds (ran 10000 potentials in 15.25s) du_dp=True, du_dx=True, u=True
HarmonicBond_f32: N=8840 Frames=1000 Params=5 speed: 1639.11 executions/seconds (ran 10000 potentials in 6.10s) du_dp=True, du_dx=True, u=True
HarmonicBond_f64: N=8840 Frames=1000 Params=5 speed: 1637.70 executions/seconds (ran 10000 potentials in 6.11s) du_dp=True, du_dx=True, u=True
HarmonicAngleStable_f32: N=8840 Frames=1000 Params=5 speed: 1589.35 executions/seconds (ran 10000 potentials in 6.29s) du_dp=True, du_dx=True, u=True
HarmonicAngleStable_f64: N=8840 Frames=1000 Params=5 speed: 1578.86 executions/seconds (ran 10000 potentials in 6.33s) du_dp=True, du_dx=True, u=True
PeriodicTorsion_f32: N=8840 Frames=1000 Params=5 speed: 1572.66 executions/seconds (ran 10000 potentials in 6.36s) du_dp=True, du_dx=True, u=True
PeriodicTorsion_f64: N=8840 Frames=1000 Params=5 speed: 1563.70 executions/seconds (ran 10000 potentials in 6.40s) du_dp=True, du_dx=True, u=True
NonbondedPairListPrecomputed_f32: N=8840 Frames=1000 Params=5 speed: 1760.06 executions/seconds (ran 10000 potentials in 5.68s) du_dp=True, du_dx=True, u=True
NonbondedPairListPrecomputed_f64: N=8840 Frames=1000 Params=5 speed: 1737.07 executions/seconds (ran 10000 potentials in 5.76s) du_dp=True, du_dx=True, u=True
Nonbonded_f32: N=8840 Frames=1000 Params=5 speed: 977.28 executions/seconds (ran 10000 potentials in 10.23s) du_dp=True, du_dx=True, u=True
Nonbonded_f64: N=8840 Frames=1000 Params=5 speed: 131.97 executions/seconds (ran 10000 potentials in 75.78s) du_dp=True, du_dx=True, u=True
SummedPotential(NonbondedInteractionGroup, NonbondedInteractionGroup)_f32: N=8840 Frames=1000 Params=5 speed: 996.78 executions/seconds (ran 10000 potentials in 10.03s) du_dp=True, du_dx=True, u=True
SummedPotential(NonbondedInteractionGroup, NonbondedInteractionGroup)_f64: N=8840 Frames=1000 Params=5 speed: 507.24 executions/seconds (ran 10000 potentials in 19.71s) du_dp=True, du_dx=True, u=True
```
