### PR TITLE
Fixes syntax typo in centroid kernel

### DIFF
--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -41,6 +41,7 @@ def compute_ref_log_prob(ref_exchange, water_idx, vi_mols, vj_mols, vol_i, vol_j
     return trial_coords, log_p_accept
 
 
+@pytest.mark.memcheck
 @pytest.mark.parametrize("seed", [2023, 2024])
 @pytest.mark.parametrize("radius", [0.1, 0.5, 1.2, 2.0])
 @pytest.mark.parametrize("precision", [np.float64, np.float32])

--- a/timemachine/cpp/src/kernels/k_exchange.cu
+++ b/timemachine/cpp/src/kernels/k_exchange.cu
@@ -441,9 +441,9 @@ void __global__ k_compute_centroid_of_atoms(
 
     int atom_idx;
 
-    if (threadIdx.x < 3)
-        ;
-    { fixed_centroid[threadIdx.x] = 0; }
+    if (threadIdx.x < 3) {
+        fixed_centroid[threadIdx.x] = 0;
+    }
     __syncthreads();
 
     while (idx < num_atoms) {


### PR DESCRIPTION
* Results in crashes with some combinations of nvcc (version V11.7.64, Build cuda_11.7.r11.7/compiler.31294372_0
), gcc (7.5.0), cuda arch (7.5) and nvidia driver (515.43.04). Unclear what exactly triggers this, but the code is straight up wrong.
* Not sure how this got in there, looks to have just been a typo that compiled
* This test fails https://github.com/proteneer/timemachine/blob/master/tests/test_cuda_targeted_insertion_mover.py#L47 on the tool combination stated above without the fix, though not on CI, or my personal machine. 