### PR TITLE
Reduce kernel calls for water sampling

### DIFF
--- a/tests/test_cuda_bd_exchange_mover.py
+++ b/tests/test_cuda_bd_exchange_mover.py
@@ -290,8 +290,8 @@ def test_bd_exchange_deterministic_moves(moves, precision, seed):
     "steps_per_move,moves,box_size",
     [
         (1, 2500, 3.0),
-        (10, 2500, 3.0),
-        # (300000, 300000, 3.0),
+        (2500, 2500, 3.0),
+        (250000, 250000, 3.0),
         # The 6.0nm box triggers a failure that would occur with systems of certain sizes, may be flaky in identifying issues
         pytest.param(1, 2500, 6.0, marks=pytest.mark.nightly(reason="slow")),
     ],
@@ -370,7 +370,7 @@ def test_moves_in_a_water_box(steps_per_move, moves, box_size, precision, rtol, 
         assert accepted > 0, "No moves were made, nothing was tested"
     else:
         assert bdem.n_accepted() > 10
-        np.testing.assert_allclose(0.0002, bdem.acceptance_fraction(), atol=5e-5)
+        np.testing.assert_allclose(0.0002, bdem.acceptance_fraction(), atol=1e-4)
     if steps_per_move == 1:
         np.testing.assert_allclose(bdem.acceptance_fraction(), accepted / moves)
         assert bdem.n_accepted() == accepted
@@ -580,7 +580,7 @@ def hif2a_rbfe_state() -> InitialState:
 
 @pytest.mark.parametrize(
     "steps_per_move,moves",
-    [pytest.param(1, 10000, marks=pytest.mark.nightly(reason="slow")), (10000, 10000)],
+    [pytest.param(1, 15000, marks=pytest.mark.nightly(reason="slow")), (15000, 15000)],
 )
 @pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 5e-6, 5e-6), (np.float32, 1e-4, 2e-3)])
 @pytest.mark.parametrize("seed", [2023])

--- a/tests/test_cuda_bd_exchange_mover.py
+++ b/tests/test_cuda_bd_exchange_mover.py
@@ -272,17 +272,18 @@ def test_bd_exchange_deterministic_moves(moves, precision, seed):
         klass = custom_ops.BDExchangeMove_f64
 
     # Reference that makes a single proposal per move
-    bdem_a = klass(N, group_idxs, params, DEFAULT_TEMP, nb.potential.beta, cutoff, seed, 1, 1)
+    bdem_a = klass(N, group_idxs, params, DEFAULT_TEMP, nb.potential.beta, cutoff, seed, moves, 1)
     # Test version that makes all proposals in a single move
     bdem_b = klass(N, group_idxs, params, DEFAULT_TEMP, nb.potential.beta, cutoff, seed, moves, 1)
 
-    iterative_moved_coords = conf.copy()
-    for _ in range(moves):
-        iterative_moved_coords, _ = bdem_a.move(iterative_moved_coords, box)
-        assert not np.all(conf == iterative_moved_coords)  # We should move every time since its a single mol
-    batch_moved_coords, _ = bdem_b.move(conf, box)
-    # Moves should be deterministic regardless the number of steps taken per move
-    np.testing.assert_array_equal(iterative_moved_coords, batch_moved_coords)
+    moved_a, _ = bdem_a.move(conf, box)
+    moved_b, _ = bdem_b.move(conf, box)
+    # Moves will be deterministic if the the number of steps taken per move match
+    np.testing.assert_array_equal(moved_a, moved_b)
+    assert bdem_a.n_accepted() > 0
+    assert bdem_a.n_proposed() == moves
+    assert bdem_a.n_accepted() == bdem_b.n_accepted()
+    assert bdem_a.n_proposed() == bdem_b.n_proposed()
 
 
 @pytest.mark.parametrize(
@@ -290,7 +291,7 @@ def test_bd_exchange_deterministic_moves(moves, precision, seed):
     [
         (1, 2500, 3.0),
         (10, 2500, 3.0),
-        (200000, 200000, 3.0),
+        # (300000, 300000, 3.0),
         # The 6.0nm box triggers a failure that would occur with systems of certain sizes, may be flaky in identifying issues
         pytest.param(1, 2500, 6.0, marks=pytest.mark.nightly(reason="slow")),
     ],

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -428,7 +428,7 @@ def test_tibd_exchange_deterministic_moves(radius, moves, precision, seed):
         cutoff,
         radius,
         seed,
-        moves,
+        1,
         1,
     )
 
@@ -446,10 +446,13 @@ def test_tibd_exchange_deterministic_moves(radius, moves, precision, seed):
         1,
     )
 
-    moved_a, _ = bdem_a.move(conf, box)
-    moved_b, _ = bdem_b.move(conf, box)
-    # Moves are only deterministic if the number of steps taken per move is the same
-    np.testing.assert_array_equal(moved_a, moved_b)
+    iterative_moved_coords = conf.copy()
+    for _ in range(moves):
+        iterative_moved_coords, _ = bdem_a.move(iterative_moved_coords, box)
+
+    batch_moved_coords, _ = bdem_b.move(conf, box)
+    # Moves should be deterministic regardless the number of steps taken per move
+    np.testing.assert_array_equal(iterative_moved_coords, batch_moved_coords)
     assert bdem_a.n_accepted() > 0
     assert bdem_a.n_proposed() == moves
     assert bdem_a.n_accepted() == bdem_b.n_accepted()

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -428,7 +428,7 @@ def test_tibd_exchange_deterministic_moves(radius, moves, precision, seed):
         cutoff,
         radius,
         seed,
-        1,
+        moves,
         1,
     )
 
@@ -446,12 +446,10 @@ def test_tibd_exchange_deterministic_moves(radius, moves, precision, seed):
         1,
     )
 
-    iterative_moved_coords = conf.copy()
-    for _ in range(moves):
-        iterative_moved_coords, _ = bdem_a.move(iterative_moved_coords, box)
-    batch_moved_coords, _ = bdem_b.move(conf, box)
-    # Moves should be deterministic regardless the number of steps taken per move
-    np.testing.assert_array_equal(iterative_moved_coords, batch_moved_coords)
+    moved_a, _ = bdem_a.move(conf, box)
+    moved_b, _ = bdem_b.move(conf, box)
+    # Moves are only deterministic if the number of steps taken per move is the same
+    np.testing.assert_array_equal(moved_a, moved_b)
     assert bdem_a.n_accepted() > 0
     assert bdem_a.n_proposed() == moves
     assert bdem_a.n_accepted() == bdem_b.n_accepted()

