### PR TITLE
Format colorbar labels consistently with annotations in heatmaps

### DIFF
--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -312,26 +312,26 @@ def plot_fwd_reverse_predictions(
 
 
 def plot_hrex_transition_matrix(
-    transition_rate: NDArray,
+    transition_probability: NDArray,
     figsize: Tuple[float, float] = (13, 10),
     annotate_threshold: int = DEFAULT_HEATMAP_ANNOTATE_THRESHOLD,
     format_annotation: Callable[[float], str] = lambda x: f"{100.0*x:.2g}",
     format_cbar_tick: Callable[[float], str] = lambda x: f"{100.0*x:.2g}%",
 ):
-    """Plot matrix of estimated transition rates for permutation moves as a heatmap."""
-    n_states, _ = transition_rate.shape
+    """Plot matrix of estimated transition probabilities for permutation moves as a heatmap."""
+    n_states, _ = transition_probability.shape
     states = np.arange(n_states)
 
     fig, ax = plt.subplots(figsize=figsize)
-    p = ax.pcolormesh(states, states, transition_rate)
+    p = ax.pcolormesh(states, states, transition_probability)
 
     # Skip text annotations when number of states is large
     if n_states <= annotate_threshold:
         for from_state in states:
             for to_state in states:
-                rate = transition_rate[to_state, from_state]
-                if rate > 0.0:
-                    label = format_annotation(cast(float, rate))
+                prob = transition_probability[to_state, from_state]
+                if prob > 0.0:
+                    label = format_annotation(cast(float, prob))
                     ax.text(from_state, to_state, label, ha="center", va="center", color="w", fontsize=8)
 
     ax.set_xlabel("from state")

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -315,7 +315,8 @@ def plot_hrex_transition_matrix(
     transition_rate: NDArray,
     figsize: Tuple[float, float] = (13, 10),
     annotate_threshold: int = DEFAULT_HEATMAP_ANNOTATE_THRESHOLD,
-    format_rate: Callable[[float], str] = lambda x: f"{100.0*x:.1f}",
+    format_rate: Callable[[float], str] = lambda x: f"{100.0*x:.2g}",
+    cbar_tick_label_suffix: str = "%",
 ):
     """Plot matrix of estimated transition rates for permutation moves as a heatmap."""
     n_states, _ = transition_rate.shape
@@ -339,7 +340,7 @@ def plot_hrex_transition_matrix(
     ax.yaxis.get_major_locator().set_params(integer=True)
     ax.set_aspect("equal")
 
-    fig.colorbar(p, label="transition rate")
+    fig.colorbar(p, label="fraction of iterations", format=lambda x, _: format_rate(x) + cbar_tick_label_suffix)
 
 
 def plot_hrex_swap_acceptance_rates_convergence(cumulative_swap_acceptance_rates: NDArray):
@@ -383,7 +384,8 @@ def plot_hrex_replica_state_distribution_heatmap(
     cumulative_replica_state_counts: NDArray,
     figsize: Tuple[float, float] = (13, 10),
     annotate_threshold: int = DEFAULT_HEATMAP_ANNOTATE_THRESHOLD,
-    format_rate: Callable[[float], str] = lambda x: f"{100.0*x:.1f}",
+    format_rate: Callable[[float], str] = lambda x: f"{100.0*x:.2g}",
+    cbar_tick_label_suffix: str = "%",
 ):
     """Plot distribution of (replica, state) pairs as a heatmap."""
     n_iters, n_states, n_replicas = cumulative_replica_state_counts.shape
@@ -409,7 +411,7 @@ def plot_hrex_replica_state_distribution_heatmap(
     ax.yaxis.get_major_locator().set_params(integer=True)
     ax.set_aspect("equal")
 
-    fig.colorbar(p, label="fraction of iterations")
+    fig.colorbar(p, label="fraction of iterations", format=lambda x, _: format_rate(x) + cbar_tick_label_suffix)
 
 
 def plot_hrex_replica_state_distribution_convergence(cumulative_replica_state_counts: NDArray, ncols: int = 4):

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -315,7 +315,7 @@ def plot_hrex_transition_matrix(
     transition_rate: NDArray,
     figsize: Tuple[float, float] = (13, 10),
     annotate_threshold: int = DEFAULT_HEATMAP_ANNOTATE_THRESHOLD,
-    format_heatmap_cell: Callable[[float], str] = lambda x: f"{100.0*x:.1f}",
+    format_annotation: Callable[[float], str] = lambda x: f"{100.0*x:.2g}",
     format_cbar_tick: Callable[[float], str] = lambda x: f"{100.0*x:.2g}%",
 ):
     """Plot matrix of estimated transition rates for permutation moves as a heatmap."""
@@ -331,7 +331,7 @@ def plot_hrex_transition_matrix(
             for to_state in states:
                 rate = transition_rate[to_state, from_state]
                 if rate > 0.0:
-                    label = format_rate(cast(float, rate))
+                    label = format_annotation(cast(float, rate))
                     ax.text(from_state, to_state, label, ha="center", va="center", color="w", fontsize=8)
 
     ax.set_xlabel("from state")
@@ -340,7 +340,7 @@ def plot_hrex_transition_matrix(
     ax.yaxis.get_major_locator().set_params(integer=True)
     ax.set_aspect("equal")
 
-    fig.colorbar(p, label="fraction of iterations", format=lambda x, _: format_rate(x) + cbar_tick_label_suffix)
+    fig.colorbar(p, label="fraction of iterations", format=lambda x, _: format_cbar_tick(x))
 
 
 def plot_hrex_swap_acceptance_rates_convergence(cumulative_swap_acceptance_rates: NDArray):
@@ -384,8 +384,8 @@ def plot_hrex_replica_state_distribution_heatmap(
     cumulative_replica_state_counts: NDArray,
     figsize: Tuple[float, float] = (13, 10),
     annotate_threshold: int = DEFAULT_HEATMAP_ANNOTATE_THRESHOLD,
-    format_rate: Callable[[float], str] = lambda x: f"{100.0*x:.2g}",
-    cbar_tick_label_suffix: str = "%",
+    format_annotation: Callable[[float], str] = lambda x: f"{100.0*x:.2g}",
+    format_cbar_tick: Callable[[float], str] = lambda x: f"{100.0*x:.2g}%",
 ):
     """Plot distribution of (replica, state) pairs as a heatmap."""
     n_iters, n_states, n_replicas = cumulative_replica_state_counts.shape
@@ -402,7 +402,7 @@ def plot_hrex_replica_state_distribution_heatmap(
         for replica in replicas:
             for state in states:
                 fraction = fraction_by_replica_by_state[state, replica]
-                label = format_rate(fraction)
+                label = format_annotation(fraction)
                 ax.text(replica, state, label, ha="center", va="center", color="w", fontsize=8)
 
     ax.set_xlabel("replica")
@@ -411,7 +411,7 @@ def plot_hrex_replica_state_distribution_heatmap(
     ax.yaxis.get_major_locator().set_params(integer=True)
     ax.set_aspect("equal")
 
-    fig.colorbar(p, label="fraction of iterations", format=lambda x, _: format_rate(x) + cbar_tick_label_suffix)
+    fig.colorbar(p, label="fraction of iterations", format=lambda x, _: format_cbar_tick(x))
 
 
 def plot_hrex_replica_state_distribution_convergence(cumulative_replica_state_counts: NDArray, ncols: int = 4):

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -315,8 +315,8 @@ def plot_hrex_transition_matrix(
     transition_rate: NDArray,
     figsize: Tuple[float, float] = (13, 10),
     annotate_threshold: int = DEFAULT_HEATMAP_ANNOTATE_THRESHOLD,
-    format_rate: Callable[[float], str] = lambda x: f"{100.0*x:.2g}",
-    cbar_tick_label_suffix: str = "%",
+    format_heatmap_cell: Callable[[float], str] = lambda x: f"{100.0*x:.1f}",
+    format_cbar_tick: Callable[[float], str] = lambda x: f"{100.0*x:.2g}%",
 ):
     """Plot matrix of estimated transition rates for permutation moves as a heatmap."""
     n_states, _ = transition_rate.shape

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -113,7 +113,7 @@ def estimate_transition_matrix(replica_idx_by_state_by_iter: Sequence[Sequence[R
     Returns
     -------
     NDArray
-        (from state, to state) -> transition rate: float
+        (from state, to state) -> transition probability: float
     """
     replica_idx_by_state_by_iter_ = np.array(replica_idx_by_state_by_iter)  # (iter, state) -> replica
     n_iters, _ = replica_idx_by_state_by_iter_.shape
@@ -122,9 +122,9 @@ def estimate_transition_matrix(replica_idx_by_state_by_iter: Sequence[Sequence[R
     transition_by_iter = replica_idx_by_state_by_iter_[:-1, None, :] == replica_idx_by_state_by_iter_[1:, :, None]
 
     transition_count = np.sum(transition_by_iter, axis=0)  # (to state, from state) -> int
-    transition_rate = transition_count / (n_iters - 1)  # (to state, from state) -> float
+    transition_probability = transition_count / (n_iters - 1)  # (to state, from state) -> float
 
-    return transition_rate
+    return transition_probability
 
 
 def estimate_relaxation_time(transition_matrix: NDArray) -> float:


### PR DESCRIPTION
Minor fix to HREX heatmap plots to format colorbar tick labels consistently with the annotations that are shown on the plot when the number of states is less than 20. Currently, the former is shown as a fraction between 0 and 1, while the latter is shown as a percentage.

Before:
![image](https://github.com/proteneer/timemachine/assets/319411/0794dabb-d28a-48f6-ac2e-df4c9d5fd6ca)
After:
![image](https://github.com/proteneer/timemachine/assets/319411/0b79908a-ddfe-409a-afec-3a99359fac66)
