### PR TITLE
Use different seeds for ExchangeMover RNGs

### DIFF
--- a/timemachine/cpp/src/bd_exchange_move.cu
+++ b/timemachine/cpp/src/bd_exchange_move.cu
@@ -90,10 +90,10 @@ BDExchangeMove<RealType>::BDExchangeMove(
     curandErrchk(curandSetPseudoRandomGeneratorSeed(cr_rng_quat_, seed));
 
     curandErrchk(curandCreateGenerator(&cr_rng_translations_, CURAND_RNG_PSEUDO_DEFAULT));
-    curandErrchk(curandSetPseudoRandomGeneratorSeed(cr_rng_translations_, seed));
+    curandErrchk(curandSetPseudoRandomGeneratorSeed(cr_rng_translations_, seed + 1));
 
     curandErrchk(curandCreateGenerator(&cr_rng_samples_, CURAND_RNG_PSEUDO_DEFAULT));
-    curandErrchk(curandSetPseudoRandomGeneratorSeed(cr_rng_samples_, seed));
+    curandErrchk(curandSetPseudoRandomGeneratorSeed(cr_rng_samples_, seed + 2));
 }
 
 template <typename RealType> BDExchangeMove<RealType>::~BDExchangeMove() {

--- a/timemachine/cpp/src/tibd_exchange_move.cu
+++ b/timemachine/cpp/src/tibd_exchange_move.cu
@@ -63,10 +63,11 @@ TIBDExchangeMove<RealType>::TIBDExchangeMove(
     // Create event with timings disabled as timings slow down events
     gpuErrchk(cudaEventCreateWithFlags(&host_copy_event_, cudaEventDisableTiming));
 
+    // Add 3 to the seed provided to avoid correlating with the three other RNGs
     k_initialize_curand_states<<<
         ceil_divide(d_rand_states_.length, DEFAULT_THREADS_PER_BLOCK),
         DEFAULT_THREADS_PER_BLOCK,
-        0>>>(static_cast<int>(d_rand_states_.length), seed, d_rand_states_.data);
+        0>>>(static_cast<int>(d_rand_states_.length), seed + 3, d_rand_states_.data);
     gpuErrchk(cudaPeekAtLastError());
 
     k_arange<<<ceil_divide(this->num_target_mols_, DEFAULT_THREADS_PER_BLOCK), DEFAULT_THREADS_PER_BLOCK, 0>>>(


### PR DESCRIPTION
* Don't want the noise to correlate

@proteneer had requested this offline for https://github.com/proteneer/timemachine/pull/1234 but I forgot to add it. 