### PR TITLE
Atom mapping performance improvements

### DIFF
--- a/tests/test_chiral_utils.py
+++ b/tests/test_chiral_utils.py
@@ -1,9 +1,7 @@
 from collections import Counter
-from typing import Sequence
 
 import numpy as np
 import pytest
-from numpy.typing import NDArray
 from rdkit import Chem
 from rdkit.Chem import AllChem
 
@@ -16,7 +14,7 @@ from timemachine.fe.chiral_utils import (
     has_chiral_atom_flips,
     setup_find_flipped_planar_torsions,
 )
-from timemachine.fe.mcgregor import UNMAPPED
+from timemachine.fe.mcgregor import core_to_perm
 from timemachine.fe.utils import get_romol_conf
 from timemachine.ff import Forcefield
 from timemachine.md.minimizer import replace_conformer_with_minimized
@@ -230,11 +228,6 @@ molblock_CN = """
   2  6  1  0
   2  7  1  0
 M  END"""
-
-
-def core_to_perm(core: NDArray, num_atoms_a: int) -> Sequence[int]:
-    a_to_b = {a: b for a, b in core}
-    return [a_to_b.get(a, UNMAPPED) for a in range(num_atoms_a)]
 
 
 def test_chiral_conflict_flip():

--- a/tests/test_chiral_utils.py
+++ b/tests/test_chiral_utils.py
@@ -399,7 +399,7 @@ def test_find_flipped_planar_torsions():
 
     find_flipped_planar_torsions = setup_find_flipped_planar_torsions(mol, mol)
 
