### PR TITLE
Plot Chiral Heatmap

### DIFF
--- a/tests/test_chiral_restraints.py
+++ b/tests/test_chiral_restraints.py
@@ -3,7 +3,6 @@ from dataclasses import replace
 import numpy as np
 import pytest
 import scipy
-from jax import jit
 from jax import numpy as jnp
 from rdkit import Chem
 
@@ -14,8 +13,9 @@ from timemachine.constants import (
 )
 from timemachine.fe import topology, utils
 from timemachine.fe.atom_mapping import get_cores
+from timemachine.fe.chiral_utils import make_chiral_flip_heatmaps
 from timemachine.fe.free_energy import HREXParams
-from timemachine.fe.rbfe import DEFAULT_HREX_PARAMS, run_vacuum
+from timemachine.fe.rbfe import DEFAULT_HREX_PARAMS, run_solvent, run_vacuum
 from timemachine.fe.single_topology import AtomMapMixin
 from timemachine.fe.system import simulate_system
 from timemachine.ff import Forcefield
@@ -687,82 +687,6 @@ def test_chiral_inversion_in_single_topology_runs(well_aligned):
     _ = run_vacuum(atom_map.mol_a, atom_map.mol_b, atom_map.core, ff, None, very_short_hrex_params, n_windows=3)
 
 
-# some util fxns: TODO: move these where appropriate
-def make_chiral_restr_fxns(mol_a, mol_b, chiral_k=1000.0):
-    from timemachine.fe.chiral_utils import setup_all_chiral_atom_restr_idxs
-
-    restr_idxs_a = np.array(setup_all_chiral_atom_restr_idxs(mol_a, utils.get_romol_conf(mol_a)))
-    restr_idxs_b = np.array(setup_all_chiral_atom_restr_idxs(mol_b, utils.get_romol_conf(mol_b)))
-
-    @jit
-    def U_a(x_a):
-        return U_chiral_atom_batch(x_a, restr_idxs_a, chiral_k).sum()
-
-    @jit
-    def U_b(x_b):
-        return U_chiral_atom_batch(x_b, restr_idxs_b, chiral_k).sum()
-
-    return U_a, U_b
-
-
-# TODO: should def x_ab_from_x, def xs_ab_from_xs move to a utils.py?
-def x_ab_from_x(x, atom_map):
-    """extract confs of mol_a, mol_b from combined conf
-
-    TODO: jaxify this...
-    """
-    # duplicating from https://github.com/proteneer/timemachine/blob/85c15ac58315e7304233ac847fe2d24db8c1773f/timemachine/fe/cif_writer.py#L9
-    n_a = atom_map.mol_a.GetNumAtoms()
-    n_b = atom_map.mol_b.GetNumAtoms()
-
-    x_a = np.zeros((n_a, 3))
-    x_b = np.zeros((n_b, 3))
-
-    for a_idx, c_idx in enumerate(atom_map.a_to_c):
-        x_a[a_idx] = x[c_idx]
-    for b_idx, c_idx in enumerate(atom_map.b_to_c):
-        x_b[b_idx] = x[c_idx]
-    #
-
-    return x_a, x_b
-
-
-def xs_ab_from_xs(xs, atom_map):
-    """map x_ab_from_x over xs
-
-    TODO: remove when x_ab_from_x is jaxified
-    """
-    xs_a, xs_b = [], []
-    for x in xs:
-        x_a, x_b = x_ab_from_x(x, atom_map)
-        xs_a.append(x_a)
-        xs_b.append(x_b)
-    xs_a = np.array(xs_a)
-    xs_b = np.array(xs_b)
-    return xs_a, xs_b
-
-
-def make_chiral_flip_heatmaps(vacuum_results, atom_map):
-    """evaluate mol_a and mol_b chiral restraint energy in each frame of every trajectory"""
-    mol_a_chiral_conflicts = []
-    mol_b_chiral_conflicts = []
-    U_a, U_b = make_chiral_restr_fxns(atom_map.mol_a, atom_map.mol_b)
-
-    for traj in vacuum_results.frames:
-        xs = np.array(traj)
-        xs_a, xs_b = xs_ab_from_xs(np.array(xs), atom_map)
-        # TODO: probably vmap
-        mol_a_chiral_conflicts.append(np.array([U_a(x) for x in xs_a]))
-        mol_b_chiral_conflicts.append(np.array([U_b(x) for x in xs_b]))
-
-    mol_a_chiral_conflicts = np.array(mol_a_chiral_conflicts)
-    mol_b_chiral_conflicts = np.array(mol_b_chiral_conflicts)
-
-    assert mol_a_chiral_conflicts.shape == (len(vacuum_results.frames), len(vacuum_results.frames[0]))
-
-    return mol_a_chiral_conflicts, mol_b_chiral_conflicts
-
-
 @pytest.mark.nightly(reason="slow")
 @pytest.mark.parametrize("well_aligned", [True, False])
 def test_chiral_inversion_in_single_topology(well_aligned):
