### PR TITLE
Removes float64 dtype for torsion parameterization

### DIFF
--- a/tests/test_exchange_mover.py
+++ b/tests/test_exchange_mover.py
@@ -14,6 +14,7 @@ pytestmark = [pytest.mark.nocuda]
 
 def test_batch_log_weights_incremental():
     # test that our trick for computing incremental batched log weights is correct
+    np.random.seed(2023)
     W = 111  # num waters
     N = 439  # num atoms
     nb_beta = 1.2
@@ -52,6 +53,7 @@ def test_batch_log_weights_incremental():
 
 def test_inner_insertion():
     # test that we can insert correctly inside a sphere under PBC
+    np.random.seed(2023)
     for _ in range(1000):
         radius = np.random.rand()
         center = np.random.rand(3)
@@ -62,6 +64,7 @@ def test_inner_insertion():
 
 def test_outer_insertion():
     # test that we can insert correctly outside a sphere but inside the box under PBC
+    np.random.seed(2023)
     for _ in range(1000):
         center = np.random.rand(3)
         box = np.eye(3) * np.random.rand()
@@ -74,6 +77,7 @@ def test_outer_insertion():
 
 def test_get_water_groups():
     # test that we can partition waters into their groups correctly
+    np.random.seed(2023)
     N = 1000
     W = 231
 

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1349,7 +1349,7 @@ class SingleTopology(AtomMapMixin):
         else:
             # solvent waters don't have torsions
             combined_torsion_idxs = np.array(guest_system.torsion.potential.idxs, dtype=np.int32) + num_host_atoms
-            combined_torsion_params = jnp.array(guest_system.torsion.params, dtype=np.float64)
+            combined_torsion_params = jnp.array(guest_system.torsion.params)
 
         combined_torsion = PeriodicTorsion(combined_torsion_idxs).bind(combined_torsion_params)
 


### PR DESCRIPTION
* Inconsistent with the rest of the code and throws a warning when jax is not configured for float64