### PR TITLE
Add atom mapping function returning MCS diagnostics

### DIFF
--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -1005,4 +1005,6 @@ def test_get_cores_and_diagnostics():
 
         assert diagnostics.core_size >= len(all_cores[0])
         assert diagnostics.num_cores >= len(all_cores)
-        assert diagnostics.total_nodes_visited >= diagnostics.core_size  # must visit at least one node per edge in core
+        assert (
+            diagnostics.total_nodes_visited >= diagnostics.core_size
+        )  # must visit at least one node per atom pair in core

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -8,7 +8,7 @@ from rdkit.Chem import AllChem
 from timemachine.constants import DEFAULT_ATOM_MAPPING_KWARGS
 from timemachine.fe import atom_mapping
 from timemachine.fe.mcgregor import MaxVisitsWarning, NoMappingError
-from timemachine.fe.utils import plot_atom_mapping_grid
+from timemachine.fe.utils import plot_atom_mapping_grid, read_sdf
 
 pytestmark = [pytest.mark.nocuda]
 
@@ -376,8 +376,7 @@ def get_mol_name(mol) -> str:
 @pytest.mark.parametrize("filepath", datasets)
 @pytest.mark.nightly(reason="Slow")
 def test_all_pairs(filepath):
-    mols = Chem.SDMolSupplier(filepath, removeHs=False)
-    mols = [m for m in mols]
+    mols = read_sdf(filepath)
     for idx, mol_a in enumerate(mols):
         for mol_b in mols[idx + 1 :]:
             all_cores = atom_mapping.get_cores(
@@ -992,8 +991,7 @@ def test_min_threshold():
 
 
 def test_get_cores_and_diagnostics():
-    mols = Chem.SDMolSupplier(hif2a_set, removeHs=False)
-    mols = [m for m in mols]
+    mols = read_sdf(hif2a_set)
     n_pairs = 30
     random_pair_idxs = np.random.default_rng(2024).choice(len(mols), size=(n_pairs, 2))
 

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -1005,4 +1005,4 @@ def test_get_cores_and_diagnostics():
 
         assert diagnostics.core_size >= len(all_cores[0])
         assert diagnostics.num_cores >= len(all_cores)
-        assert diagnostics.total_nodes_visited >= diagnostics.core_size
+        assert diagnostics.total_nodes_visited >= diagnostics.core_size  # must visit at least one node per edge in core

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -46,7 +46,7 @@ from timemachine.fe.utils import get_romol_bonds, get_romol_conf
 # - refinement of marcs matrix is done on uint8 arrays
 
 
-def get_cores_and_total_nodes_visited(
+def get_cores_and_diagnostics(
     mol_a,
     mol_b,
     ring_cutoff,
@@ -60,7 +60,7 @@ def get_cores_and_total_nodes_visited(
     enforce_chiral,
     disallow_planar_torsion_flips,
     min_threshold,
-) -> Tuple[List[NDArray], int]:
+) -> Tuple[List[NDArray], mcgregor.MCSDiagnostics]:
     """Like :py:func:`get_cores`, but additionally returns the total number of nodes visited during the MCS search."""
     assert max_cores > 0
 
@@ -80,15 +80,15 @@ def get_cores_and_total_nodes_visited(
 
     # we require that mol_a.GetNumAtoms() <= mol_b.GetNumAtoms()
     if mol_a.GetNumAtoms() > mol_b.GetNumAtoms():
-        all_cores, total_nodes_visited = _get_cores_impl(mol_b, mol_a, **core_kwargs)
+        all_cores, mcs_diagnostics = _get_cores_impl(mol_b, mol_a, **core_kwargs)
         new_cores = []
         for core in all_cores:
             core = np.array([(x[1], x[0]) for x in core], dtype=core.dtype)
             new_cores.append(core)
-        return new_cores, total_nodes_visited
+        return new_cores, mcs_diagnostics
     else:
-        all_cores, total_nodes_visited = _get_cores_impl(mol_a, mol_b, **core_kwargs)
-        return all_cores, total_nodes_visited
+        all_cores, mcs_diagnostics = _get_cores_impl(mol_a, mol_b, **core_kwargs)
+        return all_cores, mcs_diagnostics
 
 
 def get_cores(
@@ -174,7 +174,7 @@ def get_cores(
     timemachine.fe.mcgregor.NoMappingError
         If no mapping is found
     """
-    all_cores, _ = get_cores_and_total_nodes_visited(
+    all_cores, _ = get_cores_and_diagnostics(
         mol_a,
         mol_b,
         ring_cutoff,
@@ -347,7 +347,7 @@ def _get_cores_impl(
     enforce_chiral,
     disallow_planar_torsion_flips,
     min_threshold,
-) -> Tuple[List[NDArray], int]:
+) -> Tuple[List[NDArray], mcgregor.MCSDiagnostics]:
     mol_a, perm = reorder_atoms_by_degree(mol_a)  # UNINVERT
 
     bonds_a = get_romol_bonds(mol_a)
@@ -411,7 +411,7 @@ def _get_cores_impl(
     def filter_fxn(trial_core):
         return all(f(trial_core) for f in filter_fxns)
 
-    all_cores, all_marcs, total_nodes_visited = mcgregor.mcs(
+    all_cores, all_marcs, mcs_diagnostics = mcgregor.mcs(
         n_a,
         n_b,
         priority_idxs,
@@ -467,7 +467,7 @@ def _get_cores_impl(
             inv_core.append(perm[atom])
         core[:, 0] = inv_core
 
-    return sorted_cores, total_nodes_visited
+    return sorted_cores, mcs_diagnostics
 
 
 # maintainer: jkaus

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -61,7 +61,7 @@ def get_cores_and_diagnostics(
     disallow_planar_torsion_flips,
     min_threshold,
 ) -> Tuple[List[NDArray], mcgregor.MCSDiagnostics]:
-    """Like :py:func:`get_cores`, but additionally returns diagnostics collected during the MCS search."""
+    """Same as :py:func:`get_cores`, but additionally returns diagnostics collected during the MCS search."""
     assert max_cores > 0
 
     core_kwargs = dict(

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -375,7 +375,7 @@ def _get_cores_impl(
     def filter_fxn(trial_core):
         return all(f(trial_core) for f in filter_fxns)
 
-    all_cores, all_marcs = mcgregor.mcs(
+    all_cores, mcs_result = mcgregor.mcs(
         n_a,
         n_b,
         priority_idxs,
@@ -388,7 +388,7 @@ def _get_cores_impl(
         filter_fxn=filter_fxn,
     )
 
-    all_bond_cores = [_compute_bond_cores(mol_a, mol_b, marcs) for marcs in all_marcs]
+    all_bond_cores = [_compute_bond_cores(mol_a, mol_b, marcs) for marcs in mcs_result.all_marcs]
 
     if connected_core and complete_rings:
         # 1) remove any disconnected components or lone atoms in the mapping

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -61,7 +61,7 @@ def get_cores_and_diagnostics(
     disallow_planar_torsion_flips,
     min_threshold,
 ) -> Tuple[List[NDArray], mcgregor.MCSDiagnostics]:
-    """Like :py:func:`get_cores`, but additionally returns the total number of nodes visited during the MCS search."""
+    """Like :py:func:`get_cores`, but additionally returns diagnostics collected during the MCS search."""
     assert max_cores > 0
 
     core_kwargs = dict(

--- a/timemachine/fe/mcgregor.py
+++ b/timemachine/fe/mcgregor.py
@@ -2,9 +2,10 @@
 import copy
 import time
 import warnings
-from typing import Callable, Sequence
+from typing import Callable, List, Sequence, Tuple
 
 import numpy as np
+from numpy.typing import NDArray
 
 
 def _arcs_left(marcs):
@@ -176,7 +177,7 @@ def mcs(
     enforce_core_core,
     min_threshold,
     filter_fxn: Callable[[Sequence[int]], bool] = lambda core: True,
-):
+) -> Tuple[List[NDArray], MCSResult]:
     assert n_a <= n_b
 
     g_a = Graph(n_a, bonds_a)
@@ -188,6 +189,8 @@ def mcs(
     priority_idxs = tuple(tuple(x) for x in priority_idxs)
     # Keep start time for debugging purposes below
     start_time = time.time()  # noqa
+
+    mcs_result = None
 
     # run in reverse by guessing max # of edges to avoid getting stuck in minima.
     max_threshold = _arcs_left(marcs)
@@ -233,6 +236,8 @@ def mcs(
         # f"==FAILED==[NODES VISITED {mcs_result.nodes_visited} | time taken: {time.time()-start_time} | time out? {mcs_result.timed_out}]====="
         # )
 
+    assert mcs_result is not None
+
     if len(mcs_result.all_maps) == 0:
         raise NoMappingError("Unable to find mapping")
 
@@ -246,7 +251,7 @@ def mcs(
         core_array = np.array(sorted(core))
         all_cores.append(core_array)
 
-    return all_cores, mcs_result.all_marcs
+    return all_cores, mcs_result
 
 
 def atom_map_add(map_1_to_2, map_2_to_1, idx, jdx):

--- a/timemachine/fe/mcgregor.py
+++ b/timemachine/fe/mcgregor.py
@@ -170,6 +170,8 @@ class NoMappingError(Exception):
 @dataclass
 class MCSDiagnostics:
     total_nodes_visited: int
+    core_size: int
+    num_cores: int
 
 
 def mcs(
@@ -260,7 +262,15 @@ def mcs(
         core_array = np.array(sorted(core))
         all_cores.append(core_array)
 
-    return all_cores, mcs_result.all_marcs, MCSDiagnostics(total_nodes_visited)
+    return (
+        all_cores,
+        mcs_result.all_marcs,
+        MCSDiagnostics(
+            total_nodes_visited=total_nodes_visited,
+            core_size=len(all_cores[0]),
+            num_cores=len(all_cores),
+        ),
+    )
 
 
 def atom_map_add(map_1_to_2, map_2_to_1, idx, jdx):

--- a/timemachine/fe/mcgregor.py
+++ b/timemachine/fe/mcgregor.py
@@ -177,7 +177,7 @@ def mcs(
     enforce_core_core,
     min_threshold,
     filter_fxn: Callable[[Sequence[int]], bool] = lambda core: True,
-) -> Tuple[List[NDArray], MCSResult]:
+) -> Tuple[List[NDArray], List[NDArray], int]:
     assert n_a <= n_b
 
     g_a = Graph(n_a, bonds_a)
@@ -194,6 +194,7 @@ def mcs(
 
     # run in reverse by guessing max # of edges to avoid getting stuck in minima.
     max_threshold = _arcs_left(marcs)
+    total_nodes_visited = 0
     for idx in range(max_threshold):
         cur_threshold = max_threshold - idx
         if cur_threshold < min_threshold:
@@ -216,6 +217,8 @@ def mcs(
             enforce_core_core,
             filter_fxn,
         )
+
+        total_nodes_visited += mcs_result.nodes_visited
 
         # If timed out, either due to max_visits or max_cores, raise exception.
         if mcs_result.timed_out:
@@ -251,7 +254,7 @@ def mcs(
         core_array = np.array(sorted(core))
         all_cores.append(core_array)
 
-    return all_cores, mcs_result
+    return all_cores, mcs_result.all_marcs, total_nodes_visited
 
 
 def atom_map_add(map_1_to_2, map_2_to_1, idx, jdx):

--- a/timemachine/fe/mcgregor.py
+++ b/timemachine/fe/mcgregor.py
@@ -2,6 +2,7 @@
 import copy
 import time
 import warnings
+from dataclasses import dataclass
 from typing import Callable, List, Sequence, Tuple
 
 import numpy as np
@@ -166,6 +167,11 @@ class NoMappingError(Exception):
     pass
 
 
+@dataclass
+class MCSDiagnostics:
+    total_nodes_visited: int
+
+
 def mcs(
     n_a,
     n_b,
@@ -177,7 +183,7 @@ def mcs(
     enforce_core_core,
     min_threshold,
     filter_fxn: Callable[[Sequence[int]], bool] = lambda core: True,
-) -> Tuple[List[NDArray], List[NDArray], int]:
+) -> Tuple[List[NDArray], List[NDArray], MCSDiagnostics]:
     assert n_a <= n_b
 
     g_a = Graph(n_a, bonds_a)
@@ -254,7 +260,7 @@ def mcs(
         core_array = np.array(sorted(core))
         all_cores.append(core_array)
 
-    return all_cores, mcs_result.all_marcs, total_nodes_visited
+    return all_cores, mcs_result.all_marcs, MCSDiagnostics(total_nodes_visited)
 
 
 def atom_map_add(map_1_to_2, map_2_to_1, idx, jdx):


### PR DESCRIPTION
Adds `atom_mapping.get_cores_and_diagnostics` having the same signature as `get_cores` except that it additionally returns an `MCSDiagnostics` object containing diagnostic information collected during the MCS search.

Useful for benchmarking.