### PR TITLE
Set ylim for forward rev free energy plots

### DIFF
--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -292,13 +292,16 @@ def plot_fwd_reverse_predictions(
     rev_mask = np.isfinite(rev_err)
     xs = np.linspace(1.0 / len(fwd), 1.0, len(fwd))
 
-    plt.figure(figsize=(6, 6))
+    fig = plt.figure(figsize=(6, 6))
 
     # Compute the upper and lower bounds and add +/- 1 kcal/mol to the y axis limits
     combined_vals = np.concatenate([fwd, rev])
     y_max = np.max(combined_vals)
     y_min = np.min(combined_vals)
     plt.ylim(y_min - 1.0, y_max + 1.0)
+
+    max_error = np.abs(np.concatenate([fwd_err, rev_err])).max()
+    fig.text(0.55, 0.15, f"Max error = {max_error:.2g} kcal/mol")
 
     plt.title(f"{energy_type} Convergence Over Time")
     plt.plot(xs, fwd, label=f"Forward {energy_type}", marker="o")

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -292,12 +292,14 @@ def plot_fwd_reverse_predictions(
     rev_mask = np.isfinite(rev_err)
     xs = np.linspace(1.0 / len(fwd), 1.0, len(fwd))
 
+    plt.figure(figsize=(6, 6))
+
+    # Compute the upper and lower bounds and add +/- 1 kcal/mol to the y axis limits
     combined_vals = np.concatenate([fwd, rev])
     y_max = np.max(combined_vals)
     y_min = np.min(combined_vals)
-
-    plt.figure(figsize=(6, 6))
     plt.ylim(y_min - 1.0, y_max + 1.0)
+
     plt.title(f"{energy_type} Convergence Over Time")
     plt.plot(xs, fwd, label=f"Forward {energy_type}", marker="o")
     plt.fill_between(xs[fwd_mask], fwd[fwd_mask] - fwd_err[fwd_mask], fwd[fwd_mask] + fwd_err[fwd_mask], alpha=0.25)

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -292,7 +292,12 @@ def plot_fwd_reverse_predictions(
     rev_mask = np.isfinite(rev_err)
     xs = np.linspace(1.0 / len(fwd), 1.0, len(fwd))
 
+    combined_vals = np.concatenate([fwd, rev])
+    y_max = np.max(combined_vals)
+    y_min = np.min(combined_vals)
+
     plt.figure(figsize=(6, 6))
+    plt.ylim(y_min - 1.0, y_max + 1.0)
     plt.title(f"{energy_type} Convergence Over Time")
     plt.plot(xs, fwd, label=f"Forward {energy_type}", marker="o")
     plt.fill_between(xs[fwd_mask], fwd[fwd_mask] - fwd_err[fwd_mask], fwd[fwd_mask] + fwd_err[fwd_mask], alpha=0.25)


### PR DESCRIPTION
* Plots were unintelligible if the errors were large, this ensures that we only allow the y limits to be off from the min/max by 1kcal.

# Example

Previous plot of a ukln where the errors were large and the free energies over time were unintelligible.

![screeny_of_screeny](https://github.com/proteneer/timemachine/assets/5840832/7329138a-a019-4cbd-8b82-487f59dac04e)


After this PR:

![screenyagain](https://github.com/proteneer/timemachine/assets/5840832/ae78b5f0-61a1-4fd0-b8f6-720634a38661)