@@ -772,7 +696,53 @@ def test_chiral_inversion_in_single_topology(well_aligned):
 
     atom_map = make_chiral_flip_pair(well_aligned)
 
-    vacuum_results = run_vacuum(atom_map.mol_a, atom_map.mol_b, atom_map.core, ff, None, DEFAULT_HREX_PARAMS)
+    vacuum_results = run_vacuum(
+        atom_map.mol_a,
+        atom_map.mol_b,
+        atom_map.core,
+        ff,
+        None,
+        DEFAULT_HREX_PARAMS,
+        min_overlap=0.667,  # No need to have a higher overlap then 0.667
+    )
     heatmap_a, heatmap_b = make_chiral_flip_heatmaps(vacuum_results, atom_map)
     assert (heatmap_a[0] == 0).all(), "chirality in end state A was not preserved"
     assert (heatmap_b[-1] == 0).all(), "chirality in end state B was not preserved"
+
+    # from timemachine.fe.plots import plot_as_png_fxn, plot_chiral_restraint_energies
+
+    # with open(f"vacuum_chiral_energies_aligned_{well_aligned}_a.png", "wb") as ofs:
+    #     data_a = plot_as_png_fxn(plot_chiral_restraint_energies, heatmap_a)
+    #     ofs.write(data_a)
+
+    # with open(f"vacuum_chiral_energies_aligned_{well_aligned}_b.png", "wb") as ofs:
+    #     data_b = plot_as_png_fxn(plot_chiral_restraint_energies, heatmap_b)
+    #     ofs.write(data_b)
+
+
+@pytest.mark.nightly(reason="slow")
+def test_chiral_inversion_in_single_topology_solvent():
+    """assert chiral consistency preserved through solvent HREX"""
+
+    ff = Forcefield.load_default()
+
+    # Run the poorly aligned version, restraints get exercised
+    atom_map = make_chiral_flip_pair(False)
+
+    md_params = DEFAULT_HREX_PARAMS
+    md_params = replace(md_params, n_frames=100)
+
+    res, _, _ = run_solvent(atom_map.mol_a, atom_map.mol_b, atom_map.core, ff, None, md_params, n_windows=3)
+    heatmap_a, heatmap_b = make_chiral_flip_heatmaps(res, atom_map)
+    assert (heatmap_a[0] == 0).all(), "chirality in end state A was not preserved"
+    assert (heatmap_b[-1] == 0).all(), "chirality in end state B was not preserved"
+
+    # from timemachine.fe.plots import plot_as_png_fxn, plot_chiral_restraint_energies
+
+    # with open("solvent_chiral_energies_a.png", "wb") as ofs:
+    #     data_a = plot_as_png_fxn(plot_chiral_restraint_energies, heatmap_a)
+    #     ofs.write(data_a)
+
+    # with open("solvent_chiral_energies_b.png", "wb") as ofs:
+    #     data_b = plot_as_png_fxn(plot_chiral_restraint_energies, heatmap_b)
+    #     ofs.write(data_b)

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -4,13 +4,16 @@ from functools import partial
 from typing import Callable, Iterator, List, Mapping, Sequence, Set, Tuple
 
 import numpy as np
