### PR TITLE
Add utility for extracting replica trajectories from HREX results

### DIFF
--- a/tests/hrex/test_hrex.py
+++ b/tests/hrex/test_hrex.py
@@ -1,8 +1,9 @@
 import hypothesis.strategies as st
 import numpy as np
+import pytest
 from hypothesis import given, seed
 
-from timemachine.md.hrex import get_samples_by_iter_by_replica
+from timemachine.md.hrex import ReplicaIdx, get_samples_by_iter_by_replica
 
 
 @given(
@@ -30,3 +31,8 @@ def test_get_samples_by_iter_by_replica(perms):
     )
 
     np.testing.assert_array_equal(samples_by_iter_by_replica, samples_by_iter_by_replica_ref)
+
+
+def test_get_samples_by_iter_by_replica_invalid_args():
+    with pytest.raises(AssertionError):
+        get_samples_by_iter_by_replica([[1]], [[ReplicaIdx(0)], [ReplicaIdx(0)]])

--- a/tests/hrex/test_hrex.py
+++ b/tests/hrex/test_hrex.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+from timemachine.md.hrex import get_samples_by_iter_by_replica
+
+
+def test_get_samples_by_iter_by_replica():
+    rng = np.random.default_rng()
+    n_states = 5
+    n_iters = 10
+    samples_per_iter = 2
+
+    # (replica, iter) -> samples
+    samples_by_iter_by_replica_ref = rng.uniform(0, 1, size=(n_states, n_iters, samples_per_iter))
+
+    # (iter, state) -> replica
+    replica_idx_by_state_by_iter = rng.permuted(np.repeat(np.arange(n_states)[None, :], n_iters, axis=0), axis=1)
+    # (iter, replica) -> samples
+    samples_by_replica_by_iter = samples_by_iter_by_replica_ref.swapaxes(0, 1)
+
+    # (iter, state) -> samples
+    samples_by_state_by_iter = np.take_along_axis(
+        samples_by_replica_by_iter, replica_idx_by_state_by_iter[:, :, None], 1
+    )
+
+    samples_by_iter_by_replica = get_samples_by_iter_by_replica(
+        samples_by_state_by_iter.tolist(), replica_idx_by_state_by_iter.tolist()
+    )
+
+    np.testing.assert_array_equal(samples_by_iter_by_replica, samples_by_iter_by_replica_ref)

--- a/tests/hrex/test_hrex.py
+++ b/tests/hrex/test_hrex.py
@@ -1,26 +1,29 @@
+import hypothesis.strategies as st
 import numpy as np
+from hypothesis import given, seed
 
 from timemachine.md.hrex import get_samples_by_iter_by_replica
 
 
-def test_get_samples_by_iter_by_replica():
-    rng = np.random.default_rng()
-    n_states = 5
-    n_iters = 10
-    samples_per_iter = 2
+@given(
+    st.integers(1, 10)
+    .flatmap(lambda n_states: st.lists(st.permutations(range(n_states)), min_size=1, max_size=10))
+    .map(np.array)
+)
+@seed(2023)
+def test_get_samples_by_iter_by_replica(perms):
+    n_iters, n_states = perms.shape
+    replica_idx_by_state_by_iter = perms
 
+    # NOTE: the implementation is agnostic to the instantiation of Samples; here we test with Samples = int
     # (replica, iter) -> samples
-    samples_by_iter_by_replica_ref = rng.uniform(0, 1, size=(n_states, n_iters, samples_per_iter))
+    samples_by_iter_by_replica_ref = np.arange(n_states * n_iters).reshape((n_states, n_iters))
 
-    # (iter, state) -> replica
-    replica_idx_by_state_by_iter = rng.permuted(np.repeat(np.arange(n_states)[None, :], n_iters, axis=0), axis=1)
     # (iter, replica) -> samples
     samples_by_replica_by_iter = samples_by_iter_by_replica_ref.swapaxes(0, 1)
 
     # (iter, state) -> samples
