### PR TITLE
Switch C++ Parameters to Float

### DIFF
--- a/tests/test_energy_overflows.py
+++ b/tests/test_energy_overflows.py
@@ -243,7 +243,7 @@ def test_energy_overflow_cancelled_by_exclusions(precision, rtol, atol):
     assert fixed_overflowed(fixed_pair_list_energy)
 
     # The values are identical because of overflow, as its not clear how to go from
-    # C++ __int128 to python integer.
+    # C++ EnergyType to python integer.
     assert fixed_all_pairs_energy == fixed_pair_list_energy
 
 

--- a/timemachine/cpp/src/barostat.hpp
+++ b/timemachine/cpp/src/barostat.hpp
@@ -71,11 +71,11 @@ private:
     int *d_num_attempted_;
     int *d_num_accepted_;
 
-    __int128 *d_u_buffer_;
-    __int128 *d_u_after_buffer_;
+    EnergyType *d_u_buffer_;
+    EnergyType *d_u_after_buffer_;
 
-    __int128 *d_init_u_;
-    __int128 *d_final_u_;
+    EnergyType *d_init_u_;
+    EnergyType *d_final_u_;
 
     RealType *d_volume_;
     RealType *d_volume_delta_;

--- a/timemachine/cpp/src/bound_potential.cu
+++ b/timemachine/cpp/src/bound_potential.cu
@@ -14,7 +14,7 @@ void BoundPotential::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
     this->potential->execute_device(
         N, this->size, d_x, this->size > 0 ? this->d_p.data : nullptr, d_box, d_du_dx, d_du_dp, d_u, stream);