+from jax import jit
+from numpy.typing import NDArray
 from rdkit import Chem
 from rdkit.Chem.rdchem import BondType
 
+from timemachine.constants import DEFAULT_CHIRAL_ATOM_RESTRAINT_K
 from timemachine.fe.dummy import canonicalize_bond
 from timemachine.fe.utils import get_romol_conf
 from timemachine.graph_utils import convert_to_nx, enumerate_simple_paths
-from timemachine.potentials.chiral_restraints import pyramidal_volume, torsion_volume
+from timemachine.potentials.chiral_restraints import U_chiral_atom_batch, pyramidal_volume, torsion_volume
 
 FourTuple = Tuple[int, int, int, int]
 
@@ -398,3 +401,72 @@ def setup_find_flipped_planar_torsions(
     find_flipped_planar_torsions = partial(_find_flipped_torsions, planar_torsions_a, planar_torsions_b)
 
     return find_flipped_planar_torsions
+
+
+def make_chiral_restr_fxns(mol_a, mol_b, chiral_k: float = DEFAULT_CHIRAL_ATOM_RESTRAINT_K):
+    restr_idxs_a = np.array(setup_all_chiral_atom_restr_idxs(mol_a, get_romol_conf(mol_a)))
+    restr_idxs_b = np.array(setup_all_chiral_atom_restr_idxs(mol_b, get_romol_conf(mol_b)))
+
+    @jit
+    def U_a(x_a):
+        return U_chiral_atom_batch(x_a, restr_idxs_a, chiral_k).sum()
+
+    @jit
+    def U_b(x_b):
+        return U_chiral_atom_batch(x_b, restr_idxs_b, chiral_k).sum()
+
+    return U_a, U_b
+
+
+def xs_ab_from_xs(xs: NDArray, atom_map):
+    """map convert_single_topology_mols over xs"""
+    # Import here to avoid circular, TBD Deboggle
+    from timemachine.fe.cif_writer import convert_single_topology_mols
+
+    n_a = atom_map.mol_a.GetNumAtoms()
+    xs_a_, xs_b_ = [], []
+    for x in xs:
+        combined = convert_single_topology_mols(x, atom_map)
+        xs_a_.append(combined[:n_a])
+        xs_b_.append(combined[n_a:])
+    xs_a = np.array(xs_a_)
+    xs_b = np.array(xs_b_)
+    return xs_a, xs_b
+
+
+def make_chiral_flip_heatmaps(simulation_result, atom_map):
+    """Evaluate mol_a and mol_b chiral restraint energy in each frame of a simulation
+
+    Parameters
+    ----------
+    simulation_result: timemachine.fe.free_energy.SimulationResult
+        Containing all of the frames that make up a simulation_result, may contain intermediate windows
+
+    atom_map: timemachine.fe.single_topology.AtomMapMixin
+        Contains the atom map between the two end state molecules
+
+    Returns
+    -------
+    2-tuple
+        Returns a tuple of the chiral energies in endstate A (lamb=0.0) and endstate B (lamb=1.0)
+        each with shape (num_states, frames_per_state). Chiral energies are zero when there is no inversion
+    """
+    mol_a_chiral_conflicts = []
+    mol_b_chiral_conflicts = []
+    U_a, U_b = make_chiral_restr_fxns(atom_map.mol_a, atom_map.mol_b)
+
+    for traj in simulation_result.frames:
+        # Truncate off just the ligands, to handle all type of simulations
+        # Use list comprehension to avoid loading the complete frames into memory traj is a StoredArrays object
+        xs = np.array([frame[-atom_map.get_num_atoms() :] for frame in traj])
+        xs_a, xs_b = xs_ab_from_xs(xs, atom_map)
+        # TODO: probably vmap
+        mol_a_chiral_conflicts.append(np.array([U_a(x) for x in xs_a]))
+        mol_b_chiral_conflicts.append(np.array([U_b(x) for x in xs_b]))
+
+    mol_a_chiral_conflicts = np.array(mol_a_chiral_conflicts)
+    mol_b_chiral_conflicts = np.array(mol_b_chiral_conflicts)
+
+    assert mol_a_chiral_conflicts.shape == (len(simulation_result.frames), len(simulation_result.frames[0]))
+
+    return mol_a_chiral_conflicts, mol_b_chiral_conflicts

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -780,7 +780,7 @@ def run_sims_bisection(
             if min_overlap is not None:
                 overlap_info = f"Current minimum BAR overlap {cost_to_overlap(max(costs)):.3g} <= {min_overlap:.3g} "
             else:
-                overlap_info = f"Current minimum BAR overlap {cost_to_overlap(max(costs)):.3g} (min_overlap == None)"
+                overlap_info = f"Current minimum BAR overlap {cost_to_overlap(max(costs)):.3g} (min_overlap == None) "
 
             print(
                 f"Bisection iteration {iteration} (of {n_bisections}): "

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -16,6 +16,8 @@ def plot_work(w_forward, w_reverse, axes):
     """histograms of +forward and -reverse works"""
 
     w_all = np.concatenate([+w_forward, -w_reverse])
+    # Tear out any non-finite works
+    w_all = w_all[np.isfinite(w_all)]
     a_min, a_max = np.amin(w_all), np.amax(w_all)
 
     axes.hist(+w_forward, alpha=0.5, label="fwd", density=True, bins=20, range=(a_min, a_max))

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -328,6 +328,31 @@ def plot_fwd_reverse_predictions(
     return plot_png
 
 
+def plot_chiral_restraint_energies(
+    chiral_energies: NDArray,
+    annotate_threshold: int = DEFAULT_HEATMAP_ANNOTATE_THRESHOLD,
+    figsize: Tuple[float, float] = (13, 10),
+):
+    """Plot matrix of chiral restraint energies as a heatmap.
+
+    For use with the outputs of timemachine.fe.chiral_utils.make_chiral_flip_heatmaps.
+    """
+    n_states, n_frames = chiral_energies.shape
+    states = np.arange(n_states)
+    frames = np.arange(n_frames)
+
+    fig, ax = plt.subplots(figsize=figsize)
+    p = ax.pcolormesh(frames, states, chiral_energies, vmin=0.0)
+
+    ax.set_xlabel("frame")
+    ax.set_ylabel("state")
+    ax.xaxis.get_major_locator().set_params(integer=True)
+    ax.yaxis.get_major_locator().set_params(integer=True)
+
+    fig.colorbar(p, label="chiral restraint energy")
+    fig.suptitle("Chiral Restraint Energies")
+
+
 def plot_hrex_transition_matrix(
     transition_probability: NDArray,
     figsize: Tuple[float, float] = (13, 10),


### PR DESCRIPTION
* Moves the chiral heatmap code out of tests
* Reuses some of the existing single topology code (should probably move out of the cif writer at some point, left for deboggling unless we want to do it now)


# Plot examples

## Vacuum
Both from the poorly aligned cases, as in the well aligned there are no chiral restraint energies that are non-zero

### Mol A
![vacuum_chiral_energies_aligned_False_a](https://github.com/proteneer/timemachine/assets/5840832/268f5747-d01a-4aa4-8929-ce040b03a3fb)

### Mol B
![vacuum_chiral_energies_aligned_False_b](https://github.com/proteneer/timemachine/assets/5840832/523702dc-13f7-4acb-9d12-ff495b1fe429)

## Solvent

### Mol A
![solvent_chiral_energies_a](https://github.com/proteneer/timemachine/assets/5840832/b58411b7-c3e6-42b9-96d1-59258ff59ab7)

### Mol B
![solvent_chiral_energies_b](https://github.com/proteneer/timemachine/assets/5840832/68f505e4-0a70-4a17-8bfa-d3d6db5c5f50)
