### PR TITLE
Fix Water Sampling Bug

### DIFF
--- a/tests/nonbonded/test_nonbonded_mol_energy.py
+++ b/tests/nonbonded/test_nonbonded_mol_energy.py
@@ -107,16 +107,16 @@ def test_nonbonded_mol_energy_matches_exchange_mover_batch_U(num_mols, precision
     np.testing.assert_allclose(u_test(conf, box, params), u_ref(conf, box, params), rtol=rtol, atol=atol)
 
 
-@pytest.mark.parametrize("num_mols", [500])
-@pytest.mark.parametrize("moves", [100])
+@pytest.mark.parametrize("moves,box_size,num_mols", [(100, 4.0, 500), (1, 8.0, 10000)])
 @pytest.mark.parametrize("precision,atol,rtol", [(np.float64, 1e-8, 1e-8), (np.float32, 5e-4, 2e-3)])
-def test_nonbonded_mol_energy_random_moves(num_mols, moves, precision, atol, rtol):
+def test_nonbonded_mol_energy_random_moves(box_size, num_mols, moves, precision, atol, rtol):
     """Verify that with random move for waters that the exchange mover and Nonbonded water match in the case
     where clashes are likely to be introduced
     """
     rng = np.random.default_rng(2023)
     ff = Forcefield.load_default()
-    system, conf, _, _ = builders.build_water_system(4.0, ff.water_ff)
+
+    system, conf, _, _ = builders.build_water_system(box_size, ff.water_ff)
     bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     nb = next(bp for bp in bps if isinstance(bp.potential, Nonbonded))
     bond_pot = next(bp for bp in bps if isinstance(bp.potential, HarmonicBond)).potential

--- a/tests/nonbonded/test_nonbonded_mol_energy.py
+++ b/tests/nonbonded/test_nonbonded_mol_energy.py
@@ -111,7 +111,7 @@ def test_nonbonded_mol_energy_matches_exchange_mover_batch_U(num_mols, precision
     np.testing.assert_allclose(u_test(conf, box, params), u_ref(conf, box, params), rtol=rtol, atol=atol)
 
 
-@pytest.mark.parametrize("moves,box_size,num_mols", [(100, 4.0, 500), (1, 8.0, 10000)])
+@pytest.mark.parametrize("moves,box_size,num_mols", [(100, 4.0, 500), (1, 6.5, 5500)])
 @pytest.mark.parametrize("precision,atol,rtol", [(np.float64, 1e-8, 1e-8), (np.float32, 5e-4, 2e-3)])
 def test_nonbonded_mol_energy_random_moves(box_size, num_mols, moves, precision, atol, rtol):
     """Verify that with random move for waters that the exchange mover and Nonbonded water match in the case

--- a/tests/nonbonded/test_nonbonded_mol_energy.py
+++ b/tests/nonbonded/test_nonbonded_mol_energy.py
@@ -43,6 +43,10 @@ def test_nonbonded_mol_energy_potential_validation(precision):
     with pytest.raises(RuntimeError, match="All grouped indices must be unique"):
         klass(N, indices_in_multiple_groups, beta, cutoff)
 
+    empty_groups = []
+    with pytest.raises(RuntimeError, match="must provide at least one target mol"):
+        klass(N, empty_groups, beta, cutoff)
+
     group_idxs = [[0, 1, 2]]
     pot = klass(N, group_idxs, beta, cutoff)
     with pytest.raises(RuntimeError, match="params N != coords N"):

--- a/tests/test_cuda_bd_exchange_mover.py
+++ b/tests/test_cuda_bd_exchange_mover.py
@@ -286,15 +286,21 @@ def test_bd_exchange_deterministic_moves(moves, precision, seed):
 
 
 @pytest.mark.parametrize(
-    "steps_per_move,moves",
-    [(1, 2500), (10, 2500), (200000, 200000)],
+    "steps_per_move,moves,box_size",
+    [
+        (1, 2500, 3.0),
+        (10, 2500, 3.0),
+        (200000, 200000, 3.0),
+        # The 6.0nm box triggers a failure that would occur with systems of certain sizes, may be flaky in identifying issues
+        pytest.param(1, 2500, 6.0, marks=pytest.mark.nightly(reason="slow")),
+    ],
 )
 @pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 5e-6, 5e-6), (np.float32, 1e-4, 2e-3)])
 @pytest.mark.parametrize("seed", [2023])
-def test_moves_in_a_water_box(steps_per_move, moves, precision, rtol, atol, seed):
+def test_moves_in_a_water_box(steps_per_move, moves, box_size, precision, rtol, atol, seed):
     """Verify that the log acceptance probability between the reference and cuda implementation agree"""
     ff = Forcefield.load_default()
-    system, conf, box, _ = builders.build_water_system(3.0, ff.water_ff)
+    system, conf, box, _ = builders.build_water_system(box_size, ff.water_ff)
     bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     nb = next(bp for bp in bps if isinstance(bp.potential, Nonbonded))

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -460,15 +460,20 @@ def test_tibd_exchange_deterministic_moves(radius, moves, precision, seed):
 
 @pytest.mark.parametrize("radius", [1.2])
 @pytest.mark.parametrize(
-    "steps_per_move,moves",
-    [(1, 500), (5000, 5000)],
+    "steps_per_move,moves,box_size",
+    [
+        (1, 500, 4.0),
+        (5000, 5000, 4.0),
+        # The 6.0nm box triggers a failure that would occur with systems of certain sizes, may be flaky in identifying issues
+        pytest.param(1, 5000, 6.0, marks=pytest.mark.nightly(reason="slow")),
+    ],
 )
 @pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 5e-6, 5e-6), (np.float32, 1e-4, 2e-3)])
 @pytest.mark.parametrize("seed", [2023])
-def test_targeted_moves_in_bulk_water(radius, steps_per_move, moves, precision, rtol, atol, seed):
+def test_targeted_moves_in_bulk_water(radius, steps_per_move, moves, box_size, precision, rtol, atol, seed):
     """Given bulk water molecules with one of them treated as the targeted region"""
     ff = Forcefield.load_default()
-    system, conf, ref_box, topo = builders.build_water_system(4.0, ff.water_ff)
+    system, conf, ref_box, topo = builders.build_water_system(box_size, ff.water_ff)
     bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     nb = next(bp for bp in bps if isinstance(bp.potential, Nonbonded))

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -465,7 +465,7 @@ def test_tibd_exchange_deterministic_moves(radius, moves, precision, seed):
         (1, 500, 4.0),
         (5000, 5000, 4.0),
         # The 6.0nm box triggers a failure that would occur with systems of certain sizes, may be flaky in identifying issues
-        pytest.param(1, 5000, 6.0, marks=pytest.mark.nightly(reason="slow")),
+        pytest.param(1, 5000, 5.0, marks=pytest.mark.nightly(reason="slow")),
     ],
 )
 @pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 5e-6, 5e-6), (np.float32, 1e-4, 2e-3)])

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -464,8 +464,8 @@ def test_tibd_exchange_deterministic_moves(radius, moves, precision, seed):
     [
         (1, 500, 4.0),
         (5000, 5000, 4.0),
-        # The 6.0nm box triggers a failure that would occur with systems of certain sizes, may be flaky in identifying issues
-        pytest.param(1, 5000, 5.0, marks=pytest.mark.nightly(reason="slow")),
+        # The 5.7nm box triggers a failure that would occur with systems of certain sizes, may be flaky in identifying issues
+        pytest.param(1, 5000, 5.7, marks=pytest.mark.nightly(reason="slow")),
     ],
 )
 @pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 5e-6, 5e-6), (np.float32, 1e-4, 2e-3)])

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -468,7 +468,7 @@ def test_tibd_exchange_deterministic_moves(radius, moves, precision, seed):
         pytest.param(1, 5000, 5.7, marks=pytest.mark.nightly(reason="slow")),
     ],
 )
-@pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 5e-6, 5e-6), (np.float32, 1e-4, 2e-3)])
+@pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 2e-5, 2e-5), (np.float32, 1e-4, 2e-3)])
 @pytest.mark.parametrize("seed", [2023])
 def test_targeted_moves_in_bulk_water(radius, steps_per_move, moves, box_size, precision, rtol, atol, seed):
     """Given bulk water molecules with one of them treated as the targeted region"""

--- a/timemachine/cpp/src/kernels/k_nonbonded.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded.cuh
@@ -481,12 +481,13 @@ void __global__ k_compute_nonbonded_target_atom_energies(
         RealType ci_z = coords[atom_i_idx * 3 + 2];
 
         int atom_j_idx = blockIdx.x * blockDim.x + threadIdx.x;
-        // Zero out the energy buffer
-        block_energy_buffer[threadIdx.x] = 0;
-        while (atom_j_idx < N) {
+        // All threads in the threadblock must loop to allow for __syncthreads() and the row accumulation.
+        while (atom_j_idx - threadIdx.x < N) {
+            // Zero out the energy buffer
+            block_energy_buffer[threadIdx.x] = 0;
             // The two atoms are in the same molecule, don't compute the energies
             // requires that the atom indices in each target mol is consecutive
-            if (atom_j_idx < min_atom_idx || atom_j_idx > max_atom_idx) {
+            if (atom_j_idx < N && (atom_j_idx < min_atom_idx || atom_j_idx > max_atom_idx)) {
 
                 int params_j_idx = atom_j_idx * PARAMS_PER_ATOM;
                 int charge_param_idx_j = params_j_idx + PARAM_OFFSET_CHARGE;
@@ -523,8 +524,7 @@ void __global__ k_compute_nonbonded_target_atom_energies(
                     RealType inv_d2ij;
                     compute_electrostatics<RealType, true>(
                         1.0, qi, qj, d2ij, beta, dij, inv_dij, inv_d2ij, ebd, delta_prefactor, u);
-
-                    // lennard jones force
+                    // lennard jones energy
                     if (eps_i != 0 && eps_j != 0) {
                         RealType sig_grad;
                         RealType eps_grad;
@@ -547,8 +547,6 @@ void __global__ k_compute_nonbonded_target_atom_energies(
             __syncthreads();
 
             atom_j_idx += gridDim.x * blockDim.x;
-            // Always zero before the end of the loop, in case one thread no longer loops
-            block_energy_buffer[threadIdx.x] = 0;
         }
         row_idx += gridDim.y * blockDim.y;
     }
@@ -558,9 +556,7 @@ void __global__ k_compute_nonbonded_target_atom_energies(
 // of values that need to be accumulated per atom.
 template <typename RealType, int NUM_BLOCKS>
 void __global__ k_accumulate_atom_energies_to_per_mol_energies(
-    const int target_atoms,
     const int target_mols,
-    const int *__restrict__ mol_idxs,               // [target_atoms]
     const int *__restrict__ mol_offsets,            // [target_mols + 1]
     const __int128 *__restrict__ per_atom_energies, // [target_atoms, NUM_BLOCKS]
     __int128 *__restrict__ per_mol_energies) {

--- a/timemachine/cpp/src/nonbonded_mol_energy.cu
+++ b/timemachine/cpp/src/nonbonded_mol_energy.cu
@@ -17,6 +17,10 @@ NonbondedMolEnergyPotential<RealType>::NonbondedMolEnergyPotential(
       cutoff_squared_(static_cast<RealType>(cutoff * cutoff)) {
     verify_group_idxs(N_, target_mols);
 
+    if (num_target_mols_ <= 0) {
+        throw std::runtime_error("must provide at least one target mol");
+    }
+
     std::array<std::vector<int>, 3> target_flattened_groups = prepare_group_idxs_for_gpu(target_mols);
 
     d_target_atom_idxs_.realloc(target_flattened_groups[0].size());

--- a/timemachine/cpp/src/nonbonded_mol_energy.cu
+++ b/timemachine/cpp/src/nonbonded_mol_energy.cu
@@ -70,14 +70,10 @@ void NonbondedMolEnergyPotential<RealType>::mol_energies_device(
         cutoff_squared_,
         d_atom_energy_buffer_.data);
     gpuErrchk(cudaPeekAtLastError());
+
     k_accumulate_atom_energies_to_per_mol_energies<RealType, BLOCK_SIZE>
         <<<ceil_divide(target_mols, tpb), tpb, 0, stream>>>(
-            static_cast<int>(d_target_atom_idxs_.length),
-            target_mols,
-            d_target_mol_idxs_.data,
-            d_target_mol_offsets_.data,
-            d_atom_energy_buffer_.data,
-            d_output_energies);
+            target_mols, d_target_mol_offsets_.data, d_atom_energy_buffer_.data, d_output_energies);
     gpuErrchk(cudaPeekAtLastError());
 }
 

--- a/timemachine/cpp/src/nonbonded_mol_energy.cu
+++ b/timemachine/cpp/src/nonbonded_mol_energy.cu
@@ -74,14 +74,10 @@ void NonbondedMolEnergyPotential<RealType>::mol_energies_device(
         cutoff_squared_,
         d_atom_energy_buffer_.data);
     gpuErrchk(cudaPeekAtLastError());
+
     k_accumulate_atom_energies_to_per_mol_energies<RealType, BLOCK_SIZE>
         <<<ceil_divide(target_mols, tpb), tpb, 0, stream>>>(
-            static_cast<int>(d_target_atom_idxs_.length),
-            target_mols,
-            d_target_mol_idxs_.data,
-            d_target_mol_offsets_.data,
-            d_atom_energy_buffer_.data,
-            d_output_energies);
+            target_mols, d_target_mol_offsets_.data, d_atom_energy_buffer_.data, d_output_energies);
     gpuErrchk(cudaPeekAtLastError());
 }
 

--- a/timemachine/cpp/src/nonbonded_mol_energy.cu
+++ b/timemachine/cpp/src/nonbonded_mol_energy.cu
@@ -74,10 +74,14 @@ void NonbondedMolEnergyPotential<RealType>::mol_energies_device(
         cutoff_squared_,
         d_atom_energy_buffer_.data);
     gpuErrchk(cudaPeekAtLastError());
-
     k_accumulate_atom_energies_to_per_mol_energies<RealType, BLOCK_SIZE>
         <<<ceil_divide(target_mols, tpb), tpb, 0, stream>>>(
-            target_mols, d_target_mol_offsets_.data, d_atom_energy_buffer_.data, d_output_energies);
+            static_cast<int>(d_target_atom_idxs_.length),
+            target_mols,
+            d_target_mol_idxs_.data,
+            d_target_mol_offsets_.data,
+            d_atom_energy_buffer_.data,
+            d_output_energies);
     gpuErrchk(cudaPeekAtLastError());
 }
 


### PR DESCRIPTION
"Beware the undefined behavior" - @proteneer 

- When I had originally written `k_compute_nonbonded_target_atom_energies` I had somehow convinced myself that `__syncthreads()` handled exited threads. It **DOES NOT**, per https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#synchronization-functions
> __syncthreads() is allowed in conditional code but only if the conditional evaluates identically across the entire thread block, otherwise the code execution is likely to hang or produce unintended side effects.
- This issue only showed up for larger system sizes


Nightly pipeline: https://gitlab.com/relaytx/physics-platform/timemachine/-/pipelines/1106085189
Failed tests without the fix: https://github.com/proteneer/timemachine/pull/1218/commits/3ec9b712671f78709f4b8a8a3d8c374ff8034a10

- [x] Reduce memory usage by test_targeted_moves_in_bulk_water that caused failure in nightly tests