### PR TITLE
Minimal repro showing cyclopropane hydrogens being invertible

### DIFF
--- a/timemachine/potentials/bonded.py
+++ b/timemachine/potentials/bonded.py
@@ -132,7 +132,7 @@ def harmonic_angle(conf, params, box, angle_idxs, cos_angles=True):
     tb = top / bot
 
     # (ytz): we use the squared version so that the energy is strictly positive
-    if cos_angles:
+    if 0:
         energies = kas / 2 * jnp.power(tb - jnp.cos(a0s), 2)
     else:
         angle = jnp.arccos(tb)


### PR DESCRIPTION
I compared the chiral volumes of cyclopropane in a typical vacuum simulation, with and without the `cos_angle=True` term. Unfortunately it looks like the default OFF parameters has them as naturally invertible. 

```
dt = 1.5e-3
with `cos_angles=True`:
pos vols 14
neg vols 1199986

with `cos_angles=False`:
pos vols 8
neg vols 1199992
```