### PR TITLE
Add atom mapping filter disallowing flipped torsions in core

### DIFF
--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -351,6 +351,7 @@ $$$$""",
         ring_matches_ring_only=False,
         complete_rings=True,
         enforce_chiral=True,
+        disallow_torsion_flips=False,
         min_threshold=0,
     )
     assert len(all_cores) > 0
@@ -390,6 +391,7 @@ def test_all_pairs(filepath):
                 ring_matches_ring_only=False,
                 complete_rings=False,
                 enforce_chiral=True,
+                disallow_torsion_flips=False,
                 min_threshold=0,
             )
 
@@ -441,6 +443,7 @@ def test_complete_rings_only():
         ring_matches_ring_only=True,
         complete_rings=True,
         enforce_chiral=True,
+        disallow_torsion_flips=False,
         min_threshold=0,
     )
 
@@ -577,6 +580,7 @@ $$$$""",
         ring_matches_ring_only=False,
         complete_rings=False,
         enforce_chiral=True,
+        disallow_torsion_flips=False,
         min_threshold=0,
     )
 
@@ -599,6 +603,7 @@ $$$$""",
         ring_matches_ring_only=False,
         complete_rings=False,
         enforce_chiral=True,
+        disallow_torsion_flips=False,
         min_threshold=0,
     )
 
@@ -623,6 +628,7 @@ $$$$""",
         ring_matches_ring_only=False,
         complete_rings=False,
         enforce_chiral=True,
+        disallow_torsion_flips=False,
         min_threshold=0,
     )
 
@@ -754,6 +760,7 @@ def test_hif2a_failure():
         ring_matches_ring_only=False,
         complete_rings=True,
         enforce_chiral=True,
+        disallow_torsion_flips=False,
         min_threshold=0,
     )
 
@@ -811,6 +818,7 @@ def test_cyclohexane_stereo():
         ring_matches_ring_only=True,
         complete_rings=False,
         enforce_chiral=True,
+        disallow_torsion_flips=False,
         min_threshold=0,
     )
 
@@ -871,8 +879,12 @@ def test_chiral_atom_map():
         min_threshold=0,
     )
 
-    chiral_aware_cores = atom_mapping.get_cores(mol_a, mol_b, enforce_chiral=True, **core_kwargs)
-    chiral_oblivious_cores = atom_mapping.get_cores(mol_a, mol_b, enforce_chiral=False, **core_kwargs)
+    chiral_aware_cores = atom_mapping.get_cores(
+        mol_a, mol_b, enforce_chiral=True, disallow_torsion_flips=False, **core_kwargs
+    )
+    chiral_oblivious_cores = atom_mapping.get_cores(
+        mol_a, mol_b, enforce_chiral=False, disallow_torsion_flips=False, **core_kwargs
+    )
 
     assert len(chiral_oblivious_cores) == 4 * 3 * 2 * 1, "expected all hydrogen permutations to be valid"
     assert len(chiral_aware_cores) == (len(chiral_oblivious_cores) // 2), "expected only rotations to be valid"
@@ -905,6 +917,7 @@ def test_ring_matches_ring_only(ring_matches_ring_only):
         enforce_core_core=False,
         complete_rings=False,
         enforce_chiral=False,
+        disallow_torsion_flips=False,
         min_threshold=0,
     )
 
@@ -932,6 +945,7 @@ def test_max_visits_warning():
         ring_matches_ring_only=False,
         complete_rings=False,
         enforce_chiral=True,
+        disallow_torsion_flips=False,
         min_threshold=0,
     )
     cores = atom_mapping.get_cores(mol_a, mol_b, **core_kwargs, max_visits=10000)
@@ -952,6 +966,7 @@ def test_max_cores_warning():
         ring_matches_ring_only=False,
         complete_rings=False,
         enforce_chiral=True,
+        disallow_torsion_flips=False,
         min_threshold=0,
         max_visits=1e7,
     )
@@ -970,6 +985,7 @@ def test_min_threshold():
         ring_matches_ring_only=False,
         complete_rings=False,
         enforce_chiral=True,
+        disallow_torsion_flips=False,
         min_threshold=mol_a.GetNumAtoms(),
     )
 

--- a/timemachine/constants.py
+++ b/timemachine/constants.py
@@ -35,5 +35,6 @@ DEFAULT_ATOM_MAPPING_KWARGS = {
     "ring_matches_ring_only": True,
     "complete_rings": False,
     "enforce_chiral": True,
+    "disallow_torsion_flips": False,
     "min_threshold": 0,
 }

--- a/timemachine/constants.py
+++ b/timemachine/constants.py
@@ -35,6 +35,6 @@ DEFAULT_ATOM_MAPPING_KWARGS = {
     "ring_matches_ring_only": True,
     "complete_rings": False,
     "enforce_chiral": True,
-    "disallow_torsion_flips": False,
+    "disallow_torsion_flips": True,
     "min_threshold": 0,
 }

--- a/timemachine/graph_utils.py
+++ b/timemachine/graph_utils.py
@@ -14,3 +14,21 @@ def convert_to_nx(mol):
         g.add_edge(src, dst)
 
     return g
+
+
+def enumerate_simple_paths_from(graph, start_node, cutoff):
+    def go(node, cutoff, visited):
+        if cutoff == 1:
+            return [[node]]
+        return [
+            [node] + path
+            for neighbor in nx.neighbors(graph, node)
+            if neighbor not in visited
+            for path in go(neighbor, cutoff - 1, visited | {node})
+        ]
+
+    return go(start_node, cutoff, set())
+
+
+def enumerate_simple_paths(graph, cutoff):
+    return [path for start_node in graph for path in enumerate_simple_paths_from(graph, start_node, cutoff)]


### PR DESCRIPTION
Adds an atom mapping filter removing mappings where a torsion is "flipped" (i.e. the sign of `torsion_volume` changes) by the mapping.

#### TODO
- [ ] validate atom mapping benchmark
- [ ] add test for filter