--- a/timemachine/cpp/src/bd_exchange_move.cu
+++ b/timemachine/cpp/src/bd_exchange_move.cu
@@ -45,8 +45,9 @@ BDExchangeMove<RealType>::BDExchangeMove(
       d_sample_per_atom_energy_buffer_(mol_size_ * N), d_atom_idxs_(get_atom_indices(target_mols)),
       d_mol_offsets_(get_mol_offsets(target_mols)), d_log_weights_before_(num_target_mols_),
       d_log_weights_after_(num_target_mols_), d_log_sum_exp_before_(2), d_log_sum_exp_after_(2), d_samples_(1),
-      d_quaternions_(round_up_even(4)), d_translations_(round_up_even(4)), d_num_accepted_(1),
-      d_target_mol_atoms_(mol_size_), d_target_mol_offsets_(num_target_mols_ + 1) {
+      d_quaternions_(round_up_even(QUATERNIONS_PER_STEP * get_random_batch_size(proposals_per_move))),
+      d_translations_(round_up_even(4)), d_num_accepted_(1), d_target_mol_atoms_(mol_size_),
+      d_target_mol_offsets_(num_target_mols_ + 1) {
 
     if (proposals_per_move_ <= 0) {
         throw std::runtime_error("proposals per move must be greater than 0");
@@ -101,7 +102,6 @@ void BDExchangeMove<RealType>::move(
         if (quaternion_offset >= this->d_quaternions_.length) {
             // reset the noise to zero and generate more noise
             quaternion_offset = 0;
-            // Quaternions generated from normal noise generate uniform rotations
             curandErrchk(templateCurandNormal(cr_rng_, d_quaternions_.data, d_quaternions_.length, 0.0, 1.0));
         }
         // Run only after the first pass, to maintain meaningful `log_probability_host` values

--- a/timemachine/cpp/src/bd_exchange_move.hpp
+++ b/timemachine/cpp/src/bd_exchange_move.hpp
@@ -10,11 +10,14 @@
 
 namespace timemachine {
 
+int get_random_batch_size(int moves);
+
 // BDExchangeMove uses biased deletion to move waters randomly in a box. The reference implementation
 // is in timemachine/md/exchange/exchange_mover.py::BDExchangeMove
 template <typename RealType> class BDExchangeMove : public Mover {
 
 protected:
+    static const int QUATERNIONS_PER_STEP = 4;
     const int N_;
     // Number of atom in all mols
     // All molecules are currently expected to have same number of atoms (typically 3 for waters)
@@ -53,8 +56,8 @@ protected:
 
     void compute_initial_weights(const int N, double *d_coords, double *d_box, cudaStream_t stream);
 
-    void
-    compute_incremental_weights(const int N, const bool scale, double *d_coords, double *d_box, cudaStream_t stream);
+    void compute_incremental_weights(
+        const int N, const bool scale, double *d_coords, double *d_box, RealType *d_quaternions, cudaStream_t stream);
 
 public:
     BDExchangeMove(

--- a/timemachine/cpp/src/bd_exchange_move.hpp
+++ b/timemachine/cpp/src/bd_exchange_move.hpp
@@ -51,7 +51,7 @@ protected:
     DeviceBuffer<size_t> d_num_accepted_;
     DeviceBuffer<int> d_target_mol_atoms_;
     DeviceBuffer<int> d_target_mol_offsets_;
-    DeviceBuffer<__int128> d_intermediate_sample_weights_; // ceil_divide(N_, DEFAULT_THREADS_PER_BLOCK)
+    DeviceBuffer<__int128> d_intermediate_sample_weights_;
 
     curandGenerator_t cr_rng_;
 

--- a/timemachine/cpp/src/bd_exchange_move.hpp
+++ b/timemachine/cpp/src/bd_exchange_move.hpp
@@ -51,6 +51,7 @@ protected:
     DeviceBuffer<size_t> d_num_accepted_;
     DeviceBuffer<int> d_target_mol_atoms_;
     DeviceBuffer<int> d_target_mol_offsets_;
+    DeviceBuffer<__int128> d_intermediate_sample_weights_; // ceil_divide(N_, DEFAULT_THREADS_PER_BLOCK)
 
     curandGenerator_t cr_rng_;
 

--- a/timemachine/cpp/src/bd_exchange_move.hpp
+++ b/timemachine/cpp/src/bd_exchange_move.hpp
@@ -10,13 +10,13 @@
 
 namespace timemachine {
 
-int get_random_batch_size(int moves);
-
 // BDExchangeMove uses biased deletion to move waters randomly in a box. The reference implementation
 // is in timemachine/md/exchange/exchange_mover.py::BDExchangeMove
 template <typename RealType> class BDExchangeMove : public Mover {
 
 protected:
+    // Amount of random values to generate at a time
+    static const int RANDOM_BATCH_SIZE = 10000;
     static const int QUATERNIONS_PER_STEP = 4;
     const int N_;
     // Number of atom in all mols
@@ -29,6 +29,7 @@ protected:
     const RealType nb_beta_;
     const RealType beta_; // 1 / kT
     const RealType cutoff_squared_;
+    size_t noise_offset_;
     size_t num_attempted_;
     NonbondedMolEnergyPotential<RealType> mol_potential_;
     WeightedRandomSampler<RealType> sampler_;

--- a/timemachine/cpp/src/kernels/k_exchange.cu
+++ b/timemachine/cpp/src/kernels/k_exchange.cu
@@ -85,6 +85,7 @@ template void __global__ k_attempt_exchange_move<double>(
 template <typename RealType>
 void __global__ k_attempt_exchange_move_targeted(
     const int N,
+    const int num_target_mols,
     const int *__restrict__ targeting_inner_volume,
     const RealType *__restrict__ box_vol, // [1]
     const RealType inner_volume,
@@ -93,6 +94,8 @@ void __global__ k_attempt_exchange_move_targeted(
     const RealType *__restrict__ after_log_sum_exp,  // [2]
     const double *__restrict__ moved_coords,         // [N, 3]
     double *__restrict__ dest_coords,                // [N, 3]
+    RealType *__restrict__ before_weights,           // [num_target_mols]
+    RealType *__restrict__ after_weights,            // [num_target_mols]
     size_t *__restrict__ num_accepted                // [1]
 ) {
     int atom_idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -117,16 +120,29 @@ void __global__ k_attempt_exchange_move_targeted(
     }
 
     // If accepted, move the coords into place
-    while (accepted && atom_idx < N) {
-        dest_coords[atom_idx * 3 + 0] = moved_coords[atom_idx * 3 + 0];
-        dest_coords[atom_idx * 3 + 1] = moved_coords[atom_idx * 3 + 1];
-        dest_coords[atom_idx * 3 + 2] = moved_coords[atom_idx * 3 + 2];
+    // Always move the weights
+    while (atom_idx < N) {
+        if (accepted) {
+            dest_coords[atom_idx * 3 + 0] = moved_coords[atom_idx * 3 + 0];
+            dest_coords[atom_idx * 3 + 1] = moved_coords[atom_idx * 3 + 1];
+            dest_coords[atom_idx * 3 + 2] = moved_coords[atom_idx * 3 + 2];
+        }
+        // Store the weights. If accepted store the after weights as before else
+        // copy the before weights to the after so the next iteration can incrementally update the weights
+        if (atom_idx < num_target_mols) {
+            if (accepted) {
+                before_weights[atom_idx] = after_weights[atom_idx];
+            } else {
+                after_weights[atom_idx] = before_weights[atom_idx];
+            }
+        }
         atom_idx += gridDim.x * blockDim.x;
     }
 }
 
 template void __global__ k_attempt_exchange_move_targeted<float>(
     const int N,
+    const int num_target_mols,
     const int *__restrict__ targeting_inner_volume,
     const float *__restrict__ box_vol,
     const float inner_volume,
@@ -135,9 +151,12 @@ template void __global__ k_attempt_exchange_move_targeted<float>(
     const float *__restrict__ after_log_sum_exp,
     const double *__restrict__ moved_coords,
     double *__restrict__ dest_coords,
+    float *__restrict__ before_weights,
+    float *__restrict__ after_weights,
     size_t *__restrict__ num_accepted);
 template void __global__ k_attempt_exchange_move_targeted<double>(
     const int N,
+    const int num_target_mols,
     const int *__restrict__ targeting_inner_volume,
     const double *__restrict__ box_vol,
     const double inner_volume,
@@ -146,6 +165,8 @@ template void __global__ k_attempt_exchange_move_targeted<double>(
     const double *__restrict__ after_log_sum_exp,
     const double *__restrict__ moved_coords,
     double *__restrict__ dest_coords,
+    double *__restrict__ before_weights,
+    double *__restrict__ after_weights,
     size_t *__restrict__ num_accepted);
 
 template <typename RealType>
@@ -193,74 +214,6 @@ template void __global__ k_store_accepted_log_probability<float>(
     const float *__restrict__ after_weights);
 template void __global__ k_store_accepted_log_probability<double>(
     const int num_weights,
-    const double *__restrict__ rand,
-    double *__restrict__ before_log_sum_exp,
-    const double *__restrict__ after_log_sum_exp,
-    double *__restrict__ before_weights,
-    const double *__restrict__ after_weights);
-
-template <typename RealType>
-void __global__ k_store_accepted_log_probability_targeted(
-    const int num_weights,
-    const int *__restrict__ targeting_inner_volume,
-    const RealType *__restrict__ box_vol, // [1]
-    const RealType inner_volume,
-    const RealType *__restrict__ rand,              // [1]
-    RealType *__restrict__ before_log_sum_exp,      // [2]
-    const RealType *__restrict__ after_log_sum_exp, // [2]
-    RealType *__restrict__ before_weights,          // [num_weights]
-    const RealType *__restrict__ after_weights      // [num_weights]
-) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    assert(gridDim.x == 1);
-    if (blockIdx.x > 0) {
-        return; // Only one block can run this
-    }
-
-    int flag = targeting_inner_volume[0];
-
-    const RealType outer_vol = box_vol[0] - inner_volume;
-
-    const RealType log_vol_prob = flag == 1 ? log(inner_volume) - log(outer_vol) : log(outer_vol) - log(inner_volume);
-
-    // All kernels compute the same acceptance
-    // TBD investigate shared memory for speed
-    RealType before_log_prob = convert_nan_to_inf<RealType>(compute_logsumexp_final<RealType>(before_log_sum_exp));
-    RealType after_log_prob = convert_nan_to_inf<RealType>(compute_logsumexp_final<RealType>(after_log_sum_exp));
-
-    RealType log_acceptance_prob = min(before_log_prob - after_log_prob + log_vol_prob, static_cast<RealType>(0.0));
-    const bool accepted = rand[0] < exp(log_acceptance_prob);
-    if (!accepted) {
-        return;
-    }
-    __syncthreads();
-    // Swap the values after all threads have computed the log probability
-    if (idx == 0) {
-        before_log_sum_exp[0] = after_log_sum_exp[0];
-        before_log_sum_exp[1] = after_log_sum_exp[1];
-    }
-    // Copy over the weights
-    while (idx < num_weights) {
-        before_weights[idx] = after_weights[idx];
-        idx += gridDim.x * blockDim.x;
-    }
-}
-
-template void __global__ k_store_accepted_log_probability_targeted<float>(
-    const int num_weights,
-    const int *__restrict__ targeting_inner_volume,
-    const float *__restrict__ box_vol,
-    const float inner_volume,
-    const float *__restrict__ rand,
-    float *__restrict__ before_log_sum_exp,
-    const float *__restrict__ after_log_sum_exp,
-    float *__restrict__ before_weights,
-    const float *__restrict__ after_weights);
-template void __global__ k_store_accepted_log_probability_targeted<double>(
-    const int num_weights,
-    const int *__restrict__ targeting_inner_volume,
-    const double *__restrict__ box_vol,
-    const double inner_volume,
     const double *__restrict__ rand,
     double *__restrict__ before_log_sum_exp,
     const double *__restrict__ after_log_sum_exp,

--- a/timemachine/cpp/src/kernels/k_exchange.cu
+++ b/timemachine/cpp/src/kernels/k_exchange.cu
@@ -382,9 +382,9 @@ template void __global__ k_set_sampled_weight_block<double, 512>(
 
 template <typename RealType, int THREADS_PER_BLOCK>
 void __global__ k_set_sampled_weight_reduce(
-    const int intermediates,
-    const int *__restrict__ samples, // [1]
-    const __int128 *__restrict__ intermediate_accum,
+    const int num_intermediates,
+    const int *__restrict__ samples,                 // [1]
+    const __int128 *__restrict__ intermediate_accum, // [num_intermediates]
     RealType *__restrict__ log_weights) {
     __shared__ __int128 accumulators[THREADS_PER_BLOCK];
 
@@ -392,7 +392,7 @@ void __global__ k_set_sampled_weight_reduce(
 
     // Zero all of the accumulators
     __int128 accumulator = 0;
-    while (idx < intermediates) {
+    while (idx < num_intermediates) {
         accumulator += intermediate_accum[idx];
         idx += gridDim.x * blockDim.x;
     }
@@ -407,14 +407,14 @@ void __global__ k_set_sampled_weight_reduce(
 }
 
 template void __global__ k_set_sampled_weight_reduce<float, 512>(
-    const int intermediates,
-    const int *__restrict__ samples, // [1]
-    const __int128 *__restrict__ intermediate_accum,
+    const int num_intermediates,
+    const int *__restrict__ samples,                 // [1]
+    const __int128 *__restrict__ intermediate_accum, // [num_intermediates]
     float *__restrict__ log_weights);
 template void __global__ k_set_sampled_weight_reduce<double, 512>(
-    const int intermediates,
-    const int *__restrict__ samples, // [1]
-    const __int128 *__restrict__ intermediate_accum,
+    const int num_intermediates,
+    const int *__restrict__ samples,                 // [1]
+    const __int128 *__restrict__ intermediate_accum, // [num_intermediates]
     double *__restrict__ log_weights);
 
 template <typename RealType>

--- a/timemachine/cpp/src/kernels/k_exchange.cu
+++ b/timemachine/cpp/src/kernels/k_exchange.cu
@@ -90,12 +90,14 @@ void __global__ k_attempt_exchange_move_targeted(
     const RealType *__restrict__ box_vol, // [1]
     const RealType inner_volume,
     const RealType *__restrict__ rand,               // [1]
+    const int *__restrict__ samples,                 // [1]
     const RealType *__restrict__ before_log_sum_exp, // [2]
     const RealType *__restrict__ after_log_sum_exp,  // [2]
     const double *__restrict__ moved_coords,         // [N, 3]
     double *__restrict__ dest_coords,                // [N, 3]
     RealType *__restrict__ before_weights,           // [num_target_mols]
     RealType *__restrict__ after_weights,            // [num_target_mols]
+    int *__restrict__ inner_flags,                   // [num_target_mols]
     size_t *__restrict__ num_accepted                // [1]
 ) {
     int atom_idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -117,6 +119,9 @@ void __global__ k_attempt_exchange_move_targeted(
     const bool accepted = rand[0] < exp(log_acceptance_prob);
     if (atom_idx == 0 && accepted) {
         num_accepted[0]++;
+        int mol_idx = samples[0];
+        // XOR 1 to flip the flag from 0 to 1 or 1 to 0
+        inner_flags[mol_idx] ^= 1;
     }
 
     // If accepted, move the coords into place
@@ -147,12 +152,14 @@ template void __global__ k_attempt_exchange_move_targeted<float>(
     const float *__restrict__ box_vol,
     const float inner_volume,
     const float *__restrict__ rand,
+    const int *__restrict__ samples,
     const float *__restrict__ before_log_sum_exp,
     const float *__restrict__ after_log_sum_exp,
     const double *__restrict__ moved_coords,
     double *__restrict__ dest_coords,
     float *__restrict__ before_weights,
     float *__restrict__ after_weights,
+    int *__restrict__ inner_flags,
     size_t *__restrict__ num_accepted);
 template void __global__ k_attempt_exchange_move_targeted<double>(
     const int N,
@@ -161,12 +168,14 @@ template void __global__ k_attempt_exchange_move_targeted<double>(
     const double *__restrict__ box_vol,
     const double inner_volume,
     const double *__restrict__ rand,
+    const int *__restrict__ samples,
     const double *__restrict__ before_log_sum_exp,
     const double *__restrict__ after_log_sum_exp,
     const double *__restrict__ moved_coords,
     double *__restrict__ dest_coords,
     double *__restrict__ before_weights,
     double *__restrict__ after_weights,
+    int *__restrict__ inner_flags,
     size_t *__restrict__ num_accepted);
 
 template <typename RealType>

--- a/timemachine/cpp/src/kernels/k_exchange.cu
+++ b/timemachine/cpp/src/kernels/k_exchange.cu
@@ -125,15 +125,16 @@ void __global__ k_attempt_exchange_move_targeted(
     }
 
     // If accepted, move the coords into place
-    // Always move the weights
+    // Always copy the weights, either copying from before to after or after to before
     while (atom_idx < N) {
         if (accepted) {
             dest_coords[atom_idx * 3 + 0] = moved_coords[atom_idx * 3 + 0];
             dest_coords[atom_idx * 3 + 1] = moved_coords[atom_idx * 3 + 1];
             dest_coords[atom_idx * 3 + 2] = moved_coords[atom_idx * 3 + 2];
         }
-        // Store the weights. If accepted store the after weights as before else
-        // copy the before weights to the after so the next iteration can incrementally update the weights
+        // If accepted store the after weights as before weights else copy the before weights to the after weights
+        // so the next iteration can incrementally update the weights. The copying of the before to the after is
+        // to avoid an additional memcpy kernel.
         if (atom_idx < num_target_mols) {
             if (accepted) {
                 before_weights[atom_idx] = after_weights[atom_idx];

--- a/timemachine/cpp/src/kernels/k_exchange.cuh
+++ b/timemachine/cpp/src/kernels/k_exchange.cuh
@@ -88,7 +88,7 @@ void __global__ k_set_sampled_weight_block(
 
 template <typename RealType, int THREADS_PER_BLOCK>
 void __global__ k_set_sampled_weight_reduce(
-    const int intermediates,
+    const int num_intermediates,
     const int *__restrict__ samples, // [1]
     const __int128 *__restrict__ intermediate_accum,
     RealType *__restrict__ log_weights);

--- a/timemachine/cpp/src/kernels/k_exchange.cuh
+++ b/timemachine/cpp/src/kernels/k_exchange.cuh
@@ -78,14 +78,19 @@ void __global__ k_adjust_weights(
     RealType *__restrict__ log_weights);
 
 template <typename RealType, int THREADS_PER_BLOCK>
-void __global__ k_set_sampled_weight(
+void __global__ k_set_sampled_weight_block(
     const int N,
     const int mol_size,
-    const int *__restrict__ samples, // [1]
     const int *__restrict__ target_atoms,
-    const int *__restrict__ mol_offsets,
     const RealType *__restrict__ per_atom_energies,
     const RealType inv_kT, // 1 / kT
+    __int128 *__restrict__ intermediate_accum);
+
+template <typename RealType, int THREADS_PER_BLOCK>
+void __global__ k_set_sampled_weight_reduce(
+    const int intermediates,
+    const int *__restrict__ samples, // [1]
+    const __int128 *__restrict__ intermediate_accum,
     RealType *__restrict__ log_weights);
 
 template <typename RealType>

--- a/timemachine/cpp/src/kernels/k_exchange.cuh
+++ b/timemachine/cpp/src/kernels/k_exchange.cuh
@@ -32,33 +32,23 @@ void __global__ k_attempt_exchange_move(
 template <typename RealType>
 void __global__ k_attempt_exchange_move_targeted(
     const int N,
+    const int num_target_mols,
     const int *__restrict__ targeting_inner_volume,
-    const RealType *__restrict__ box_vol,
+    const RealType *__restrict__ box_vol, // [1]
     const RealType inner_volume,
     const RealType *__restrict__ rand,               // [1]
     const RealType *__restrict__ before_log_sum_exp, // [2]
     const RealType *__restrict__ after_log_sum_exp,  // [2]
     const double *__restrict__ moved_coords,         // [N, 3]
     double *__restrict__ dest_coords,                // [N, 3]
+    RealType *__restrict__ before_weights,           // [num_target_mols]
+    RealType *__restrict__ after_weights,            // [num_target_mols]
     size_t *__restrict__ num_accepted                // [1]
 );
 
 template <typename RealType>
 void __global__ k_store_accepted_log_probability(
     const int num_weights,
-    const RealType *__restrict__ rand,              // [1]
-    RealType *__restrict__ before_log_sum_exp,      // [2]
-    const RealType *__restrict__ after_log_sum_exp, // [2]
-    RealType *__restrict__ before_weights,          // [num_weights]
-    const RealType *__restrict__ after_weights      // [num_weights]
-);
-
-template <typename RealType>
-void __global__ k_store_accepted_log_probability_targeted(
-    const int num_weights,
-    const int *__restrict__ targeting_inner_volume,
-    const RealType *__restrict__ box_vol,
-    const RealType inner_volume,
     const RealType *__restrict__ rand,              // [1]
     RealType *__restrict__ before_log_sum_exp,      // [2]
     const RealType *__restrict__ after_log_sum_exp, // [2]

--- a/timemachine/cpp/src/kernels/k_exchange.cuh
+++ b/timemachine/cpp/src/kernels/k_exchange.cuh
@@ -36,14 +36,16 @@ void __global__ k_attempt_exchange_move_targeted(
     const int *__restrict__ targeting_inner_volume,
     const RealType *__restrict__ box_vol, // [1]
     const RealType inner_volume,
-    const RealType *__restrict__ rand,               // [1]
+    const RealType *__restrict__ rand, // [1]
+    const int *__restrict__ samples,
     const RealType *__restrict__ before_log_sum_exp, // [2]
     const RealType *__restrict__ after_log_sum_exp,  // [2]
     const double *__restrict__ moved_coords,         // [N, 3]
     double *__restrict__ dest_coords,                // [N, 3]
     RealType *__restrict__ before_weights,           // [num_target_mols]
     RealType *__restrict__ after_weights,            // [num_target_mols]
-    size_t *__restrict__ num_accepted                // [1]
+    int *__restrict__ inner_flags,
+    size_t *__restrict__ num_accepted // [1]
 );
 
 template <typename RealType>

--- a/timemachine/cpp/src/tibd_exchange_move.cu
+++ b/timemachine/cpp/src/tibd_exchange_move.cu
@@ -43,8 +43,6 @@ TIBDExchangeMove<RealType>::TIBDExchangeMove(
     if (radius <= 0.0) {
         throw std::runtime_error("radius must be greater than 0.0");
     }
-    this->d_quaternions_.realloc(
-        round_up_even(this->QUATERNIONS_PER_STEP * get_random_batch_size(this->proposals_per_move_)));
     if (d_uniform_noise_buffer_.length / NOISE_PER_STEP != this->d_quaternions_.length / this->QUATERNIONS_PER_STEP) {
         throw std::runtime_error("bug in the code: buffers with random values don't match in batch size");
     }

--- a/timemachine/cpp/src/tibd_exchange_move.cu
+++ b/timemachine/cpp/src/tibd_exchange_move.cu
@@ -15,6 +15,8 @@
 
 namespace timemachine {
 
+// NOISE_PER_STEP is the uniform generated per step that is used for deciding the targeted move as well as the acceptance
+// in the metropolis hasting check.
 static const int NOISE_PER_STEP = 2;
 
 template <typename RealType>

--- a/timemachine/cpp/src/tibd_exchange_move.hpp
+++ b/timemachine/cpp/src/tibd_exchange_move.hpp
@@ -19,6 +19,7 @@ template <typename RealType> class TIBDExchangeMove : public BDExchangeMove<Real
 protected:
     const RealType radius_;
     const RealType inner_volume_;
+    size_t quaternion_offset_;
 
     DeviceBuffer<curandState_t> d_rand_states_;
 


### PR DESCRIPTION
Speeds up targeted insertion by about 20%. These are the simpler changes.


## Kernel Performance
Ran following test: `pytest tests/test_cuda_targeted_insertion_mover.py -k 'test_moves_with_complex_and_ligand[2023-float32-0.0001-0.002-12500-12500-2.0]'`
Cuda Arch 8.6
GPU: A4000

### Changes

* `void timemachine::k_set_sampled_weight` previously took 20k ns per run, split into two kernels each kernel is only 4k ns each thanks to additional parallelism.
* `void timemachine::k_flag_mols_inner_outer` is now only run once, reducing 1.4% kernel run time

### Old
```
CUDA API Statistics:

 Time (%)  Total Time (ns)  Num Calls  Avg (ns)   Med (ns)   Min (ns)   Max (ns)    StdDev (ns)            Name           
 --------  ---------------  ---------  ---------  ---------  --------  -----------  -----------  -------------------------
     51.0    1,793,051,451    449,433    3,989.6    3,734.0     3,043    1,218,286      2,511.8  cudaLaunchKernel         
     22.7      798,663,183     25,013   31,929.9    1,787.0     1,467      347,431     65,191.8  cudaEventSynchronize     
      8.4      296,085,609     66,162    4,475.2    3,930.0     2,247      487,328      7,847.4  cudaMemcpyAsync          
      6.4      224,447,919      2,017  111,278.1    7,092.0       131  177,337,124  3,948,571.0  cudaMalloc               
      2.7       95,882,718     18,827    5,092.8    4,169.0     2,030      160,571      4,398.3  cudaMemsetAsync          
      2.6       92,579,194      1,175   78,790.8   48,487.0     5,311    1,333,294    119,639.1  cudaMemcpy               
      2.4       83,363,817    113,346      735.5      591.0       429       20,854        617.7  cudaEventRecord          
      2.0       70,461,715     88,420      796.9      650.0       464       19,230        667.7  cudaStreamWaitEvent      
      1.2       42,871,077      2,037   21,046.2    5,717.0       312   11,492,198    258,040.3  cudaFree                 
      0.1        5,270,871        392   13,446.1    6,890.5     1,736      420,042     30,833.5  cudaStreamSynchronize    
      0.1        4,177,442          5  835,488.4  166,974.0    97,309    3,341,631  1,406,091.4  cudaDeviceSynchronize    
      0.1        3,779,216         11  343,565.1   11,075.0     6,748      951,056    462,976.2  cudaHostAlloc            
      0.1        2,731,243         11  248,294.8   22,248.0     5,687    1,117,100    366,668.7  cudaFreeHost             
      0.0          319,140         37    8,625.4    2,920.0     2,582      146,537     23,715.8  cudaStreamCreateWithFlags
      0.0          227,646         37    6,152.6    3,789.0     2,693       26,548      5,000.8  cudaStreamDestroy        
      0.0          206,135         22    9,369.8    5,272.0     2,343       30,115      7,624.9  cudaMemset               
      0.0          188,107        756      248.8      225.5       134        3,329        145.5  cuGetProcAddress         
      0.0           68,142         47    1,449.8      865.0       419        4,819      1,092.7  cudaEventDestroy         
      0.0           62,089         47    1,321.0      851.0       505        3,075        857.9  cudaEventCreateWithFlags 
      0.0            5,978          2    2,989.0    2,989.0     2,888        3,090        142.8  cuInit                   
      0.0              442          2      221.0      221.0       176          266         63.6  cuModuleGetLoadingMode   

[5/7] Executing 'gpukernsum' stats report

CUDA Kernel Statistics:

 Time (%)  Total Time (ns)  Instances   Avg (ns)     Med (ns)    Min (ns)   Max (ns)   StdDev (ns)                                                  Name                                                
 --------  ---------------  ---------  -----------  -----------  ---------  ---------  -----------  ----------------------------------------------------------------------------------------------------
     32.0      875,510,612     10,809     80,998.3     26,112.0     15,168    212,960     82,075.4  void timemachine::k_nonbonded_unified<float, (int)256, (bool)0, (bool)1, (bool)0>(int, int, const u…
      9.4      256,673,574     12,500     20,533.9     20,512.0     19,424     21,504        262.2  void timemachine::k_set_sampled_weight<float, (int)512>(int, int, const int *, const int *, const i…
      4.2      114,834,551     25,000      4,593.4      4,576.0      4,385     12,993        167.5  void timemachine::k_atom_by_atom_energies<float>(int, int, const int *, const double *, const doubl…
      3.5       96,536,551      1,200     80,447.1     25,728.0     21,952    217,856     78,319.0  void timemachine::k_nonbonded_unified<float, (int)256, (bool)1, (bool)0, (bool)0>(int, int, const u…
      2.5       69,135,838        559    123,677.7    124,577.0    107,008    143,936      8,428.7  void timemachine::k_find_blocks_with_ixns<float, (bool)1>(int, int, int, const unsigned int *, cons…
      2.4       66,868,869      1,019     65,622.1     57,183.0     41,792    144,704     19,836.0  void timemachine::k_find_blocks_with_ixns<float, (bool)0>(int, int, int, const unsigned int *, cons…
      2.4       66,416,429     12,426      5,345.0      4,383.0      2,432     18,592      1,904.5  void timemachine::k_check_rebuild_coords_and_box_gather<float>(int, const unsigned int *, const dou…
      2.2       61,331,720     25,001      2,453.2      2,528.0      2,207     13,504        233.9  void cub::DeviceReduceSingleTileKernel<cub::DeviceReducePolicy<float, float, int, cub::Max>::Policy…
      2.2       60,777,227      4,171     14,571.4     13,248.0     10,400     37,472      4,142.6  void timemachine::k_nonbonded_precomputed<float>(int, const double *, const double *, const double …
      2.2       60,602,612        504    120,243.3     38,512.0     29,216    297,504    121,432.2  void timemachine::k_nonbonded_unified<float, (int)256, (bool)1, (bool)1, (bool)0>(int, int, const u…
      2.2       60,212,386     25,001      2,408.4      2,527.0      2,175     13,216        228.7  void cub::DeviceReduceSingleTileKernel<cub::DeviceReducePolicy<float, float, int, cub::Sum>::Policy…
      1.8       48,095,748      4,171     11,531.0     11,488.0      5,632     24,352      1,415.0  void timemachine::k_nonbonded_pair_list<float, (bool)1>(int, const double *, const double *, const …
      1.7       47,272,312     12,500      3,781.8      3,776.0      3,711     13,152        289.8  void timemachine::k_adjust_weights<float, (bool)1>(int, int, int, const int *, const int *, const T…
      1.7       47,269,592     25,001      1,890.7      1,888.0      1,695     12,672        196.0  void gen_sequenced<curandStateXORWOW, float, int, &curand_uniform_noargs<curandStateXORWOW>, rng_co…
      1.7       47,256,556     12,500      3,780.5      3,776.0      3,392     12,736        241.6  void timemachine::k_adjust_weights<float, (bool)0>(int, int, int, const int *, const int *, const T…
      1.7       46,195,008     12,513      3,691.8      3,680.0      2,016     14,816        648.9  void timemachine::k_gather_coords_and_params<double, (int)3, (int)4>(int, const unsigned int *, con…
      1.6       44,752,179     25,001      1,790.0      1,761.0      1,472     12,960        190.1  void timemachine::k_exp_sub_max<float>(int, const T1 *, const T1 *, T1 *)                           
      1.5       41,902,140     12,500      3,352.2      3,328.0      3,199     13,408        111.9  void timemachine::k_rotate_and_translate_mols<float, (bool)0>(int, const double *, const double *, …
      1.5       40,107,947     12,500      3,208.6      3,200.0      2,816      3,680         60.6  void cub::DeviceSelectSweepKernel<cub::DispatchSelectIf<int *, int *, int *, int *, cub::NullType, …
      1.4       39,429,407     12,500      3,154.4      3,136.0      3,071     12,832        135.1  void timemachine::k_flag_mols_inner_outer<float>(int, const int *, const int *, const T1 *, T1, con…
      1.3       35,171,424      4,171      8,432.4      8,256.0      3,776     18,784      1,798.7  void timemachine::k_periodic_torsion<float, (int)3>(int, const double *, const double *, const int …
      1.2       34,214,426     11,313      3,024.3      3,136.0      1,632     14,656        725.4  void timemachine::k_scatter_accum<unsigned long long, (int)3>(int, const unsigned int *, const T1 *…
      1.2       33,155,558     12,500      2,652.4      2,784.0      2,431     12,992        220.7  void cub::DeviceReduceSingleTileKernel<cub::DeviceReducePolicy<cub::KeyValuePair<int, float>, cub::…
      1.1       30,036,309     12,500      2,402.9      2,400.0      2,271      8,448        101.8  void timemachine::k_generate_translations_within_or_outside_a_sphere<float>(int, const double *, co…
      1.0       28,030,023     12,500      2,242.4      2,240.0      2,176      2,656         49.1  timemachine::k_setup_sample_atoms(int, const int *, const int *, const int *, int *, int *)         
      1.0       27,924,209      6,248      4,469.3      3,871.0      2,304     20,960      1,595.4  void timemachine::k_accumulate_energy<(unsigned int)512>(int, const __int128 *, __int128 *)         
      1.0       27,289,816     12,500      2,183.2      2,144.0      1,920     12,896        463.2  void timemachine::k_setup_destination_weights_for_targeted<float>(int, const int *, const int *, co…
      1.0       27,153,906     12,850      2,113.1      1,920.0      1,823     18,305      1,063.0  void gen_sequenced<curandStateXORWOW, float2, normal_args_st, &curand_normal_scaled2<curandStateXOR…
      0.9       25,577,974     12,500      2,046.2      2,048.0      1,983      2,496         49.5  void timemachine::k_separate_weights_for_targeted<float>(int, const int *, const int *, const int *…
      0.9       25,531,796      4,171      6,121.3      5,665.0      3,392     17,504      1,432.4  void timemachine::k_harmonic_bond<float>(int, const double *, const double *, const int *, unsigned…
      0.9       24,962,028     12,500      1,997.0      1,984.0      1,600     12,768        108.4  void timemachine::k_decide_targeted_move<float>(int, const T1 *, const int *, int *)                
      0.9       24,643,923     12,499      1,971.7      1,952.0      1,919     10,303         97.5  void timemachine::k_store_accepted_log_probability_targeted<float>(int, const int *, const T1 *, T1…
      0.9       24,635,810     12,500      1,970.9      1,952.0      1,919      7,136         67.3  void timemachine::k_attempt_exchange_move_targeted<float>(int, const int *, const T1 *, T1, const T…
      0.9       24,589,002     12,500      1,967.1      1,952.0      1,919      2,400         48.9  timemachine::k_adjust_sample_idx(const int *, const int *, const int *, int *)                      
      0.9       23,300,062     12,500      1,864.0      1,856.0      1,823      2,273         53.5  void timemachine::k_setup_gumbel_max_trick<float>(int, const T1 *, T1 *)                            
      0.8       23,027,997     12,500      1,842.2      1,824.0      1,791      2,272         58.3  void timemachine::k_copy_kv_key<float>(int, const cub::KeyValuePair<int, T1> *, int *)              
      0.8       20,998,507     12,500      1,679.9      1,664.0      1,631     12,576        193.1  void cub::DeviceCompactInitKernel<cub::ScanTileState<int, (bool)1>, int *>(T1, int, T2)             
      0.7       19,885,371      3,500      5,681.5      5,697.0      4,992     13,792        435.9  void timemachine::k_update_forward_baoab<float, (int)3>(int, T1, const unsigned int *, const T1 *, …
      0.7       19,516,722      2,603      7,497.8      6,560.0      5,344     19,136      1,960.6  void timemachine::k_harmonic_angle<float, (int)3>(int, const double *, const double *, const int *,…
      0.5       14,895,783      2,597      5,735.8      5,664.0      3,872     16,064        865.1  void timemachine::k_find_block_bounds<float>(int, int, const unsigned int *, const double *, const …
      0.4        9,628,888      1,568      6,140.9      5,888.0      3,200     11,776      1,780.3  void timemachine::k_harmonic_angle_stable<float>(int, const double *, const double *, const int *, …
      0.3        7,024,776      1,578      4,451.7      4,576.0      2,240     15,648      1,375.8  timemachine::k_compact_trim_atoms(int, int, unsigned int *, unsigned int *, int *, unsigned int *)  
      0.2        4,358,114          1  4,358,114.0  4,358,114.0  4,358,114  4,358,114          0.0  void timemachine::k_compute_nonbonded_target_atom_energies<float, (int)64>(int, int, const int *, c…
      0.1        3,409,176        260     13,112.2     13,136.0      9,984     17,856      1,275.7  void cub::DeviceRadixSortOnesweepKernel<cub::DeviceRadixSortPolicy<unsigned int, unsigned int, int>…
      0.1        1,387,907         66     21,028.9     20,688.0     17,216     30,688      2,730.3  void cub::DeviceRadixSortSingleTileKernel<cub::DeviceRadixSortPolicy<unsigned int, unsigned int, in…
      0.0        1,293,277        200      6,466.4      6,304.0      5,920      7,744        435.8  void timemachine::k_find_group_centroids<float>(int, const double *, const int *, const int *, unsi…
      0.0        1,236,728        200      6,183.6      6,368.0      4,480      7,488        762.6  void timemachine::k_decide_move<float>(int, bool, int, double, double, const T1 *, T1 *, double *, …
      0.0          955,106        200      4,775.5      4,640.0      4,512      5,472        275.1  void timemachine::k_rescale_positions<float>(int, double *, const T1 *, const double *, double *, c…
      0.0          720,672        131      5,501.3      5,344.0      2,880     13,920      1,693.3  timemachine::k_coords_to_kv_gather(int, const unsigned int *, const double *, const double *, const…
      0.0          698,593          5    139,718.6    155,424.0     94,272    156,832     26,819.0  void generate_seed_pseudo<rng_config<curandStateXORWOW, (curandOrdering)101>>(unsigned long long, u…
      0.0          482,080        200      2,410.4      2,336.0      2,271      2,912        137.4  void timemachine::k_setup_barostat_move<float>(bool, const T1 *, double *, T1 *, double *, T1 *)    
      0.0          294,948         65      4,537.7      4,384.0      3,071      6,496        570.5  void cub::DeviceRadixSortHistogramKernel<cub::DeviceRadixSortPolicy<unsigned int, unsigned int, int…
      0.0          164,223         65      2,526.5      2,336.0      1,920      4,000        490.9  void cub::DeviceRadixSortExclusiveSumKernel<cub::DeviceRadixSortPolicy<unsigned int, unsigned int, …
      0.0          161,792          1    161,792.0    161,792.0    161,792    161,792          0.0  void timemachine::k_accumulate_atom_energies_to_per_mol_energies<float, (int)256>(int, const int *,…
      0.0           98,369         48      2,049.4      1,936.5      1,856      2,592        207.3  timemachine::k_arange(int, unsigned int *, unsigned int)                                            
      0.0           23,360         12      1,946.7      1,920.0      1,888      2,112         74.5  void timemachine::k_initialize_array<unsigned int>(int, T1 *, T1)                                   
      0.0            8,512          1      8,512.0      8,512.0      8,512      8,512          0.0  void timemachine::k_compute_centroid_of_atoms<float>(int, const int *, const double *, T1 *)        
      0.0            2,368          1      2,368.0      2,368.0      2,368      2,368          0.0  timemachine::k_initialize_curand_states(int, int, curandStateXORWOW *)                              
      0.0            2,336          1      2,336.0      2,336.0      2,336      2,336          0.0  void timemachine::k_compute_log_weights_from_energies<float>(int, T1, const __int128 *, T1 *)       
      0.0            2,079          1      2,079.0      2,079.0      2,079      2,079          0.0  void timemachine::k_compute_box_volume<float>(const double *, T1 *)                                 
      0.0            1,760          1      1,760.0      1,760.0      1,760      1,760          0.0  timemachine::k_arange(int, int *, int)                                                              

[6/7] Executing 'gpumemtimesum' stats report

CUDA Memory Operation Statistics (by time):

 Time (%)  Total Time (ns)  Count   Avg (ns)  Med (ns)  Min (ns)  Max (ns)   StdDev (ns)      Operation     
 --------  ---------------  ------  --------  --------  --------  ---------  -----------  ------------------
     31.6       55,441,222  28,634   1,936.2   1,952.0     1,472     13,088        340.0  [CUDA memcpy DtoD]
     27.0       47,421,508  38,034   1,246.8     864.0       511    185,792      3,210.6  [CUDA memcpy DtoH]
     22.0       38,632,289  18,849   2,049.6   2,208.0       735     81,312        887.1  [CUDA memset]     
     19.3       33,913,640     669  50,693.0  35,744.0       736  1,378,273    163,245.2  [CUDA memcpy HtoD]

[7/7] Executing 'gpumemsizesum' stats report

CUDA Memory Operation Statistics (by size):

 Total (MB)  Count   Avg (MB)  Med (MB)  Min (MB)  Max (MB)  StdDev (MB)      Operation     
 ----------  ------  --------  --------  --------  --------  -----------  ------------------
  3,147.496  28,634     0.110     0.009     0.000     0.213        0.102  [CUDA memcpy DtoD]
  2,478.263  18,849     0.131     0.171     0.000    28.865        0.243  [CUDA memset]     
    202.479     669     0.303     0.212     0.000     8.389        0.996  [CUDA memcpy HtoD]
     72.439  38,034     0.002     0.000     0.000     1.206        0.021  [CUDA memcpy DtoH]
```

### PR
```
CUDA API Statistics:

 Time (%)  Total Time (ns)  Num Calls  Avg (ns)   Med (ns)   Min (ns)   Max (ns)    StdDev (ns)            Name           
 --------  ---------------  ---------  ---------  ---------  --------  -----------  -----------  -------------------------
     48.7    1,575,151,965    411,939    3,823.8    3,545.0     2,915    1,268,397      2,684.8  cudaLaunchKernel         
     25.4      820,327,593     25,013   32,796.0    1,806.0     1,450      512,163     66,810.8  cudaEventSynchronize     
      7.1      228,595,522     53,663    4,259.8    3,526.0     2,241      492,149      8,515.4  cudaMemcpyAsync          
      6.8      220,584,485      2,018  109,308.5    7,480.5       121  174,145,828  3,876,526.8  cudaMalloc               
      2.9       92,296,377     18,827    4,902.3    4,007.0     2,119       51,719      4,272.9  cudaMemsetAsync          
      2.8       91,593,025      1,175   77,951.5   48,597.0     5,102    1,327,707    117,099.7  cudaMemcpy               
      2.5       80,999,532    113,346      714.6      576.0       427       17,652        616.9  cudaEventRecord          
      2.1       66,836,774     88,420      755.9      619.0       451       22,192        659.3  cudaStreamWaitEvent      
      1.3       41,176,225      2,038   20,204.2    5,772.5       270   11,013,383    246,261.4  cudaFree                 
      0.2        5,152,540        392   13,144.2    6,842.0     1,751      416,895     30,094.5  cudaStreamSynchronize    
      0.1        4,103,122          5  820,624.4  159,303.0    98,116    3,251,814  1,365,335.4  cudaDeviceSynchronize    
      0.1        4,023,985         11  365,816.8   10,805.0     6,987    1,008,019    494,524.7  cudaHostAlloc            
      0.1        2,677,096         11  243,372.4   20,497.0     5,904    1,117,458    361,395.9  cudaFreeHost             
      0.0          283,974         37    7,675.0    2,986.0     2,323      124,723     20,187.4  cudaStreamCreateWithFlags
      0.0          223,894         37    6,051.2    3,695.0     2,576       26,551      4,847.0  cudaStreamDestroy        
      0.0          208,561         22    9,480.0    5,705.5     2,450       21,660      7,040.4  cudaMemset               
      0.0          193,856        756      256.4      233.0       127        2,978        139.5  cuGetProcAddress         
      0.0           60,786         47    1,293.3      753.0       359        4,047        930.5  cudaEventDestroy         
      0.0           57,534         47    1,224.1      826.0       433        2,773        778.7  cudaEventCreateWithFlags 
      0.0            6,091          2    3,045.5    3,045.5     2,572        3,519        669.6  cuInit                   
      0.0              681          2      340.5      340.5       335          346          7.8  cuModuleGetLoadingMode   

[5/7] Executing 'gpukernsum' stats report

CUDA Kernel Statistics:

 Time (%)  Total Time (ns)  Instances   Avg (ns)     Med (ns)    Min (ns)   Max (ns)   StdDev (ns)                                                  Name                                                
 --------  ---------------  ---------  -----------  -----------  ---------  ---------  -----------  ----------------------------------------------------------------------------------------------------
     35.6      879,527,357     10,809     81,369.9     26,175.0     14,976    213,021     82,422.9  void timemachine::k_nonbonded_unified<float, (int)256, (bool)0, (bool)1, (bool)0>(int, int, const u…
      4.6      114,987,765     25,000      4,599.5      4,576.0      4,288     12,640        166.1  void timemachine::k_atom_by_atom_energies<float>(int, int, const int *, const double *, const doubl…
      4.0       98,374,531      1,200     81,978.8     26,207.5     22,144    216,893     79,858.0  void timemachine::k_nonbonded_unified<float, (int)256, (bool)1, (bool)0, (bool)0>(int, int, const u…
      2.8       69,871,365        559    124,993.5    127,262.0    106,335    145,599      8,395.8  void timemachine::k_find_blocks_with_ixns<float, (bool)1>(int, int, int, const unsigned int *, cons…
      2.8       68,258,970      1,019     66,986.2     59,968.0     41,920    145,598     20,343.1  void timemachine::k_find_blocks_with_ixns<float, (bool)0>(int, int, int, const unsigned int *, cons…
      2.7       67,367,897     12,426      5,421.5      4,481.0      2,496     18,560      1,913.8  void timemachine::k_check_rebuild_coords_and_box_gather<float>(int, const unsigned int *, const dou…
      2.5       62,209,300      4,171     14,914.7     13,280.0     10,368     46,016      4,296.0  void timemachine::k_nonbonded_precomputed<float>(int, const double *, const double *, const double …
      2.5       60,943,387     25,001      2,437.6      2,527.0      2,175     13,567        233.2  void cub::DeviceReduceSingleTileKernel<cub::DeviceReducePolicy<float, float, int, cub::Max>::Policy…
      2.4       60,587,427        504    120,213.1     38,495.5     29,023    297,532    121,505.0  void timemachine::k_nonbonded_unified<float, (int)256, (bool)1, (bool)1, (bool)0>(int, int, const u…
      2.4       59,976,306     25,001      2,399.0      2,496.0      2,175     13,088        201.1  void cub::DeviceReduceSingleTileKernel<cub::DeviceReducePolicy<float, float, int, cub::Sum>::Policy…
      2.0       48,233,857      4,171     11,564.1     11,520.0      7,296     24,031      1,337.6  void timemachine::k_nonbonded_pair_list<float, (bool)1>(int, const double *, const double *, const …
      1.9       47,846,456     12,500      3,827.7      3,808.0      3,775     12,992        306.9  void timemachine::k_set_sampled_weight_block<float, (int)512>(int, int, const int *, const T1 *, T1…
      1.9       47,374,625     12,500      3,790.0      3,776.0      3,711     13,248        340.5  void timemachine::k_adjust_weights<float, (bool)1>(int, int, int, const int *, const int *, const T…
      1.9       47,353,087     12,500      3,788.2      3,776.0      3,711     12,863        267.5  void timemachine::k_adjust_weights<float, (bool)0>(int, int, int, const int *, const int *, const T…
      1.9       46,244,660     12,513      3,695.7      3,680.0      2,016     14,592        630.8  void timemachine::k_gather_coords_and_params<double, (int)3, (int)4>(int, const unsigned int *, con…
      1.8       44,713,131     25,001      1,788.5      1,792.0      1,727      2,208         50.6  void timemachine::k_exp_sub_max<float>(int, const T1 *, const T1 *, T1 *)                           
      1.7       42,143,866     12,500      3,371.5      3,328.0      2,944      7,743         93.3  void timemachine::k_rotate_and_translate_mols<float, (bool)0>(int, const double *, const double *, …
      1.6       40,154,654     12,500      3,212.4      3,200.0      3,008     13,056        160.7  void cub::DeviceSelectSweepKernel<cub::DispatchSelectIf<int *, int *, int *, int *, cub::NullType, …
      1.5       36,867,960      4,171      8,839.1      8,704.0      3,808     19,872      1,948.4  void timemachine::k_periodic_torsion<float, (int)3>(int, const double *, const double *, const int …
      1.4       34,193,171     12,500      2,735.5      2,720.0      2,655     13,120        318.8  void timemachine::k_set_sampled_weight_reduce<float, (int)512>(int, const int *, const __int128 *, …
      1.4       34,081,710     11,313      3,012.6      3,136.0      1,664     14,048        699.8  void timemachine::k_scatter_accum<unsigned long long, (int)3>(int, const unsigned int *, const T1 *…
      1.3       32,959,288     12,500      2,636.7      2,783.0      2,049     13,024        218.5  void cub::DeviceReduceSingleTileKernel<cub::DeviceReducePolicy<cub::KeyValuePair<int, float>, cub::…
      1.3       31,100,645     12,500      2,488.1      2,496.0      2,335     13,696        133.7  void timemachine::k_generate_translations_within_or_outside_a_sphere<float>(int, const double *, co…
      1.1       28,434,820      6,248      4,551.0      3,873.0      2,272     16,383      1,622.4  void timemachine::k_accumulate_energy<(unsigned int)512>(int, const __int128 *, __int128 *)         
      1.1       28,042,681     12,500      2,243.4      2,240.0      2,175      8,576         77.0  timemachine::k_setup_sample_atoms(int, const int *, const int *, const int *, int *, int *)         
      1.1       27,329,493     12,500      2,186.4      2,176.0      2,112     12,928        202.1  void timemachine::k_setup_destination_weights_for_targeted<float>(int, const int *, const int *, co…
      1.1       26,756,760      4,171      6,415.0      6,240.0      3,040     18,880      1,476.9  void timemachine::k_harmonic_bond<float>(int, const double *, const double *, const int *, unsigned…
      1.1       26,607,994     12,500      2,128.6      2,112.0      2,079      2,752         51.5  void timemachine::k_attempt_exchange_move_targeted<float>(int, int, const int *, const T1 *, T1, co…
      1.0       25,671,644     12,500      2,053.7      2,048.0      1,664      2,528         53.8  void timemachine::k_separate_weights_for_targeted<float>(int, const int *, const int *, const int *…
      1.0       25,142,348     12,503      2,010.9      1,920.0      1,536      7,968        178.5  void gen_sequenced<curandStateXORWOW, float, int, &curand_uniform_noargs<curandStateXORWOW>, rng_co…
      1.0       25,107,392     12,500      2,008.6      1,984.0      1,919      2,528         63.8  void timemachine::k_decide_targeted_move<float>(int, const T1 *, const int *, int *)                
      1.0       24,708,507     12,500      1,976.7      1,983.0      1,919      2,400         47.0  timemachine::k_adjust_sample_idx(const int *, const int *, const int *, int *)                      
      0.9       23,354,060     12,500      1,868.3      1,856.0      1,823      2,272         47.3  void timemachine::k_setup_gumbel_max_trick<float>(int, const T1 *, T1 *)                            
      0.9       23,085,331     12,500      1,846.8      1,824.0      1,792      2,272         49.3  void timemachine::k_copy_kv_key<float>(int, const cub::KeyValuePair<int, T1> *, int *)              
      0.9       21,404,442      2,603      8,223.0      7,712.0      5,344     16,544      2,004.1  void timemachine::k_harmonic_angle<float, (int)3>(int, const double *, const double *, const int *,…
      0.8       20,998,189     12,500      1,679.9      1,664.0      1,631     13,504        260.5  void cub::DeviceCompactInitKernel<cub::ScanTileState<int, (bool)1>, int *>(T1, int, T2)             
      0.8       19,932,129      3,500      5,694.9      5,728.0      4,992     13,728        350.5  void timemachine::k_update_forward_baoab<float, (int)3>(int, T1, const unsigned int *, const T1 *, …
      0.6       15,161,525      2,597      5,838.1      5,665.0      3,968     17,120        987.5  void timemachine::k_find_block_bounds<float>(int, int, const unsigned int *, const double *, const …
      0.4       10,525,493      1,568      6,712.7      6,304.0      3,263     19,616      1,961.3  void timemachine::k_harmonic_angle_stable<float>(int, const double *, const double *, const int *, …
      0.3        7,100,966      1,578      4,500.0      4,528.0      2,143     12,352      1,333.0  timemachine::k_compact_trim_atoms(int, int, unsigned int *, unsigned int *, int *, unsigned int *)  
      0.2        4,362,860          1  4,362,860.0  4,362,860.0  4,362,860  4,362,860          0.0  void timemachine::k_compute_nonbonded_target_atom_energies<float, (int)64>(int, int, const int *, c…
      0.1        3,433,811        260     13,207.0     13,231.5     10,015     18,112      1,317.1  void cub::DeviceRadixSortOnesweepKernel<cub::DeviceRadixSortPolicy<unsigned int, unsigned int, int>…
      0.1        2,936,953        352      8,343.6      8,448.0      2,944      9,216        543.8  void gen_sequenced<curandStateXORWOW, float2, normal_args_st, &curand_normal_scaled2<curandStateXOR…
      0.1        1,395,985         66     21,151.3     20,799.5     17,343     29,376      2,399.4  void cub::DeviceRadixSortSingleTileKernel<cub::DeviceRadixSortPolicy<unsigned int, unsigned int, in…
      0.1        1,313,676        200      6,568.4      6,336.0      5,888      7,808        450.0  void timemachine::k_find_group_centroids<float>(int, const double *, const int *, const int *, unsi…
      0.1        1,260,488        200      6,302.4      6,432.0      4,544      7,808        813.3  void timemachine::k_decide_move<float>(int, bool, int, double, double, const T1 *, T1 *, double *, …
      0.0          973,755        200      4,868.8      4,704.0      4,512      5,664        305.9  void timemachine::k_rescale_positions<float>(int, double *, const T1 *, const double *, double *, c…
      0.0          706,004        131      5,389.3      5,248.0      2,591     12,640      1,440.5  timemachine::k_coords_to_kv_gather(int, const unsigned int *, const double *, const double *, const…
      0.0          698,999          5    139,799.8    154,910.0     94,974    156,510     26,367.1  void generate_seed_pseudo<rng_config<curandStateXORWOW, (curandOrdering)101>>(unsigned long long, u…
      0.0          490,321        200      2,451.6      2,368.0      2,303      3,008        150.8  void timemachine::k_setup_barostat_move<float>(bool, const T1 *, double *, T1 *, double *, T1 *)    
      0.0          326,684         65      5,025.9      4,416.0      3,200     33,055      3,581.1  void cub::DeviceRadixSortHistogramKernel<cub::DeviceRadixSortPolicy<unsigned int, unsigned int, int…
      0.0          163,612         65      2,517.1      2,336.0      1,919      4,544        513.6  void cub::DeviceRadixSortExclusiveSumKernel<cub::DeviceRadixSortPolicy<unsigned int, unsigned int, …
      0.0          160,414          1    160,414.0    160,414.0    160,414    160,414          0.0  void timemachine::k_accumulate_atom_energies_to_per_mol_energies<float, (int)256>(int, const int *,…
      0.0           97,567         48      2,032.6      1,920.0      1,856      2,560        194.4  timemachine::k_arange(int, unsigned int *, unsigned int)                                            
      0.0           23,455         12      1,954.6      1,920.0      1,887      2,176         97.0  void timemachine::k_initialize_array<unsigned int>(int, T1 *, T1)                                   
      0.0            8,417          1      8,417.0      8,417.0      8,417      8,417          0.0  void timemachine::k_compute_centroid_of_atoms<float>(int, const int *, const double *, T1 *)        
      0.0            4,064          1      4,064.0      4,064.0      4,064      4,064          0.0  void timemachine::k_flag_mols_inner_outer<float>(int, const int *, const int *, const T1 *, T1, con…
      0.0            2,432          1      2,432.0      2,432.0      2,432      2,432          0.0  timemachine::k_initialize_curand_states(int, int, curandStateXORWOW *)                              
      0.0            2,272          1      2,272.0      2,272.0      2,272      2,272          0.0  void timemachine::k_compute_log_weights_from_energies<float>(int, T1, const __int128 *, T1 *)       
      0.0            2,080          1      2,080.0      2,080.0      2,080      2,080          0.0  void timemachine::k_compute_box_volume<float>(const double *, T1 *)                                 
      0.0            1,728          1      1,728.0      1,728.0      1,728      1,728          0.0  timemachine::k_arange(int, int *, int)                                                              

[6/7] Executing 'gpumemtimesum' stats report

CUDA Memory Operation Statistics (by time):

 Time (%)  Total Time (ns)  Count   Avg (ns)  Med (ns)  Min (ns)  Max (ns)   StdDev (ns)      Operation     
 --------  ---------------  ------  --------  --------  --------  ---------  -----------  ------------------
     31.1       47,873,529  38,034   1,258.7     896.0       512    185,470      3,207.2  [CUDA memcpy DtoH]
     25.1       38,651,238  18,849   2,050.6   2,208.0       704     81,535        881.6  [CUDA memset]     
     22.0       33,902,981     669  50,677.1  35,999.0       736  1,375,568    163,080.9  [CUDA memcpy HtoD]
     21.8       33,505,041  16,135   2,076.5   1,984.0     1,472     14,943        363.8  [CUDA memcpy DtoD]

[7/7] Executing 'gpumemsizesum' stats report

CUDA Memory Operation Statistics (by size):

 Total (MB)  Count   Avg (MB)  Med (MB)  Min (MB)  Max (MB)  StdDev (MB)      Operation     
 ----------  ------  --------  --------  --------  --------  -----------  ------------------
  3,030.056  16,135     0.188     0.212     0.000     0.213        0.068  [CUDA memcpy DtoD]
  2,478.263  18,849     0.131     0.171     0.000    28.865        0.243  [CUDA memset]     
    202.479     669     0.303     0.212     0.000     8.389        0.996  [CUDA memcpy HtoD]
     72.439  38,034     0.002     0.000     0.000     1.206        0.021  [CUDA memcpy DtoH]
```


## Next Steps

- Combine the two k_atom_by_atom energies into a single call, compute delta and adjuted weights (WIP: ~5% of runtime)
- Segmented LogSumExp to reduce calls to Max/Sum (5% of kernel time) 
- Remove cub:Partition, recompute partition incrementally (WIP: ~1.5% of runtime)
- Speed up `k_compute_nonbonded_target_atom_energies`, only 0.2% in the `n_proposals_per_move > 1` case, but slows down tests and will become more significant as the rest of the code gets faster
- Batch translations