### PR TITLE
Avoid storing velocities for intermediate frames in HREX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,7 @@ setup(
             "pytest-cov",
             "hilbertcurve==1.0.5",
             "hypothesis[numpy]==6.54.6",
+            "psutil==5.9.5",
             "py3Dmol==2.0.3",
         ],
         "viz": ["py3Dmol"],

--- a/timemachine/fe/energy_decomposition.py
+++ b/timemachine/fe/energy_decomposition.py
@@ -3,12 +3,13 @@ from dataclasses import dataclass
 from typing import Callable, Generic, Iterable, List, Sequence, TypeVar
 
 import numpy as np
+from numpy.typing import NDArray
 
 from timemachine.constants import BOLTZ, DEFAULT_TEMP
 from timemachine.lib.custom_ops import BoundPotential
 
 Frames = TypeVar("Frames")
-Boxes = np.ndarray
+Boxes = List[NDArray]
 ReducedEnergies = np.ndarray
 Batch_u_fn = Callable[[Frames, Boxes], ReducedEnergies]
 

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -727,6 +727,8 @@ def estimate_relative_free_energy_bisection_hrex(
             min_overlap=min_overlap,
         )
 
+        assert all(traj.final_velocities is not None for traj in trajectories_by_state)
+
         initial_states = results[-1].initial_states
         has_barostat_by_state = [initial_state.barostat is not None for initial_state in initial_states]
         assert all(has_barostat_by_state) or not any(has_barostat_by_state)


### PR DESCRIPTION
- Currently HREX unnecessarily uses O(n_iterations) memory to store velocities from intermediate frames, when only the final velocities are returned
- This PR fixes the accumulation of trajectories for each state to update velocities in place, avoiding memory usage for intermediate frames that will be discarded
- Changes the representation of `boxes` in `Trajectory` from `NDArray` to `List[NDArray]`. This allows for more efficient concatenation of intermediate trajectories and is more consistent with `frames`.
- Adds a probabilistic test asserting that memory usage is constant during HREX iterations