### PR TITLE
Move switch_fn to attic, add norm'd switch_fn_2

### DIFF
--- a/attic/modules/potentials/nonbonded.py
+++ b/attic/modules/potentials/nonbonded.py
@@ -1,0 +1,16 @@
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+
+def switch_fn(dij, cutoff):
+    """assumes cutoff=1.0"""
+    return jnp.power(jnp.cos((jnp.pi * jnp.power(dij, 8)) / (2 * cutoff)), 2)
+
+def switch_fn_2(dij, cutoff):
+    """possible normalization of switch_fn, but untested -- still might introduce large forces near cutoff"""
+    return jnp.power(jnp.cos((jnp.pi * jnp.power(dij/cutoff, 8)) / 2), 2)
+
+cutoff = 1.2
+dij = jnp.linspace(0, cutoff, 10000)
+plt.plot(dij, switch_fn(dij, cutoff), label='switch_fn');
+plt.plot(dij, switch_fn_2(dij, cutoff), label='switch_fn_2');
+plt.xlabel('dij'); plt.ylabel('f(dij)'); plt.legend();

--- a/timemachine/potentials/nonbonded.py
+++ b/timemachine/potentials/nonbonded.py
@@ -19,11 +19,6 @@ from timemachine.potentials.jax_utils import (
 
 Array = Any
 
-
-def switch_fn(dij, cutoff):
-    return jnp.power(jnp.cos((jnp.pi * jnp.power(dij, 8)) / (2 * cutoff)), 2)
-
-
 from typing import Optional
 
 


### PR DESCRIPTION
Move switch_fn from nonbonded.py to attic.

Doesn't have expected boundary conditions when cutoff != 1.0, and is unused (only usages were in commented-out code when introduced in https://github.com/proteneer/timemachine/pull/205 ).

Possible normalization suggested, but untested

![image](https://github.com/proteneer/timemachine/assets/5759036/ff2e4a64-587e-4286-9d02-e22567c86e6d)
