### PR TITLE
Adds support for CUDA_VISIBLE_DEVICES in cuda pool client

### DIFF
--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -188,10 +188,18 @@ class TestCUDAPoolClient(unittest.TestCase):
             cli.verify()
 
     def test_single_worker(self):
-        cli = client.CUDAPoolClient(1)
         with patch.dict("os.environ", {"CUDA_VISIBLE_DEVICES": "123"}):
-            result = cli.submit(environ_check).result()
+            cli = client.CUDAPoolClient(1)
+        # Don't patch this, else it will use the patched value rather than the true value
+        result = cli.submit(environ_check).result()
         assert result == "123"
+
+    def test_multiple_workers_cuda_visible_devices(self):
+        with patch.dict("os.environ", {"CUDA_VISIBLE_DEVICES": "5,6,7"}):
+            cli = client.CUDAPoolClient(3)
+        for i in range(10):
+            result = cli.submit(environ_check).result()
+            assert result == str(i % 3 + 5)
 
 
 def test_batch_list():

--- a/timemachine/parallel/client.py
+++ b/timemachine/parallel/client.py
@@ -229,7 +229,7 @@ class CUDAPoolClient(ProcessPoolClient):
         assert (
             len(self._gpu_list) >= self.max_workers
         ), "Fewer available GPUs than max workers expects, check CUDA_VISIBLE_DEVICES"
-        assert len(self._gpu_list) <= gpus, "More GPUs available than the machine has, check CUDA_VISIBLE_DEVICES"
+        assert len(self._gpu_list) <= gpus, "More GPUs requested than the machine has, check CUDA_VISIBLE_DEVICES"
 
 
 class BinaryFutureWrapper:

--- a/timemachine/parallel/client.py
+++ b/timemachine/parallel/client.py
@@ -199,7 +199,7 @@ class CUDAPoolClient(ProcessPoolClient):
         super().__init__(max_workers)
         visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
         if visible_devices:
-            self._gpu_list = [i for i in map(int, visible_devices.split(","))]
+            self._gpu_list = [int(i) for i in visible_devices.split(",")]
         else:
             self._gpu_list = list(range(max_workers))
 

--- a/timemachine/parallel/client.py
+++ b/timemachine/parallel/client.py
@@ -197,20 +197,24 @@ class CUDAPoolClient(ProcessPoolClient):
 
     def __init__(self, max_workers):
         super().__init__(max_workers)
+        visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+        if visible_devices:
+            self._gpu_list = [i for i in map(int, visible_devices.split(","))]
+        else:
+            self._gpu_list = list(range(max_workers))
 
     @staticmethod
     def wrapper(max_workers, idx, fn, *args, **kwargs):
-        # for a single worker, do not overwrite CUDA_VISIBLE_DEVICES
-        # so that multiple single gpu jobs can be run on the same node
-        if max_workers > 1:
-            os.environ["CUDA_VISIBLE_DEVICES"] = str(idx)
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(idx)
         return fn(*args, **kwargs)
 
     def submit(self, task_fn, *args, **kwargs) -> BaseFuture:
         """
         See abstract class for documentation.
         """
-        future = self.executor.submit(self.wrapper, self.max_workers, self._idx, task_fn, *args, **kwargs)
+        future = self.executor.submit(
+            self.wrapper, self.max_workers, self._gpu_list[self._idx], task_fn, *args, **kwargs
+        )
         job_id = str(self._total_idx)
         self._total_idx += 1
         self._idx = (self._idx + 1) % self.max_workers
@@ -222,6 +226,10 @@ class CUDAPoolClient(ProcessPoolClient):
         """
         gpus = get_gpu_count()
         assert self.max_workers <= gpus, f"More workers '{self.max_workers}' requested than GPUs '{gpus}'"
+        assert (
+            len(self._gpu_list) >= self.max_workers
+        ), "Fewer available GPUs than max workers expects, check CUDA_VISIBLE_DEVICES"
+        assert len(self._gpu_list) <= gpus, "More GPUs available than the machine has, check CUDA_VISIBLE_DEVICES"
 
 
 class BinaryFutureWrapper:


### PR DESCRIPTION
Previously if you were on a multi-gpu machine and set `CUDA_VISIBLE_DEVICES` it would use [0, ... max_workers-1] GPUs rather than the idxs defined in `CUDA_VISIBLE_DEVICES`. The test that passed before was simply because it was patched in the subprocess.

Verified this on a 10 GPU instance and been able to target 1 - 3 GPUs with `CUDA_VISIBLE_DEVICES` after these changes. 