-    assert find_flipped_planar_torsions(core_ok) == []
+    assert next(find_flipped_planar_torsions(core_ok), None) is None
     assert set(find_flipped_planar_torsions(core_bad)) == {
         ((0, 1, 3, 4), (2, 1, 3, 4)),
         ((2, 1, 3, 4), (0, 1, 3, 4)),
@@ -416,7 +416,7 @@ def test_find_flipped_planar_torsions():
     core_bad = [0, 1, 2, 3, 5, 4, 6, 7, 8]
 
     find_flipped_planar_torsions = setup_find_flipped_planar_torsions(mol, mol)
-    assert find_flipped_planar_torsions(core_ok) == []
+    assert next(find_flipped_planar_torsions(core_ok), None) is None
     assert set(find_flipped_planar_torsions(core_bad)) == {
         ((0, 1, 2, 4), (0, 1, 2, 5)),
         ((0, 1, 2, 5), (0, 1, 2, 4)),

--- a/tests/test_mcgregor.py
+++ b/tests/test_mcgregor.py
@@ -1,0 +1,28 @@
+import hypothesis.strategies as st
+import numpy as np
+from hypothesis import given
+
+from timemachine.fe.mcgregor import UNMAPPED, core_to_perm, perm_to_core
+
+
+@st.composite
+def permutations(draw):
+    num_atoms_a = draw(st.integers(1, 30))
+    num_atoms_b = draw(st.integers(1, 30))
+    num_atoms_c = draw(st.integers(1, min(num_atoms_a, num_atoms_b)))
+
+    indices_a = st.integers(0, num_atoms_a - 1)
+    indices_b = st.integers(0, num_atoms_b - 1)
+    mapping_a = draw(st.lists(indices_a, min_size=num_atoms_c, max_size=num_atoms_c, unique=True))
+    mapping_b = draw(st.lists(indices_b, min_size=num_atoms_c, max_size=num_atoms_c, unique=True))
+
+    mapping = {a: b for a, b in zip(mapping_a, mapping_b)}
+    perm = [mapping.get(a, UNMAPPED) for a in range(num_atoms_a)]
+    return perm
+
+
+@given(permutations())
+def test_core_to_perm_inv(perm):
+    num_atoms_a = len(perm)
+    assert core_to_perm(perm_to_core(perm), num_atoms_a) == perm
+    np.testing.assert_array_equal(perm_to_core(core_to_perm(perm_to_core(perm), num_atoms_a)), perm_to_core(perm))

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -401,7 +401,7 @@ def _get_cores_impl(
 
         def planar_torsion_flip_filter(trial_core):
             flipped = find_flipped_planar_torsions(trial_core)
-            passed = len(flipped) == 0
+            passed = next(flipped, None) is None  # i.e. iterator is empty
             return passed
 
         filter_fxns.append(planar_torsion_flip_filter)

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -391,9 +391,7 @@ def _get_cores_impl(
         chiral_set_b = ChiralRestrIdxSet.from_mol(mol_b, conf_b)
 
         def chiral_filter(trial_core):
-            # TODO: avoid conversion
-            np_core = np.array([(i, trial_core[i]) for i in range(len(trial_core)) if trial_core[i] != -1])
-            passed = not has_chiral_atom_flips(np_core, chiral_set_a, chiral_set_b)
+            passed = not has_chiral_atom_flips(trial_core, chiral_set_a, chiral_set_b)
             return passed
 
         filter_fxns.append(chiral_filter)

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -248,10 +248,7 @@ def has_chiral_atom_flips(
 
     # iterate over restraints defined in A, searching for possible conflicts
     for c_a, i_a, j_a, k_a in chiral_set_a.restr_idxs:
-        try:
-            mapped_tuple_b = mapping_a_to_b[c_a], mapping_a_to_b[i_a], mapping_a_to_b[j_a], mapping_a_to_b[k_a]
-        except KeyError:
-            continue
+        mapped_tuple_b = mapping_a_to_b[c_a], mapping_a_to_b[i_a], mapping_a_to_b[j_a], mapping_a_to_b[k_a]
         if chiral_set_b.disallows(mapped_tuple_b):
             return True
     return False

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -237,7 +237,7 @@ def _find_atom_map_chiral_conflicts_one_direction(
     return conflicts
 
 
-def _has_chiral_atom_map_flips_one_direction(
+def has_chiral_atom_flips(
     core: np.ndarray,
     chiral_set_a: ChiralRestrIdxSet,
     chiral_set_b: ChiralRestrIdxSet,
@@ -299,16 +299,6 @@ def find_atom_map_chiral_conflicts(
     conflicts = conflicts_a2b.union(set((a, b) for (b, a) in conflicts_b2a))
 
     return conflicts
-
-
-def has_chiral_atom_flips(core, chiral_set_a, chiral_set_b) -> bool:
-    """find_atom_map_chiral_conflicts, except (1) return bool not set, (2) hard-code mode = FLIP"""
-    # both directions
-    if _has_chiral_atom_map_flips_one_direction(core, chiral_set_a, chiral_set_b):
-        return True
-    if _has_chiral_atom_map_flips_one_direction(core[:, ::-1], chiral_set_b, chiral_set_a):
-        return True
-    return False
 
 
 def find_chiral_bonds(mol):

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -238,14 +238,13 @@ def _find_atom_map_chiral_conflicts_one_direction(
 
 
 def has_chiral_atom_flips(
-    core: np.ndarray,
+    core: Sequence[int],
     chiral_set_a: ChiralRestrIdxSet,
     chiral_set_b: ChiralRestrIdxSet,
 ) -> bool:
     # _find_atom_map_chiral_conflicts_one_direction, except (1) return bool not set, (2) hard-code mode = FLIP
 
-    # initialize convenient representations
-    mapping_a_to_b = {int(a_i): int(b_i) for (a_i, b_i) in core}
+    mapping_a_to_b = core
 
     # iterate over restraints defined in A, searching for possible conflicts
     for c_a, i_a, j_a, k_a in chiral_set_a.restr_idxs:

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -244,22 +244,17 @@ def _has_chiral_atom_map_flips_one_direction(
 ) -> bool:
     # _find_atom_map_chiral_conflicts_one_direction, except (1) return bool not set, (2) hard-code mode = FLIP
 
-    conflict_condition_fxn = chiral_set_b.disallows
-
     # initialize convenient representations
-    mapped_set_a = set(core[:, 0])
     mapping_a_to_b = {int(a_i): int(b_i) for (a_i, b_i) in core}
 
-    def apply_mapping(c, i, j, k):
-        return mapping_a_to_b[c], mapping_a_to_b[i], mapping_a_to_b[j], mapping_a_to_b[k]
-
     # iterate over restraints defined in A, searching for possible conflicts
-    for restr_tuple_a in chiral_set_a.restr_idxs:
-        if set(restr_tuple_a).issubset(mapped_set_a):
-            mapped_tuple_b = apply_mapping(*restr_tuple_a)
-
-            if conflict_condition_fxn(mapped_tuple_b):
-                return True
+    for c_a, i_a, j_a, k_a in chiral_set_a.restr_idxs:
+        try:
+            mapped_tuple_b = mapping_a_to_b[c_a], mapping_a_to_b[i_a], mapping_a_to_b[j_a], mapping_a_to_b[k_a]
+        except KeyError:
+            continue
+        if chiral_set_b.disallows(mapped_tuple_b):
+            return True
     return False
 
 

--- a/timemachine/fe/mcgregor.py
+++ b/timemachine/fe/mcgregor.py
@@ -169,6 +169,20 @@ class MCSDiagnostics:
     num_cores: int
 
 
+def core_to_perm(core: NDArray, num_atoms_a: int) -> Sequence[int]:
+    a_to_b = {a: b for a, b in core}
+    return [a_to_b.get(a, UNMAPPED) for a in range(num_atoms_a)]
+
+
+def perm_to_core(perm: Sequence[int]) -> NDArray:
+    core = []
+    for a, b in enumerate(perm):
+        if b != UNMAPPED:
+            core.append((a, b))
+    core_array = np.array(sorted(core))
+    return core_array
+
+
 def mcs(
     n_a,
     n_b,
@@ -250,11 +264,7 @@ def mcs(
     all_cores = []
 
     for atom_map_1_to_2 in mcs_result.all_maps:
-        core = []
-        for a, b in enumerate(atom_map_1_to_2):
-            if b != UNMAPPED:
-                core.append((a, b))
-        core_array = np.array(sorted(core))
+        core_array = perm_to_core(atom_map_1_to_2)
         all_cores.append(core_array)
 
     return (

--- a/timemachine/fe/mcgregor.py
+++ b/timemachine/fe/mcgregor.py
@@ -21,7 +21,7 @@ UNMAPPED = -1
 def _initialize_marcs_given_predicate(g1, g2, predicate):
     num_a_edges = g1.n_edges
     num_b_edges = g2.n_edges
-    marcs = np.ones((num_a_edges, num_b_edges), dtype=np.byte)
+    marcs = np.full((num_a_edges, num_b_edges), True, dtype=bool)
     for e_a in range(num_a_edges):
         src_a, dst_a = g1.edges[e_a]
         for e_b in range(num_b_edges):
@@ -36,7 +36,7 @@ def _initialize_marcs_given_predicate(g1, g2, predicate):
             elif predicate[src_a][dst_b] and predicate[dst_a][src_b]:
                 continue
             else:
-                marcs[e_a][e_b] = 0
+                marcs[e_a][e_b] = False
 
     return marcs
 
@@ -48,7 +48,7 @@ def _verify_core_impl(g1, g2, new_v1, map_1_to_2):
         src_2, dst_2 = map_1_to_2[src], map_1_to_2[dst]
         if src_2 != UNMAPPED and dst_2 != UNMAPPED:
             # see if this edge is present in g2
-            if g2.cmat[src_2][dst_2] == 0:
+            if not g2.cmat[src_2][dst_2]:
                 return False
     return True
 
@@ -69,20 +69,15 @@ def refine_marcs(g1, g2, new_v1, new_v2, marcs):
 
     if new_v2 == UNMAPPED:
         # zero out rows corresponding to the edges of new_v1
-        for e1 in g1.get_edges(new_v1):
-            # this is equivalent to new_marcs[e1] = np.zeros(marcs.shape[1])
-            new_marcs[e1] = 0
+        new_marcs[g1.get_edges_as_vector(new_v1)] = False
     else:
-        # mask out every row in marcs
-        # eg. returns [0,1,0,0,1,0,1]
         mask = g2.get_edges_as_vector(new_v2)
-        # eg. returns [1,0,1,1,0,1,0]
-        antimask = 1 - mask
-        for e1_idx, is_v1_edge in enumerate(g1.get_edges_as_vector(new_v1)):
-            if is_v1_edge:
-                new_marcs[e1_idx] &= mask
-            else:
-                new_marcs[e1_idx] &= antimask
+        mask = np.where(
+            g1.get_edges_as_vector(new_v1)[:, np.newaxis],
+            mask,
+            ~mask,
+        )
+        new_marcs &= mask
 
     return new_marcs
 
@@ -102,10 +97,10 @@ class Graph:
         self.n_edges = len(edges)
         self.edges = edges
 
-        cmat = np.zeros((n_vertices, n_vertices), dtype=np.byte)
+        cmat = np.full((n_vertices, n_vertices), False, dtype=bool)
         for i, j in edges:
-            cmat[i][j] = 1
-            cmat[j][i] = 1
+            cmat[i][j] = True
+            cmat[j][i] = True
 
         self.cmat = cmat
 
@@ -126,10 +121,10 @@ class Graph:
             self.lol_edges[src].append(edge_idx)
             self.lol_edges[dst].append(edge_idx)
 
-        self.ve_matrix = np.zeros((self.n_vertices, self.n_edges), dtype=np.byte)
+        self.ve_matrix = np.full((self.n_vertices, self.n_edges), False, dtype=bool)
         for vertex_idx, edges in enumerate(self.lol_edges):
             for edge_idx in edges:
-                self.ve_matrix[vertex_idx][edge_idx] = 1
+                self.ve_matrix[vertex_idx][edge_idx] = True
 
     def get_neighbors(self, vertex):
         return self.lol_vertices[vertex]
@@ -152,10 +147,10 @@ def max_tree_size(priority_list):
 
 def build_predicate_matrix(n_a, n_b, priority_idxs):
     assert len(priority_idxs) == n_a
-    pmat = np.zeros((n_a, n_b), dtype=np.int32)
+    pmat = np.full((n_a, n_b), False, dtype=bool)
     for idx, jdxs in enumerate(priority_idxs):
         for jdx in jdxs:
-            pmat[idx][jdx] = 1
+            pmat[idx][jdx] = True
     return pmat
 
 

--- a/timemachine/fe/mcgregor.py
+++ b/timemachine/fe/mcgregor.py
@@ -71,12 +71,10 @@ def refine_marcs(g1, g2, new_v1, new_v2, marcs):
         # zero out rows corresponding to the edges of new_v1
         new_marcs[g1.get_edges_as_vector(new_v1)] = False
     else:
-        mask = g2.get_edges_as_vector(new_v2)
-        mask = np.where(
-            g1.get_edges_as_vector(new_v1)[:, np.newaxis],
-            mask,
-            ~mask,
-        )
+        # mask out every row in marcs
+        adj1 = g1.get_edges_as_vector(new_v1)
+        adj2 = g2.get_edges_as_vector(new_v2)
+        mask = np.where(adj1[:, np.newaxis], adj2, ~adj2)
         new_marcs &= mask
 
     return new_marcs

--- a/timemachine/potentials/chiral_restraints.py
+++ b/timemachine/potentials/chiral_restraints.py
@@ -6,6 +6,7 @@ def normalize(x):
     return x / jnp.linalg.norm(x)
 
 
+@jax.jit
 def pyramidal_volume(xc, x1, x2, x3):
     """
     Compute the normalized pyramidal volume given four points. This is implemented
@@ -34,6 +35,7 @@ def pyramidal_volume(xc, x1, x2, x3):
     return jnp.dot(jnp.cross(v0, v1), v2)
 
 
+@jax.jit
 def torsion_volume(ci, cj, ck, cl):
     """
     Compute normalized torsional volume given four points. This is implemented


### PR DESCRIPTION
Miscellaneous optimizations reduce runtime by about 40%.

Benchmarks with `run_atom_mapping.py`, single process, first 200 edges:

|                                              | approximate speedup |
|-------------------------------------------- |------------------- |
| Jit `torsion_volume`, `pyramidal_volume`     | 10%                 |
| Avoid intermediate set construction          | 5%                  |
| Avoid redundant reverse check                | 10%                 |
| Avoid conversion                             | < 5%                |
| Use boolean arrays, vectorize `refine_marcs` | 15%                 |
| Short-circuit rejection                      | < 5%                |
| Remove redundant try block                   | < 5%                |