-    samples_by_state_by_iter = np.take_along_axis(
-        samples_by_replica_by_iter, replica_idx_by_state_by_iter[:, :, None], 1
-    )
+    samples_by_state_by_iter = np.take_along_axis(samples_by_replica_by_iter, replica_idx_by_state_by_iter, 1)
 
     samples_by_iter_by_replica = get_samples_by_iter_by_replica(
         samples_by_state_by_iter.tolist(), replica_idx_by_state_by_iter.tolist()

--- a/tests/hrex/test_hrex.py
+++ b/tests/hrex/test_hrex.py
@@ -36,3 +36,7 @@ def test_get_samples_by_iter_by_replica(perms):
 def test_get_samples_by_iter_by_replica_invalid_args():
     with pytest.raises(AssertionError):
         get_samples_by_iter_by_replica([[1]], [[ReplicaIdx(0)], [ReplicaIdx(0)]])
+    with pytest.raises(AssertionError):
+        get_samples_by_iter_by_replica([[1], [2, 3]], [[ReplicaIdx(0)], [ReplicaIdx(0)]])
+    with pytest.raises(AssertionError):
+        get_samples_by_iter_by_replica([[1, 2], [3, 4]], [[ReplicaIdx(0)], [ReplicaIdx(0), ReplicaIdx(1)]])

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -168,9 +168,8 @@ def get_samples_by_iter_by_replica(
         return [i for i, _ in sorted(enumerate(p), key=lambda t: t[1])]
 
     samples_by_replica_by_iter = [
-        [samples_by_state[state_idx] for state_idx in state_idx_by_replica]
+        [samples_by_state[state_idx] for state_idx in inverse_permutation(replica_idx_by_state)]
         for samples_by_state, replica_idx_by_state in zip(samples_by_state_by_iter, replica_idx_by_state_by_iter)
-        for state_idx_by_replica in [inverse_permutation(replica_idx_by_state)]
     ]
 
     # transpose

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -166,11 +166,8 @@ def get_samples_by_iter_by_replica(
 
     assert len(samples_by_state_by_iter) == len(replica_idx_by_state_by_iter)
 
-    def inverse_permutation(p):
-        return [i for i, _ in sorted(enumerate(p), key=lambda t: t[1])]
-
     samples_by_replica_by_iter = [
-        [samples_by_state[state_idx] for state_idx in inverse_permutation(replica_idx_by_state)]
+        [samples_by_state[state_idx] for state_idx in np.argsort(replica_idx_by_state)]
         for samples_by_state, replica_idx_by_state in zip(samples_by_state_by_iter, replica_idx_by_state_by_iter)
     ]
 

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable, Generic, List, NewType, Optional, Sequence, Tuple, TypeVar, cast
+from typing import Callable, Generic, List, NewType, Optional, Sequence, Tuple, TypeVar
 
 import numpy as np
 from numpy.typing import NDArray
@@ -172,8 +172,7 @@ def get_samples_by_iter_by_replica(
         for samples_by_state, replica_idx_by_state in zip(samples_by_state_by_iter, replica_idx_by_state_by_iter)
     ]
 
-    # transpose
-    samples_by_iter_by_replica = cast(List[List[Samples]], [list(xs) for xs in zip(*samples_by_replica_by_iter)])
+    samples_by_iter_by_replica = [list(xs) for xs in zip(*samples_by_replica_by_iter)]  # transpose
 
     return samples_by_iter_by_replica
 

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -167,13 +167,10 @@ def get_samples_by_iter_by_replica(
     def inverse_permutation(p):
         return [i for i, _ in sorted(enumerate(p), key=lambda t: t[1])]
 
-    state_idx_by_replica_by_iter = [
-        inverse_permutation(replica_idx_by_state) for replica_idx_by_state in replica_idx_by_state_by_iter
-    ]
-
     samples_by_replica_by_iter = [
         [samples_by_state[state_idx] for state_idx in state_idx_by_replica]
-        for samples_by_state, state_idx_by_replica in zip(samples_by_state_by_iter, state_idx_by_replica_by_iter)
+        for samples_by_state, replica_idx_by_state in zip(samples_by_state_by_iter, replica_idx_by_state_by_iter)
+        for state_idx_by_replica in [inverse_permutation(replica_idx_by_state)]
     ]
 
     # transpose

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -217,22 +217,22 @@ def run_hrex(
 
     Parameters
     ----------
-    replicas: sequence of _Replica
+    replicas: sequence of Replica
         Sequence of initial states of each replica
 
-    sample_replica: (_Replica, StateIdx, n_samples: int) -> _Samples
+    sample_replica: (Replica, StateIdx, n_samples: int) -> Samples
         Local sampling function. Should return n_samples samples from the given replica and state
 
-    replica_from_samples: _Samples -> _Replica
+    replica_from_samples: Samples -> Replica
         Function that returns a replica state given a sequence of local samples. This is used to update the state of
         individual replicas following local sampling.
 
     neighbor_pairs: sequence of (StateIdx, StateIdx)
         Pairs of states for which to attempt swap moves
 
-    get_log_q_fn: sequence of _Replica -> ((ReplicaIdx, StateIdx) -> float)
+    get_log_q_fn: sequence of Replica -> ((ReplicaIdx, StateIdx) -> float)
         Function that returns a function from replica-state pairs to log unnormalized probability. Note that this is
-        equivalent to the simpler signature (_Replica, StateIdx) -> float; the "curried" form here is to allow for the
+        equivalent to the simpler signature (Replica, StateIdx) -> float; the "curried" form here is to allow for the
         implementation to compute the full matrix as a batch operation when this is more efficient.
 
     n_samples: int
@@ -246,7 +246,7 @@ def run_hrex(
 
     Returns
     -------
-    List[List[_Samples]]
+    List[List[Samples]]
         samples grouped by state and iteration
 
     HREXDiagnostics

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -164,6 +164,8 @@ def get_samples_by_iter_by_replica(
         (replica_idx, hrex_iter) -> samples
     """
 
+    assert len(samples_by_state_by_iter) == len(replica_idx_by_state_by_iter)
+
     def inverse_permutation(p):
         return [i for i, _ in sorted(enumerate(p), key=lambda t: t[1])]
 

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from timemachine.md.moves import MixtureOfMoves, MonteCarloMove
-from timemachine.utils import batches
+from timemachine.utils import batches, not_ragged
 
 Replica = TypeVar("Replica")
 
@@ -165,6 +165,8 @@ def get_samples_by_iter_by_replica(
     """
 
     assert len(samples_by_state_by_iter) == len(replica_idx_by_state_by_iter)
+    assert not_ragged(samples_by_state_by_iter)
+    assert not_ragged(replica_idx_by_state_by_iter)
 
     samples_by_replica_by_iter = [
         [samples_by_state[state_idx] for state_idx in np.argsort(replica_idx_by_state)]

--- a/timemachine/utils.py
+++ b/timemachine/utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, Iterable, Iterator, Optional, TypeVar
+from typing import Callable, Iterable, Iterator, Optional, Sequence, TypeVar
 
 
 def batches(n: int, batch_size: int) -> Iterator[int]:
@@ -14,6 +14,10 @@ def batches(n: int, batch_size: int) -> Iterator[int]:
 A = TypeVar("A")
 B = TypeVar("B")
 C = TypeVar("C")
+
+
+def not_ragged(xss: Sequence[Sequence]) -> bool:
+    return all(len(xs) == len(xss[0]) for xs in xss)
 
 
 def pairwise_transform_and_combine(xs: Iterable[A], f: Callable[[A], B], g: Callable[[B, B], C]) -> Iterator[C]:


### PR DESCRIPTION
Adds a simple utility function for converting the output of `timemachine.md.hrex.run_hrex` into a form suitable for extracting replica trajectories.

Note: this does not yet make it easy to extract replica trajectories from (non-vacuum) RBFE simulations, since the frames from each HREX iteration are concatenated into a single long trajectory for each state in the output. Solving this cleanly in general might require modifying the RBFE output schema to additionally group frames by HREX iteration.