### PR TITLE
Test has_chiral_atom_flips

### DIFF
--- a/tests/test_chiral_utils.py
+++ b/tests/test_chiral_utils.py
@@ -264,7 +264,7 @@ def test_chiral_conflict_flip():
     assert len(swap_map_flips) == 8  # TODO: deduplicate idxs?
     assert len(swap_map_undefineds) == 0
 
-    assert not has_chiral_atom_flips(swap_map, chiral_set_a, chiral_set_b)
+    assert has_chiral_atom_flips(swap_map, chiral_set_a, chiral_set_b)
 
 
 def test_chiral_conflict_undefined():

--- a/tests/test_chiral_utils.py
+++ b/tests/test_chiral_utils.py
@@ -328,7 +328,7 @@ def test_chiral_conflict_mixed():
     assert has_chiral_atom_flips(mixed_map, chiral_set_a, chiral_set_b)
 
 
-def test_has_chiral_atom_conflicts_symmetric(n_trials=100):
+def test_has_chiral_atom_flips_symmetric(n_trials=100):
     """On random atom mappings of random pairs of freesolv molecules,
     assert has_chiral_atom_flips(core, a, b) == has_chiral_atom_flips(core[:,::-1], b, a)
     """


### PR DESCRIPTION
`has_chiral_atom_flips` was covered in integration tests, but didn't have a unit test -- adds a small randomized test that the function is symmetric

(based on an observation by @mcwitt that checking [both ways](https://github.com/proteneer/timemachine/blob/9e1ece76b088d4b7e3cf753fbe53f4a4da2de036/timemachine/fe/chiral_utils.py#L304-L311) may be redundant and might be simplified for a 2x speedup)