@@ -25,7 +25,7 @@ void BoundPotential::execute_host(
     const double *h_x,           // [N,3]
     const double *h_box,         // [3, 3]
     unsigned long long *h_du_dx, // [N, 3]
-    __int128 *h_u                // [1]
+    EnergyType *h_u              // [1]
 ) {
 
     const int D = 3;
@@ -37,7 +37,7 @@ void BoundPotential::execute_host(
     d_box.copy_from(h_box);
 
     DeviceBuffer<unsigned long long> d_du_dx(N * D);
-    DeviceBuffer<__int128> d_u(1);
+    DeviceBuffer<EnergyType> d_u(1);
 
     // very important that these are initialized to zero since the kernels themselves just accumulate
     gpuErrchk(cudaMemset(d_du_dx.data, 0, d_du_dx.size));

--- a/timemachine/cpp/src/bound_potential.cu
+++ b/timemachine/cpp/src/bound_potential.cu
@@ -3,7 +3,7 @@
 
 namespace timemachine {
 
-BoundPotential::BoundPotential(std::shared_ptr<Potential> potential, const std::vector<double> &params)
+BoundPotential::BoundPotential(std::shared_ptr<Potential> potential, const std::vector<ParamsType> &params)
     : size(params.size()), buffer_size_(size), d_p(buffer_size_), potential(potential) {
     set_params(params);
 }
@@ -55,7 +55,7 @@ void BoundPotential::execute_host(
     }
 };
 
-void BoundPotential::set_params(const std::vector<double> &params) {
+void BoundPotential::set_params(const std::vector<ParamsType> &params) {
     if (params.size() != buffer_size_) {
         throw std::runtime_error(
             "parameter size is not equal to device buffer size: " + std::to_string(params.size()) +
@@ -65,7 +65,7 @@ void BoundPotential::set_params(const std::vector<double> &params) {
     this->size = params.size();
 }
 
-void BoundPotential::set_params_device(const int new_size, const double *d_new_params, const cudaStream_t stream) {
+void BoundPotential::set_params_device(const int new_size, const ParamsType *d_new_params, const cudaStream_t stream) {
     if (static_cast<size_t>(new_size) > buffer_size_) {
         throw std::runtime_error(
             "parameter size is greater than device buffer size: " + std::to_string(new_size) + " > " +

--- a/timemachine/cpp/src/bound_potential.hpp
+++ b/timemachine/cpp/src/bound_potential.hpp
@@ -23,7 +23,8 @@ struct BoundPotential {
 
     void set_params_device(const int size, const ParamsType *d_p, const cudaStream_t stream);
 
-    void execute_host(const int N, const double *h_x, const double *h_box, unsigned long long *h_du_dx, __int128 *h_u);
+    void
+    execute_host(const int N, const double *h_x, const double *h_box, unsigned long long *h_du_dx, EnergyType *h_u);
 
     void execute_device(
         const int N,
@@ -31,7 +32,7 @@ struct BoundPotential {
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream);
 };
 

--- a/timemachine/cpp/src/bound_potential.hpp
+++ b/timemachine/cpp/src/bound_potential.hpp
@@ -5,22 +5,23 @@
 
 #include "device_buffer.hpp"
 #include "potential.hpp"
+#include "types.hpp"
 
 namespace timemachine {
 
 // a potential bounded to a set of parameters with some shape
 struct BoundPotential {
 
-    BoundPotential(std::shared_ptr<Potential> potential, const std::vector<double> &params);
+    BoundPotential(std::shared_ptr<Potential> potential, const std::vector<ParamsType> &params);
 
     int size;
     const size_t buffer_size_; // d_p.size / sizeof(*d_p.data) TODO: remove when DeviceBuffer::length or similar added
-    DeviceBuffer<double> d_p;
+    DeviceBuffer<ParamsType> d_p;
     std::shared_ptr<Potential> potential;
 
-    void set_params(const std::vector<double> &params);
+    void set_params(const std::vector<ParamsType> &params);
 
-    void set_params_device(const int size, const double *d_p, const cudaStream_t stream);
+    void set_params_device(const int size, const ParamsType *d_p, const cudaStream_t stream);
 
     void execute_host(const int N, const double *h_x, const double *h_box, unsigned long long *h_du_dx, __int128 *h_u);
 

--- a/timemachine/cpp/src/centroid_restraint.cu
+++ b/timemachine/cpp/src/centroid_restraint.cu
@@ -37,7 +37,8 @@ void CentroidRestraint<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/centroid_restraint.cu
+++ b/timemachine/cpp/src/centroid_restraint.cu
@@ -42,7 +42,7 @@ void CentroidRestraint<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (N_B_ + N_A_ > 0) {

--- a/timemachine/cpp/src/centroid_restraint.hpp
+++ b/timemachine/cpp/src/centroid_restraint.hpp
@@ -14,7 +14,7 @@ private:
     unsigned long long *d_centroid_a_;
     unsigned long long *d_centroid_b_;
 
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     int N_A_;
     int N_B_;
@@ -37,7 +37,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/centroid_restraint.hpp
+++ b/timemachine/cpp/src/centroid_restraint.hpp
@@ -32,7 +32,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/chiral_atom_restraint.cu
+++ b/timemachine/cpp/src/chiral_atom_restraint.cu
@@ -36,7 +36,7 @@ void ChiralAtomRestraint<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (P != R_) {

--- a/timemachine/cpp/src/chiral_atom_restraint.cu
+++ b/timemachine/cpp/src/chiral_atom_restraint.cu
@@ -31,7 +31,8 @@ void ChiralAtomRestraint<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/chiral_atom_restraint.hpp
+++ b/timemachine/cpp/src/chiral_atom_restraint.hpp
@@ -9,7 +9,7 @@ template <typename RealType> class ChiralAtomRestraint : public Potential {
 
 private:
     int *d_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     const int R_;
 
@@ -28,7 +28,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/chiral_atom_restraint.hpp
+++ b/timemachine/cpp/src/chiral_atom_restraint.hpp
@@ -23,7 +23,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/chiral_bond_restraint.cu
+++ b/timemachine/cpp/src/chiral_bond_restraint.cu
@@ -51,7 +51,7 @@ void ChiralBondRestraint<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (P != R_) {

--- a/timemachine/cpp/src/chiral_bond_restraint.cu
+++ b/timemachine/cpp/src/chiral_bond_restraint.cu
@@ -46,7 +46,8 @@ void ChiralBondRestraint<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/chiral_bond_restraint.hpp
+++ b/timemachine/cpp/src/chiral_bond_restraint.hpp
@@ -10,7 +10,7 @@ template <typename RealType> class ChiralBondRestraint : public Potential {
 private:
     int *d_idxs_;
     int *d_signs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     const int R_;
 
@@ -31,7 +31,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,
-        __int128 *d_u, // buffered
+        EnergyType *d_u, // buffered
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/chiral_bond_restraint.hpp
+++ b/timemachine/cpp/src/chiral_bond_restraint.hpp
@@ -26,7 +26,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -34,5 +34,5 @@ template class DeviceBuffer<int>;
 template class DeviceBuffer<char>;
 template class DeviceBuffer<unsigned int>;
 template class DeviceBuffer<unsigned long long>;
-template class DeviceBuffer<__int128>;
+template class DeviceBuffer<EnergyType>;
 } // namespace timemachine

--- a/timemachine/cpp/src/energy_accumulation.cu
+++ b/timemachine/cpp/src/energy_accumulation.cu
@@ -3,8 +3,8 @@
 
 void accumulate_energy(
     int N,
-    const __int128 *__restrict__ d_input_buffer, // [N]
-    __int128 *__restrict d_u_buffer,             // [1]
+    const EnergyType *__restrict__ d_input_buffer, // [N]
+    EnergyType *__restrict d_u_buffer,             // [1]
     cudaStream_t stream) {
     const static unsigned int THREADS_PER_BLOCK = 512;
     k_accumulate_energy<THREADS_PER_BLOCK><<<1, THREADS_PER_BLOCK, 0, stream>>>(N, d_input_buffer, d_u_buffer);

--- a/timemachine/cpp/src/energy_accumulation.hpp
+++ b/timemachine/cpp/src/energy_accumulation.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "types.hpp"
+
 void accumulate_energy(
     int N,
-    const __int128 *__restrict__ d_input_buffer, // [N]
-    __int128 *__restrict d_u_buffer,             // [1]
+    const EnergyType *__restrict__ d_input_buffer, // [N]
+    EnergyType *__restrict d_u_buffer,             // [1]
     cudaStream_t stream);

--- a/timemachine/cpp/src/fanout_summed_potential.cu
+++ b/timemachine/cpp/src/fanout_summed_potential.cu
@@ -21,7 +21,7 @@ void FanoutSummedPotential::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (d_u) {

--- a/timemachine/cpp/src/fanout_summed_potential.cu
+++ b/timemachine/cpp/src/fanout_summed_potential.cu
@@ -16,7 +16,8 @@ void FanoutSummedPotential::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/fanout_summed_potential.hpp
+++ b/timemachine/cpp/src/fanout_summed_potential.hpp
@@ -25,7 +25,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/fanout_summed_potential.hpp
+++ b/timemachine/cpp/src/fanout_summed_potential.hpp
@@ -13,7 +13,7 @@ class FanoutSummedPotential : public Potential {
 private:
     const std::vector<std::shared_ptr<Potential>> potentials_;
     const bool parallel_;
-    DeviceBuffer<__int128> d_u_buffer_;
+    DeviceBuffer<EnergyType> d_u_buffer_;
     StreamManager manager_;
 
 public:
@@ -30,7 +30,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 
     void du_dp_fixed_to_float(const int N, const int P, const unsigned long long *du_dp, double *du_dp_float) override;

--- a/timemachine/cpp/src/fixed_point.hpp
+++ b/timemachine/cpp/src/fixed_point.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "types.hpp"
+
 #define FIXED_EXPONENT 0x1000000000
 
 // we need to use a different level of precision for parameter derivatives
@@ -19,14 +21,14 @@ template <typename RealType> RealType __host__ __device__ __forceinline__ FIXED_
 
 // FIXED_ENERGY_TO_FLOAT should be paired with a `fixed_point_overflow` as if it is beyond the long long representation
 // the value returned will be meaningless
-template <typename RealType> RealType __host__ __device__ __forceinline__ FIXED_ENERGY_TO_FLOAT(__int128 v) {
+template <typename RealType> RealType __host__ __device__ __forceinline__ FIXED_ENERGY_TO_FLOAT(EnergyType v) {
     return static_cast<RealType>(static_cast<long long>(v)) / FIXED_EXPONENT;
 }
 
-// fixed_point_overflow detects if a __int128 fixed point representation is 'overflowed'
+// fixed_point_overflow detects if a EnergyType fixed point representation is 'overflowed'
 // which means is outside of the long long range of representation.
-bool __host__ __device__ __forceinline__ fixed_point_overflow(__int128 val) {
-    __int128 max = LLONG_MAX;
-    __int128 min = LLONG_MIN;
+bool __host__ __device__ __forceinline__ fixed_point_overflow(EnergyType val) {
+    EnergyType max = static_cast<EnergyType>(LLONG_MAX);
+    EnergyType min = static_cast<EnergyType>(LLONG_MIN);
     return val >= max || val <= min;
 }

--- a/timemachine/cpp/src/flat_bottom_bond.cu
+++ b/timemachine/cpp/src/flat_bottom_bond.cu
@@ -45,7 +45,8 @@ void FlatBottomBond<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/flat_bottom_bond.cu
+++ b/timemachine/cpp/src/flat_bottom_bond.cu
@@ -50,7 +50,7 @@ void FlatBottomBond<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     const int num_params_per_bond = 3;

--- a/timemachine/cpp/src/flat_bottom_bond.hpp
+++ b/timemachine/cpp/src/flat_bottom_bond.hpp
@@ -26,7 +26,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/flat_bottom_bond.hpp
+++ b/timemachine/cpp/src/flat_bottom_bond.hpp
@@ -9,7 +9,7 @@ template <typename RealType> class FlatBottomBond : public Potential {
 
 private:
     int *d_bond_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     int B_;
 
@@ -31,7 +31,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/gpu_utils.cuh
+++ b/timemachine/cpp/src/gpu_utils.cuh
@@ -102,7 +102,7 @@ double __device__ __forceinline__ radd_rn(double a, double b) { return __dadd_rn
 
 // If this were not int128s, we could do __shfl_down_sync, but only supports up to 64 values
 // For more details reference the PDF in the docstring for k_accumulate_energy
-__device__ __forceinline__ void energy_warp_reduce(volatile __int128 *shared_data, int thread_idx) {
+__device__ __forceinline__ void energy_warp_reduce(volatile EnergyType *shared_data, int thread_idx) {
     // Repeatedly sum up the two halfs of the shared data
 #pragma unroll 6
     for (int i = 32; i > 0; i /= 2) {
@@ -118,7 +118,7 @@ __device__ __forceinline__ void energy_warp_reduce(volatile __int128 *shared_dat
 // values repeatedly until the final warp level reduction which stores the final accumulated value in `shared_data[0]`.
 // For more details reference the PDF in the docstring for k_accumulate_energy
 template <unsigned int THREADS_PER_BLOCK>
-__device__ __forceinline__ void block_energy_reduce(volatile __int128 *shared_data, int tid) {
+__device__ __forceinline__ void block_energy_reduce(volatile EnergyType *shared_data, int tid) {
     static_assert(THREADS_PER_BLOCK <= 1024 && (THREADS_PER_BLOCK & (THREADS_PER_BLOCK - 1)) == 0);
 
     // For larger blocks larger than a warp
@@ -159,11 +159,11 @@ __device__ __forceinline__ void block_energy_reduce(volatile __int128 *shared_da
 template <unsigned int BLOCK_SIZE>
 void __global__ k_accumulate_energy(
     int N,
-    const __int128 *__restrict__ input_buffer, // [N]
-    __int128 *__restrict__ u_buffer            // [1]
+    const EnergyType *__restrict__ input_buffer, // [N]
+    EnergyType *__restrict__ u_buffer            // [1]
 ) {
 
-    __shared__ __int128 shared_mem[BLOCK_SIZE];
+    __shared__ EnergyType shared_mem[BLOCK_SIZE];
     unsigned int tid = threadIdx.x;
     if (tid >= BLOCK_SIZE) {
         return;

--- a/timemachine/cpp/src/harmonic_angle.cu
+++ b/timemachine/cpp/src/harmonic_angle.cu
@@ -47,7 +47,7 @@ void HarmonicAngle<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     const int tpb = DEFAULT_THREADS_PER_BLOCK;

--- a/timemachine/cpp/src/harmonic_angle.cu
+++ b/timemachine/cpp/src/harmonic_angle.cu
@@ -42,7 +42,8 @@ void HarmonicAngle<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/harmonic_angle.hpp
+++ b/timemachine/cpp/src/harmonic_angle.hpp
@@ -22,7 +22,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/harmonic_angle.hpp
+++ b/timemachine/cpp/src/harmonic_angle.hpp
@@ -9,7 +9,7 @@ template <typename RealType> class HarmonicAngle : public Potential {
 
 private:
     int *d_angle_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     const int A_;
 
@@ -27,7 +27,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/harmonic_angle_stable.cu
+++ b/timemachine/cpp/src/harmonic_angle_stable.cu
@@ -41,7 +41,8 @@ void HarmonicAngleStable<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/harmonic_angle_stable.cu
+++ b/timemachine/cpp/src/harmonic_angle_stable.cu
@@ -46,7 +46,7 @@ void HarmonicAngleStable<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     const int tpb = DEFAULT_THREADS_PER_BLOCK;

--- a/timemachine/cpp/src/harmonic_angle_stable.hpp
+++ b/timemachine/cpp/src/harmonic_angle_stable.hpp
@@ -22,7 +22,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/harmonic_angle_stable.hpp
+++ b/timemachine/cpp/src/harmonic_angle_stable.hpp
@@ -9,7 +9,7 @@ template <typename RealType> class HarmonicAngleStable : public Potential {
 
 private:
     int *d_angle_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     const int A_;
 
@@ -27,7 +27,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/harmonic_bond.cu
+++ b/timemachine/cpp/src/harmonic_bond.cu
@@ -38,7 +38,8 @@ void HarmonicBond<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/harmonic_bond.cu
+++ b/timemachine/cpp/src/harmonic_bond.cu
@@ -43,7 +43,7 @@ void HarmonicBond<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (P != 2 * B_) {

--- a/timemachine/cpp/src/harmonic_bond.hpp
+++ b/timemachine/cpp/src/harmonic_bond.hpp
@@ -9,7 +9,7 @@ template <typename RealType> class HarmonicBond : public Potential {
 
 private:
     int *d_bond_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     const int B_;
 
@@ -30,7 +30,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,
-        __int128 *d_u, // buffered
+        EnergyType *d_u, // buffered
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/harmonic_bond.hpp
+++ b/timemachine/cpp/src/harmonic_bond.hpp
@@ -25,7 +25,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/kernels/k_barostat.cuh
+++ b/timemachine/cpp/src/kernels/k_barostat.cuh
@@ -122,8 +122,8 @@ void __global__ k_decide_move(
     const RealType *__restrict__ rand, // [2] Use second value
     RealType *__restrict__ d_volume_delta,
     double *__restrict__ d_volume_scale,
-    const __int128 *__restrict__ d_init_u,
-    const __int128 *__restrict__ d_final_u,
+    const EnergyType *__restrict__ d_init_u,
+    const EnergyType *__restrict__ d_final_u,
     double *__restrict__ d_box,
     const double *__restrict__ d_box_output,
     double *__restrict__ d_x,

--- a/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
@@ -40,7 +40,7 @@ void __global__ k_centroid_restraint(
     const double kb,
     const double b0,
     unsigned long long *d_du_dx,
-    __int128 *d_u) {
+    EnergyType *d_u) {
 
     const int t_idx = blockDim.x * blockIdx.x + threadIdx.x;
     if (N_A + N_B <= t_idx) {

--- a/timemachine/cpp/src/kernels/k_chiral_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_chiral_restraint.cuh
@@ -11,7 +11,7 @@ void __global__ k_chiral_atom_restraint(
     const int *__restrict__ idxs,          // [R, 2]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     const auto r_idx = blockDim.x * blockIdx.x + threadIdx.x;
 
@@ -98,7 +98,7 @@ void __global__ k_chiral_bond_restraint(
     const int *__restrict__ signs,         // [R]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     const auto r_idx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/timemachine/cpp/src/kernels/k_chiral_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_chiral_restraint.cuh
@@ -1,4 +1,5 @@
 #include "../fixed_point.hpp"
+#include "../types.hpp"
 #include "chiral_utils.cuh"
 #include "k_fixed_point.cuh"
 
@@ -6,8 +7,8 @@ template <typename RealType>
 void __global__ k_chiral_atom_restraint(
     const int R, // number of restraints
     const double *__restrict__ coords,
-    const double *__restrict__ params, // [R]
-    const int *__restrict__ idxs,      // [R, 2]
+    const ParamsType *__restrict__ params, // [R]
+    const int *__restrict__ idxs,          // [R, 2]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
     __int128 *__restrict__ u) {
@@ -92,9 +93,9 @@ template <typename RealType>
 void __global__ k_chiral_bond_restraint(
     const int R, // number of restraints
     const double *__restrict__ coords,
-    const double *__restrict__ params, // [R]
-    const int *__restrict__ idxs,      // [R, 2]
-    const int *__restrict__ signs,     // [R]
+    const ParamsType *__restrict__ params, // [R]
+    const int *__restrict__ idxs,          // [R, 2]
+    const int *__restrict__ signs,         // [R]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
     __int128 *__restrict__ u) {

--- a/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
@@ -69,7 +69,7 @@ void __global__ k_flat_bottom_bond(
     const int *__restrict__ bond_idxs,     // [B, 2]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     // which bond
     const auto b_idx = blockDim.x * blockIdx.x + threadIdx.x;

--- a/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
@@ -1,4 +1,5 @@
 #include "../fixed_point.hpp"
+#include "../types.hpp"
 #include "k_fixed_point.cuh"
 
 // branchless implementation of piecewise function
@@ -64,8 +65,8 @@ void __global__ k_flat_bottom_bond(
     const int B, // number of bonds
     const double *__restrict__ coords,
     const double *__restrict__ box,
-    const double *__restrict__ params, // [B, 3]
-    const int *__restrict__ bond_idxs, // [B, 2]
+    const ParamsType *__restrict__ params, // [B, 3]
+    const int *__restrict__ bond_idxs,     // [B, 2]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
     __int128 *__restrict__ u) {

--- a/timemachine/cpp/src/kernels/k_harmonic_angle.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_angle.cuh
@@ -10,7 +10,7 @@ void __global__ k_harmonic_angle(
     const int *__restrict__ angle_idxs,    // [A, 3]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     const auto a_idx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/timemachine/cpp/src/kernels/k_harmonic_angle.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_angle.cuh
@@ -1,12 +1,13 @@
 #include "../fixed_point.hpp"
+#include "../types.hpp"
 #include "k_fixed_point.cuh"
 
 template <typename RealType, int D>
 void __global__ k_harmonic_angle(
-    const int A,                        // number of bonds
-    const double *__restrict__ coords,  // [N, 3]
-    const double *__restrict__ params,  // [P, 2]
-    const int *__restrict__ angle_idxs, // [A, 3]
+    const int A,                           // number of bonds
+    const double *__restrict__ coords,     // [N, 3]
+    const ParamsType *__restrict__ params, // [P, 2]
+    const int *__restrict__ angle_idxs,    // [A, 3]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
     __int128 *__restrict__ u) {

--- a/timemachine/cpp/src/kernels/k_harmonic_angle_stable.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_angle_stable.cuh
@@ -11,7 +11,7 @@ void __global__ k_harmonic_angle_stable(
     const int *__restrict__ angle_idxs,    // [A, 3]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     const auto a_idx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/timemachine/cpp/src/kernels/k_harmonic_angle_stable.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_angle_stable.cuh
@@ -1,13 +1,14 @@
 #include "../fixed_point.hpp"
 #include "../gpu_utils.cuh"
+#include "../types.hpp"
 #include "k_fixed_point.cuh"
 
 template <typename RealType>
 void __global__ k_harmonic_angle_stable(
-    const int A,                        // number of angles
-    const double *__restrict__ coords,  // [N, 3]
-    const double *__restrict__ params,  // [P, 3]
-    const int *__restrict__ angle_idxs, // [A, 3]
+    const int A,                           // number of angles
+    const double *__restrict__ coords,     // [N, 3]
+    const ParamsType *__restrict__ params, // [P, 3]
+    const int *__restrict__ angle_idxs,    // [A, 3]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
     __int128 *__restrict__ u) {

--- a/timemachine/cpp/src/kernels/k_harmonic_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_bond.cuh
@@ -10,7 +10,7 @@ void __global__ k_harmonic_bond(
     const int *__restrict__ bond_idxs,     // [B, 2]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     const auto b_idx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/timemachine/cpp/src/kernels/k_harmonic_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_bond.cuh
@@ -1,12 +1,13 @@
 #include "../fixed_point.hpp"
+#include "../types.hpp"
 #include "k_fixed_point.cuh"
 
 template <typename RealType>
 void __global__ k_harmonic_bond(
     const int B, // number of bonds
     const double *__restrict__ coords,
-    const double *__restrict__ params, // [B, 2]
-    const int *__restrict__ bond_idxs, // [B, 2]
+    const ParamsType *__restrict__ params, // [B, 2]
+    const int *__restrict__ bond_idxs,     // [B, 2]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
     __int128 *__restrict__ u) {

--- a/timemachine/cpp/src/kernels/k_local_md.cuh
+++ b/timemachine/cpp/src/kernels/k_local_md.cuh
@@ -1,4 +1,5 @@
 // Kernels specific to Local MD implementation.
+#include "../types.hpp"
 
 void __global__ k_construct_bonded_params(
     const int num_idxs,               // Number of idxs
@@ -9,7 +10,7 @@ void __global__ k_construct_bonded_params(
     const double r_max,
     const unsigned int *__restrict__ idxs, // [num_idxs]
     int *__restrict__ bonds,               // [num_idxs * 2]
-    double *__restrict__ params            // [num_idxs * 3]
+    ParamsType *__restrict__ params        // [num_idxs * 3]
 ) {
     const auto idx = blockDim.x * blockIdx.x + threadIdx.x;
     if (idx >= num_idxs) {

--- a/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
@@ -12,8 +12,8 @@ void __global__ k_log_flat_bottom_bond(
     const int B, // number of bonds
     const double *__restrict__ coords,
     const double *__restrict__ box,
-    const double *__restrict__ params, // [B, 3]
-    const int *__restrict__ bond_idxs, // [B, 2]
+    const ParamsType *__restrict__ params, // [B, 3]
+    const int *__restrict__ bond_idxs,     // [B, 2]
     const double beta,
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,

--- a/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
@@ -17,7 +17,7 @@ void __global__ k_log_flat_bottom_bond(
     const double beta,
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     // which bond
     const auto b_idx = blockDim.x * blockIdx.x + threadIdx.x;

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -2,6 +2,7 @@
 
 #include "../fixed_point.hpp"
 #include "../gpu_utils.cuh"
+#include "../types.hpp"
 #include "k_nonbonded_common.cuh"
 #include "kernel_utils.cuh"
 
@@ -57,9 +58,9 @@ void __global__ k_gather_coords_and_params(
     const int N,
     const unsigned int *__restrict__ idxs,
     const RealType *__restrict__ coords,
-    const RealType *__restrict__ params,
+    const ParamsType *__restrict__ params,
     RealType *__restrict__ gathered_coords,
-    RealType *__restrict__ gathered_params) {
+    ParamsType *__restrict__ gathered_params) {
     static_assert(COORDS_DIM == 3);
     static_assert(PARAMS_DIM == PARAMS_PER_ATOM);
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -109,8 +110,8 @@ void __device__ v_nonbonded_unified(
     const int tile_idx,
     const int N,
     const int NR,
-    const double *__restrict__ coords, // [N * 3]
-    const double *__restrict__ params, // [N * PARAMS_PER_ATOM]
+    const double *__restrict__ coords,     // [N * 3]
+    const ParamsType *__restrict__ params, // [N * PARAMS_PER_ATOM]
     box_cache<RealType> &shared_box,
     __int128 *energy_buffer, // [blockDim.x]
     const double beta,
@@ -328,9 +329,9 @@ void __global__ k_nonbonded_unified(
     const int N,  // Number of atoms
     const int NR, // Number of row indices
     const unsigned int *ixn_count,
-    const double *__restrict__ coords, // [N, 3]
-    const double *__restrict__ params, // [N, PARAMS_PER_ATOM]
-    const double *__restrict__ box,    // [3, 3]
+    const double *__restrict__ coords,     // [N, 3]
+    const ParamsType *__restrict__ params, // [N, PARAMS_PER_ATOM]
+    const double *__restrict__ box,        // [3, 3]
     const double beta,
     const double cutoff,
     const unsigned int *__restrict__ row_idxs,

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -113,7 +113,7 @@ void __device__ v_nonbonded_unified(
     const double *__restrict__ coords,     // [N * 3]
     const ParamsType *__restrict__ params, // [N * PARAMS_PER_ATOM]
     box_cache<RealType> &shared_box,
-    __int128 *energy_buffer, // [blockDim.x]
+    EnergyType *energy_buffer, // [blockDim.x]
     const double beta,
     const double cutoff,
     const unsigned int *__restrict__ row_idxs,
@@ -339,11 +339,11 @@ void __global__ k_nonbonded_unified(
     const unsigned int *__restrict__ ixn_atoms,
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u_buffer // [blockDim.x]
+    EnergyType *__restrict__ u_buffer // [blockDim.x]
 ) {
     static_assert(THREADS <= 256 && (THREADS & (THREADS - 1)) == 0);
     __shared__ box_cache<RealType> shared_box;
-    __shared__ __int128 block_energy_buffer[THREADS];
+    __shared__ EnergyType block_energy_buffer[THREADS];
     if (COMPUTE_U) {
         block_energy_buffer[threadIdx.x] = 0; // Zero out the energy buffer
     }

--- a/timemachine/cpp/src/kernels/k_nonbonded_pair_list.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_pair_list.cuh
@@ -6,6 +6,7 @@
 // using this kernel.
 
 #include "../fixed_point.hpp"
+#include "../types.hpp"
 #include "k_nonbonded_common.cuh"
 
 template <bool Negated>
@@ -17,7 +18,7 @@ template <typename RealType, bool Negated>
 void __global__ k_nonbonded_pair_list(
     const int M, // number of pairs
     const double *__restrict__ coords,
-    const double *__restrict__ params,
+    const ParamsType *__restrict__ params,
     const double *__restrict__ box,
     const int *__restrict__ pair_idxs, // [M, 2] pair-list of atoms
     const double *__restrict__ scales, // [M]

--- a/timemachine/cpp/src/kernels/k_nonbonded_pair_list.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_pair_list.cuh
@@ -26,7 +26,7 @@ void __global__ k_nonbonded_pair_list(
     const double cutoff,
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u_buffer) {
+    EnergyType *__restrict__ u_buffer) {
 
     // (ytz): oddly enough the order of atom_i and atom_j
     // seem to not matter. I think this is because distance calculations

--- a/timemachine/cpp/src/kernels/k_nonbonded_precomputed.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_precomputed.cuh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../types.hpp"
 #include "k_nonbonded_common.cuh"
 
 // Shape of parameter array is identical to other nonbonded variants
@@ -8,11 +9,11 @@ static const int PARAMS_PER_PAIR = PARAMS_PER_ATOM;
 
 template <typename RealType>
 void __global__ k_nonbonded_precomputed(
-    const int M,                       // number of pairs
-    const double *__restrict__ coords, // [N, 3] coordinates
-    const double *__restrict__ params, // [M, 4] q_ij, s_ij, e_ij, w_offset_ij
-    const double *__restrict__ box,    // box vectors
-    const int *__restrict__ pair_idxs, // [M, 2] pair-list of atoms
+    const int M,                           // number of pairs
+    const double *__restrict__ coords,     // [N, 3] coordinates
+    const ParamsType *__restrict__ params, // [M, 4] q_ij, s_ij, e_ij, w_offset_ij
+    const double *__restrict__ box,        // box vectors
+    const int *__restrict__ pair_idxs,     // [M, 2] pair-list of atoms
     const double beta,
     const double cutoff,
     unsigned long long *__restrict__ du_dx,

--- a/timemachine/cpp/src/kernels/k_nonbonded_precomputed.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_precomputed.cuh
@@ -18,7 +18,7 @@ void __global__ k_nonbonded_precomputed(
     const double cutoff,
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u_buffer) {
+    EnergyType *__restrict__ u_buffer) {
 
     const int pair_idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (pair_idx >= M) {
@@ -75,7 +75,7 @@ void __global__ k_nonbonded_precomputed(
     delta_y -= box_y * nearbyint(delta_y * inv_box_y);
     delta_z -= box_z * nearbyint(delta_z * inv_box_z);
 
-    __int128 energy = 0;
+    EnergyType energy = 0;
 
     RealType d2_ij = delta_x * delta_x + delta_y * delta_y + delta_z * delta_z + delta_w * delta_w;
 

--- a/timemachine/cpp/src/kernels/k_periodic_torsion.cuh
+++ b/timemachine/cpp/src/kernels/k_periodic_torsion.cuh
@@ -24,7 +24,7 @@ void __global__ k_periodic_torsion(
     const int *__restrict__ torsion_idxs,  // [b, 4]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     const auto t_idx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/timemachine/cpp/src/kernels/k_periodic_torsion.cuh
+++ b/timemachine/cpp/src/kernels/k_periodic_torsion.cuh
@@ -1,5 +1,6 @@
 #include "../fixed_point.hpp"
 #include "../gpu_utils.cuh"
+#include "../types.hpp"
 #include "k_fixed_point.cuh"
 
 template <typename RealType> inline __device__ RealType dot_product(const RealType a[3], const RealType b[3]) {
@@ -17,10 +18,10 @@ inline __device__ void cross_product(const RealType a[3], const RealType b[3], R
 
 template <typename RealType, int D>
 void __global__ k_periodic_torsion(
-    const int T,                          // number of bonds
-    const double *__restrict__ coords,    // [n, 3]
-    const double *__restrict__ params,    // [p, 3]
-    const int *__restrict__ torsion_idxs, // [b, 4]
+    const int T,                           // number of bonds
+    const double *__restrict__ coords,     // [n, 3]
+    const ParamsType *__restrict__ params, // [p, 3]
+    const int *__restrict__ torsion_idxs,  // [b, 4]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
     __int128 *__restrict__ u) {

--- a/timemachine/cpp/src/local_md_potentials.cu
+++ b/timemachine/cpp/src/local_md_potentials.cu
@@ -54,7 +54,7 @@ LocalMDPotentials::LocalMDPotentials(
         default_bonds[i * 2 + 0] = 0;
         default_bonds[i * 2 + 1] = i + 1;
     }
-    std::vector<double> default_params(N_ * 3);
+    std::vector<ParamsType> default_params(N_ * 3);
     free_restraint_ = std::shared_ptr<FlatBottomBond<double>>(new FlatBottomBond<double>(default_bonds));
     // Construct a bound potential with 0 params
     bound_free_restraint_ = std::shared_ptr<BoundPotential>(new BoundPotential(free_restraint_, default_params));

--- a/timemachine/cpp/src/local_md_potentials.hpp
+++ b/timemachine/cpp/src/local_md_potentials.hpp
@@ -9,6 +9,7 @@
 #include "flat_bottom_bond.hpp"
 #include "local_md_utils.hpp"
 #include "log_flat_bottom_bond.hpp"
+#include "types.hpp"
 
 namespace timemachine {
 
@@ -65,7 +66,7 @@ private:
     std::shared_ptr<BoundPotential> bound_frozen_restraint_;
 
     DeviceBuffer<int> d_restraint_pairs_;
-    DeviceBuffer<double> d_bond_params_;
+    DeviceBuffer<ParamsType> d_bond_params_;
 
     DeviceBuffer<float> d_probability_buffer_;
 

--- a/timemachine/cpp/src/local_md_utils.cu
+++ b/timemachine/cpp/src/local_md_utils.cu
@@ -70,8 +70,8 @@ void set_nonbonded_ixn_potential_idxs(
 }
 
 std::shared_ptr<BoundPotential>
-construct_ixn_group_potential(const int N, std::shared_ptr<Potential> pot, const int P, const double *d_params) {
-    std::vector<double> h_params(P);
+construct_ixn_group_potential(const int N, std::shared_ptr<Potential> pot, const int P, const ParamsType *d_params) {
+    std::vector<ParamsType> h_params(P);
     gpuErrchk(cudaMemcpy(&h_params[0], d_params, P * sizeof(*d_params), cudaMemcpyDeviceToHost));
     std::vector<int> row_dummy_idxs{0};
     std::vector<int> col_dummy_idxs{1};

--- a/timemachine/cpp/src/local_md_utils.hpp
+++ b/timemachine/cpp/src/local_md_utils.hpp
@@ -4,6 +4,7 @@
 
 #include "bound_potential.hpp"
 #include "potential.hpp"
+#include "types.hpp"
 
 namespace timemachine {
 
@@ -22,7 +23,7 @@ void set_nonbonded_ixn_potential_idxs(
     const cudaStream_t stream);
 
 std::shared_ptr<BoundPotential>
-construct_ixn_group_potential(const int N, std::shared_ptr<Potential> pot, const int P, const double *d_params);
+construct_ixn_group_potential(const int N, std::shared_ptr<Potential> pot, const int P, const ParamsType *d_params);
 
 void verify_local_md_parameters(double radius, double k);
 

--- a/timemachine/cpp/src/log_flat_bottom_bond.cu
+++ b/timemachine/cpp/src/log_flat_bottom_bond.cu
@@ -49,7 +49,8 @@ void LogFlatBottomBond<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/log_flat_bottom_bond.cu
+++ b/timemachine/cpp/src/log_flat_bottom_bond.cu
@@ -54,7 +54,7 @@ void LogFlatBottomBond<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     const int num_params_per_bond = 3;

--- a/timemachine/cpp/src/log_flat_bottom_bond.hpp
+++ b/timemachine/cpp/src/log_flat_bottom_bond.hpp
@@ -27,7 +27,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/log_flat_bottom_bond.hpp
+++ b/timemachine/cpp/src/log_flat_bottom_bond.hpp
@@ -9,7 +9,7 @@ template <typename RealType> class LogFlatBottomBond : public Potential {
 
 private:
     int *d_bond_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     int B_;
     double beta_;
@@ -32,7 +32,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/nonbonded_all_pairs.cu
+++ b/timemachine/cpp/src/nonbonded_all_pairs.cu
@@ -167,7 +167,7 @@ void NonbondedAllPairs<RealType>::execute_device(
     const double *d_box, // 3 * 3
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     // (ytz) the nonbonded algorithm proceeds as follows:

--- a/timemachine/cpp/src/nonbonded_all_pairs.cu
+++ b/timemachine/cpp/src/nonbonded_all_pairs.cu
@@ -162,7 +162,8 @@ void NonbondedAllPairs<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,   // N * PARAMS_PER_ATOM
+    const ParamsType *d_p,
+    // N * PARAMS_PER_ATOM
     const double *d_box, // 3 * 3
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -31,7 +31,7 @@ private:
     const double nblist_padding_;
     double *d_nblist_x_;   // coords which were used to compute the nblist
     double *d_nblist_box_; // box which was used to rebuild the nblist
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
     int *d_rebuild_nblist_; // whether or not we have to rebuild the nblist
     int *p_rebuild_nblist_; // pinned
 
@@ -79,7 +79,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 
     double get_cutoff() const { return cutoff_; };

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -44,7 +44,7 @@ private:
     // specified)
     unsigned int *d_sorted_atom_idxs_; // [K_] indices of interacting atoms, sorted by hilbert curve index
     double *d_gathered_x_;             // sorted coordinates for subset of atoms
-    double *d_gathered_p_;             // sorted parameters for subset of atoms
+    ParamsType *d_gathered_p_;         // sorted parameters for subset of atoms
     unsigned long long *d_gathered_du_dx_;
     unsigned long long *d_gathered_du_dp_;
 
@@ -75,7 +75,7 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/nonbonded_common.cpp
+++ b/timemachine/cpp/src/nonbonded_common.cpp
@@ -12,6 +12,7 @@
 #include "summed_potential.hpp"
 
 #include "set_utils.hpp"
+#include "types.hpp"
 
 namespace timemachine {
 
@@ -80,7 +81,7 @@ void get_nonbonded_all_pair_potentials(
         if (std::shared_ptr<FanoutSummedPotential> fanned_potential =
                 std::dynamic_pointer_cast<FanoutSummedPotential>(pot->potential);
             fanned_potential != nullptr) {
-            std::vector<double> h_params(pot->size);
+            std::vector<ParamsType> h_params(pot->size);
             if (pot->size > 0) {
                 pot->d_p.copy_to(&h_params[0]);
             }
@@ -95,7 +96,7 @@ void get_nonbonded_all_pair_potentials(
         } else if (std::shared_ptr<SummedPotential> summed_potential =
                        std::dynamic_pointer_cast<SummedPotential>(pot->potential);
                    summed_potential != nullptr) {
-            std::vector<double> h_params(pot->size);
+            std::vector<ParamsType> h_params(pot->size);
             int i = 0;
             int offset = 0;
             if (pot->size > 0) {
@@ -107,7 +108,8 @@ void get_nonbonded_all_pair_potentials(
             for (auto summed_pot : summed_potential->get_potentials()) {
 
                 if (is_summed_potential(summed_pot) || is_nonbonded_all_pairs_potential(summed_pot)) {
-                    std::vector<double> slice(h_params.begin() + offset, h_params.begin() + offset + param_sizes[i]);
+                    std::vector<ParamsType> slice(
+                        h_params.begin() + offset, h_params.begin() + offset + param_sizes[i]);
                     flattened_bps.push_back(std::shared_ptr<BoundPotential>(new BoundPotential(summed_pot, slice)));
                 }
 

--- a/timemachine/cpp/src/nonbonded_common.hpp
+++ b/timemachine/cpp/src/nonbonded_common.hpp
@@ -13,7 +13,7 @@ typedef void (*k_nonbonded_fn)(
     const int NR,
     const unsigned int *ixn_count,
     const double *__restrict__ coords,
-    const double *__restrict__ params, // [N]
+    const ParamsType *__restrict__ params, // [N]
     const double *__restrict__ box,
     const double beta,
     const double cutoff,

--- a/timemachine/cpp/src/nonbonded_common.hpp
+++ b/timemachine/cpp/src/nonbonded_common.hpp
@@ -22,7 +22,7 @@ typedef void (*k_nonbonded_fn)(
     const unsigned int *__restrict__ ixn_atoms,
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u_buffer);
+    EnergyType *__restrict__ u_buffer);
 
 void verify_atom_idxs(int N, const std::vector<int> &atom_idxs, const bool allow_empty = false);
 

--- a/timemachine/cpp/src/nonbonded_interaction_group.cu
+++ b/timemachine/cpp/src/nonbonded_interaction_group.cu
@@ -125,7 +125,8 @@ void NonbondedInteractionGroup<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,   // N * PARAMS_PER_ATOM
+    const ParamsType *d_p,
+    // N * PARAMS_PER_ATOM
     const double *d_box, // 3 * 3
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/nonbonded_interaction_group.cu
+++ b/timemachine/cpp/src/nonbonded_interaction_group.cu
@@ -130,7 +130,7 @@ void NonbondedInteractionGroup<RealType>::execute_device(
     const double *d_box, // 3 * 3
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     // (ytz) the nonbonded algorithm proceeds as follows:

--- a/timemachine/cpp/src/nonbonded_interaction_group.hpp
+++ b/timemachine/cpp/src/nonbonded_interaction_group.hpp
@@ -33,11 +33,11 @@ private:
     Neighborlist<RealType> nblist_;
 
     const double nblist_padding_;
-    __int128 *d_u_buffer_;  // [NONBONDED_KERNEL_BLOCKS]
-    double *d_nblist_x_;    // coords which were used to compute the nblist
-    double *d_nblist_box_;  // box which was used to rebuild the nblist
-    int *d_rebuild_nblist_; // whether or not we have to rebuild the nblist
-    int *p_rebuild_nblist_; // pinned
+    EnergyType *d_u_buffer_; // [NONBONDED_KERNEL_BLOCKS]
+    double *d_nblist_x_;     // coords which were used to compute the nblist
+    double *d_nblist_box_;   // box which was used to rebuild the nblist
+    int *d_rebuild_nblist_;  // whether or not we have to rebuild the nblist
+    int *p_rebuild_nblist_;  // pinned
     double *p_box_;
 
     unsigned int *d_perm_; // hilbert curve permutation
@@ -94,7 +94,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 
     void du_dp_fixed_to_float(const int N, const int P, const unsigned long long *du_dp, double *du_dp_float) override;

--- a/timemachine/cpp/src/nonbonded_interaction_group.hpp
+++ b/timemachine/cpp/src/nonbonded_interaction_group.hpp
@@ -4,6 +4,7 @@
 #include "neighborlist.hpp"
 #include "nonbonded_common.hpp"
 #include "potential.hpp"
+#include "types.hpp"
 #include <array>
 #include <memory>
 #include <optional>
@@ -47,8 +48,8 @@ private:
     //   independently
     // - otherwise, atoms are sorted into contiguous blocks by
     //   interaction group, with arbitrary ordering within each block
-    double *d_sorted_x_; // sorted coordinates
-    double *d_sorted_p_; // sorted parameters
+    double *d_sorted_x_;     // sorted coordinates
+    ParamsType *d_sorted_p_; // sorted parameters
     unsigned long long *d_sorted_du_dx_;
     unsigned long long *d_sorted_du_dp_;
 
@@ -89,7 +90,7 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/nonbonded_pair_list.cu
+++ b/timemachine/cpp/src/nonbonded_pair_list.cu
@@ -56,7 +56,7 @@ void NonbondedPairList<RealType, Negated>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/nonbonded_pair_list.cu
+++ b/timemachine/cpp/src/nonbonded_pair_list.cu
@@ -60,7 +60,7 @@ void NonbondedPairList<RealType, Negated>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (M_ > 0) {

--- a/timemachine/cpp/src/nonbonded_pair_list.hpp
+++ b/timemachine/cpp/src/nonbonded_pair_list.hpp
@@ -35,7 +35,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/nonbonded_pair_list.hpp
+++ b/timemachine/cpp/src/nonbonded_pair_list.hpp
@@ -17,7 +17,7 @@ private:
     double beta_;
     double cutoff_;
 
-    __int128 *d_u_buffer_; // [M]
+    EnergyType *d_u_buffer_; // [M]
 
     int *d_pair_idxs_; // [M, 2]
     double *d_scales_; // [M, 2]
@@ -40,7 +40,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 
     void du_dp_fixed_to_float(const int N, const int P, const unsigned long long *du_dp, double *du_dp_float) override;

--- a/timemachine/cpp/src/nonbonded_precomputed.cu
+++ b/timemachine/cpp/src/nonbonded_precomputed.cu
@@ -48,7 +48,7 @@ void NonbondedPairListPrecomputed<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (P != PARAMS_PER_PAIR * B_) {

--- a/timemachine/cpp/src/nonbonded_precomputed.cu
+++ b/timemachine/cpp/src/nonbonded_precomputed.cu
@@ -43,7 +43,8 @@ void NonbondedPairListPrecomputed<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/nonbonded_precomputed.hpp
+++ b/timemachine/cpp/src/nonbonded_precomputed.hpp
@@ -15,7 +15,7 @@ private:
     double cutoff_;
 
     int *d_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
 public:
     int num_bonds() const { return B_; }
@@ -36,7 +36,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,
-        __int128 *d_u, // buffered
+        EnergyType *d_u, // buffered
         cudaStream_t stream) override;
 
     void du_dp_fixed_to_float(const int N, const int P, const unsigned long long *du_dp, double *du_dp_float) override;

--- a/timemachine/cpp/src/nonbonded_precomputed.hpp
+++ b/timemachine/cpp/src/nonbonded_precomputed.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "potential.hpp"
+#include "types.hpp"
 #include <vector>
 
 namespace timemachine {
@@ -30,7 +31,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/periodic_torsion.cu
+++ b/timemachine/cpp/src/periodic_torsion.cu
@@ -48,7 +48,7 @@ void PeriodicTorsion<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     const int tpb = DEFAULT_THREADS_PER_BLOCK;

--- a/timemachine/cpp/src/periodic_torsion.cu
+++ b/timemachine/cpp/src/periodic_torsion.cu
@@ -43,7 +43,8 @@ void PeriodicTorsion<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/periodic_torsion.hpp
+++ b/timemachine/cpp/src/periodic_torsion.hpp
@@ -9,7 +9,7 @@ template <typename RealType> class PeriodicTorsion : public Potential {
 
 private:
     int *d_torsion_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     const int T_;
 
@@ -29,7 +29,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/periodic_torsion.hpp
+++ b/timemachine/cpp/src/periodic_torsion.hpp
@@ -24,7 +24,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/potential.cu
+++ b/timemachine/cpp/src/potential.cu
@@ -22,7 +22,7 @@ void Potential::execute_batch_host(
     const double *h_box,         // [coord_batch_size, 3, 3]
     unsigned long long *h_du_dx, // [coord_batch_size, param_batch_size, N, 3]
     unsigned long long *h_du_dp, // [coord_batch_size, param_batch_size, P]
-    __int128 *h_u                // [coord_batch_size, param_batch_size, N]
+    EnergyType *h_u              // [coord_batch_size, param_batch_size, N]
 ) {
     std::unique_ptr<DeviceBuffer<ParamsType>> d_p(nullptr);
     if (P > 0) {
@@ -38,7 +38,7 @@ void Potential::execute_batch_host(
 
     std::unique_ptr<DeviceBuffer<unsigned long long>> d_du_dx_buffer(nullptr);
     std::unique_ptr<DeviceBuffer<unsigned long long>> d_du_dp_buffer(nullptr);
-    std::unique_ptr<DeviceBuffer<__int128>> d_u_buffer(nullptr);
+    std::unique_ptr<DeviceBuffer<EnergyType>> d_u_buffer(nullptr);
 
     const int total_executions = coord_batch_size * param_batch_size;
 
@@ -56,7 +56,7 @@ void Potential::execute_batch_host(
     }
 
     if (h_u) {
-        d_u_buffer.reset(new DeviceBuffer<__int128>(total_executions));
+        d_u_buffer.reset(new DeviceBuffer<EnergyType>(total_executions));
         gpuErrchk(cudaMemsetAsync(d_u_buffer->data, 0, d_u_buffer->size, stream));
     }
 
@@ -99,7 +99,7 @@ void Potential::execute_host(
     const double *h_box,         // [3, 3]
     unsigned long long *h_du_dx, // [N,3]
     unsigned long long *h_du_dp, // [P]
-    __int128 *h_u                // [1]
+    EnergyType *h_u              // [1]
 ) {
 
     const int &D = Potential::D;
@@ -113,7 +113,7 @@ void Potential::execute_host(
     std::unique_ptr<DeviceBuffer<ParamsType>> d_p;
     std::unique_ptr<DeviceBuffer<unsigned long long>> d_du_dx;
     std::unique_ptr<DeviceBuffer<unsigned long long>> d_du_dp;
-    std::unique_ptr<DeviceBuffer<__int128>> d_u;
+    std::unique_ptr<DeviceBuffer<EnergyType>> d_u;
 
     // very important that these are initialized to zero since the kernels themselves just accumulate
 
@@ -132,7 +132,7 @@ void Potential::execute_host(
         gpuErrchk(cudaMemset(d_du_dp->data, 0, d_du_dp->size));
     }
     if (h_u) {
-        d_u.reset(new DeviceBuffer<__int128>(1));
+        d_u.reset(new DeviceBuffer<EnergyType>(1));
         gpuErrchk(cudaMemset(d_u->data, 0, d_u->size));
     }
 

--- a/timemachine/cpp/src/potential.cu
+++ b/timemachine/cpp/src/potential.cu
@@ -4,8 +4,8 @@
 #include "fixed_point.hpp"
 #include "gpu_utils.cuh"
 #include "potential.hpp"
+#include "types.hpp"
 
-#include <chrono>
 #include <iostream>
 
 namespace timemachine {
@@ -18,15 +18,15 @@ void Potential::execute_batch_host(
     const int param_batch_size,  // Number of batches of parameters
     const int P,                 // Number of parameters
     const double *h_x,           // [coord_batch_size, N, 3]
-    const double *h_p,           // [param_batch_size, P]
+    const ParamsType *h_p,       // [param_batch_size, P]
     const double *h_box,         // [coord_batch_size, 3, 3]
     unsigned long long *h_du_dx, // [coord_batch_size, param_batch_size, N, 3]
     unsigned long long *h_du_dp, // [coord_batch_size, param_batch_size, P]
     __int128 *h_u                // [coord_batch_size, param_batch_size, N]
 ) {
-    std::unique_ptr<DeviceBuffer<double>> d_p(nullptr);
+    std::unique_ptr<DeviceBuffer<ParamsType>> d_p(nullptr);
     if (P > 0) {
-        d_p.reset(new DeviceBuffer<double>(param_batch_size * P));
+        d_p.reset(new DeviceBuffer<ParamsType>(param_batch_size * P));
         d_p->copy_from(h_p);
     }
 
@@ -95,7 +95,7 @@ void Potential::execute_host(
     const int N,
     const int P,
     const double *h_x,           // [N,3]
-    const double *h_p,           // [P,]
+    const ParamsType *h_p,       // [P,]
     const double *h_box,         // [3, 3]
     unsigned long long *h_du_dx, // [N,3]
     unsigned long long *h_du_dp, // [P]
@@ -110,7 +110,7 @@ void Potential::execute_host(
     d_x.copy_from(h_x);
     d_box.copy_from(h_box);
 
-    std::unique_ptr<DeviceBuffer<double>> d_p;
+    std::unique_ptr<DeviceBuffer<ParamsType>> d_p;
     std::unique_ptr<DeviceBuffer<unsigned long long>> d_du_dx;
     std::unique_ptr<DeviceBuffer<unsigned long long>> d_du_dp;
     std::unique_ptr<DeviceBuffer<__int128>> d_u;
@@ -118,7 +118,7 @@ void Potential::execute_host(
     // very important that these are initialized to zero since the kernels themselves just accumulate
 
     if (P > 0) {
-        d_p.reset(new DeviceBuffer<double>(P));
+        d_p.reset(new DeviceBuffer<ParamsType>(P));
         d_p->copy_from(h_p);
     }
 
@@ -162,21 +162,21 @@ void Potential::execute_host(
 void Potential::execute_host_du_dx(
     const int N,
     const int P,
-    const double *h_x,   // [N,3]
-    const double *h_p,   // [P,]
-    const double *h_box, // [3, 3]
+    const double *h_x,     // [N,3]
+    const ParamsType *h_p, // [P,]
+    const double *h_box,   // [3, 3]
     unsigned long long *h_du_dx) {
 
     const int &D = Potential::D;
-
+    // TODO: Convert this to DeviceBuffer
     double *d_x;
-    double *d_p;
+    ParamsType *d_p;
     double *d_box;
 
     cudaSafeMalloc(&d_x, N * D * sizeof(double));
     gpuErrchk(cudaMemcpy(d_x, h_x, N * D * sizeof(double), cudaMemcpyHostToDevice));
 
-    cudaSafeMalloc(&d_p, P * sizeof(double));
+    cudaSafeMalloc(&d_p, P * sizeof(ParamsType));
     gpuErrchk(cudaMemcpy(d_p, h_p, P * sizeof(double), cudaMemcpyHostToDevice));
 
     cudaSafeMalloc(&d_box, D * D * sizeof(double));

--- a/timemachine/cpp/src/potential.hpp
+++ b/timemachine/cpp/src/potential.hpp
@@ -23,7 +23,7 @@ public:
         const double *h_box,
         unsigned long long *h_du_dx,
         unsigned long long *h_du_dp,
-        __int128 *h_u);
+        EnergyType *h_u);
 
     void execute_host(
         const int N,
@@ -33,7 +33,7 @@ public:
         const double *h_box,
         unsigned long long *h_du_dx,
         unsigned long long *h_du_dp,
-        __int128 *h_u);
+        EnergyType *h_u);
 
     void execute_host_du_dx(
         const int N,
@@ -51,7 +51,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *h_u,
+        EnergyType *h_u,
         cudaStream_t stream) = 0;
 
     virtual void du_dp_fixed_to_float(const int N, const int P, const unsigned long long *du_dp, double *du_dp_float);

--- a/timemachine/cpp/src/potential.hpp
+++ b/timemachine/cpp/src/potential.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "types.hpp"
 #include <cuda_runtime.h>
 
 namespace timemachine {
@@ -18,7 +19,7 @@ public:
         const int param_batch_size,
         const int P,
         const double *h_x,
-        const double *h_p,
+        const ParamsType *h_p,
         const double *h_box,
         unsigned long long *h_du_dx,
         unsigned long long *h_du_dp,
@@ -28,7 +29,7 @@ public:
         const int N,
         const int P,
         const double *h_x,
-        const double *h_p,
+        const ParamsType *h_p,
         const double *h_box,
         unsigned long long *h_du_dx,
         unsigned long long *h_du_dp,
@@ -38,7 +39,7 @@ public:
         const int N,
         const int P,
         const double *h_x,
-        const double *h_p,
+        const ParamsType *h_p,
         const double *h_box,
         unsigned long long *h_du_dx);
 
@@ -46,7 +47,7 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/streamed_potential_runner.cu
+++ b/timemachine/cpp/src/streamed_potential_runner.cu
@@ -14,7 +14,7 @@ void StreamedPotentialRunner::execute_potentials(
     const double *d_box, // [3 * 3]
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u, // [bps.size()]
+    EnergyType *d_u, // [bps.size()]
     cudaStream_t stream) {
     for (int i = 0; i < bps.size(); i++) {
         // Always sync the new streams with the incoming stream to ensure that the state

--- a/timemachine/cpp/src/streamed_potential_runner.hpp
+++ b/timemachine/cpp/src/streamed_potential_runner.hpp
@@ -24,7 +24,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream);
 
 private:

--- a/timemachine/cpp/src/summed_potential.cu
+++ b/timemachine/cpp/src/summed_potential.cu
@@ -32,7 +32,7 @@ void SummedPotential::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (P != P_) {

--- a/timemachine/cpp/src/summed_potential.cu
+++ b/timemachine/cpp/src/summed_potential.cu
@@ -27,7 +27,8 @@ void SummedPotential::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/summed_potential.hpp
+++ b/timemachine/cpp/src/summed_potential.hpp
@@ -32,7 +32,7 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/summed_potential.hpp
+++ b/timemachine/cpp/src/summed_potential.hpp
@@ -15,7 +15,7 @@ private:
     const std::vector<int> params_sizes_;
     const int P_; // sum(params_sizes)
     const bool parallel_;
-    DeviceBuffer<__int128> d_u_buffer_;
+    DeviceBuffer<EnergyType> d_u_buffer_;
     StreamManager manager_;
 
 public:
@@ -36,7 +36,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 
     void du_dp_fixed_to_float(const int N, const int P, const unsigned long long *du_dp, double *du_dp_float) override;

--- a/timemachine/cpp/src/types.hpp
+++ b/timemachine/cpp/src/types.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+typedef float ParamsType;

--- a/timemachine/cpp/src/types.hpp
+++ b/timemachine/cpp/src/types.hpp
@@ -1,3 +1,5 @@
 #pragma once
 
 typedef float ParamsType;
+// TBD: Investigate a 96bit version for energies
+typedef __int128 EnergyType;

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -753,7 +753,7 @@ def get_ligand_ixn_pots_params(
     )
     hg_water_params = jnp.concatenate([host_nb_params, guest_params_ixn_water])
 
-    # Lignad-Other (protein) terms
+    # Ligand-Other (protein) terms
     hg_other_pots = []
     hg_other_params = []
     if len(other_idxs):


### PR DESCRIPTION
* Change parameters to be stored as floats in C++/Cuda, as when we run this in production we don't have float64 support in Jax which is what constructs our potentials
* Adds EnergyType for __int128 to make it easier to try int96 version at some point

# Benchmarks
Cuda Arch 8.6
Nvidia A10

About 2% faster

## Parameters as Doubles
```
dhfr-apo: N=23558 speed: 708.99ns/day dt: 2.5fs (ran 100000 steps in 30.47s)
dhfr-apo-barostat-interval-25: N=23558 speed: 637.04ns/day dt: 2.5fs (ran 100000 steps in 33.91s)
hif2a-apo: N=8805 speed: 1235.90ns/day dt: 2.5fs (ran 100000 steps in 17.48s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1050.07ns/day dt: 2.5fs (ran 100000 steps in 20.57s)
hif2a-rbfe-barostat-interval-15: N=8840 speed: 784.25ns/day dt: 2.5fs (ran 100000 steps in 27.55s)
hif2a-rbfe-local: N=8840 speed: 1376.63ns/day dt: 2.5fs (ran 100000 steps in 15.69s)
solvent-apo: N=6282 speed: 1510.94ns/day dt: 2.5fs (ran 100000 steps in 14.30s)
solvent-apo-barostat-interval-25: N=6282 speed: 1347.81ns/day dt: 2.5fs (ran 100000 steps in 16.03s)
solvent-rbfe-barostat-interval-15: N=6317 speed: 1027.39ns/day dt: 2.5fs (ran 100000 steps in 21.03s)
solvent-rbfe-local: N=6317 speed: 1470.29ns/day dt: 2.5fs (ran 100000 steps in 14.70s)
```

## Parameters as Floats
```
dhfr-apo: N=23558 speed: 720.52ns/day dt: 2.5fs (ran 100000 steps in 29.98s)
dhfr-apo-barostat-interval-25: N=23558 speed: 647.59ns/day dt: 2.5fs (ran 100000 steps in 33.36s)
hif2a-apo: N=8805 speed: 1259.99ns/day dt: 2.5fs (ran 100000 steps in 17.15s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1064.52ns/day dt: 2.5fs (ran 100000 steps in 20.29s)
hif2a-rbfe-barostat-interval-15: N=8840 speed: 798.10ns/day dt: 2.5fs (ran 100000 steps in 27.07s)
hif2a-rbfe-local: N=8840 speed: 1404.14ns/day dt: 2.5fs (ran 100000 steps in 15.39s)
solvent-apo: N=6282 speed: 1534.76ns/day dt: 2.5fs (ran 100000 steps in 14.08s)
solvent-apo-barostat-interval-25: N=6282 speed: 1368.44ns/day dt: 2.5fs (ran 100000 steps in 15.79s)
solvent-rbfe-barostat-interval-15: N=6317 speed: 1050.70ns/day dt: 2.5fs (ran 100000 steps in 20.56s)
solvent-rbfe-local: N=6317 speed: 1496.76ns/day dt: 2.5fs (ran 100000 steps in 14.44s)
```