### PR TITLE
Remove round_up_even when not generating normal noise

### DIFF
--- a/timemachine/cpp/src/local_md_potentials.cu
+++ b/timemachine/cpp/src/local_md_potentials.cu
@@ -119,7 +119,7 @@ void LocalMDPotentials::setup_from_idxs(
     gpuErrchk(cudaPeekAtLastError());
 
     // Generate values between (0, 1.0]
-    curandErrchk(curandGenerateUniform(cr_rng_, d_probability_buffer_.data, round_up_even(N_)));
+    curandErrchk(curandGenerateUniform(cr_rng_, d_probability_buffer_.data, d_probability_buffer_.length));
 
     std::mt19937 rng;
     rng.seed(seed);

--- a/timemachine/cpp/src/local_md_potentials.cu
+++ b/timemachine/cpp/src/local_md_potentials.cu
@@ -23,9 +23,9 @@ struct LessThan {
 LocalMDPotentials::LocalMDPotentials(
     const int N, const std::vector<std::shared_ptr<BoundPotential>> &bps, bool freeze_reference, double temperature)
     : freeze_reference(freeze_reference), temperature(temperature), N_(N), temp_storage_bytes_(0), all_potentials_(bps),
-      d_restraint_pairs_(N_ * 2), d_bond_params_(N_ * 3), d_probability_buffer_(round_up_even(N_)), d_free_idxs_(N_),
-      d_temp_idxs_(N_), d_all_pairs_idxs_(N_), d_temp_storage_buffer_(0), d_row_idxs_(N_), d_col_idxs_(N_),
-      p_num_selected_(1), d_num_selected_buffer_(1) {
+      d_restraint_pairs_(N_ * 2), d_bond_params_(N_ * 3), d_probability_buffer_(N_), d_free_idxs_(N_), d_temp_idxs_(N_),
+      d_all_pairs_idxs_(N_), d_temp_storage_buffer_(0), d_row_idxs_(N_), d_col_idxs_(N_), p_num_selected_(1),
+      d_num_selected_buffer_(1) {
 
     if (temperature <= 0.0) {
         throw std::runtime_error("temperature must be greater than 0");

--- a/timemachine/cpp/src/segmented_weighted_random_sampler.cu
+++ b/timemachine/cpp/src/segmented_weighted_random_sampler.cu
@@ -11,7 +11,7 @@ template <typename RealType>
 SegmentedWeightedRandomSampler<RealType>::SegmentedWeightedRandomSampler(
     const int max_vals_per_segment, const int num_segments, const int seed)
     : max_vals_per_segment_(max_vals_per_segment), num_segments_(num_segments), temp_storage_bytes_(0),
-      d_gumbel_(round_up_even(max_vals_per_segment_ * num_segments_)), d_arg_max_(num_segments_), d_argmax_storage_(0) {
+      d_gumbel_(max_vals_per_segment_ * num_segments_), d_arg_max_(num_segments_), d_argmax_storage_(0) {
 
     int *dummy_segments = nullptr;
     gpuErrchk(cub::DeviceSegmentedReduce::ArgMax(


### PR DESCRIPTION
* Identified in https://github.com/proteneer/timemachine/pull/1268 that not required when generating uniform noise
* A very trivial change, but good to have out of the way