### PR TITLE
Add C++ Typedefs for common types

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -242,6 +242,9 @@ class GradientTest(unittest.TestCase):
 
         assert x.dtype == np.float64
 
+        # Reduce the precision of parameters to single precision to emulate production where jax is not configured to
+        # use double precision. Cuda/C++ stores parameters in double precision so that it is possible to determine
+        # where there is test failures due to loss of precision.
         params = (params.astype(np.float32)).astype(np.float64)
         assert params.dtype == np.float64
         ref_u = ref_potential(x, params, box)

--- a/tests/test_energy_overflows.py
+++ b/tests/test_energy_overflows.py
@@ -243,7 +243,7 @@ def test_energy_overflow_cancelled_by_exclusions(precision, rtol, atol):
     assert fixed_overflowed(fixed_pair_list_energy)
 
     # The values are identical because of overflow, as its not clear how to go from
-    # C++ __int128 to python integer.
+    # C++ EnergyType to python integer.
     assert fixed_all_pairs_energy == fixed_pair_list_energy
 
 

--- a/timemachine/cpp/src/barostat.cu
+++ b/timemachine/cpp/src/barostat.cu
@@ -161,10 +161,10 @@ void MonteCarloBarostat<RealType>::set_adaptive_scaling(const bool adaptive_scal
     this->adaptive_scaling_enabled_ = adaptive_scaling_enabled;
 }
 
