### PR TITLE
Fixes and improvements for HREX replica-state convergence plot

### DIFF
--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -448,7 +448,7 @@ def plot_hrex_replica_state_distribution_convergence(cumulative_replica_state_co
     cmap.set_bad("white")
 
     for replica_idx, (fraction_by_state_by_iter, ax) in enumerate(zip(fraction_by_state_by_iter_by_replica, axs.flat)):
-        p = ax.pcolormesh(iteration, np.arange(n_states), np.log10(fraction_by_state_by_iter.T))
+        p = ax.pcolormesh(iteration, np.arange(n_states), np.log10(fraction_by_state_by_iter.T), cmap=cmap)
         ax.set_title(f"replica = {replica_idx}")
 
     for ax in axs[-1, :]:

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -431,13 +431,9 @@ def plot_hrex_replica_state_distribution_heatmap(
 def plot_hrex_replica_state_distribution_convergence(cumulative_replica_state_counts: NDArray, ncols: int = 4):
     """Plot distribution of states as a function of iteration for each replica."""
     n_iters, n_states, _ = cumulative_replica_state_counts.shape
-    iteration = np.arange(n_iters) + 1
 
-    # (iter, state, replica) -> float
-    fraction_by_replica_by_state_by_iter = cumulative_replica_state_counts / iteration[:, None, None]
-
-    # (replica, iter, state) -> float
-    fraction_by_state_by_iter_by_replica = np.moveaxis(fraction_by_replica_by_state_by_iter, 2, 0)
+    # (replica, iter, state) -> int
+    count_by_state_by_iter_by_replica = np.moveaxis(cumulative_replica_state_counts, 2, 0)
 
     ncols = min(n_states, ncols)
     nrows = (n_states + ncols - 1) // ncols
@@ -447,8 +443,8 @@ def plot_hrex_replica_state_distribution_convergence(cumulative_replica_state_co
     cmap = plt.get_cmap("viridis_r")
     cmap.set_bad("white")
 
-    for replica_idx, (fraction_by_state_by_iter, ax) in enumerate(zip(fraction_by_state_by_iter_by_replica, axs.flat)):
-        p = ax.pcolormesh(iteration, np.arange(n_states), np.log10(fraction_by_state_by_iter.T), cmap=cmap)
+    for replica_idx, (count_by_state_by_iter, ax) in enumerate(zip(count_by_state_by_iter_by_replica, axs.flat)):
+        p = ax.pcolormesh(np.arange(n_iters) + 1, np.arange(n_states), np.log10(count_by_state_by_iter.T), cmap=cmap)
         ax.set_title(f"replica = {replica_idx}")
 
     for ax in axs[-1, :]:
@@ -468,7 +464,7 @@ def plot_hrex_replica_state_distribution_convergence(cumulative_replica_state_co
 
     fig.subplots_adjust(right=0.8, hspace=0.2, wspace=0.2)
     cbar_ax = fig.add_axes([0.85, 0.15, 0.02, 0.7])
-    fig.colorbar(p, cax=cbar_ax, label=r"$\log_{10}$(fraction of iterations)")
+    fig.colorbar(p, cax=cbar_ax, label=r"$\log_{10}$(number of iterations)")
 
 
 def plot_fxn(f, *args, **kwargs) -> bytes:

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -468,7 +468,7 @@ def plot_hrex_replica_state_distribution_convergence(cumulative_replica_state_co
 
     fig.subplots_adjust(right=0.8, hspace=0.2, wspace=0.2)
     cbar_ax = fig.add_axes([0.85, 0.15, 0.02, 0.7])
-    fig.colorbar(p, cax=cbar_ax, label=r"$\log_{10}(\mathrm{fraction of iterations})$")
+    fig.colorbar(p, cax=cbar_ax, label=r"$\log_{10}$(fraction of iterations)")
 
 
 def plot_fxn(f, *args, **kwargs) -> bytes:

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -444,7 +444,7 @@ def plot_hrex_replica_state_distribution_convergence(cumulative_replica_state_co
     fig, axs = plt.subplots(ncols=ncols, nrows=nrows, figsize=(13, 10), sharex=True, sharey=True, squeeze=False)
 
     # (replica, state) pairs with no observations will be colored white
-    cmap = plt.get_cmap("viridis")
+    cmap = plt.get_cmap("viridis_r")
     cmap.set_bad("white")
 
     for replica_idx, (fraction_by_state_by_iter, ax) in enumerate(zip(fraction_by_state_by_iter_by_replica, axs.flat)):


### PR DESCRIPTION
* fix missing row when `n_states` is a multiple of `ncols`
* fix incorrect axis label placement
* fix divide by zero
* change color scale to log; color pairs with zero observations white

Before:
<img src=https://github.com/proteneer/timemachine/assets/319411/c3c7e162-4011-48f6-a5eb-826b84d2deab width=600px>
After:
<img src=https://github.com/proteneer/timemachine/assets/319411/e0eeb43a-fd2e-4aad-88c1-9e0119ce976d width=600px>

