### PR TITLE
Document origin of AM1BCC charges in the repo

### DIFF
--- a/timemachine/ff/readme.md
+++ b/timemachine/ff/readme.md
@@ -33,4 +33,4 @@ Timemachine does not currently support the full OpenForceField definition. The f
 
 ## AM1BCC Charges
 
-The AM1BCC charges we use as the basis for our CCC originally come from the [recharge](https://github.com/openforcefield/openff-recharge) project. The source of the charges comes directly from the charges defined [here](https://github.com/openforcefield/openff-recharge/blob/cf18f1920d35af0025ce90c4e1a7f7280b4bd76d/openff/recharge/data/bcc/original-am1-bcc.json).
+The AM1BCC charges used as the basis for our CCC originally come from the [recharge](https://github.com/openforcefield/openff-recharge) project, a port of the original AM1BCC parameters by Christopher Bayly. The source of the charges comes directly from the charges defined [here](https://github.com/openforcefield/openff-recharge/blob/cf18f1920d35af0025ce90c4e1a7f7280b4bd76d/openff/recharge/data/bcc/original-am1-bcc.json).

--- a/timemachine/ff/readme.md
+++ b/timemachine/ff/readme.md
@@ -29,3 +29,8 @@ Timemachine does not currently support the full OpenForceField definition. The f
 * [Virtual Sites](https://open-forcefield-toolkit.readthedocs.io/en/latest/virtualsites.html)
 * Fractional bond order Interpolation for [bonds](https://open-forcefield-toolkit.readthedocs.io/en/0.10.0/users/smirnoff.html#fractional-bond-orders) and [torsions](https://open-forcefield-toolkit.readthedocs.io/en/0.10.0/users/smirnoff.html#fractional-torsion-bond-orders)
 * [Library Charges](https://open-forcefield-toolkit.readthedocs.io/en/latest/smirnoff.html#librarycharges-library-charges-for-polymeric-residues-and-special-solvent-models)
+
+
+## AM1BCC Charges
+
+The AM1BCC charges we use as the basis for our CCC originally come from the [recharge](https://github.com/openforcefield/openff-recharge) project. The source of the charges comes directly from the charges defined [here](https://github.com/openforcefield/openff-recharge/blob/cf18f1920d35af0025ce90c4e1a7f7280b4bd76d/openff/recharge/data/bcc/original-am1-bcc.json).


### PR DESCRIPTION
* Adds the details to the FF readme so that it is less ambiguous where we sourced our charges from

Look at https://github.com/proteneer/timemachine/tree/task/document-origin-of-bcc-charges/timemachine/ff to see how it looks in the UI