-template <typename RealType> bool MonteCarloBarostat<RealType>::inplace_move_host(double *h_x, double *h_box) {
+template <typename RealType> bool MonteCarloBarostat<RealType>::inplace_move_host(CoordsType *h_x, CoordsType *h_box) {
 
-    DeviceBuffer<double> d_x(N_ * 3);
-    DeviceBuffer<double> d_box(3 * 3);
+    DeviceBuffer<CoordsType> d_x(N_ * 3);
+    DeviceBuffer<CoordsType> d_box(3 * 3);
     int h_accepted_before;
 
     cudaMemcpy(&h_accepted_before, d_num_accepted_, 1 * sizeof(h_accepted_before), cudaMemcpyDeviceToHost);
@@ -182,8 +182,8 @@ template <typename RealType> bool MonteCarloBarostat<RealType>::inplace_move_hos
 
 template <typename RealType>
 void MonteCarloBarostat<RealType>::inplace_move(
-    double *d_x,   // [N*3]
-    double *d_box, // [3*3]
+    CoordsType *d_x,   // [N*3]
+    CoordsType *d_box, // [3*3]
     cudaStream_t stream) {
     step_++;
     if (step_ % interval_ != 0) {

--- a/timemachine/cpp/src/barostat.hpp
+++ b/timemachine/cpp/src/barostat.hpp
@@ -26,10 +26,10 @@ public:
     ~MonteCarloBarostat();
 
     // inplace_move() may modify d_x and d_box
-    void inplace_move(double *d_x, double *d_box, cudaStream_t stream);
+    void inplace_move(CoordsType *d_x, CoordsType *d_box, cudaStream_t stream);
 
     // used for testing, bool return tells you if move was accepted
-    bool inplace_move_host(double *h_x, double *h_box);
+    bool inplace_move_host(double *h_x, CoordsType *h_box);
 
     void set_interval(const int interval);
 
@@ -82,8 +82,8 @@ private:
     RealType *d_length_scale_;
     double *d_volume_scale_;
 
-    double *d_x_after_;
-    double *d_box_after_;
+    CoordsType *d_x_after_;
+    CoordsType *d_box_after_;
 
     int *d_atom_idxs_;   // grouped index to atom coords
     int *d_mol_idxs_;    // grouped index to molecule index

--- a/timemachine/cpp/src/barostat.hpp
+++ b/timemachine/cpp/src/barostat.hpp
@@ -71,11 +71,11 @@ private:
     int *d_num_attempted_;
     int *d_num_accepted_;
 
-    __int128 *d_u_buffer_;
-    __int128 *d_u_after_buffer_;
+    EnergyType *d_u_buffer_;
+    EnergyType *d_u_after_buffer_;
 
-    __int128 *d_init_u_;
-    __int128 *d_final_u_;
+    EnergyType *d_init_u_;
+    EnergyType *d_final_u_;
 
     RealType *d_volume_;
     RealType *d_volume_delta_;

--- a/timemachine/cpp/src/bound_potential.cu
+++ b/timemachine/cpp/src/bound_potential.cu
@@ -14,7 +14,7 @@ void BoundPotential::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
     this->potential->execute_device(
         N, this->size, d_x, this->size > 0 ? this->d_p.data : nullptr, d_box, d_du_dx, d_du_dp, d_u, stream);
@@ -25,7 +25,7 @@ void BoundPotential::execute_host(
     const double *h_x,           // [N,3]
     const double *h_box,         // [3, 3]
     unsigned long long *h_du_dx, // [N, 3]
-    __int128 *h_u                // [1]
+    EnergyType *h_u              // [1]
 ) {
 
     const int D = 3;
@@ -37,7 +37,7 @@ void BoundPotential::execute_host(
     d_box.copy_from(h_box);
 
     DeviceBuffer<unsigned long long> d_du_dx(N * D);
-    DeviceBuffer<__int128> d_u(1);
+    DeviceBuffer<EnergyType> d_u(1);
 
     // very important that these are initialized to zero since the kernels themselves just accumulate
     gpuErrchk(cudaMemset(d_du_dx.data, 0, d_du_dx.size));

--- a/timemachine/cpp/src/bound_potential.cu
+++ b/timemachine/cpp/src/bound_potential.cu
@@ -3,7 +3,7 @@
 
 namespace timemachine {
 
-BoundPotential::BoundPotential(std::shared_ptr<Potential> potential, const std::vector<double> &params)
+BoundPotential::BoundPotential(std::shared_ptr<Potential> potential, const std::vector<ParamsType> &params)
     : size(params.size()), buffer_size_(size), d_p(buffer_size_), potential(potential) {
     set_params(params);
 }
@@ -55,7 +55,7 @@ void BoundPotential::execute_host(
     }
 };
 
-void BoundPotential::set_params(const std::vector<double> &params) {
+void BoundPotential::set_params(const std::vector<ParamsType> &params) {
     if (params.size() != buffer_size_) {
         throw std::runtime_error(
             "parameter size is not equal to device buffer size: " + std::to_string(params.size()) +
@@ -65,7 +65,7 @@ void BoundPotential::set_params(const std::vector<double> &params) {
     this->size = params.size();
 }
 
-void BoundPotential::set_params_device(const int new_size, const double *d_new_params, const cudaStream_t stream) {
+void BoundPotential::set_params_device(const int new_size, const ParamsType *d_new_params, const cudaStream_t stream) {
     if (static_cast<size_t>(new_size) > buffer_size_) {
         throw std::runtime_error(
             "parameter size is greater than device buffer size: " + std::to_string(new_size) + " > " +

--- a/timemachine/cpp/src/bound_potential.cu
+++ b/timemachine/cpp/src/bound_potential.cu
@@ -10,8 +10,8 @@ BoundPotential::BoundPotential(std::shared_ptr<Potential> potential, const std::
 
 void BoundPotential::execute_device(
     const int N,
-    const double *d_x,
-    const double *d_box,
+    const CoordsType *d_x,
+    const CoordsType *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,
@@ -22,16 +22,16 @@ void BoundPotential::execute_device(
 
 void BoundPotential::execute_host(
     const int N,
-    const double *h_x,           // [N,3]
-    const double *h_box,         // [3, 3]
+    const CoordsType *h_x,       // [N,3]
+    const CoordsType *h_box,     // [3, 3]
     unsigned long long *h_du_dx, // [N, 3]
     EnergyType *h_u              // [1]
 ) {
 
     const int D = 3;
 
-    DeviceBuffer<double> d_x(N * D);
-    DeviceBuffer<double> d_box(D * D);
+    DeviceBuffer<CoordsType> d_x(N * D);
+    DeviceBuffer<CoordsType> d_box(D * D);
 
     d_x.copy_from(h_x);
     d_box.copy_from(h_box);

--- a/timemachine/cpp/src/bound_potential.hpp
+++ b/timemachine/cpp/src/bound_potential.hpp
@@ -23,7 +23,8 @@ struct BoundPotential {
 
     void set_params_device(const int size, const ParamsType *d_p, const cudaStream_t stream);
 
-    void execute_host(const int N, const double *h_x, const double *h_box, unsigned long long *h_du_dx, __int128 *h_u);
+    void
+    execute_host(const int N, const double *h_x, const double *h_box, unsigned long long *h_du_dx, EnergyType *h_u);
 
     void execute_device(
         const int N,
@@ -31,7 +32,7 @@ struct BoundPotential {
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream);
 };
 

--- a/timemachine/cpp/src/bound_potential.hpp
+++ b/timemachine/cpp/src/bound_potential.hpp
@@ -5,22 +5,23 @@
 
 #include "device_buffer.hpp"
 #include "potential.hpp"
+#include "types.hpp"
 
 namespace timemachine {
 
 // a potential bounded to a set of parameters with some shape
 struct BoundPotential {
 
-    BoundPotential(std::shared_ptr<Potential> potential, const std::vector<double> &params);
+    BoundPotential(std::shared_ptr<Potential> potential, const std::vector<ParamsType> &params);
 
     int size;
     const size_t buffer_size_; // d_p.size / sizeof(*d_p.data) TODO: remove when DeviceBuffer::length or similar added
-    DeviceBuffer<double> d_p;
+    DeviceBuffer<ParamsType> d_p;
     std::shared_ptr<Potential> potential;
 
-    void set_params(const std::vector<double> &params);
+    void set_params(const std::vector<ParamsType> &params);
 
-    void set_params_device(const int size, const double *d_p, const cudaStream_t stream);
+    void set_params_device(const int size, const ParamsType *d_p, const cudaStream_t stream);
 
     void execute_host(const int N, const double *h_x, const double *h_box, unsigned long long *h_du_dx, __int128 *h_u);
 

--- a/timemachine/cpp/src/bound_potential.hpp
+++ b/timemachine/cpp/src/bound_potential.hpp
@@ -23,13 +23,13 @@ struct BoundPotential {
 
     void set_params_device(const int size, const ParamsType *d_p, const cudaStream_t stream);
 
-    void
-    execute_host(const int N, const double *h_x, const double *h_box, unsigned long long *h_du_dx, EnergyType *h_u);
+    void execute_host(
+        const int N, const CoordsType *h_x, const CoordsType *h_box, unsigned long long *h_du_dx, EnergyType *h_u);
 
     void execute_device(
         const int N,
-        const double *d_x,
-        const double *d_box,
+        const CoordsType *d_x,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
         EnergyType *d_u,

--- a/timemachine/cpp/src/centroid_restraint.cu
+++ b/timemachine/cpp/src/centroid_restraint.cu
@@ -36,10 +36,10 @@ template <typename RealType>
 void CentroidRestraint<RealType>::execute_device(
     const int N,
     const int P,
-    const double *d_x,
+    const CoordsType *d_x,
     const ParamsType *d_p,
 
-    const double *d_box,
+    const CoordsType *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,

--- a/timemachine/cpp/src/centroid_restraint.cu
+++ b/timemachine/cpp/src/centroid_restraint.cu
@@ -37,7 +37,8 @@ void CentroidRestraint<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/centroid_restraint.cu
+++ b/timemachine/cpp/src/centroid_restraint.cu
@@ -42,7 +42,7 @@ void CentroidRestraint<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (N_B_ + N_A_ > 0) {

--- a/timemachine/cpp/src/centroid_restraint.hpp
+++ b/timemachine/cpp/src/centroid_restraint.hpp
@@ -31,10 +31,10 @@ public:
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
 
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
         EnergyType *d_u,

--- a/timemachine/cpp/src/centroid_restraint.hpp
+++ b/timemachine/cpp/src/centroid_restraint.hpp
@@ -14,7 +14,7 @@ private:
     unsigned long long *d_centroid_a_;
     unsigned long long *d_centroid_b_;
 
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     int N_A_;
     int N_B_;
@@ -37,7 +37,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/centroid_restraint.hpp
+++ b/timemachine/cpp/src/centroid_restraint.hpp
@@ -32,7 +32,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/chiral_atom_restraint.cu
+++ b/timemachine/cpp/src/chiral_atom_restraint.cu
@@ -30,10 +30,10 @@ template <typename RealType>
 void ChiralAtomRestraint<RealType>::execute_device(
     const int N,
     const int P,
-    const double *d_x,
+    const CoordsType *d_x,
     const ParamsType *d_p,
 
-    const double *d_box,
+    const CoordsType *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,

--- a/timemachine/cpp/src/chiral_atom_restraint.cu
+++ b/timemachine/cpp/src/chiral_atom_restraint.cu
@@ -36,7 +36,7 @@ void ChiralAtomRestraint<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (P != R_) {

--- a/timemachine/cpp/src/chiral_atom_restraint.cu
+++ b/timemachine/cpp/src/chiral_atom_restraint.cu
@@ -31,7 +31,8 @@ void ChiralAtomRestraint<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/chiral_atom_restraint.hpp
+++ b/timemachine/cpp/src/chiral_atom_restraint.hpp
@@ -22,10 +22,10 @@ public:
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
 
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,
         EnergyType *d_u,

--- a/timemachine/cpp/src/chiral_atom_restraint.hpp
+++ b/timemachine/cpp/src/chiral_atom_restraint.hpp
@@ -9,7 +9,7 @@ template <typename RealType> class ChiralAtomRestraint : public Potential {
 
 private:
     int *d_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     const int R_;
 
@@ -28,7 +28,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/chiral_atom_restraint.hpp
+++ b/timemachine/cpp/src/chiral_atom_restraint.hpp
@@ -23,7 +23,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/chiral_bond_restraint.cu
+++ b/timemachine/cpp/src/chiral_bond_restraint.cu
@@ -51,7 +51,7 @@ void ChiralBondRestraint<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (P != R_) {

--- a/timemachine/cpp/src/chiral_bond_restraint.cu
+++ b/timemachine/cpp/src/chiral_bond_restraint.cu
@@ -46,7 +46,8 @@ void ChiralBondRestraint<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/chiral_bond_restraint.cu
+++ b/timemachine/cpp/src/chiral_bond_restraint.cu
@@ -45,10 +45,10 @@ template <typename RealType>
 void ChiralBondRestraint<RealType>::execute_device(
     const int N,
     const int P,
-    const double *d_x,
+    const CoordsType *d_x,
     const ParamsType *d_p,
 
-    const double *d_box,
+    const CoordsType *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,

--- a/timemachine/cpp/src/chiral_bond_restraint.hpp
+++ b/timemachine/cpp/src/chiral_bond_restraint.hpp
@@ -10,7 +10,7 @@ template <typename RealType> class ChiralBondRestraint : public Potential {
 private:
     int *d_idxs_;
     int *d_signs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     const int R_;
 
@@ -31,7 +31,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,
-        __int128 *d_u, // buffered
+        EnergyType *d_u, // buffered
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/chiral_bond_restraint.hpp
+++ b/timemachine/cpp/src/chiral_bond_restraint.hpp
@@ -25,10 +25,10 @@ public:
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
 
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,
         EnergyType *d_u, // buffered

--- a/timemachine/cpp/src/chiral_bond_restraint.hpp
+++ b/timemachine/cpp/src/chiral_bond_restraint.hpp
@@ -26,7 +26,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/context.hpp
+++ b/timemachine/cpp/src/context.hpp
@@ -12,9 +12,9 @@ class Context {
 public:
     Context(
         int N,
-        const double *x_0,
+        const CoordsType *x_0,
         const double *v_0,
-        const double *box_0,
+        const CoordsType *box_0,
         std::shared_ptr<Integrator> intg,
         std::vector<std::shared_ptr<BoundPotential>> bps,
         std::shared_ptr<MonteCarloBarostat<float>> barostat = nullptr);
@@ -25,9 +25,9 @@ public:
     void initialize();
     void finalize();
 
-    std::array<std::vector<double>, 2> multiple_steps(const int n_steps, int store_x_interval);
+    std::array<std::vector<CoordsType>, 2> multiple_steps(const int n_steps, int store_x_interval);
 
-    std::array<std::vector<double>, 2> multiple_steps_local(
+    std::array<std::vector<CoordsType>, 2> multiple_steps_local(
         const int n_steps,
         const std::vector<int> &local_idxs,
         const int store_x_interval,
@@ -35,7 +35,7 @@ public:
         const double k,
         const int seed);
 
-    std::array<std::vector<double>, 2> multiple_steps_local_selection(
+    std::array<std::vector<CoordsType>, 2> multiple_steps_local_selection(
         const int n_steps,
         const int reference_idx,
         const std::vector<int> &selection_idxs,
@@ -45,17 +45,17 @@ public:
 
     int num_atoms() const;
 
-    void set_x_t(const double *in_buffer);
+    void set_x_t(const CoordsType *in_buffer);
 
-    void get_x_t(double *out_buffer) const;
+    void get_x_t(CoordsType *out_buffer) const;
 
     void set_v_t(const double *in_buffer);
 
     void get_v_t(double *out_buffer) const;
 
-    void set_box(const double *in_buffer);
+    void set_box(const CoordsType *in_buffer);
 
-    void get_box(double *out_buffer) const;
+    void get_box(CoordsType *out_buffer) const;
 
     void setup_local_md(double temperature, bool freeze_reference);
 
@@ -80,9 +80,9 @@ private:
 
     int step_;
 
-    double *d_x_t_;   // coordinates
-    double *d_v_t_;   // velocities
-    double *d_box_t_; // box vectors
+    CoordsType *d_x_t_;   // coordinates
+    double *d_v_t_;       // velocities
+    CoordsType *d_box_t_; // box vectors
 
     std::shared_ptr<Integrator> intg_;
     std::vector<std::shared_ptr<BoundPotential>> bps_;

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -34,5 +34,5 @@ template class DeviceBuffer<int>;
 template class DeviceBuffer<char>;
 template class DeviceBuffer<unsigned int>;
 template class DeviceBuffer<unsigned long long>;
-template class DeviceBuffer<__int128>;
+template class DeviceBuffer<EnergyType>;
 } // namespace timemachine

--- a/timemachine/cpp/src/energy_accumulation.cu
+++ b/timemachine/cpp/src/energy_accumulation.cu
@@ -3,8 +3,8 @@
 
 void accumulate_energy(
     int N,
-    const __int128 *__restrict__ d_input_buffer, // [N]
-    __int128 *__restrict d_u_buffer,             // [1]
+    const EnergyType *__restrict__ d_input_buffer, // [N]
+    EnergyType *__restrict d_u_buffer,             // [1]
     cudaStream_t stream) {
     const static unsigned int THREADS_PER_BLOCK = 512;
     k_accumulate_energy<THREADS_PER_BLOCK><<<1, THREADS_PER_BLOCK, 0, stream>>>(N, d_input_buffer, d_u_buffer);

--- a/timemachine/cpp/src/energy_accumulation.hpp
+++ b/timemachine/cpp/src/energy_accumulation.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "types.hpp"
+
 void accumulate_energy(
     int N,
-    const __int128 *__restrict__ d_input_buffer, // [N]
-    __int128 *__restrict d_u_buffer,             // [1]
+    const EnergyType *__restrict__ d_input_buffer, // [N]
+    EnergyType *__restrict d_u_buffer,             // [1]
     cudaStream_t stream);

--- a/timemachine/cpp/src/fanout_summed_potential.cu
+++ b/timemachine/cpp/src/fanout_summed_potential.cu
@@ -21,7 +21,7 @@ void FanoutSummedPotential::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (d_u) {

--- a/timemachine/cpp/src/fanout_summed_potential.cu
+++ b/timemachine/cpp/src/fanout_summed_potential.cu
@@ -15,10 +15,10 @@ const std::vector<std::shared_ptr<Potential>> &FanoutSummedPotential::get_potent
 void FanoutSummedPotential::execute_device(
     const int N,
     const int P,
-    const double *d_x,
+    const CoordsType *d_x,
     const ParamsType *d_p,
 
-    const double *d_box,
+    const CoordsType *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,

--- a/timemachine/cpp/src/fanout_summed_potential.cu
+++ b/timemachine/cpp/src/fanout_summed_potential.cu
@@ -16,7 +16,8 @@ void FanoutSummedPotential::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/fanout_summed_potential.hpp
+++ b/timemachine/cpp/src/fanout_summed_potential.hpp
@@ -25,7 +25,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/fanout_summed_potential.hpp
+++ b/timemachine/cpp/src/fanout_summed_potential.hpp
@@ -13,7 +13,7 @@ class FanoutSummedPotential : public Potential {
 private:
     const std::vector<std::shared_ptr<Potential>> potentials_;
     const bool parallel_;
-    DeviceBuffer<__int128> d_u_buffer_;
+    DeviceBuffer<EnergyType> d_u_buffer_;
     StreamManager manager_;
 
 public:
@@ -30,7 +30,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 
     void du_dp_fixed_to_float(const int N, const int P, const unsigned long long *du_dp, double *du_dp_float) override;

--- a/timemachine/cpp/src/fanout_summed_potential.hpp
+++ b/timemachine/cpp/src/fanout_summed_potential.hpp
@@ -24,10 +24,10 @@ public:
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
 
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
         EnergyType *d_u,

--- a/timemachine/cpp/src/fixed_point.hpp
+++ b/timemachine/cpp/src/fixed_point.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "types.hpp"
+
 #define FIXED_EXPONENT 0x1000000000
 
 // we need to use a different level of precision for parameter derivatives
@@ -19,14 +21,14 @@ template <typename RealType> RealType __host__ __device__ __forceinline__ FIXED_
 
 // FIXED_ENERGY_TO_FLOAT should be paired with a `fixed_point_overflow` as if it is beyond the long long representation
 // the value returned will be meaningless
-template <typename RealType> RealType __host__ __device__ __forceinline__ FIXED_ENERGY_TO_FLOAT(__int128 v) {
+template <typename RealType> RealType __host__ __device__ __forceinline__ FIXED_ENERGY_TO_FLOAT(EnergyType v) {
     return static_cast<RealType>(static_cast<long long>(v)) / FIXED_EXPONENT;
 }
 
-// fixed_point_overflow detects if a __int128 fixed point representation is 'overflowed'
+// fixed_point_overflow detects if a EnergyType fixed point representation is 'overflowed'
 // which means is outside of the long long range of representation.
-bool __host__ __device__ __forceinline__ fixed_point_overflow(__int128 val) {
-    __int128 max = LLONG_MAX;
-    __int128 min = LLONG_MIN;
+bool __host__ __device__ __forceinline__ fixed_point_overflow(EnergyType val) {
+    EnergyType max = static_cast<EnergyType>(LLONG_MAX);
+    EnergyType min = static_cast<EnergyType>(LLONG_MIN);
     return val >= max || val <= min;
 }

--- a/timemachine/cpp/src/flat_bottom_bond.cu
+++ b/timemachine/cpp/src/flat_bottom_bond.cu
@@ -45,7 +45,8 @@ void FlatBottomBond<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/flat_bottom_bond.cu
+++ b/timemachine/cpp/src/flat_bottom_bond.cu
@@ -50,7 +50,7 @@ void FlatBottomBond<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     const int num_params_per_bond = 3;

--- a/timemachine/cpp/src/flat_bottom_bond.cu
+++ b/timemachine/cpp/src/flat_bottom_bond.cu
@@ -44,10 +44,10 @@ template <typename RealType>
 void FlatBottomBond<RealType>::execute_device(
     const int N,
     const int P,
-    const double *d_x,
+    const CoordsType *d_x,
     const ParamsType *d_p,
 
-    const double *d_box,
+    const CoordsType *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,

--- a/timemachine/cpp/src/flat_bottom_bond.hpp
+++ b/timemachine/cpp/src/flat_bottom_bond.hpp
@@ -26,7 +26,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/flat_bottom_bond.hpp
+++ b/timemachine/cpp/src/flat_bottom_bond.hpp
@@ -9,7 +9,7 @@ template <typename RealType> class FlatBottomBond : public Potential {
 
 private:
     int *d_bond_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     int B_;
 
@@ -31,7 +31,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/flat_bottom_bond.hpp
+++ b/timemachine/cpp/src/flat_bottom_bond.hpp
@@ -25,10 +25,10 @@ public:
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
 
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
         EnergyType *d_u,

--- a/timemachine/cpp/src/gpu_utils.cuh
+++ b/timemachine/cpp/src/gpu_utils.cuh
@@ -102,7 +102,7 @@ double __device__ __forceinline__ radd_rn(double a, double b) { return __dadd_rn
 
 // If this were not int128s, we could do __shfl_down_sync, but only supports up to 64 values
 // For more details reference the PDF in the docstring for k_accumulate_energy
-__device__ __forceinline__ void energy_warp_reduce(volatile __int128 *shared_data, int thread_idx) {
+__device__ __forceinline__ void energy_warp_reduce(volatile EnergyType *shared_data, int thread_idx) {
     // Repeatedly sum up the two halfs of the shared data
 #pragma unroll 6
     for (int i = 32; i > 0; i /= 2) {
@@ -118,7 +118,7 @@ __device__ __forceinline__ void energy_warp_reduce(volatile __int128 *shared_dat
 // values repeatedly until the final warp level reduction which stores the final accumulated value in `shared_data[0]`.
 // For more details reference the PDF in the docstring for k_accumulate_energy
 template <unsigned int THREADS_PER_BLOCK>
-__device__ __forceinline__ void block_energy_reduce(volatile __int128 *shared_data, int tid) {
+__device__ __forceinline__ void block_energy_reduce(volatile EnergyType *shared_data, int tid) {
     static_assert(THREADS_PER_BLOCK <= 1024 && (THREADS_PER_BLOCK & (THREADS_PER_BLOCK - 1)) == 0);
 
     // For larger blocks larger than a warp
@@ -159,11 +159,11 @@ __device__ __forceinline__ void block_energy_reduce(volatile __int128 *shared_da
 template <unsigned int BLOCK_SIZE>
 void __global__ k_accumulate_energy(
     int N,
-    const __int128 *__restrict__ input_buffer, // [N]
-    __int128 *__restrict__ u_buffer            // [1]
+    const EnergyType *__restrict__ input_buffer, // [N]
+    EnergyType *__restrict__ u_buffer            // [1]
 ) {
 
-    __shared__ __int128 shared_mem[BLOCK_SIZE];
+    __shared__ EnergyType shared_mem[BLOCK_SIZE];
     unsigned int tid = threadIdx.x;
     if (tid >= BLOCK_SIZE) {
         return;

--- a/timemachine/cpp/src/harmonic_angle.cu
+++ b/timemachine/cpp/src/harmonic_angle.cu
@@ -47,7 +47,7 @@ void HarmonicAngle<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     const int tpb = DEFAULT_THREADS_PER_BLOCK;

--- a/timemachine/cpp/src/harmonic_angle.cu
+++ b/timemachine/cpp/src/harmonic_angle.cu
@@ -41,10 +41,10 @@ template <typename RealType>
 void HarmonicAngle<RealType>::execute_device(
     const int N,
     const int P,
-    const double *d_x,
+    const CoordsType *d_x,
     const ParamsType *d_p,
 
-    const double *d_box,
+    const CoordsType *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,

--- a/timemachine/cpp/src/harmonic_angle.cu
+++ b/timemachine/cpp/src/harmonic_angle.cu
@@ -42,7 +42,8 @@ void HarmonicAngle<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/harmonic_angle.hpp
+++ b/timemachine/cpp/src/harmonic_angle.hpp
@@ -22,7 +22,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/harmonic_angle.hpp
+++ b/timemachine/cpp/src/harmonic_angle.hpp
@@ -21,10 +21,10 @@ public:
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
 
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
         EnergyType *d_u,

--- a/timemachine/cpp/src/harmonic_angle.hpp
+++ b/timemachine/cpp/src/harmonic_angle.hpp
@@ -9,7 +9,7 @@ template <typename RealType> class HarmonicAngle : public Potential {
 
 private:
     int *d_angle_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     const int A_;
 
@@ -27,7 +27,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/harmonic_angle_stable.cu
+++ b/timemachine/cpp/src/harmonic_angle_stable.cu
@@ -40,10 +40,10 @@ template <typename RealType>
 void HarmonicAngleStable<RealType>::execute_device(
     const int N,
     const int P,
-    const double *d_x,
+    const CoordsType *d_x,
     const ParamsType *d_p,
 
-    const double *d_box,
+    const CoordsType *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,

--- a/timemachine/cpp/src/harmonic_angle_stable.cu
+++ b/timemachine/cpp/src/harmonic_angle_stable.cu
@@ -41,7 +41,8 @@ void HarmonicAngleStable<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/harmonic_angle_stable.cu
+++ b/timemachine/cpp/src/harmonic_angle_stable.cu
@@ -46,7 +46,7 @@ void HarmonicAngleStable<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     const int tpb = DEFAULT_THREADS_PER_BLOCK;

--- a/timemachine/cpp/src/harmonic_angle_stable.hpp
+++ b/timemachine/cpp/src/harmonic_angle_stable.hpp
@@ -22,7 +22,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/harmonic_angle_stable.hpp
+++ b/timemachine/cpp/src/harmonic_angle_stable.hpp
@@ -9,7 +9,7 @@ template <typename RealType> class HarmonicAngleStable : public Potential {
 
 private:
     int *d_angle_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     const int A_;
 
@@ -27,7 +27,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/harmonic_angle_stable.hpp
+++ b/timemachine/cpp/src/harmonic_angle_stable.hpp
@@ -21,10 +21,10 @@ public:
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
 
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
         EnergyType *d_u,

--- a/timemachine/cpp/src/harmonic_bond.cu
+++ b/timemachine/cpp/src/harmonic_bond.cu
@@ -38,7 +38,8 @@ void HarmonicBond<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/harmonic_bond.cu
+++ b/timemachine/cpp/src/harmonic_bond.cu
@@ -37,10 +37,10 @@ template <typename RealType>
 void HarmonicBond<RealType>::execute_device(
     const int N,
     const int P,
-    const double *d_x,
+    const CoordsType *d_x,
     const ParamsType *d_p,
 
-    const double *d_box,
+    const CoordsType *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,

--- a/timemachine/cpp/src/harmonic_bond.cu
+++ b/timemachine/cpp/src/harmonic_bond.cu
@@ -43,7 +43,7 @@ void HarmonicBond<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (P != 2 * B_) {

--- a/timemachine/cpp/src/harmonic_bond.hpp
+++ b/timemachine/cpp/src/harmonic_bond.hpp
@@ -9,7 +9,7 @@ template <typename RealType> class HarmonicBond : public Potential {
 
 private:
     int *d_bond_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     const int B_;
 
@@ -30,7 +30,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,
-        __int128 *d_u, // buffered
+        EnergyType *d_u, // buffered
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/harmonic_bond.hpp
+++ b/timemachine/cpp/src/harmonic_bond.hpp
@@ -25,7 +25,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/harmonic_bond.hpp
+++ b/timemachine/cpp/src/harmonic_bond.hpp
@@ -24,10 +24,10 @@ public:
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
 
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,
         EnergyType *d_u, // buffered

--- a/timemachine/cpp/src/hilbert_sort.cu
+++ b/timemachine/cpp/src/hilbert_sort.cu
@@ -51,8 +51,8 @@ HilbertSort::~HilbertSort(){};
 void HilbertSort::sort_device(
     const int N,
     const unsigned int *d_atom_idxs,
-    const double *d_coords,
-    const double *d_box,
+    const CoordsType *d_coords,
+    const CoordsType *d_box,
     unsigned int *d_output_perm,
     cudaStream_t stream) {
     if (N > N_) {
@@ -82,7 +82,7 @@ void HilbertSort::sort_device(
     gpuErrchk(cudaPeekAtLastError());
 }
 
-std::vector<unsigned int> HilbertSort::sort_host(const int N, const double *h_coords, const double *h_box) {
+std::vector<unsigned int> HilbertSort::sort_host(const int N, const CoordsType *h_coords, const CoordsType *h_box) {
 
     std::vector<unsigned int> h_atom_idxs(N);
     std::iota(h_atom_idxs.begin(), h_atom_idxs.end(), 0);

--- a/timemachine/cpp/src/hilbert_sort.hpp
+++ b/timemachine/cpp/src/hilbert_sort.hpp
@@ -2,6 +2,7 @@
 #include "cuda_runtime.h"
 #include "device_buffer.hpp"
 #include "math_utils.cuh"
+#include "types.hpp"
 #include <memory>
 #include <numeric>
 #include <vector>
@@ -30,12 +31,12 @@ public:
     void sort_device(
         const int N,
         const unsigned int *d_atom_idxs,
-        const double *d_coords,
-        const double *d_box,
+        const CoordsType *d_coords,
+        const CoordsType *d_box,
         unsigned int *d_output_perm,
         cudaStream_t stream);
 
-    std::vector<unsigned int> sort_host(const int N, const double *h_coords, const double *h_box);
+    std::vector<unsigned int> sort_host(const int N, const CoordsType *h_coords, const CoordsType *h_box);
 };
 
 } // namespace timemachine

--- a/timemachine/cpp/src/integrator.hpp
+++ b/timemachine/cpp/src/integrator.hpp
@@ -12,25 +12,25 @@ public:
 
     virtual void step_fwd(
         std::vector<std::shared_ptr<BoundPotential>> &bps,
-        double *d_x_t,
+        CoordsType *d_x_t,
         double *d_v_t,
-        double *d_box_t,
+        CoordsType *d_box_t,
         unsigned int *d_idxs,
         cudaStream_t stream) = 0;
 
     virtual void initialize(
         std::vector<std::shared_ptr<BoundPotential>> &bps,
-        double *d_x_t,
+        CoordsType *d_x_t,
         double *d_v_t,
-        double *d_box_t,
+        CoordsType *d_box_t,
         unsigned int *d_idxs,
         cudaStream_t stream) = 0;
 
     virtual void finalize(
         std::vector<std::shared_ptr<BoundPotential>> &bps,
-        double *d_x_t,
+        CoordsType *d_x_t,
         double *d_v_t,
-        double *d_box_t,
+        CoordsType *d_box_t,
         unsigned int *d_idxs,
         cudaStream_t stream) = 0;
 };

--- a/timemachine/cpp/src/kernels/k_barostat.cuh
+++ b/timemachine/cpp/src/kernels/k_barostat.cuh
@@ -7,10 +7,10 @@
 template <typename RealType>
 void __global__ k_rescale_positions(
     const int N,                                     // Number of atoms to shift
-    double *__restrict__ coords,                     // Coordinates
+    CoordsType *__restrict__ coords,                 // Coordinates
     const RealType *__restrict__ length_scale,       // [1]
-    const double *__restrict__ box,                  // [9]
-    double *__restrict__ scaled_box,                 // [9]
+    const CoordsType *__restrict__ box,              // [9]
+    CoordsType *__restrict__ scaled_box,             // [9]
     const int *__restrict__ atom_idxs,               // [N]
     const int *__restrict__ mol_idxs,                // [N]
     const int *__restrict__ mol_offsets,             // [N]
@@ -68,7 +68,7 @@ void __global__ k_rescale_positions(
 template <typename RealType>
 void __global__ k_find_group_centroids(
     const int N,                               // Number of atoms to shift
-    const double *__restrict__ coords,         // Coordinates [N * 3]
+    const CoordsType *__restrict__ coords,     // Coordinates [N * 3]
     const int *__restrict__ atom_idxs,         // [N]
     const int *__restrict__ mol_idxs,          // [N]
     unsigned long long *__restrict__ centroids // [num_molecules * 3]
@@ -90,7 +90,7 @@ template <typename RealType>
 void __global__ k_setup_barostat_move(
     const bool adaptive,
     const RealType *__restrict__ rand,     // [2], use first value, second value is metropolis condition
-    double *__restrict__ d_box,            // [3*3]
+    CoordsType *__restrict__ d_box,        // [3*3]
     RealType *__restrict__ d_volume_delta, // [1]
     double *__restrict__ d_volume_scale,   // [1]
     RealType *__restrict__ d_length_scale  // [1]
@@ -124,10 +124,10 @@ void __global__ k_decide_move(
     double *__restrict__ d_volume_scale,
     const EnergyType *__restrict__ d_init_u,
     const EnergyType *__restrict__ d_final_u,
-    double *__restrict__ d_box,
-    const double *__restrict__ d_box_output,
-    double *__restrict__ d_x,
-    const double *__restrict__ d_x_output,
+    CoordsType *__restrict__ d_box,
+    const CoordsType *__restrict__ d_box_output,
+    CoordsType *__restrict__ d_x,
+    const CoordsType *__restrict__ d_x_output,
     int *__restrict__ num_accepted,
     int *__restrict__ num_attempted) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;

--- a/timemachine/cpp/src/kernels/k_barostat.cuh
+++ b/timemachine/cpp/src/kernels/k_barostat.cuh
@@ -122,8 +122,8 @@ void __global__ k_decide_move(
     const RealType *__restrict__ rand, // [2] Use second value
     RealType *__restrict__ d_volume_delta,
     double *__restrict__ d_volume_scale,
-    const __int128 *__restrict__ d_init_u,
-    const __int128 *__restrict__ d_final_u,
+    const EnergyType *__restrict__ d_init_u,
+    const EnergyType *__restrict__ d_final_u,
     double *__restrict__ d_box,
     const double *__restrict__ d_box_output,
     double *__restrict__ d_x,

--- a/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
@@ -1,10 +1,11 @@
 #pragma once
 
+#include "../types.hpp"
 #include "k_fixed_point.cuh"
 
 template <typename RealType>
 void __global__ k_calc_centroid(
-    const double *__restrict__ d_coords, // [n, 3]
+    const CoordsType *__restrict__ d_coords, // [n, 3]
     const int *__restrict__ d_group_a_idxs,
     const int *__restrict__ d_group_b_idxs,
     const int N_A,
@@ -29,7 +30,7 @@ void __global__ k_calc_centroid(
 template <typename RealType>
 void __global__ k_centroid_restraint(
     // const int N,     // number of bonds, ignore for now
-    const double *__restrict__ d_coords, // [n, 3]
+    const CoordsType *__restrict__ d_coords, // [n, 3]
     const int *__restrict__ d_group_a_idxs,
     const int *__restrict__ d_group_b_idxs,
     const int N_A,

--- a/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_centroid_restraint.cuh
@@ -40,7 +40,7 @@ void __global__ k_centroid_restraint(
     const double kb,
     const double b0,
     unsigned long long *d_du_dx,
-    __int128 *d_u) {
+    EnergyType *d_u) {
 
     const int t_idx = blockDim.x * blockIdx.x + threadIdx.x;
     if (N_A + N_B <= t_idx) {

--- a/timemachine/cpp/src/kernels/k_chiral_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_chiral_restraint.cuh
@@ -11,7 +11,7 @@ void __global__ k_chiral_atom_restraint(
     const int *__restrict__ idxs,          // [R, 2]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     const auto r_idx = blockDim.x * blockIdx.x + threadIdx.x;
 
@@ -98,7 +98,7 @@ void __global__ k_chiral_bond_restraint(
     const int *__restrict__ signs,         // [R]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     const auto r_idx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/timemachine/cpp/src/kernels/k_chiral_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_chiral_restraint.cuh
@@ -1,4 +1,5 @@
 #include "../fixed_point.hpp"
+#include "../types.hpp"
 #include "chiral_utils.cuh"
 #include "k_fixed_point.cuh"
 
@@ -6,8 +7,8 @@ template <typename RealType>
 void __global__ k_chiral_atom_restraint(
     const int R, // number of restraints
     const double *__restrict__ coords,
-    const double *__restrict__ params, // [R]
-    const int *__restrict__ idxs,      // [R, 2]
+    const ParamsType *__restrict__ params, // [R]
+    const int *__restrict__ idxs,          // [R, 2]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
     __int128 *__restrict__ u) {
@@ -92,9 +93,9 @@ template <typename RealType>
 void __global__ k_chiral_bond_restraint(
     const int R, // number of restraints
     const double *__restrict__ coords,
-    const double *__restrict__ params, // [R]
-    const int *__restrict__ idxs,      // [R, 2]
-    const int *__restrict__ signs,     // [R]
+    const ParamsType *__restrict__ params, // [R]
+    const int *__restrict__ idxs,          // [R, 2]
+    const int *__restrict__ signs,         // [R]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
     __int128 *__restrict__ u) {

--- a/timemachine/cpp/src/kernels/k_chiral_restraint.cuh
+++ b/timemachine/cpp/src/kernels/k_chiral_restraint.cuh
@@ -6,7 +6,7 @@
 template <typename RealType>
 void __global__ k_chiral_atom_restraint(
     const int R, // number of restraints
-    const double *__restrict__ coords,
+    const CoordsType *__restrict__ coords,
     const ParamsType *__restrict__ params, // [R]
     const int *__restrict__ idxs,          // [R, 2]
     unsigned long long *__restrict__ du_dx,
@@ -92,7 +92,7 @@ void __global__ k_chiral_atom_restraint(
 template <typename RealType>
 void __global__ k_chiral_bond_restraint(
     const int R, // number of restraints
-    const double *__restrict__ coords,
+    const CoordsType *__restrict__ coords,
     const ParamsType *__restrict__ params, // [R]
     const int *__restrict__ idxs,          // [R, 2]
     const int *__restrict__ signs,         // [R]

--- a/timemachine/cpp/src/kernels/k_fixed_point.cuh
+++ b/timemachine/cpp/src/kernels/k_fixed_point.cuh
@@ -2,6 +2,7 @@
 
 // cuda specific version
 #include "../fixed_point.hpp"
+#include "../types.hpp"
 
 // (ytz): courtesy of @scottlegrand/NVIDIA, even faster conversion
 // This was original a hack to improve perf on Maxwell, that is now needed for Ampere
@@ -70,12 +71,12 @@ template <typename RealType> unsigned long long __device__ __forceinline__ FLOAT
 
 /* FLOAT_TO_FIXED_ENERGY converts floating point energies into fixed point. Values beyond LLONG_MAX/LLONG_MIN
 * (or non-finite) will be capped to LLONG_MAX. This is accumulated into __int128 which handles the positive/negative overflows,
-* allows to account for overflows triggered by the summation of energies.
+* allows to account for overflows triggered by the summation of energies. EnergyType is a typedef for __int128.
 *
 * The energy values are only considered valid between the values LLONG_MIN and LLONG_MAX, and we use __int128 to be able to detect that the energies are invalid.
 * If there are individual interactions that are overflows (beyond limit or non-finite) we set LLONG_MAX to be the value. This way
 * the energy is beyond the bounds and only exclusion cancellations (only done between NonbondedAllPairs/IxnGroups and NonbondedPairList<..., true>) do not trigger invalid energies.
-* In the case where all interactions are within the bounds, we can still overflows due to summation which int128 allows us to detect.
+* In the case where all interactions are within the bounds, we can still overflows due to summation which __int128 allows us to detect.
 *
 * Example of Summation overflow
 * -----------------------------
@@ -83,14 +84,14 @@ template <typename RealType> unsigned long long __device__ __forceinline__ FLOAT
 * (__int128)accumulated_energy > LLONG_MAX  - Correctly detects that energies are beyond valid range
 * (long long)accumulated_energy > LLONG_MAX - Overflows and results in seemingly valid energies
 */
-template <typename RealType> __int128 __device__ __forceinline__ FLOAT_TO_FIXED_ENERGY(RealType u_orig) {
+template <typename RealType> EnergyType __device__ __forceinline__ FLOAT_TO_FIXED_ENERGY(RealType u_orig) {
     RealType u = u_orig * FIXED_EXPONENT;
     // All clashes (beyond representation of long long) are treated as LLONG_MAX, to avoid clashes of different signs but non-identical values
     // cancelling out.
-    if (!isfinite(u) || static_cast<__int128>(u) >= static_cast<__int128>(LLONG_MAX) ||
-        static_cast<__int128>(u) <= static_cast<__int128>(LLONG_MIN)) {
-        return static_cast<__int128>(LLONG_MAX);
+    if (!isfinite(u) || static_cast<EnergyType>(u) >= static_cast<EnergyType>(LLONG_MAX) ||
+        static_cast<EnergyType>(u) <= static_cast<EnergyType>(LLONG_MIN)) {
+        return static_cast<EnergyType>(LLONG_MAX);
     } else {
-        return static_cast<__int128>(real_to_int64(u));
+        return static_cast<EnergyType>(real_to_int64(u));
     }
 }

--- a/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
@@ -17,8 +17,8 @@ void __global__ k_log_probability_selection(
     const float radius,                      // Radius, corresponds to r_max for flat bottom
     const float k,                           // Constant restraint value
     const unsigned int reference_idx,        // Idx that the probability is specific to
-    const double *__restrict__ coords,       // [N, 3]
-    const double *__restrict__ box,          // [3, 3]
+    const CoordsType *__restrict__ coords,   // [N, 3]
+    const CoordsType *__restrict__ box,      // [3, 3]
     const float *__restrict__ probabilities, // [N] probabilities of selection
     unsigned int *__restrict__ selected      // [N] idx array, N if idx is not selected, else idx of coordinate
 ) {
@@ -63,8 +63,8 @@ void __global__ k_log_probability_selection(
 template <typename RealType>
 void __global__ k_flat_bottom_bond(
     const int B, // number of bonds
-    const double *__restrict__ coords,
-    const double *__restrict__ box,
+    const CoordsType *__restrict__ coords,
+    const CoordsType *__restrict__ box,
     const ParamsType *__restrict__ params, // [B, 3]
     const int *__restrict__ bond_idxs,     // [B, 2]
     unsigned long long *__restrict__ du_dx,

--- a/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
@@ -69,7 +69,7 @@ void __global__ k_flat_bottom_bond(
     const int *__restrict__ bond_idxs,     // [B, 2]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     // which bond
     const auto b_idx = blockDim.x * blockIdx.x + threadIdx.x;

--- a/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
@@ -1,4 +1,5 @@
 #include "../fixed_point.hpp"
+#include "../types.hpp"
 #include "k_fixed_point.cuh"
 
 // branchless implementation of piecewise function
@@ -64,8 +65,8 @@ void __global__ k_flat_bottom_bond(
     const int B, // number of bonds
     const double *__restrict__ coords,
     const double *__restrict__ box,
-    const double *__restrict__ params, // [B, 3]
-    const int *__restrict__ bond_idxs, // [B, 2]
+    const ParamsType *__restrict__ params, // [B, 3]
+    const int *__restrict__ bond_idxs,     // [B, 2]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
     __int128 *__restrict__ u) {

--- a/timemachine/cpp/src/kernels/k_harmonic_angle.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_angle.cuh
@@ -5,7 +5,7 @@
 template <typename RealType, int D>
 void __global__ k_harmonic_angle(
     const int A,                           // number of bonds
-    const double *__restrict__ coords,     // [N, 3]
+    const CoordsType *__restrict__ coords, // [N, 3]
     const ParamsType *__restrict__ params, // [P, 2]
     const int *__restrict__ angle_idxs,    // [A, 3]
     unsigned long long *__restrict__ du_dx,

--- a/timemachine/cpp/src/kernels/k_harmonic_angle.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_angle.cuh
@@ -10,7 +10,7 @@ void __global__ k_harmonic_angle(
     const int *__restrict__ angle_idxs,    // [A, 3]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     const auto a_idx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/timemachine/cpp/src/kernels/k_harmonic_angle.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_angle.cuh
@@ -1,12 +1,13 @@
 #include "../fixed_point.hpp"
+#include "../types.hpp"
 #include "k_fixed_point.cuh"
 
 template <typename RealType, int D>
 void __global__ k_harmonic_angle(
-    const int A,                        // number of bonds
-    const double *__restrict__ coords,  // [N, 3]
-    const double *__restrict__ params,  // [P, 2]
-    const int *__restrict__ angle_idxs, // [A, 3]
+    const int A,                           // number of bonds
+    const double *__restrict__ coords,     // [N, 3]
+    const ParamsType *__restrict__ params, // [P, 2]
+    const int *__restrict__ angle_idxs,    // [A, 3]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
     __int128 *__restrict__ u) {

--- a/timemachine/cpp/src/kernels/k_harmonic_angle_stable.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_angle_stable.cuh
@@ -11,7 +11,7 @@ void __global__ k_harmonic_angle_stable(
     const int *__restrict__ angle_idxs,    // [A, 3]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     const auto a_idx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/timemachine/cpp/src/kernels/k_harmonic_angle_stable.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_angle_stable.cuh
@@ -1,13 +1,14 @@
 #include "../fixed_point.hpp"
 #include "../gpu_utils.cuh"
+#include "../types.hpp"
 #include "k_fixed_point.cuh"
 
 template <typename RealType>
 void __global__ k_harmonic_angle_stable(
-    const int A,                        // number of angles
-    const double *__restrict__ coords,  // [N, 3]
-    const double *__restrict__ params,  // [P, 3]
-    const int *__restrict__ angle_idxs, // [A, 3]
+    const int A,                           // number of angles
+    const double *__restrict__ coords,     // [N, 3]
+    const ParamsType *__restrict__ params, // [P, 3]
+    const int *__restrict__ angle_idxs,    // [A, 3]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
     __int128 *__restrict__ u) {

--- a/timemachine/cpp/src/kernels/k_harmonic_angle_stable.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_angle_stable.cuh
@@ -6,7 +6,7 @@
 template <typename RealType>
 void __global__ k_harmonic_angle_stable(
     const int A,                           // number of angles
-    const double *__restrict__ coords,     // [N, 3]
+    const CoordsType *__restrict__ coords, // [N, 3]
     const ParamsType *__restrict__ params, // [P, 3]
     const int *__restrict__ angle_idxs,    // [A, 3]
     unsigned long long *__restrict__ du_dx,

--- a/timemachine/cpp/src/kernels/k_harmonic_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_bond.cuh
@@ -10,7 +10,7 @@ void __global__ k_harmonic_bond(
     const int *__restrict__ bond_idxs,     // [B, 2]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     const auto b_idx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/timemachine/cpp/src/kernels/k_harmonic_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_bond.cuh
@@ -5,7 +5,7 @@
 template <typename RealType>
 void __global__ k_harmonic_bond(
     const int B, // number of bonds
-    const double *__restrict__ coords,
+    const CoordsType *__restrict__ coords,
     const ParamsType *__restrict__ params, // [B, 2]
     const int *__restrict__ bond_idxs,     // [B, 2]
     unsigned long long *__restrict__ du_dx,

--- a/timemachine/cpp/src/kernels/k_harmonic_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_harmonic_bond.cuh
@@ -1,12 +1,13 @@
 #include "../fixed_point.hpp"
+#include "../types.hpp"
 #include "k_fixed_point.cuh"
 
 template <typename RealType>
 void __global__ k_harmonic_bond(
     const int B, // number of bonds
     const double *__restrict__ coords,
-    const double *__restrict__ params, // [B, 2]
-    const int *__restrict__ bond_idxs, // [B, 2]
+    const ParamsType *__restrict__ params, // [B, 2]
+    const int *__restrict__ bond_idxs,     // [B, 2]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
     __int128 *__restrict__ u) {

--- a/timemachine/cpp/src/kernels/k_hilbert.cu
+++ b/timemachine/cpp/src/kernels/k_hilbert.cu
@@ -5,8 +5,8 @@
 void __global__ k_coords_to_kv_gather(
     const int N,
     const unsigned int *__restrict__ atom_idxs,
-    const double *__restrict__ coords,
-    const double *__restrict__ box,
+    const CoordsType *__restrict__ coords,
+    const CoordsType *__restrict__ box,
     const unsigned int *__restrict__ bin_to_idx,
     unsigned int *__restrict__ keys,
     unsigned int *__restrict__ vals) {

--- a/timemachine/cpp/src/kernels/k_hilbert.cuh
+++ b/timemachine/cpp/src/kernels/k_hilbert.cuh
@@ -1,4 +1,5 @@
 #pragma once
+#include "../types.hpp"
 
 // Divide [0,1]^3 box into HILBERT_GRID_DIM^3 voxels for Hilbert sort
 static const int HILBERT_GRID_DIM = 128;
@@ -13,8 +14,8 @@ static_assert(HILBERT_GRID_DIM <= HILBERT_MAX_GRID_DIM);
 void __global__ k_coords_to_kv_gather(
     const int N,
     const unsigned int *__restrict__ atom_idxs,
-    const double *__restrict__ coords,
-    const double *__restrict__ box,
+    const CoordsType *__restrict__ coords,
+    const CoordsType *__restrict__ box,
     const unsigned int *__restrict__ bin_to_idx,
     unsigned int *__restrict__ keys,
     unsigned int *__restrict__ vals);

--- a/timemachine/cpp/src/kernels/k_integrator.cuh
+++ b/timemachine/cpp/src/kernels/k_integrator.cuh
@@ -8,7 +8,7 @@ __global__ void k_update_forward_baoab(
     const RealType *__restrict__ cbs,             // N
     const RealType *__restrict__ ccs,             // N
     const RealType *__restrict__ noise,           // N x 3
-    double *__restrict__ x_t,                     // N x 3
+    CoordsType *__restrict__ x_t,                 // N x 3
     double *__restrict__ v_t,                     // N x 3
     const unsigned long long *__restrict__ du_dx, // N x 3
     const RealType dt) {
@@ -55,8 +55,8 @@ __global__ void half_step_velocity_verlet(
     const int D,
     const unsigned int *__restrict__ idxs,
     const RealType *__restrict__ cbs, // N, dt / mass
-    RealType *__restrict__ x_t,
-    RealType *__restrict__ v_t,
+    CoordsType *__restrict__ x_t,
+    double *__restrict__ v_t,
     const unsigned long long *__restrict__ du_dx,
     const RealType dt) {
     int kernel_idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -90,8 +90,8 @@ __global__ void update_forward_velocity_verlet(
     const int D,
     const unsigned int *__restrict__ idxs,
     const RealType *__restrict__ cbs, // N, dt / mass
-    RealType *__restrict__ x_t,
-    RealType *__restrict__ v_t,
+    CoordsType *__restrict__ x_t,
+    double *__restrict__ v_t,
     const unsigned long long *__restrict__ du_dx,
     const RealType dt) {
     int kernel_idx = blockIdx.x * blockDim.x + threadIdx.x;

--- a/timemachine/cpp/src/kernels/k_local_md.cuh
+++ b/timemachine/cpp/src/kernels/k_local_md.cuh
@@ -1,4 +1,5 @@
 // Kernels specific to Local MD implementation.
+#include "../types.hpp"
 
 void __global__ k_construct_bonded_params(
     const int num_idxs,               // Number of idxs
@@ -9,7 +10,7 @@ void __global__ k_construct_bonded_params(
     const double r_max,
     const unsigned int *__restrict__ idxs, // [num_idxs]
     int *__restrict__ bonds,               // [num_idxs * 2]
-    double *__restrict__ params            // [num_idxs * 3]
+    ParamsType *__restrict__ params        // [num_idxs * 3]
 ) {
     const auto idx = blockDim.x * blockIdx.x + threadIdx.x;
     if (idx >= num_idxs) {

--- a/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
@@ -10,8 +10,8 @@ template <typename RealType> RealType __device__ __forceinline__ stable_log_1_ex
 template <typename RealType>
 void __global__ k_log_flat_bottom_bond(
     const int B, // number of bonds
-    const double *__restrict__ coords,
-    const double *__restrict__ box,
+    const CoordsType *__restrict__ coords,
+    const CoordsType *__restrict__ box,
     const ParamsType *__restrict__ params, // [B, 3]
     const int *__restrict__ bond_idxs,     // [B, 2]
     const double beta,

--- a/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
@@ -12,8 +12,8 @@ void __global__ k_log_flat_bottom_bond(
     const int B, // number of bonds
     const double *__restrict__ coords,
     const double *__restrict__ box,
-    const double *__restrict__ params, // [B, 3]
-    const int *__restrict__ bond_idxs, // [B, 2]
+    const ParamsType *__restrict__ params, // [B, 3]
+    const int *__restrict__ bond_idxs,     // [B, 2]
     const double beta,
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,

--- a/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
@@ -17,7 +17,7 @@ void __global__ k_log_flat_bottom_bond(
     const double beta,
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     // which bond
     const auto b_idx = blockDim.x * blockIdx.x + threadIdx.x;

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -11,8 +11,8 @@ void __global__ k_find_block_bounds(
     const int num_tiles,                       // Number of tiles
     const int num_indices,                     // Number of indices
     const unsigned int *__restrict__ row_idxs, // [num_indices]
-    const double *__restrict__ coords,         // [N*3]
-    const double *__restrict__ box,            // [3*3]
+    const CoordsType *__restrict__ coords,     // [N*3]
+    const CoordsType *__restrict__ box,        // [3*3]
     RealType *__restrict__ block_bounds_ctr,   // [num_tiles*3]
     RealType *__restrict__ block_bounds_ext,   // [num_tiles*3]
     unsigned int *ixn_count                    // [1]
@@ -205,8 +205,8 @@ void __global__ k_find_blocks_with_ixns(
     const RealType *__restrict__ column_bb_ext,   // [N * 3] block extents
     const RealType *__restrict__ row_bb_ctr,      // [N * 3] block centers
     const RealType *__restrict__ row_bb_ext,      // [N * 3] block extents
-    const double *__restrict__ coords,            // [N * 3]
-    const double *__restrict__ box,
+    const CoordsType *__restrict__ coords,        // [N * 3]
+    const CoordsType *__restrict__ box,
     unsigned int *__restrict__ interactionCount, // number of tiles that have interactions
     int *__restrict__ interactingTiles,          // the row block idx of the tile that is interacting
     unsigned int *__restrict__ interactingAtoms, // [NR * WARP_SIZE] atom indices interacting with each row block

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -10,10 +10,10 @@ template <typename RealType>
 void __global__ k_check_rebuild_coords_and_box_gather(
     const int N,
     const unsigned int *atom_idxs,
-    const double *__restrict__ new_coords,
-    const double *__restrict__ old_coords,
-    const double *__restrict__ new_box,
-    const double *__restrict__ old_box,
+    const CoordsType *__restrict__ new_coords,
+    const CoordsType *__restrict__ old_coords,
+    const CoordsType *__restrict__ new_box,
+    const CoordsType *__restrict__ old_box,
     const double padding,
     int *rebuild_flag) {
 
@@ -110,7 +110,7 @@ void __device__ v_nonbonded_unified(
     const int tile_idx,
     const int N,
     const int NR,
-    const double *__restrict__ coords,     // [N * 3]
+    const CoordsType *__restrict__ coords, // [N * 3]
     const ParamsType *__restrict__ params, // [N * PARAMS_PER_ATOM]
     box_cache<RealType> &shared_box,
     EnergyType *energy_buffer, // [blockDim.x]
@@ -329,9 +329,9 @@ void __global__ k_nonbonded_unified(
     const int N,  // Number of atoms
     const int NR, // Number of row indices
     const unsigned int *ixn_count,
-    const double *__restrict__ coords,     // [N, 3]
+    const CoordsType *__restrict__ coords, // [N, 3]
     const ParamsType *__restrict__ params, // [N, PARAMS_PER_ATOM]
-    const double *__restrict__ box,        // [3, 3]
+    const CoordsType *__restrict__ box,    // [3, 3]
     const double beta,
     const double cutoff,
     const unsigned int *__restrict__ row_idxs,

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -2,6 +2,7 @@
 
 #include "../fixed_point.hpp"
 #include "../gpu_utils.cuh"
+#include "../types.hpp"
 #include "k_nonbonded_common.cuh"
 #include "kernel_utils.cuh"
 
@@ -57,9 +58,9 @@ void __global__ k_gather_coords_and_params(
     const int N,
     const unsigned int *__restrict__ idxs,
     const RealType *__restrict__ coords,
-    const RealType *__restrict__ params,
+    const ParamsType *__restrict__ params,
     RealType *__restrict__ gathered_coords,
-    RealType *__restrict__ gathered_params) {
+    ParamsType *__restrict__ gathered_params) {
     static_assert(COORDS_DIM == 3);
     static_assert(PARAMS_DIM == PARAMS_PER_ATOM);
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -109,8 +110,8 @@ void __device__ v_nonbonded_unified(
     const int tile_idx,
     const int N,
     const int NR,
-    const double *__restrict__ coords, // [N * 3]
-    const double *__restrict__ params, // [N * PARAMS_PER_ATOM]
+    const double *__restrict__ coords,     // [N * 3]
+    const ParamsType *__restrict__ params, // [N * PARAMS_PER_ATOM]
     box_cache<RealType> &shared_box,
     __int128 *energy_buffer, // [blockDim.x]
     const double beta,
@@ -328,9 +329,9 @@ void __global__ k_nonbonded_unified(
     const int N,  // Number of atoms
     const int NR, // Number of row indices
     const unsigned int *ixn_count,
-    const double *__restrict__ coords, // [N, 3]
-    const double *__restrict__ params, // [N, PARAMS_PER_ATOM]
-    const double *__restrict__ box,    // [3, 3]
+    const double *__restrict__ coords,     // [N, 3]
+    const ParamsType *__restrict__ params, // [N, PARAMS_PER_ATOM]
+    const double *__restrict__ box,        // [3, 3]
     const double beta,
     const double cutoff,
     const unsigned int *__restrict__ row_idxs,

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -113,7 +113,7 @@ void __device__ v_nonbonded_unified(
     const double *__restrict__ coords,     // [N * 3]
     const ParamsType *__restrict__ params, // [N * PARAMS_PER_ATOM]
     box_cache<RealType> &shared_box,
-    __int128 *energy_buffer, // [blockDim.x]
+    EnergyType *energy_buffer, // [blockDim.x]
     const double beta,
     const double cutoff,
     const unsigned int *__restrict__ row_idxs,
@@ -339,11 +339,11 @@ void __global__ k_nonbonded_unified(
     const unsigned int *__restrict__ ixn_atoms,
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u_buffer // [blockDim.x]
+    EnergyType *__restrict__ u_buffer // [blockDim.x]
 ) {
     static_assert(THREADS <= 256 && (THREADS & (THREADS - 1)) == 0);
     __shared__ box_cache<RealType> shared_box;
-    __shared__ __int128 block_energy_buffer[THREADS];
+    __shared__ EnergyType block_energy_buffer[THREADS];
     if (COMPUTE_U) {
         block_energy_buffer[threadIdx.x] = 0; // Zero out the energy buffer
     }

--- a/timemachine/cpp/src/kernels/k_nonbonded_pair_list.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_pair_list.cuh
@@ -6,6 +6,7 @@
 // using this kernel.
 
 #include "../fixed_point.hpp"
+#include "../types.hpp"
 #include "k_nonbonded_common.cuh"
 
 template <bool Negated>
@@ -17,7 +18,7 @@ template <typename RealType, bool Negated>
 void __global__ k_nonbonded_pair_list(
     const int M, // number of pairs
     const double *__restrict__ coords,
-    const double *__restrict__ params,
+    const ParamsType *__restrict__ params,
     const double *__restrict__ box,
     const int *__restrict__ pair_idxs, // [M, 2] pair-list of atoms
     const double *__restrict__ scales, // [M]

--- a/timemachine/cpp/src/kernels/k_nonbonded_pair_list.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_pair_list.cuh
@@ -26,7 +26,7 @@ void __global__ k_nonbonded_pair_list(
     const double cutoff,
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u_buffer) {
+    EnergyType *__restrict__ u_buffer) {
 
     // (ytz): oddly enough the order of atom_i and atom_j
     // seem to not matter. I think this is because distance calculations

--- a/timemachine/cpp/src/kernels/k_nonbonded_pair_list.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_pair_list.cuh
@@ -17,9 +17,9 @@ void __device__ __forceinline__ accumulate(unsigned long long *__restrict acc, u
 template <typename RealType, bool Negated>
 void __global__ k_nonbonded_pair_list(
     const int M, // number of pairs
-    const double *__restrict__ coords,
+    const CoordsType *__restrict__ coords,
     const ParamsType *__restrict__ params,
-    const double *__restrict__ box,
+    const CoordsType *__restrict__ box,
     const int *__restrict__ pair_idxs, // [M, 2] pair-list of atoms
     const double *__restrict__ scales, // [M]
     const double beta,

--- a/timemachine/cpp/src/kernels/k_nonbonded_precomputed.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_precomputed.cuh
@@ -10,9 +10,9 @@ static const int PARAMS_PER_PAIR = PARAMS_PER_ATOM;
 template <typename RealType>
 void __global__ k_nonbonded_precomputed(
     const int M,                           // number of pairs
-    const double *__restrict__ coords,     // [N, 3] coordinates
+    const CoordsType *__restrict__ coords, // [N, 3] coordinates
     const ParamsType *__restrict__ params, // [M, 4] q_ij, s_ij, e_ij, w_offset_ij
-    const double *__restrict__ box,        // box vectors
+    const CoordsType *__restrict__ box,    // box vectors
     const int *__restrict__ pair_idxs,     // [M, 2] pair-list of atoms
     const double beta,
     const double cutoff,

--- a/timemachine/cpp/src/kernels/k_nonbonded_precomputed.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_precomputed.cuh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../types.hpp"
 #include "k_nonbonded_common.cuh"
 
 // Shape of parameter array is identical to other nonbonded variants
@@ -8,11 +9,11 @@ static const int PARAMS_PER_PAIR = PARAMS_PER_ATOM;
 
 template <typename RealType>
 void __global__ k_nonbonded_precomputed(
-    const int M,                       // number of pairs
-    const double *__restrict__ coords, // [N, 3] coordinates
-    const double *__restrict__ params, // [M, 4] q_ij, s_ij, e_ij, w_offset_ij
-    const double *__restrict__ box,    // box vectors
-    const int *__restrict__ pair_idxs, // [M, 2] pair-list of atoms
+    const int M,                           // number of pairs
+    const double *__restrict__ coords,     // [N, 3] coordinates
+    const ParamsType *__restrict__ params, // [M, 4] q_ij, s_ij, e_ij, w_offset_ij
+    const double *__restrict__ box,        // box vectors
+    const int *__restrict__ pair_idxs,     // [M, 2] pair-list of atoms
     const double beta,
     const double cutoff,
     unsigned long long *__restrict__ du_dx,

--- a/timemachine/cpp/src/kernels/k_nonbonded_precomputed.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_precomputed.cuh
@@ -18,7 +18,7 @@ void __global__ k_nonbonded_precomputed(
     const double cutoff,
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u_buffer) {
+    EnergyType *__restrict__ u_buffer) {
 
     const int pair_idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (pair_idx >= M) {
@@ -75,7 +75,7 @@ void __global__ k_nonbonded_precomputed(
     delta_y -= box_y * nearbyint(delta_y * inv_box_y);
     delta_z -= box_z * nearbyint(delta_z * inv_box_z);
 
-    __int128 energy = 0;
+    EnergyType energy = 0;
 
     RealType d2_ij = delta_x * delta_x + delta_y * delta_y + delta_z * delta_z + delta_w * delta_w;
 

--- a/timemachine/cpp/src/kernels/k_periodic_torsion.cuh
+++ b/timemachine/cpp/src/kernels/k_periodic_torsion.cuh
@@ -24,7 +24,7 @@ void __global__ k_periodic_torsion(
     const int *__restrict__ torsion_idxs,  // [b, 4]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u) {
+    EnergyType *__restrict__ u) {
 
     const auto t_idx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/timemachine/cpp/src/kernels/k_periodic_torsion.cuh
+++ b/timemachine/cpp/src/kernels/k_periodic_torsion.cuh
@@ -1,5 +1,6 @@
 #include "../fixed_point.hpp"
 #include "../gpu_utils.cuh"
+#include "../types.hpp"
 #include "k_fixed_point.cuh"
 
 template <typename RealType> inline __device__ RealType dot_product(const RealType a[3], const RealType b[3]) {
@@ -17,10 +18,10 @@ inline __device__ void cross_product(const RealType a[3], const RealType b[3], R
 
 template <typename RealType, int D>
 void __global__ k_periodic_torsion(
-    const int T,                          // number of bonds
-    const double *__restrict__ coords,    // [n, 3]
-    const double *__restrict__ params,    // [p, 3]
-    const int *__restrict__ torsion_idxs, // [b, 4]
+    const int T,                           // number of bonds
+    const double *__restrict__ coords,     // [n, 3]
+    const ParamsType *__restrict__ params, // [p, 3]
+    const int *__restrict__ torsion_idxs,  // [b, 4]
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
     __int128 *__restrict__ u) {

--- a/timemachine/cpp/src/kernels/k_periodic_torsion.cuh
+++ b/timemachine/cpp/src/kernels/k_periodic_torsion.cuh
@@ -19,7 +19,7 @@ inline __device__ void cross_product(const RealType a[3], const RealType b[3], R
 template <typename RealType, int D>
 void __global__ k_periodic_torsion(
     const int T,                           // number of bonds
-    const double *__restrict__ coords,     // [n, 3]
+    const CoordsType *__restrict__ coords, // [n, 3]
     const ParamsType *__restrict__ params, // [p, 3]
     const int *__restrict__ torsion_idxs,  // [b, 4]
     unsigned long long *__restrict__ du_dx,

--- a/timemachine/cpp/src/langevin_integrator.cu
+++ b/timemachine/cpp/src/langevin_integrator.cu
@@ -50,9 +50,9 @@ template <typename RealType> double LangevinIntegrator<RealType>::get_temperatur
 template <typename RealType>
 void LangevinIntegrator<RealType>::step_fwd(
     std::vector<std::shared_ptr<BoundPotential>> &bps,
-    double *d_x_t,
+    CoordsType *d_x_t,
     double *d_v_t,
-    double *d_box_t,
+    CoordsType *d_box_t,
     unsigned int *d_idxs,
     cudaStream_t stream) {
     const int D = 3;
@@ -88,18 +88,18 @@ void LangevinIntegrator<RealType>::step_fwd(
 template <typename RealType>
 void LangevinIntegrator<RealType>::initialize(
     std::vector<std::shared_ptr<BoundPotential>> &bps,
-    double *d_x_t,
+    CoordsType *d_x_t,
     double *d_v_t,
-    double *d_box_t,
+    CoordsType *d_box_t,
     unsigned int *d_idxs,
     cudaStream_t stream){};
 
 template <typename RealType>
 void LangevinIntegrator<RealType>::finalize(
     std::vector<std::shared_ptr<BoundPotential>> &bps,
-    double *d_x_t,
+    CoordsType *d_x_t,
     double *d_v_t,
-    double *d_box_t,
+    CoordsType *d_box_t,
     unsigned int *d_idxs,
     cudaStream_t stream){};
 

--- a/timemachine/cpp/src/langevin_integrator.hpp
+++ b/timemachine/cpp/src/langevin_integrator.hpp
@@ -38,25 +38,25 @@ public:
 
     virtual void step_fwd(
         std::vector<std::shared_ptr<BoundPotential>> &bps,
-        double *d_x_t,
+        CoordsType *d_x_t,
         double *d_v_t,
-        double *d_box_t_,
+        CoordsType *d_box_t_,
         unsigned int *d_idxs,
         cudaStream_t stream) override;
 
     virtual void initialize(
         std::vector<std::shared_ptr<BoundPotential>> &bps,
-        double *d_x_t,
+        CoordsType *d_x_t,
         double *d_v_t,
-        double *d_box_t,
+        CoordsType *d_box_t,
         unsigned int *d_idxs,
         cudaStream_t stream) override;
 
     virtual void finalize(
         std::vector<std::shared_ptr<BoundPotential>> &bps,
-        double *d_x_t,
+        CoordsType *d_x_t,
         double *d_v_t,
-        double *d_box_t,
+        CoordsType *d_box_t,
         unsigned int *d_idxs,
         cudaStream_t stream) override;
 };

--- a/timemachine/cpp/src/local_md_potentials.cu
+++ b/timemachine/cpp/src/local_md_potentials.cu
@@ -54,7 +54,7 @@ LocalMDPotentials::LocalMDPotentials(
         default_bonds[i * 2 + 0] = 0;
         default_bonds[i * 2 + 1] = i + 1;
     }
-    std::vector<double> default_params(N_ * 3);
+    std::vector<ParamsType> default_params(N_ * 3);
     free_restraint_ = std::shared_ptr<FlatBottomBond<double>>(new FlatBottomBond<double>(default_bonds));
     // Construct a bound potential with 0 params
     bound_free_restraint_ = std::shared_ptr<BoundPotential>(new BoundPotential(free_restraint_, default_params));

--- a/timemachine/cpp/src/local_md_potentials.cu
+++ b/timemachine/cpp/src/local_md_potentials.cu
@@ -99,8 +99,8 @@ LocalMDPotentials::~LocalMDPotentials() { curandErrchk(curandDestroyGenerator(cr
 // one to ensure the same reference every time, though the seed also handles the probabilities of selecting particles, and it is suggested
 // to provide a new seed at each step.
 void LocalMDPotentials::setup_from_idxs(
-    double *d_x_t,
-    double *d_box_t,
+    CoordsType *d_x_t,
+    CoordsType *d_box_t,
     const std::vector<int> &local_idxs,
     const int seed,
     const double radius,

--- a/timemachine/cpp/src/local_md_potentials.hpp
+++ b/timemachine/cpp/src/local_md_potentials.hpp
@@ -27,8 +27,8 @@ public:
     unsigned int *get_free_idxs();
 
     void setup_from_idxs(
-        double *d_x_t_,
-        double *d_box_t,
+        CoordsType *d_x_t_,
+        CoordsType *d_box_t,
         const std::vector<int> &local_idxs,
         const int seed,
         const double radius,

--- a/timemachine/cpp/src/local_md_potentials.hpp
+++ b/timemachine/cpp/src/local_md_potentials.hpp
@@ -9,6 +9,7 @@
 #include "flat_bottom_bond.hpp"
 #include "local_md_utils.hpp"
 #include "log_flat_bottom_bond.hpp"
+#include "types.hpp"
 
 namespace timemachine {
 
@@ -65,7 +66,7 @@ private:
     std::shared_ptr<BoundPotential> bound_frozen_restraint_;
 
     DeviceBuffer<int> d_restraint_pairs_;
-    DeviceBuffer<double> d_bond_params_;
+    DeviceBuffer<ParamsType> d_bond_params_;
 
     DeviceBuffer<float> d_probability_buffer_;
 

--- a/timemachine/cpp/src/local_md_utils.cu
+++ b/timemachine/cpp/src/local_md_utils.cu
@@ -70,8 +70,8 @@ void set_nonbonded_ixn_potential_idxs(
 }
 
 std::shared_ptr<BoundPotential>
-construct_ixn_group_potential(const int N, std::shared_ptr<Potential> pot, const int P, const double *d_params) {
-    std::vector<double> h_params(P);
+construct_ixn_group_potential(const int N, std::shared_ptr<Potential> pot, const int P, const ParamsType *d_params) {
+    std::vector<ParamsType> h_params(P);
     gpuErrchk(cudaMemcpy(&h_params[0], d_params, P * sizeof(*d_params), cudaMemcpyDeviceToHost));
     std::vector<int> row_dummy_idxs{0};
     std::vector<int> col_dummy_idxs{1};

--- a/timemachine/cpp/src/local_md_utils.hpp
+++ b/timemachine/cpp/src/local_md_utils.hpp
@@ -4,6 +4,7 @@
 
 #include "bound_potential.hpp"
 #include "potential.hpp"
+#include "types.hpp"
 
 namespace timemachine {
 
@@ -22,7 +23,7 @@ void set_nonbonded_ixn_potential_idxs(
     const cudaStream_t stream);
 
 std::shared_ptr<BoundPotential>
-construct_ixn_group_potential(const int N, std::shared_ptr<Potential> pot, const int P, const double *d_params);
+construct_ixn_group_potential(const int N, std::shared_ptr<Potential> pot, const int P, const ParamsType *d_params);
 
 void verify_local_md_parameters(double radius, double k);
 

--- a/timemachine/cpp/src/log_flat_bottom_bond.cu
+++ b/timemachine/cpp/src/log_flat_bottom_bond.cu
@@ -49,7 +49,8 @@ void LogFlatBottomBond<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/log_flat_bottom_bond.cu
+++ b/timemachine/cpp/src/log_flat_bottom_bond.cu
@@ -54,7 +54,7 @@ void LogFlatBottomBond<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     const int num_params_per_bond = 3;

--- a/timemachine/cpp/src/log_flat_bottom_bond.cu
+++ b/timemachine/cpp/src/log_flat_bottom_bond.cu
@@ -48,10 +48,10 @@ template <typename RealType>
 void LogFlatBottomBond<RealType>::execute_device(
     const int N,
     const int P,
-    const double *d_x,
+    const CoordsType *d_x,
     const ParamsType *d_p,
 
-    const double *d_box,
+    const CoordsType *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,

--- a/timemachine/cpp/src/log_flat_bottom_bond.hpp
+++ b/timemachine/cpp/src/log_flat_bottom_bond.hpp
@@ -27,7 +27,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/log_flat_bottom_bond.hpp
+++ b/timemachine/cpp/src/log_flat_bottom_bond.hpp
@@ -26,10 +26,10 @@ public:
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
 
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
         EnergyType *d_u,

--- a/timemachine/cpp/src/log_flat_bottom_bond.hpp
+++ b/timemachine/cpp/src/log_flat_bottom_bond.hpp
@@ -9,7 +9,7 @@ template <typename RealType> class LogFlatBottomBond : public Potential {
 
 private:
     int *d_bond_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     int B_;
     double beta_;
@@ -32,7 +32,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/neighborlist.cu
+++ b/timemachine/cpp/src/neighborlist.cu
@@ -58,7 +58,7 @@ template <typename RealType> Neighborlist<RealType>::~Neighborlist() {
 
 template <typename RealType>
 void Neighborlist<RealType>::compute_block_bounds_host(
-    const int N, const double *h_coords, const double *h_box, double *h_bb_ctrs, double *h_bb_exts) {
+    const int N, const CoordsType *h_coords, const CoordsType *h_box, double *h_bb_ctrs, double *h_bb_exts) {
 
     const int D = 3;
     DeviceBuffer<double> d_coords(N * D);
@@ -101,8 +101,8 @@ template <typename RealType> unsigned int Neighborlist<RealType>::num_tile_ixns(
 }
 
 template <typename RealType>
-std::vector<std::vector<int>>
-Neighborlist<RealType>::get_nblist_host(int N, const double *h_coords, const double *h_box, const double cutoff) {
+std::vector<std::vector<int>> Neighborlist<RealType>::get_nblist_host(
+    int N, const CoordsType *h_coords, const CoordsType *h_box, const double cutoff) {
 
     if (N != N_) {
         throw std::runtime_error("N != N_");
@@ -147,7 +147,7 @@ Neighborlist<RealType>::get_nblist_host(int N, const double *h_coords, const dou
 
 template <typename RealType>
 void Neighborlist<RealType>::build_nblist_device(
-    const int N, const double *d_coords, const double *d_box, const double cutoff, const cudaStream_t stream) {
+    const int N, const CoordsType *d_coords, const CoordsType *d_box, const double cutoff, const cudaStream_t stream) {
 
     const int D = 3;
     this->compute_block_bounds_device(N, D, d_coords, d_box, stream);
@@ -207,10 +207,10 @@ void Neighborlist<RealType>::build_nblist_device(
 
 template <typename RealType>
 void Neighborlist<RealType>::compute_block_bounds_device(
-    const int N,            // Number of atoms
-    const int D,            // Box dimensions
-    const double *d_coords, // [N*3]
-    const double *d_box,    // [D*3]
+    const int N,                // Number of atoms
+    const int D,                // Box dimensions
+    const CoordsType *d_coords, // [N*3]
+    const CoordsType *d_box,    // [D*3]
     const cudaStream_t stream) {
 
     if (D != 3) {

--- a/timemachine/cpp/src/neighborlist.hpp
+++ b/timemachine/cpp/src/neighborlist.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "cuda_runtime.h"
 #include "math_utils.cuh"
+#include "types.hpp"
 #include <vector>
 
 namespace timemachine {
@@ -49,13 +50,17 @@ public:
     unsigned int num_tile_ixns();
 
     std::vector<std::vector<int>>
-    get_nblist_host(const int N, const double *h_coords, const double *h_box, const double cutoff);
+    get_nblist_host(const int N, const CoordsType *h_coords, const CoordsType *h_box, const double cutoff);
 
     void build_nblist_device(
-        const int N, const double *d_coords, const double *d_box, const double cutoff, const cudaStream_t stream);
+        const int N,
+        const CoordsType *d_coords,
+        const CoordsType *d_box,
+        const double cutoff,
+        const cudaStream_t stream);
 
     void compute_block_bounds_host(
-        const int N, const double *h_coords, const double *h_box, double *h_bb_ctrs, double *h_bb_exts);
+        const int N, const CoordsType *h_coords, const CoordsType *h_box, double *h_bb_ctrs, double *h_bb_exts);
 
     unsigned int *get_ixn_atoms() { return d_ixn_atoms_; };
 
@@ -84,7 +89,7 @@ private:
     int Y() const;
 
     void compute_block_bounds_device(
-        const int N, const int D, const double *d_coords, const double *d_box, cudaStream_t stream);
+        const int N, const int D, const CoordsType *d_coords, const CoordsType *d_box, cudaStream_t stream);
 };
 
 } // namespace timemachine

--- a/timemachine/cpp/src/nonbonded_all_pairs.cu
+++ b/timemachine/cpp/src/nonbonded_all_pairs.cu
@@ -167,7 +167,7 @@ void NonbondedAllPairs<RealType>::execute_device(
     const double *d_box, // 3 * 3
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     // (ytz) the nonbonded algorithm proceeds as follows:

--- a/timemachine/cpp/src/nonbonded_all_pairs.cu
+++ b/timemachine/cpp/src/nonbonded_all_pairs.cu
@@ -144,7 +144,7 @@ template <typename RealType> bool NonbondedAllPairs<RealType>::needs_sort() {
 }
 
 template <typename RealType>
-void NonbondedAllPairs<RealType>::sort(const double *d_coords, const double *d_box, cudaStream_t stream) {
+void NonbondedAllPairs<RealType>::sort(const CoordsType *d_coords, const CoordsType *d_box, cudaStream_t stream) {
     // We must rebuild the neighborlist after sorting, as the neighborlist is tied to a particular sort order
     if (!disable_hilbert_) {
         this->hilbert_sort_->sort_device(K_, d_atom_idxs_, d_coords, d_box, d_sorted_atom_idxs_, stream);
@@ -161,10 +161,10 @@ template <typename RealType>
 void NonbondedAllPairs<RealType>::execute_device(
     const int N,
     const int P,
-    const double *d_x,
+    const CoordsType *d_x,
     const ParamsType *d_p,
     // N * PARAMS_PER_ATOM
-    const double *d_box, // 3 * 3
+    const CoordsType *d_box, // 3 * 3
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,

--- a/timemachine/cpp/src/nonbonded_all_pairs.cu
+++ b/timemachine/cpp/src/nonbonded_all_pairs.cu
@@ -162,7 +162,8 @@ void NonbondedAllPairs<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,   // N * PARAMS_PER_ATOM
+    const ParamsType *d_p,
+    // N * PARAMS_PER_ATOM
     const double *d_box, // 3 * 3
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -29,8 +29,8 @@ private:
     Neighborlist<RealType> nblist_;
 
     const double nblist_padding_;
-    double *d_nblist_x_;   // coords which were used to compute the nblist
-    double *d_nblist_box_; // box which was used to rebuild the nblist
+    CoordsType *d_nblist_x_;   // coords which were used to compute the nblist
+    CoordsType *d_nblist_box_; // box which was used to rebuild the nblist
     EnergyType *d_u_buffer_;
     int *d_rebuild_nblist_; // whether or not we have to rebuild the nblist
     int *p_rebuild_nblist_; // pinned
@@ -43,7 +43,7 @@ private:
     // by atom_idxs (or the input ordering, if atom_idxs is not
     // specified)
     unsigned int *d_sorted_atom_idxs_; // [K_] indices of interacting atoms, sorted by hilbert curve index
-    double *d_gathered_x_;             // sorted coordinates for subset of atoms
+    CoordsType *d_gathered_x_;         // sorted coordinates for subset of atoms
     ParamsType *d_gathered_p_;         // sorted parameters for subset of atoms
     unsigned long long *d_gathered_du_dx_;
     unsigned long long *d_gathered_du_dp_;
@@ -58,7 +58,7 @@ private:
 
     bool needs_sort();
 
-    void sort(const double *d_x, const double *d_box, cudaStream_t stream);
+    void sort(const CoordsType *d_x, const CoordsType *d_box, cudaStream_t stream);
 
 public:
     NonbondedAllPairs(
@@ -74,9 +74,9 @@ public:
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
         EnergyType *d_u,

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -31,7 +31,7 @@ private:
     const double nblist_padding_;
     double *d_nblist_x_;   // coords which were used to compute the nblist
     double *d_nblist_box_; // box which was used to rebuild the nblist
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
     int *d_rebuild_nblist_; // whether or not we have to rebuild the nblist
     int *p_rebuild_nblist_; // pinned
 
@@ -79,7 +79,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 
     double get_cutoff() const { return cutoff_; };

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -44,7 +44,7 @@ private:
     // specified)
     unsigned int *d_sorted_atom_idxs_; // [K_] indices of interacting atoms, sorted by hilbert curve index
     double *d_gathered_x_;             // sorted coordinates for subset of atoms
-    double *d_gathered_p_;             // sorted parameters for subset of atoms
+    ParamsType *d_gathered_p_;         // sorted parameters for subset of atoms
     unsigned long long *d_gathered_du_dx_;
     unsigned long long *d_gathered_du_dp_;
 
@@ -75,7 +75,7 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/nonbonded_common.cpp
+++ b/timemachine/cpp/src/nonbonded_common.cpp
@@ -12,6 +12,7 @@
 #include "summed_potential.hpp"
 
 #include "set_utils.hpp"
+#include "types.hpp"
 
 namespace timemachine {
 
@@ -80,7 +81,7 @@ void get_nonbonded_all_pair_potentials(
         if (std::shared_ptr<FanoutSummedPotential> fanned_potential =
                 std::dynamic_pointer_cast<FanoutSummedPotential>(pot->potential);
             fanned_potential != nullptr) {
-            std::vector<double> h_params(pot->size);
+            std::vector<ParamsType> h_params(pot->size);
             if (pot->size > 0) {
                 pot->d_p.copy_to(&h_params[0]);
             }
@@ -95,7 +96,7 @@ void get_nonbonded_all_pair_potentials(
         } else if (std::shared_ptr<SummedPotential> summed_potential =
                        std::dynamic_pointer_cast<SummedPotential>(pot->potential);
                    summed_potential != nullptr) {
-            std::vector<double> h_params(pot->size);
+            std::vector<ParamsType> h_params(pot->size);
             int i = 0;
             int offset = 0;
             if (pot->size > 0) {
@@ -107,7 +108,8 @@ void get_nonbonded_all_pair_potentials(
             for (auto summed_pot : summed_potential->get_potentials()) {
 
                 if (is_summed_potential(summed_pot) || is_nonbonded_all_pairs_potential(summed_pot)) {
-                    std::vector<double> slice(h_params.begin() + offset, h_params.begin() + offset + param_sizes[i]);
+                    std::vector<ParamsType> slice(
+                        h_params.begin() + offset, h_params.begin() + offset + param_sizes[i]);
                     flattened_bps.push_back(std::shared_ptr<BoundPotential>(new BoundPotential(summed_pot, slice)));
                 }
 

--- a/timemachine/cpp/src/nonbonded_common.hpp
+++ b/timemachine/cpp/src/nonbonded_common.hpp
@@ -12,9 +12,9 @@ typedef void (*k_nonbonded_fn)(
     const int N,
     const int NR,
     const unsigned int *ixn_count,
-    const double *__restrict__ coords,
+    const CoordsType *__restrict__ coords,
     const ParamsType *__restrict__ params, // [N]
-    const double *__restrict__ box,
+    const CoordsType *__restrict__ box,
     const double beta,
     const double cutoff,
     const unsigned int *__restrict__ row_idxs,

--- a/timemachine/cpp/src/nonbonded_common.hpp
+++ b/timemachine/cpp/src/nonbonded_common.hpp
@@ -13,7 +13,7 @@ typedef void (*k_nonbonded_fn)(
     const int NR,
     const unsigned int *ixn_count,
     const double *__restrict__ coords,
-    const double *__restrict__ params, // [N]
+    const ParamsType *__restrict__ params, // [N]
     const double *__restrict__ box,
     const double beta,
     const double cutoff,

--- a/timemachine/cpp/src/nonbonded_common.hpp
+++ b/timemachine/cpp/src/nonbonded_common.hpp
@@ -22,7 +22,7 @@ typedef void (*k_nonbonded_fn)(
     const unsigned int *__restrict__ ixn_atoms,
     unsigned long long *__restrict__ du_dx,
     unsigned long long *__restrict__ du_dp,
-    __int128 *__restrict__ u_buffer);
+    EnergyType *__restrict__ u_buffer);
 
 void verify_atom_idxs(int N, const std::vector<int> &atom_idxs, const bool allow_empty = false);
 

--- a/timemachine/cpp/src/nonbonded_interaction_group.cu
+++ b/timemachine/cpp/src/nonbonded_interaction_group.cu
@@ -125,7 +125,8 @@ void NonbondedInteractionGroup<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,   // N * PARAMS_PER_ATOM
+    const ParamsType *d_p,
+    // N * PARAMS_PER_ATOM
     const double *d_box, // 3 * 3
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/nonbonded_interaction_group.cu
+++ b/timemachine/cpp/src/nonbonded_interaction_group.cu
@@ -104,7 +104,8 @@ template <typename RealType> bool NonbondedInteractionGroup<RealType>::needs_sor
 }
 
 template <typename RealType>
-void NonbondedInteractionGroup<RealType>::sort(const double *d_coords, const double *d_box, cudaStream_t stream) {
+void NonbondedInteractionGroup<RealType>::sort(
+    const CoordsType *d_coords, const CoordsType *d_box, cudaStream_t stream) {
     // We must rebuild the neighborlist after sorting, as the neighborlist is tied to a particular sort order
     if (!disable_hilbert_) {
         this->hilbert_sort_->sort_device(NR_, d_row_atom_idxs_, d_coords, d_box, d_perm_, stream);
@@ -124,10 +125,10 @@ template <typename RealType>
 void NonbondedInteractionGroup<RealType>::execute_device(
     const int N,
     const int P,
-    const double *d_x,
+    const CoordsType *d_x,
     const ParamsType *d_p,
     // N * PARAMS_PER_ATOM
-    const double *d_box, // 3 * 3
+    const CoordsType *d_box, // 3 * 3
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,
@@ -187,7 +188,7 @@ void NonbondedInteractionGroup<RealType>::execute_device(
     }
 
     // compute new coordinates/params
-    k_gather_coords_and_params<double, 3, PARAMS_PER_ATOM>
+    k_gather_coords_and_params<CoordsType, 3, PARAMS_PER_ATOM>
         <<<ceil_divide(K, tpb), tpb, 0, stream>>>(K, d_perm_, d_x, d_p, d_sorted_x_, d_sorted_p_);
     gpuErrchk(cudaPeekAtLastError());
     // reset buffers and sorted accumulators

--- a/timemachine/cpp/src/nonbonded_interaction_group.cu
+++ b/timemachine/cpp/src/nonbonded_interaction_group.cu
@@ -130,7 +130,7 @@ void NonbondedInteractionGroup<RealType>::execute_device(
     const double *d_box, // 3 * 3
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     // (ytz) the nonbonded algorithm proceeds as follows:

--- a/timemachine/cpp/src/nonbonded_interaction_group.hpp
+++ b/timemachine/cpp/src/nonbonded_interaction_group.hpp
@@ -33,11 +33,11 @@ private:
     Neighborlist<RealType> nblist_;
 
     const double nblist_padding_;
-    EnergyType *d_u_buffer_; // [NONBONDED_KERNEL_BLOCKS]
-    double *d_nblist_x_;     // coords which were used to compute the nblist
-    double *d_nblist_box_;   // box which was used to rebuild the nblist
-    int *d_rebuild_nblist_;  // whether or not we have to rebuild the nblist
-    int *p_rebuild_nblist_;  // pinned
+    EnergyType *d_u_buffer_;   // [NONBONDED_KERNEL_BLOCKS]
+    CoordsType *d_nblist_x_;   // coords which were used to compute the nblist
+    CoordsType *d_nblist_box_; // box which was used to rebuild the nblist
+    int *d_rebuild_nblist_;    // whether or not we have to rebuild the nblist
+    int *p_rebuild_nblist_;    // pinned
     double *p_box_;
 
     unsigned int *d_perm_; // hilbert curve permutation
@@ -48,7 +48,7 @@ private:
     //   independently
     // - otherwise, atoms are sorted into contiguous blocks by
     //   interaction group, with arbitrary ordering within each block
-    double *d_sorted_x_;     // sorted coordinates
+    CoordsType *d_sorted_x_; // sorted coordinates
     ParamsType *d_sorted_p_; // sorted parameters
     unsigned long long *d_sorted_du_dx_;
     unsigned long long *d_sorted_du_dp_;
@@ -61,7 +61,7 @@ private:
 
     bool needs_sort();
 
-    void sort(const double *d_x, const double *d_box, cudaStream_t stream);
+    void sort(const CoordsType *d_x, const CoordsType *d_box, cudaStream_t stream);
 
     void validate_idxs(
         const int N,
@@ -89,9 +89,9 @@ public:
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
         EnergyType *d_u,

--- a/timemachine/cpp/src/nonbonded_interaction_group.hpp
+++ b/timemachine/cpp/src/nonbonded_interaction_group.hpp
@@ -33,11 +33,11 @@ private:
     Neighborlist<RealType> nblist_;
 
     const double nblist_padding_;
-    __int128 *d_u_buffer_;  // [NONBONDED_KERNEL_BLOCKS]
-    double *d_nblist_x_;    // coords which were used to compute the nblist
-    double *d_nblist_box_;  // box which was used to rebuild the nblist
-    int *d_rebuild_nblist_; // whether or not we have to rebuild the nblist
-    int *p_rebuild_nblist_; // pinned
+    EnergyType *d_u_buffer_; // [NONBONDED_KERNEL_BLOCKS]
+    double *d_nblist_x_;     // coords which were used to compute the nblist
+    double *d_nblist_box_;   // box which was used to rebuild the nblist
+    int *d_rebuild_nblist_;  // whether or not we have to rebuild the nblist
+    int *p_rebuild_nblist_;  // pinned
     double *p_box_;
 
     unsigned int *d_perm_; // hilbert curve permutation
@@ -94,7 +94,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 
     void du_dp_fixed_to_float(const int N, const int P, const unsigned long long *du_dp, double *du_dp_float) override;

--- a/timemachine/cpp/src/nonbonded_interaction_group.hpp
+++ b/timemachine/cpp/src/nonbonded_interaction_group.hpp
@@ -4,6 +4,7 @@
 #include "neighborlist.hpp"
 #include "nonbonded_common.hpp"
 #include "potential.hpp"
+#include "types.hpp"
 #include <array>
 #include <memory>
 #include <optional>
@@ -47,8 +48,8 @@ private:
     //   independently
     // - otherwise, atoms are sorted into contiguous blocks by
     //   interaction group, with arbitrary ordering within each block
-    double *d_sorted_x_; // sorted coordinates
-    double *d_sorted_p_; // sorted parameters
+    double *d_sorted_x_;     // sorted coordinates
+    ParamsType *d_sorted_p_; // sorted parameters
     unsigned long long *d_sorted_du_dx_;
     unsigned long long *d_sorted_du_dp_;
 
@@ -89,7 +90,7 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/nonbonded_pair_list.cu
+++ b/timemachine/cpp/src/nonbonded_pair_list.cu
@@ -56,7 +56,7 @@ void NonbondedPairList<RealType, Negated>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/nonbonded_pair_list.cu
+++ b/timemachine/cpp/src/nonbonded_pair_list.cu
@@ -55,9 +55,9 @@ template <typename RealType, bool Negated>
 void NonbondedPairList<RealType, Negated>::execute_device(
     const int N,
     const int P,
-    const double *d_x,
+    const CoordsType *d_x,
     const ParamsType *d_p,
-    const double *d_box,
+    const CoordsType *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,

--- a/timemachine/cpp/src/nonbonded_pair_list.cu
+++ b/timemachine/cpp/src/nonbonded_pair_list.cu
@@ -60,7 +60,7 @@ void NonbondedPairList<RealType, Negated>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (M_ > 0) {

--- a/timemachine/cpp/src/nonbonded_pair_list.hpp
+++ b/timemachine/cpp/src/nonbonded_pair_list.hpp
@@ -35,7 +35,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/nonbonded_pair_list.hpp
+++ b/timemachine/cpp/src/nonbonded_pair_list.hpp
@@ -34,10 +34,10 @@ public:
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
 
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
         EnergyType *d_u,

--- a/timemachine/cpp/src/nonbonded_pair_list.hpp
+++ b/timemachine/cpp/src/nonbonded_pair_list.hpp
@@ -17,7 +17,7 @@ private:
     double beta_;
     double cutoff_;
 
-    __int128 *d_u_buffer_; // [M]
+    EnergyType *d_u_buffer_; // [M]
 
     int *d_pair_idxs_; // [M, 2]
     double *d_scales_; // [M, 2]
@@ -40,7 +40,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 
     void du_dp_fixed_to_float(const int N, const int P, const unsigned long long *du_dp, double *du_dp_float) override;

--- a/timemachine/cpp/src/nonbonded_precomputed.cu
+++ b/timemachine/cpp/src/nonbonded_precomputed.cu
@@ -48,7 +48,7 @@ void NonbondedPairListPrecomputed<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (P != PARAMS_PER_PAIR * B_) {

--- a/timemachine/cpp/src/nonbonded_precomputed.cu
+++ b/timemachine/cpp/src/nonbonded_precomputed.cu
@@ -43,7 +43,8 @@ void NonbondedPairListPrecomputed<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/nonbonded_precomputed.cu
+++ b/timemachine/cpp/src/nonbonded_precomputed.cu
@@ -42,10 +42,10 @@ template <typename RealType>
 void NonbondedPairListPrecomputed<RealType>::execute_device(
     const int N,
     const int P,
-    const double *d_x,
+    const CoordsType *d_x,
     const ParamsType *d_p,
 
-    const double *d_box,
+    const CoordsType *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,

--- a/timemachine/cpp/src/nonbonded_precomputed.hpp
+++ b/timemachine/cpp/src/nonbonded_precomputed.hpp
@@ -15,7 +15,7 @@ private:
     double cutoff_;
 
     int *d_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
 public:
     int num_bonds() const { return B_; }
@@ -36,7 +36,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,
-        __int128 *d_u, // buffered
+        EnergyType *d_u, // buffered
         cudaStream_t stream) override;
 
     void du_dp_fixed_to_float(const int N, const int P, const unsigned long long *du_dp, double *du_dp_float) override;

--- a/timemachine/cpp/src/nonbonded_precomputed.hpp
+++ b/timemachine/cpp/src/nonbonded_precomputed.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "potential.hpp"
+#include "types.hpp"
 #include <vector>
 
 namespace timemachine {
@@ -30,7 +31,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/nonbonded_precomputed.hpp
+++ b/timemachine/cpp/src/nonbonded_precomputed.hpp
@@ -30,10 +30,10 @@ public:
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
 
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx, // buffered
         unsigned long long *d_du_dp,
         EnergyType *d_u, // buffered

--- a/timemachine/cpp/src/periodic_torsion.cu
+++ b/timemachine/cpp/src/periodic_torsion.cu
@@ -48,7 +48,7 @@ void PeriodicTorsion<RealType>::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     const int tpb = DEFAULT_THREADS_PER_BLOCK;

--- a/timemachine/cpp/src/periodic_torsion.cu
+++ b/timemachine/cpp/src/periodic_torsion.cu
@@ -43,7 +43,8 @@ void PeriodicTorsion<RealType>::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/periodic_torsion.cu
+++ b/timemachine/cpp/src/periodic_torsion.cu
@@ -42,10 +42,10 @@ template <typename RealType>
 void PeriodicTorsion<RealType>::execute_device(
     const int N,
     const int P,
-    const double *d_x,
+    const CoordsType *d_x,
     const ParamsType *d_p,
 
-    const double *d_box,
+    const CoordsType *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,

--- a/timemachine/cpp/src/periodic_torsion.hpp
+++ b/timemachine/cpp/src/periodic_torsion.hpp
@@ -9,7 +9,7 @@ template <typename RealType> class PeriodicTorsion : public Potential {
 
 private:
     int *d_torsion_idxs_;
-    __int128 *d_u_buffer_;
+    EnergyType *d_u_buffer_;
 
     const int T_;
 
@@ -29,7 +29,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 };
 

--- a/timemachine/cpp/src/periodic_torsion.hpp
+++ b/timemachine/cpp/src/periodic_torsion.hpp
@@ -23,10 +23,10 @@ public:
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
 
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
         EnergyType *d_u,

--- a/timemachine/cpp/src/periodic_torsion.hpp
+++ b/timemachine/cpp/src/periodic_torsion.hpp
@@ -24,7 +24,8 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
+
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/potential.cu
+++ b/timemachine/cpp/src/potential.cu
@@ -17,9 +17,9 @@ void Potential::execute_batch_host(
     const int N,                 // Number of atoms
     const int param_batch_size,  // Number of batches of parameters
     const int P,                 // Number of parameters
-    const double *h_x,           // [coord_batch_size, N, 3]
+    const CoordsType *h_x,       // [coord_batch_size, N, 3]
     const ParamsType *h_p,       // [param_batch_size, P]
-    const double *h_box,         // [coord_batch_size, 3, 3]
+    const CoordsType *h_box,     // [coord_batch_size, 3, 3]
     unsigned long long *h_du_dx, // [coord_batch_size, param_batch_size, N, 3]
     unsigned long long *h_du_dp, // [coord_batch_size, param_batch_size, P]
     EnergyType *h_u              // [coord_batch_size, param_batch_size, N]
@@ -30,10 +30,10 @@ void Potential::execute_batch_host(
         d_p->copy_from(h_p);
     }
 
-    DeviceBuffer<double> d_box(coord_batch_size * D * D);
+    DeviceBuffer<CoordsType> d_box(coord_batch_size * D * D);
     d_box.copy_from(h_box);
 
-    DeviceBuffer<double> d_x_buffer(coord_batch_size * N * D);
+    DeviceBuffer<CoordsType> d_x_buffer(coord_batch_size * N * D);
     d_x_buffer.copy_from(h_x);
 
     std::unique_ptr<DeviceBuffer<unsigned long long>> d_du_dx_buffer(nullptr);
@@ -94,9 +94,9 @@ void Potential::execute_batch_host(
 void Potential::execute_host(
     const int N,
     const int P,
-    const double *h_x,           // [N,3]
+    const CoordsType *h_x,       // [N,3]
     const ParamsType *h_p,       // [P,]
-    const double *h_box,         // [3, 3]
+    const CoordsType *h_box,     // [3, 3]
     unsigned long long *h_du_dx, // [N,3]
     unsigned long long *h_du_dp, // [P]
     EnergyType *h_u              // [1]
@@ -104,8 +104,8 @@ void Potential::execute_host(
 
     const int &D = Potential::D;
 
-    DeviceBuffer<double> d_x(N * D);
-    DeviceBuffer<double> d_box(D * D);
+    DeviceBuffer<CoordsType> d_x(N * D);
+    DeviceBuffer<CoordsType> d_box(D * D);
 
     d_x.copy_from(h_x);
     d_box.copy_from(h_box);
@@ -162,16 +162,16 @@ void Potential::execute_host(
 void Potential::execute_host_du_dx(
     const int N,
     const int P,
-    const double *h_x,     // [N,3]
-    const ParamsType *h_p, // [P,]
-    const double *h_box,   // [3, 3]
+    const CoordsType *h_x,   // [N,3]
+    const ParamsType *h_p,   // [P,]
+    const CoordsType *h_box, // [3, 3]
     unsigned long long *h_du_dx) {
 
     const int &D = Potential::D;
     // TODO: Convert this to DeviceBuffer
-    double *d_x;
+    CoordsType *d_x;
     ParamsType *d_p;
-    double *d_box;
+    CoordsType *d_box;
 
     cudaSafeMalloc(&d_x, N * D * sizeof(double));
     gpuErrchk(cudaMemcpy(d_x, h_x, N * D * sizeof(double), cudaMemcpyHostToDevice));

--- a/timemachine/cpp/src/potential.cu
+++ b/timemachine/cpp/src/potential.cu
@@ -22,7 +22,7 @@ void Potential::execute_batch_host(
     const double *h_box,         // [coord_batch_size, 3, 3]
     unsigned long long *h_du_dx, // [coord_batch_size, param_batch_size, N, 3]
     unsigned long long *h_du_dp, // [coord_batch_size, param_batch_size, P]
-    __int128 *h_u                // [coord_batch_size, param_batch_size, N]
+    EnergyType *h_u              // [coord_batch_size, param_batch_size, N]
 ) {
     std::unique_ptr<DeviceBuffer<ParamsType>> d_p(nullptr);
     if (P > 0) {
@@ -38,7 +38,7 @@ void Potential::execute_batch_host(
 
     std::unique_ptr<DeviceBuffer<unsigned long long>> d_du_dx_buffer(nullptr);
     std::unique_ptr<DeviceBuffer<unsigned long long>> d_du_dp_buffer(nullptr);
-    std::unique_ptr<DeviceBuffer<__int128>> d_u_buffer(nullptr);
+    std::unique_ptr<DeviceBuffer<EnergyType>> d_u_buffer(nullptr);
 
     const int total_executions = coord_batch_size * param_batch_size;
 
@@ -56,7 +56,7 @@ void Potential::execute_batch_host(
     }
 
     if (h_u) {
-        d_u_buffer.reset(new DeviceBuffer<__int128>(total_executions));
+        d_u_buffer.reset(new DeviceBuffer<EnergyType>(total_executions));
         gpuErrchk(cudaMemsetAsync(d_u_buffer->data, 0, d_u_buffer->size, stream));
     }
 
@@ -99,7 +99,7 @@ void Potential::execute_host(
     const double *h_box,         // [3, 3]
     unsigned long long *h_du_dx, // [N,3]
     unsigned long long *h_du_dp, // [P]
-    __int128 *h_u                // [1]
+    EnergyType *h_u              // [1]
 ) {
 
     const int &D = Potential::D;
@@ -113,7 +113,7 @@ void Potential::execute_host(
     std::unique_ptr<DeviceBuffer<ParamsType>> d_p;
     std::unique_ptr<DeviceBuffer<unsigned long long>> d_du_dx;
     std::unique_ptr<DeviceBuffer<unsigned long long>> d_du_dp;
-    std::unique_ptr<DeviceBuffer<__int128>> d_u;
+    std::unique_ptr<DeviceBuffer<EnergyType>> d_u;
 
     // very important that these are initialized to zero since the kernels themselves just accumulate
 
@@ -132,7 +132,7 @@ void Potential::execute_host(
         gpuErrchk(cudaMemset(d_du_dp->data, 0, d_du_dp->size));
     }
     if (h_u) {
-        d_u.reset(new DeviceBuffer<__int128>(1));
+        d_u.reset(new DeviceBuffer<EnergyType>(1));
         gpuErrchk(cudaMemset(d_u->data, 0, d_u->size));
     }
 

--- a/timemachine/cpp/src/potential.hpp
+++ b/timemachine/cpp/src/potential.hpp
@@ -23,7 +23,7 @@ public:
         const double *h_box,
         unsigned long long *h_du_dx,
         unsigned long long *h_du_dp,
-        __int128 *h_u);
+        EnergyType *h_u);
 
     void execute_host(
         const int N,
@@ -33,7 +33,7 @@ public:
         const double *h_box,
         unsigned long long *h_du_dx,
         unsigned long long *h_du_dp,
-        __int128 *h_u);
+        EnergyType *h_u);
 
     void execute_host_du_dx(
         const int N,
@@ -51,7 +51,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *h_u,
+        EnergyType *h_u,
         cudaStream_t stream) = 0;
 
     virtual void du_dp_fixed_to_float(const int N, const int P, const unsigned long long *du_dp, double *du_dp_float);

--- a/timemachine/cpp/src/potential.hpp
+++ b/timemachine/cpp/src/potential.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "types.hpp"
 #include <cuda_runtime.h>
 
 namespace timemachine {
@@ -18,7 +19,7 @@ public:
         const int param_batch_size,
         const int P,
         const double *h_x,
-        const double *h_p,
+        const ParamsType *h_p,
         const double *h_box,
         unsigned long long *h_du_dx,
         unsigned long long *h_du_dp,
@@ -28,7 +29,7 @@ public:
         const int N,
         const int P,
         const double *h_x,
-        const double *h_p,
+        const ParamsType *h_p,
         const double *h_box,
         unsigned long long *h_du_dx,
         unsigned long long *h_du_dp,
@@ -38,7 +39,7 @@ public:
         const int N,
         const int P,
         const double *h_x,
-        const double *h_p,
+        const ParamsType *h_p,
         const double *h_box,
         unsigned long long *h_du_dx);
 
@@ -46,7 +47,7 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/potential.hpp
+++ b/timemachine/cpp/src/potential.hpp
@@ -18,9 +18,9 @@ public:
         const int N,
         const int param_batch_size,
         const int P,
-        const double *h_x,
+        const CoordsType *h_x,
         const ParamsType *h_p,
-        const double *h_box,
+        const CoordsType *h_box,
         unsigned long long *h_du_dx,
         unsigned long long *h_du_dp,
         EnergyType *h_u);
@@ -28,9 +28,9 @@ public:
     void execute_host(
         const int N,
         const int P,
-        const double *h_x,
+        const CoordsType *h_x,
         const ParamsType *h_p,
-        const double *h_box,
+        const CoordsType *h_box,
         unsigned long long *h_du_dx,
         unsigned long long *h_du_dp,
         EnergyType *h_u);
@@ -38,17 +38,17 @@ public:
     void execute_host_du_dx(
         const int N,
         const int P,
-        const double *h_x,
+        const CoordsType *h_x,
         const ParamsType *h_p,
-        const double *h_box,
+        const CoordsType *h_box,
         unsigned long long *h_du_dx);
 
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
         EnergyType *h_u,

--- a/timemachine/cpp/src/rmsd_align.cpp
+++ b/timemachine/cpp/src/rmsd_align.cpp
@@ -10,7 +10,7 @@ Optimally align x2 onto x1. In particular, x2 is shifted so that its centroid is
 at the same position as the of x1's centroid. x2 is also rotated so that the RMSD
 is minimized.
 */
-void rmsd_align_cpu(const int N, const double *x1_raw, const double *x2_raw, double *x2_aligned_raw) {
+void rmsd_align_cpu(const int N, const CoordsType *x1_raw, const CoordsType *x2_raw, CoordsType *x2_aligned_raw) {
 
     Eigen::MatrixXd x1(N, 3);
     Eigen::MatrixXd x2(N, 3);

--- a/timemachine/cpp/src/rmsd_align.hpp
+++ b/timemachine/cpp/src/rmsd_align.hpp
@@ -1,8 +1,9 @@
+#include "types.hpp"
 
 namespace timemachine {
 /*
 Optimally align x2 onto x1.
 */
-void rmsd_align_cpu(const int N, const double *x1_raw, const double *x2_raw, double *x2_aligned_raw);
+void rmsd_align_cpu(const int N, const CoordsType *x1_raw, const CoordsType *x2_raw, CoordsType *x2_aligned_raw);
 
 } // namespace timemachine

--- a/timemachine/cpp/src/streamed_potential_runner.cu
+++ b/timemachine/cpp/src/streamed_potential_runner.cu
@@ -10,8 +10,8 @@ StreamedPotentialRunner::~StreamedPotentialRunner() {}
 void StreamedPotentialRunner::execute_potentials(
     std::vector<std::shared_ptr<BoundPotential>> &bps,
     const int N,
-    const double *d_x,   // [N * 3]
-    const double *d_box, // [3 * 3]
+    const CoordsType *d_x,   // [N * 3]
+    const CoordsType *d_box, // [3 * 3]
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u, // [bps.size()]

--- a/timemachine/cpp/src/streamed_potential_runner.cu
+++ b/timemachine/cpp/src/streamed_potential_runner.cu
@@ -14,7 +14,7 @@ void StreamedPotentialRunner::execute_potentials(
     const double *d_box, // [3 * 3]
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u, // [bps.size()]
+    EnergyType *d_u, // [bps.size()]
     cudaStream_t stream) {
     for (int i = 0; i < bps.size(); i++) {
         // Always sync the new streams with the incoming stream to ensure that the state

--- a/timemachine/cpp/src/streamed_potential_runner.hpp
+++ b/timemachine/cpp/src/streamed_potential_runner.hpp
@@ -20,8 +20,8 @@ public:
     void execute_potentials(
         std::vector<std::shared_ptr<BoundPotential>> &bps,
         const int N,
-        const double *d_x,
-        const double *d_box,
+        const CoordsType *d_x,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
         EnergyType *d_u,

--- a/timemachine/cpp/src/streamed_potential_runner.hpp
+++ b/timemachine/cpp/src/streamed_potential_runner.hpp
@@ -24,7 +24,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream);
 
 private:

--- a/timemachine/cpp/src/summed_potential.cu
+++ b/timemachine/cpp/src/summed_potential.cu
@@ -32,7 +32,7 @@ void SummedPotential::execute_device(
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
-    __int128 *d_u,
+    EnergyType *d_u,
     cudaStream_t stream) {
 
     if (P != P_) {

--- a/timemachine/cpp/src/summed_potential.cu
+++ b/timemachine/cpp/src/summed_potential.cu
@@ -26,10 +26,10 @@ const std::vector<int> &SummedPotential::get_parameter_sizes() { return params_s
 void SummedPotential::execute_device(
     const int N,
     const int P,
-    const double *d_x,
+    const CoordsType *d_x,
     const ParamsType *d_p,
 
-    const double *d_box,
+    const CoordsType *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,
     EnergyType *d_u,

--- a/timemachine/cpp/src/summed_potential.cu
+++ b/timemachine/cpp/src/summed_potential.cu
@@ -27,7 +27,8 @@ void SummedPotential::execute_device(
     const int N,
     const int P,
     const double *d_x,
-    const double *d_p,
+    const ParamsType *d_p,
+
     const double *d_box,
     unsigned long long *d_du_dx,
     unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/summed_potential.hpp
+++ b/timemachine/cpp/src/summed_potential.hpp
@@ -32,7 +32,7 @@ public:
         const int N,
         const int P,
         const double *d_x,
-        const double *d_p,
+        const ParamsType *d_p,
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,

--- a/timemachine/cpp/src/summed_potential.hpp
+++ b/timemachine/cpp/src/summed_potential.hpp
@@ -31,9 +31,9 @@ public:
     virtual void execute_device(
         const int N,
         const int P,
-        const double *d_x,
+        const CoordsType *d_x,
         const ParamsType *d_p,
-        const double *d_box,
+        const CoordsType *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
         EnergyType *d_u,

--- a/timemachine/cpp/src/summed_potential.hpp
+++ b/timemachine/cpp/src/summed_potential.hpp
@@ -15,7 +15,7 @@ private:
     const std::vector<int> params_sizes_;
     const int P_; // sum(params_sizes)
     const bool parallel_;
-    DeviceBuffer<__int128> d_u_buffer_;
+    DeviceBuffer<EnergyType> d_u_buffer_;
     StreamManager manager_;
 
 public:
@@ -36,7 +36,7 @@ public:
         const double *d_box,
         unsigned long long *d_du_dx,
         unsigned long long *d_du_dp,
-        __int128 *d_u,
+        EnergyType *d_u,
         cudaStream_t stream) override;
 
     void du_dp_fixed_to_float(const int N, const int P, const unsigned long long *du_dp, double *du_dp_float) override;

--- a/timemachine/cpp/src/types.hpp
+++ b/timemachine/cpp/src/types.hpp
@@ -1,3 +1,6 @@
 #pragma once
 
 typedef double ParamsType;
+// TBD: Investigate a 96bit version for energies
+typedef __int128 EnergyType;
+

--- a/timemachine/cpp/src/types.hpp
+++ b/timemachine/cpp/src/types.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
+// CoordsType defines both the coordinates and the boxes
+typedef double CoordsType;
 typedef double ParamsType;
 // TBD: Investigate a 96bit version for energies
 typedef __int128 EnergyType;
-

--- a/timemachine/cpp/src/types.hpp
+++ b/timemachine/cpp/src/types.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+typedef double ParamsType;

--- a/timemachine/cpp/src/verlet_integrator.cu
+++ b/timemachine/cpp/src/verlet_integrator.cu
@@ -22,9 +22,9 @@ VelocityVerletIntegrator::~VelocityVerletIntegrator() {
 
 void VelocityVerletIntegrator::step_fwd(
     std::vector<std::shared_ptr<BoundPotential>> &bps,
-    double *d_x_t,
+    CoordsType *d_x_t,
     double *d_v_t,
-    double *d_box_t,
+    CoordsType *d_box_t,
     unsigned int *d_idxs,
     cudaStream_t stream) {
 
@@ -44,9 +44,9 @@ void VelocityVerletIntegrator::step_fwd(
 
 void VelocityVerletIntegrator::initialize(
     std::vector<std::shared_ptr<BoundPotential>> &bps,
-    double *d_x_t,
+    CoordsType *d_x_t,
     double *d_v_t,
-    double *d_box_t,
+    CoordsType *d_box_t,
     unsigned int *d_idxs,
     cudaStream_t stream) {
 
@@ -78,9 +78,9 @@ void VelocityVerletIntegrator::initialize(
 
 void VelocityVerletIntegrator::finalize(
     std::vector<std::shared_ptr<BoundPotential>> &bps,
-    double *d_x_t,
+    CoordsType *d_x_t,
     double *d_v_t,
-    double *d_box_t,
+    CoordsType *d_box_t,
     unsigned int *d_idxs,
     cudaStream_t stream) {
 

--- a/timemachine/cpp/src/verlet_integrator.hpp
+++ b/timemachine/cpp/src/verlet_integrator.hpp
@@ -25,25 +25,25 @@ public:
 
     virtual void step_fwd(
         std::vector<std::shared_ptr<BoundPotential>> &bps,
-        double *d_x_t,
+        CoordsType *d_x_t,
         double *d_v_t,
-        double *d_box_t_,
+        CoordsType *d_box_t,
         unsigned int *d_idxs,
         cudaStream_t stream) override;
 
     virtual void initialize(
         std::vector<std::shared_ptr<BoundPotential>> &bps,
-        double *d_x_t,
+        CoordsType *d_x_t,
         double *d_v_t,
-        double *d_box_t,
+        CoordsType *d_box_t,
         unsigned int *d_idxs,
         cudaStream_t stream) override;
 
     virtual void finalize(
         std::vector<std::shared_ptr<BoundPotential>> &bps,
-        double *d_x_t,
+        CoordsType *d_x_t,
         double *d_v_t,
-        double *d_box_t,
+        CoordsType *d_box_t,
         unsigned int *d_idxs,
         cudaStream_t stream) override;
 };

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -575,7 +575,7 @@ void declare_potential(py::module &m) {
             "execute",
             [](timemachine::Potential &pot,
                const py::array_t<double, py::array::c_style> &coords,
-               const py::array_t<double, py::array::c_style> &params,
+               const py::array_t<ParamsType, py::array::c_style> &params,
                const py::array_t<double, py::array::c_style> &box) -> py::tuple {
                 const long unsigned int N = coords.shape()[0];
                 const long unsigned int D = coords.shape()[1];
@@ -585,7 +585,6 @@ void declare_potential(py::module &m) {
                 std::vector<unsigned long long> du_dx(N * D, 9999);
                 std::vector<unsigned long long> du_dp(P, 9999);
                 std::vector<__int128> u(1, 9999);
-
                 pot.execute_host(N, P, coords.data(), params.data(), box.data(), &du_dx[0], &du_dp[0], &u[0]);
 
                 py::array_t<double, py::array::c_style> py_du_dx({N, D});
@@ -610,7 +609,7 @@ void declare_potential(py::module &m) {
             "execute_selective_batch",
             [](timemachine::Potential &pot,
                const py::array_t<double, py::array::c_style> &coords,
-               const py::array_t<double, py::array::c_style> &params,
+               const py::array_t<ParamsType, py::array::c_style> &params,
                const py::array_t<double, py::array::c_style> &boxes,
                const bool compute_du_dx,
                const bool compute_du_dp,
@@ -744,7 +743,7 @@ void declare_potential(py::module &m) {
             "execute_selective",
             [](timemachine::Potential &pot,
                const py::array_t<double, py::array::c_style> &coords,
-               const py::array_t<double, py::array::c_style> &params,
+               const py::array_t<ParamsType, py::array::c_style> &params,
                const py::array_t<double, py::array::c_style> &box,
                bool compute_du_dx,
                bool compute_du_dp,
@@ -805,7 +804,7 @@ void declare_potential(py::module &m) {
             "execute_du_dx",
             [](timemachine::Potential &pot,
                const py::array_t<double, py::array::c_style> &coords,
-               const py::array_t<double, py::array::c_style> &params,
+               const py::array_t<ParamsType, py::array::c_style> &params,
                const py::array_t<double, py::array::c_style> &box) -> py::array_t<double, py::array::c_style> {
                 const long unsigned int N = coords.shape()[0];
                 const long unsigned int D = coords.shape()[1];
@@ -835,7 +834,7 @@ void declare_bound_potential(py::module &m) {
     py::class_<Class, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
         .def(
             py::init([](std::shared_ptr<timemachine::Potential> potential,
-                        const py::array_t<double, py::array::c_style> &params) {
+                        const py::array_t<ParamsType, py::array::c_style> &params) {
                 return new timemachine::BoundPotential(potential, py_array_to_vector(params));
             }),
             py::arg("potential"),
@@ -843,7 +842,7 @@ void declare_bound_potential(py::module &m) {
         .def("get_potential", [](const timemachine::BoundPotential &bp) { return bp.potential; })
         .def(
             "set_params",
-            [](timemachine::BoundPotential &bp, const py::array_t<double, py::array::c_style> &params) {
+            [](timemachine::BoundPotential &bp, const py::array_t<ParamsType, py::array::c_style> &params) {
                 bp.set_params(py_array_to_vector(params));
             },
             py::arg("params"))

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -67,7 +67,7 @@ void verify_coords_and_box(
 // convert_energy_to_fp handles the combining of energies, summing them up deterministically
 // and returning nan if there are overflows.
 // The energies are collected in int128
-double convert_energy_to_fp(__int128 fixed_u) {
+double convert_energy_to_fp(EnergyType fixed_u) {
     double res = std::numeric_limits<double>::quiet_NaN();
     if (!fixed_point_overflow(fixed_u)) {
         res = FIXED_ENERGY_TO_FLOAT<double>(fixed_u);
@@ -584,7 +584,8 @@ void declare_potential(py::module &m) {
                 // initialize with fixed garbage values for debugging convenience (these should be overwritten by `execute_host`)
                 std::vector<unsigned long long> du_dx(N * D, 9999);
                 std::vector<unsigned long long> du_dp(P, 9999);
-                std::vector<__int128> u(1, 9999);
+
+                std::vector<EnergyType> u(1, 9999);
                 pot.execute_host(N, P, coords.data(), params.data(), box.data(), &du_dx[0], &du_dp[0], &u[0]);
 
                 py::array_t<double, py::array::c_style> py_du_dx({N, D});
@@ -642,7 +643,7 @@ void declare_potential(py::module &m) {
                 if (compute_du_dp) {
                     du_dp.assign(total_executions * P, 9999);
                 }
-                std::vector<__int128> u;
+                std::vector<EnergyType> u;
                 if (compute_u) {
                     u.assign(total_executions, 9999);
                 }
@@ -756,7 +757,7 @@ void declare_potential(py::module &m) {
                 std::vector<unsigned long long> du_dx(N * D, 9999);
                 std::vector<unsigned long long> du_dp(P, 9999);
 
-                std::vector<__int128> u(1, 9999);
+                std::vector<EnergyType> u(1, 9999);
 
                 pot.execute_host(
                     N,
@@ -856,7 +857,7 @@ void declare_bound_potential(py::module &m) {
                 const long unsigned int D = coords.shape()[1];
                 verify_coords_and_box(coords, box);
                 std::vector<unsigned long long> du_dx(N * D, 9999);
-                std::vector<__int128> u(1, 9999);
+                std::vector<EnergyType> u(1, 9999);
 
                 bp.execute_host(N, coords.data(), box.data(), &du_dx[0], &u[0]);
 
@@ -878,7 +879,7 @@ void declare_bound_potential(py::module &m) {
                const py::array_t<double, py::array::c_style> &box) -> const py::array_t<uint64_t, py::array::c_style> {
                 const long unsigned int N = coords.shape()[0];
                 verify_coords_and_box(coords, box);
-                std::vector<__int128> u(1, 9999);
+                std::vector<EnergyType> u(1, 9999);
 
                 bp.execute_host(N, coords.data(), box.data(), nullptr, &u[0]);
 
@@ -1327,19 +1328,19 @@ double py_accumulate_energy(const py::array_t<long long, py::array::c_style> &in
 
     int N = input_data.size();
 
-    std::vector<__int128> h_buffer(N);
+    std::vector<EnergyType> h_buffer(N);
     for (int i = 0; i < N; i++) {
-        h_buffer[i] = static_cast<__int128>(input_data.data()[i]);
+        h_buffer[i] = static_cast<EnergyType>(input_data.data()[i]);
     }
 
-    timemachine::DeviceBuffer<__int128> d_input_buffer(N);
+    timemachine::DeviceBuffer<EnergyType> d_input_buffer(N);
     d_input_buffer.copy_from(&h_buffer[0]);
 
-    timemachine::DeviceBuffer<__int128> d_output_buffer(1);
+    timemachine::DeviceBuffer<EnergyType> d_output_buffer(1);
 
     // Use default stream which will sync with the output_buffer copy_to
     accumulate_energy(N, d_input_buffer.data, d_output_buffer.data, static_cast<cudaStream_t>(0));
-    std::vector<__int128> res(1);
+    std::vector<EnergyType> res(1);
     d_output_buffer.copy_to(&res[0]);
 
     return static_cast<long long>(res[0]);


### PR DESCRIPTION
Adds types for coords, boxes, energies (@maxentile had suggested this for testing different Energy accumulators in the future) and parameters. There are several more types we might want to add (velocities, fixed du_dp, fixed du_dx, etc) but this PR already touches a good amount of code and didn't want to have it get out of hand. 

This was spun out of https://github.com/proteneer/timemachine/pull/1166 where I investigated switching our parameters to floats. 33ba60ed76f2667e6971bb171c74604a313f9256 adds a comment about the bit of code that spawned #1166 

