### PR TITLE
Enable Water Sampling in Simulations

### DIFF
--- a/tests/hrex/test_hrex_rbfe.py
+++ b/tests/hrex/test_hrex_rbfe.py
@@ -9,7 +9,14 @@ import pytest
 from psutil import Process
 from scipy import stats
 
-from timemachine.fe.free_energy import HostConfig, HREXParams, MDParams, SimulationResult, sample_with_context
+from timemachine.fe.free_energy import (
+    HostConfig,
+    HREXParams,
+    MDParams,
+    SimulationResult,
+    WaterSamplingParams,
+    sample_with_context,
+)
 from timemachine.fe.plots import (
     plot_hrex_replica_state_distribution_convergence,
     plot_hrex_replica_state_distribution_heatmap,
@@ -59,6 +66,9 @@ def test_hrex_rbfe_hif2a(hif2a_single_topology_leg):
         steps_per_frame=400,
         seed=2024,
         hrex_params=HREXParams(n_frames_bisection=100, n_frames_per_iter=1),
+        water_sampling_params=WaterSamplingParams(interval=400, n_proposals=1000, n_initial_iterations=0)
+        if host_config == "complex"
+        else None,
     )
     n_windows = 5
 

--- a/tests/hrex/test_hrex_rbfe.py
+++ b/tests/hrex/test_hrex_rbfe.py
@@ -66,9 +66,7 @@ def test_hrex_rbfe_hif2a(hif2a_single_topology_leg):
         steps_per_frame=400,
         seed=2024,
         hrex_params=HREXParams(n_frames_bisection=100, n_frames_per_iter=1),
-        water_sampling_params=WaterSamplingParams(interval=400, n_proposals=1000, n_initial_iterations=0)
-        if host_config == "complex"
-        else None,
+        water_sampling_params=WaterSamplingParams(interval=400, n_proposals=1000) if host_config == "complex" else None,
     )
     n_windows = 5
 

--- a/tests/test_benchmark_free_energy.py
+++ b/tests/test_benchmark_free_energy.py
@@ -99,7 +99,7 @@ def test_benchmark_hif2a_single_topology(
 
     _, elapsed_ns = run_with_timing(run)
 
-    print("water sampling:", enable_water_sampling, ", intermediate windows:", intermediate_window_water_sampling)
+    print(f"water sampling: {enable_water_sampling}, intermediate windows: {intermediate_window_water_sampling}")
     print("hrex:", enable_hrex)
     print("host:", host_name)
     print("n_windows:", n_windows)

--- a/tests/test_benchmark_free_energy.py
+++ b/tests/test_benchmark_free_energy.py
@@ -1,4 +1,5 @@
 import time
+from dataclasses import replace
 from functools import partial
 from importlib import resources
 from itertools import product
@@ -8,7 +9,7 @@ import numpy as np
 import pytest
 
 from timemachine.constants import DEFAULT_TEMP
-from timemachine.fe.free_energy import HostConfig, MDParams, run_sims_hrex, run_sims_sequential
+from timemachine.fe.free_energy import HostConfig, MDParams, WaterSamplingParams, run_sims_hrex, run_sims_sequential
 from timemachine.fe.rbfe import setup_initial_states, setup_optimized_host
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.ff import Forcefield
@@ -63,12 +64,26 @@ def hif2a_single_topology_leg(request):
 
 
 @pytest.mark.nightly(reason="Slow")
+@pytest.mark.parametrize(
+    "enable_water_sampling,intermediate_window_water_sampling", [(False, False), (True, False), (True, True)]
+)
 @pytest.mark.parametrize("enable_hrex", [False, True])
-def test_benchmark_hif2a_single_topology(hif2a_single_topology_leg, enable_hrex):
+def test_benchmark_hif2a_single_topology(
+    hif2a_single_topology_leg, enable_hrex, enable_water_sampling, intermediate_window_water_sampling
+):
     host_name, n_windows, initial_states = hif2a_single_topology_leg
+    if host_name != "complex" and enable_water_sampling:
+        pytest.skip("Water sampling disabled outside of complex")
 
     n_frames = 500 // n_windows
     md_params = MDParams(n_frames=n_frames, n_eq_steps=1, steps_per_frame=400, seed=2023)
+    if enable_water_sampling:
+        md_params = replace(
+            md_params,
+            water_sampling_params=WaterSamplingParams(
+                n_initial_iterations=1, intermediate_sampling=intermediate_window_water_sampling
+            ),
+        )
     temperature = DEFAULT_TEMP
 
     if enable_hrex:
@@ -84,6 +99,7 @@ def test_benchmark_hif2a_single_topology(hif2a_single_topology_leg, enable_hrex)
 
     _, elapsed_ns = run_with_timing(run)
 
+    print("water sampling:", enable_water_sampling, ", intermediate windows:", intermediate_window_water_sampling)
     print("hrex:", enable_hrex)
     print("host:", host_name)
     print("n_windows:", n_windows)

--- a/tests/test_benchmark_free_energy.py
+++ b/tests/test_benchmark_free_energy.py
@@ -64,13 +64,9 @@ def hif2a_single_topology_leg(request):
 
 
 @pytest.mark.nightly(reason="Slow")
-@pytest.mark.parametrize(
-    "enable_water_sampling,intermediate_window_water_sampling", [(False, False), (True, False), (True, True)]
-)
+@pytest.mark.parametrize("enable_water_sampling", [False, True])
 @pytest.mark.parametrize("enable_hrex", [False, True])
-def test_benchmark_hif2a_single_topology(
-    hif2a_single_topology_leg, enable_hrex, enable_water_sampling, intermediate_window_water_sampling
-):
+def test_benchmark_hif2a_single_topology(hif2a_single_topology_leg, enable_hrex, enable_water_sampling):
     host_name, n_windows, initial_states = hif2a_single_topology_leg
     if host_name != "complex" and enable_water_sampling:
         pytest.skip("Water sampling disabled outside of complex")
@@ -78,12 +74,7 @@ def test_benchmark_hif2a_single_topology(
     n_frames = 500 // n_windows
     md_params = MDParams(n_frames=n_frames, n_eq_steps=1, steps_per_frame=400, seed=2023)
     if enable_water_sampling:
-        md_params = replace(
-            md_params,
-            water_sampling_params=WaterSamplingParams(
-                n_initial_iterations=1, intermediate_sampling=intermediate_window_water_sampling
-            ),
-        )
+        md_params = replace(md_params, water_sampling_params=WaterSamplingParams())
     temperature = DEFAULT_TEMP
 
     if enable_hrex:
@@ -99,7 +90,7 @@ def test_benchmark_hif2a_single_topology(
 
     _, elapsed_ns = run_with_timing(run)
 
-    print(f"water sampling: {enable_water_sampling}, intermediate windows: {intermediate_window_water_sampling}")
+    print("water sampling:", enable_water_sampling)
     print("hrex:", enable_hrex)
     print("host:", host_name)
     print("n_windows:", n_windows)

--- a/tests/test_cuda_bd_exchange_mover.py
+++ b/tests/test_cuda_bd_exchange_mover.py
@@ -19,7 +19,7 @@ from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, custom_ops
 from timemachine.md import builders
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.md.exchange.exchange_mover import BDExchangeMove as RefBDExchangeMove
-from timemachine.md.exchange.exchange_mover import translate_coordinates
+from timemachine.md.exchange.exchange_mover import get_water_idxs, translate_coordinates
 from timemachine.md.minimizer import check_force_norm
 from timemachine.potentials import HarmonicBond, Nonbonded, SummedPotential
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
@@ -314,7 +314,7 @@ def test_bias_deletion_bulk_water_with_context(precision, seed, batch_size):
     all_group_idxs = get_group_indices(bond_list, conf.shape[0])
 
     # only act on waters
-    water_idxs = [group for group in all_group_idxs if len(group) == 3]
+    water_idxs = get_water_idxs(all_group_idxs)
 
     dt = 2.5e-3
 
@@ -817,7 +817,7 @@ def test_moves_with_complex(
     all_group_idxs = get_group_indices(bond_list, conf.shape[0])
 
     # only act on waters
-    water_idxs = [group for group in all_group_idxs if len(group) == 3]
+    water_idxs = get_water_idxs(all_group_idxs)
 
     # Re-image coords so that everything is imaged to begin with
     conf = image_frame(all_group_idxs, conf, box)
@@ -944,7 +944,7 @@ def test_bd_moves_with_complex_and_ligand(
     all_group_idxs = get_group_indices(bond_list, conf.shape[0])
 
     # only act on waters
-    water_idxs = [group for group in all_group_idxs if len(group) == 3]
+    water_idxs = get_water_idxs(all_group_idxs, ligand_idxs=initial_state.ligand_idxs)
 
     N = conf.shape[0]
 

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -21,7 +21,12 @@ from timemachine.lib import MonteCarloBarostat, custom_ops
 from timemachine.md import builders
 from timemachine.md.barostat.utils import compute_box_volume, get_bond_list, get_group_indices
 from timemachine.md.exchange.exchange_mover import TIBDExchangeMove as RefTIBDExchangeMove
-from timemachine.md.exchange.exchange_mover import compute_raw_ratio_given_weights, delta_r_np, get_water_groups
+from timemachine.md.exchange.exchange_mover import (
+    compute_raw_ratio_given_weights,
+    delta_r_np,
+    get_water_groups,
+    get_water_idxs,
+)
 from timemachine.md.minimizer import check_force_norm
 from timemachine.potentials import HarmonicBond, Nonbonded, SummedPotential
 
@@ -477,8 +482,8 @@ def test_targeted_insertion_buckyball_edge_cases(radius, moves, precision, rtol,
     all_group_idxs = get_group_indices(bond_list, conf.shape[0])
 
     # Select an arbitrary water, will be the only water considered for insertion/deletion
-    water_idxs_single = [[group for group in all_group_idxs if len(group) == 3][-1]]
-    water_idxs_double = [group for group in all_group_idxs if len(group) == 3][-2:]
+    water_idxs_single = [get_water_idxs(all_group_idxs)[-1]]
+    water_idxs_double = get_water_idxs(all_group_idxs)[-2:]
 
     conf = image_frame(all_group_idxs, conf, box)
 
@@ -535,7 +540,7 @@ def test_targeted_insertion_brd4_rbfe_with_context(
     all_group_idxs = get_group_indices(bond_list, conf.shape[0])
 
     # only act on waters
-    water_idxs = [group for group in all_group_idxs if len(group) == 3]
+    water_idxs = get_water_idxs(all_group_idxs, ligand_idxs=initial_state.ligand_idxs)
 
     N = conf.shape[0]
 
@@ -711,7 +716,7 @@ def test_targeted_insertion_buckyball_determinism(radius, proposals_per_move, ba
 
     bond_list = get_bond_list(bond_pot)
     all_group_idxs = get_group_indices(bond_list, conf.shape[0])
-    water_idxs = [group for group in all_group_idxs if len(group) == 3]
+    water_idxs = get_water_idxs(all_group_idxs, ligand_idxs=ligand_idxs)
 
     conf = image_frame(all_group_idxs, conf, box)
 
@@ -1024,7 +1029,7 @@ def test_targeted_moves_with_complex_and_ligand_in_brd4(
     all_group_idxs = get_group_indices(bond_list, conf.shape[0])
 
     # only act on waters
-    water_idxs = [group for group in all_group_idxs if len(group) == 3]
+    water_idxs = get_water_idxs(all_group_idxs, ligand_idxs=initial_state.ligand_idxs)
 
     N = conf.shape[0]
 

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -22,16 +22,18 @@ from timemachine.fe.free_energy import (
     PairBarResult,
     batches,
     estimate_free_energy_bar,
+    get_water_sampler_params,
     make_pair_bar_plots,
     run_sims_bisection,
     sample,
 )
-from timemachine.fe.rbfe import setup_initial_state, setup_initial_states, setup_optimized_host
+from timemachine.fe.rbfe import Host, setup_initial_state, setup_initial_states, setup_optimized_host
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.stored_arrays import StoredArrays
+from timemachine.fe.system import convert_omm_system
 from timemachine.ff import Forcefield
 from timemachine.md import builders
-from timemachine.potentials import SummedPotential
+from timemachine.potentials import Nonbonded, SummedPotential
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
 
 
@@ -287,6 +289,28 @@ def test_plot_pair_bar_plots(mock_fig, hif2a_ligand_pair_single_topology_lam0_st
         "ChiralAtomRestraint",
     }
     assert set(mock_fig.call_args.args[0]) == expected_potentials
+
+
+@pytest.mark.nocuda
+@pytest.mark.parametrize("num_windows", [2, 5])
+def test_get_water_sampler_params(num_windows):
+    mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
+    # Use the simple charges simply because it is faster
+    forcefield = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
+    st = SingleTopology(mol_a, mol_b, core, forcefield)
+    solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(3.0, forcefield.water_ff)
+    num_host_atoms = solvent_conf.shape[0]
+    host_system, masses = convert_omm_system(solvent_sys)
+    solvent_host = Host(host_system, masses, solvent_conf, solvent_box, num_host_atoms)
+    for lamb in np.linspace(0.0, 1.0, num_windows, endpoint=True):
+        state = setup_initial_state(st, lamb, solvent_host, DEFAULT_TEMP, 2024)
+        water_sampler_nb_params = get_water_sampler_params(state)
+        nb_pot = next(p.potential for p in state.potentials if isinstance(p.potential, Nonbonded))
+        ligand_water_params = st._get_guest_params(
+            forcefield.q_handle_solv, forcefield.lj_handle_solv, lamb, nb_pot.cutoff
+        )
+
+        np.testing.assert_array_equal(water_sampler_nb_params[num_host_atoms:], ligand_water_params)
 
 
 def test_run_sims_bisection_early_stopping(hif2a_ligand_pair_single_topology_lam0_state):

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -429,7 +429,8 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
 
 
 def get_water_sampler_params(initial_state: InitialState) -> NDArray:
-    """Given an initial state, return the parameters that define the parameters of water-environment parameters
+    """Given an initial state, return the parameters that define the nonbonded parameters of water with respect to the
+    entire system.
 
     Since we split the different components of the NB into ligand-water, ligand-protein, we want to use the ligand-water parameter
     to ensure that the ligand component is correctly configured for the specific lambda window.

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -87,13 +87,13 @@ class WaterSamplingParams:
     ----------
 
     interval:
-        How many steps of MD before running a set of water sampling moves
+        How many steps of MD between water sampling moves
 
     n_proposals:
         Number of proposals per make.
 
     batch_size:
-        Number of proposals made per kernel call, typically can be left at default.
+        Internal parameter detailing the parallelism of the mover, typically can be left at default.
 
     radius:
         Radius, in nanometers, from the centroid of the molecule to treat as the inner target volume

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -473,6 +473,10 @@ def get_context(initial_state: InitialState, md_params: Optional[MDParams] = Non
 
         water_params = get_water_sampler_params(initial_state)
 
+        # Generate a new random seed based on the md params seed
+        rng = np.random.default_rng(md_params.seed)
+        water_sampler_seed = rng.integers(np.iinfo(np.int32).max)
+
         water_sampler = custom_ops.TIBDExchangeMove_f32(
             initial_state.x0.shape[0],
             initial_state.ligand_idxs.tolist(),
@@ -482,7 +486,7 @@ def get_context(initial_state: InitialState, md_params: Optional[MDParams] = Non
             nb.beta,
             nb.cutoff,
             md_params.water_sampling_params.radius,
-            md_params.seed,
+            water_sampler_seed,
             md_params.water_sampling_params.n_proposals,
             md_params.water_sampling_params.interval,
             batch_size=md_params.water_sampling_params.batch_size,

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -1048,6 +1048,7 @@ def run_sims_hrex(
             context.set_box(xvb.box)
 
             xs, boxes = context.multiple_steps(md_params.n_eq_steps, store_x_interval=0)
+            assert len(xs) == 1
             x0 = xs[0]
             v0 = context.get_v_t()
             box0 = boxes[0]

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -1082,8 +1082,7 @@ def run_sims_hrex(
             context.set_box(xvb.box)
 
             params = params_by_state[state_idx]
-            assert len(context.get_potentials()) == 1
-            context.get_potentials()[0].set_params(params)
+            bound_potentials[0].set_params(params)
             if state_params.water_sampling_params is not None:
                 for mover in context.get_movers():
                     if isinstance(mover, (custom_ops.TIBDExchangeMove_f32, custom_ops.TIBDExchangeMove_f64)):
@@ -1152,8 +1151,7 @@ def run_sims_hrex(
             context.set_box(xvb.box)
 
             params = params_by_state[state_idx]
-            assert len(context.get_potentials()) == 1
-            context.get_potentials()[0].set_params(params)
+            bound_potentials[0].set_params(params)
 
             current_step = (iteration - 1) * n_frames_per_iter * md_params.steps_per_frame
 

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -663,16 +663,9 @@ def estimate_relative_free_energy_bisection_hrex_impl(
             for initial_state, traj in zip(initial_states, trajectories_by_state)
         ]
 
-        hrex_md_params = replace(md_params, n_eq_steps=0)  # using pre-equilibrated samples
-        if hrex_md_params.water_sampling_params is not None:
-            # Water sampling will have already been applied
-            hrex_md_params = replace(
-                hrex_md_params,
-                water_sampling_params=replace(hrex_md_params.water_sampling_params, n_initial_iterations=0),
-            )
         pair_bar_result, trajectories_by_state, diagnostics = run_sims_hrex(
             initial_states_hrex,
-            hrex_md_params,
+            replace(md_params, n_eq_steps=0),  # using pre-equilibrated samples
             n_frames_per_iter=md_params.hrex_params.n_frames_per_iter,
         )
 

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -772,6 +772,8 @@ def get_ligand_ixn_pots_params(
         )
         hg_other_params.append(jnp.concatenate([host_nb_params, guest_params_ixn_other]))
 
+    # If the ordering of these parameters change, will need to change
+    # timemachine.fe.free_energy::get_water_sampler_params
     # total potential = host_guest_pot + guest_intra_pot + lw_ixn_pots + lp_ixn_pots
     hg_ixn_pots = [hg_water_pot] + hg_other_pots
     hg_ixn_params = [hg_water_params] + hg_other_params

--- a/timemachine/lib/custom_ops.py
+++ b/timemachine/lib/custom_ops.py
@@ -24,3 +24,11 @@ class BoundPotential:
 
 class FanoutSummedPotential:
     pass
+
+
+class TIBDExchangeMove_f32:
+    pass
+
+
+class TIBDExchangeMove_f64:
+    pass

--- a/timemachine/md/exchange/exchange_mover.py
+++ b/timemachine/md/exchange/exchange_mover.py
@@ -15,7 +15,8 @@ from timemachine.potentials import nonbonded
 
 def get_water_idxs(mol_groups: List[NDArray], ligand_idxs: Optional[NDArray] = None) -> List[NDArray]:
     """Given a list of lists that make up the individual molecules in a system, return the subset that is only the waters.
-    Additional logic to handle the case where ligand_idxs is also of size 3.
+
+    Contains additional logic to handle the case where ligand_idxs is also of size 3.
     """
     water_groups = [g for g in mol_groups if len(g) == 3]
     if ligand_idxs is not None and len(ligand_idxs) == 3:

--- a/timemachine/md/exchange/exchange_mover.py
+++ b/timemachine/md/exchange/exchange_mover.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -11,6 +11,17 @@ from timemachine.constants import BOLTZ
 from timemachine.md import moves
 from timemachine.md.states import CoordsVelBox
 from timemachine.potentials import nonbonded
+
+
+def get_water_idxs(mol_groups: List[NDArray], ligand_idxs: Optional[NDArray] = None) -> List[NDArray]:
+    """Given a list of lists that make up the individual molecules in a system, return the subset that is only the waters.
+    Additional logic to handle the case where ligand_idxs is also of size 3.
+    """
+    water_groups = [g for g in mol_groups if len(g) == 3]
+    if ligand_idxs is not None and len(ligand_idxs) == 3:
+        ligand_atom_set = set(ligand_idxs)
+        water_groups = [g for g in water_groups if set(g) != ligand_atom_set]
+    return water_groups
 
 
 def randomly_rotate_and_translate(coords, new_loc):


### PR DESCRIPTION
* Disables water sampling for solvent, doesn't seem to make a difference
* Some random clean up of the example scripts that were from trying to use them to test water sampling
* Runs TIBDExchangeMove on all windows
* Defaults to 1000 MC proposals per 400 steps of MD which makes for about 10% additional runtime cost. Performance optimizations intended in a follow up. 


### Follow up questions
- How do we effectively target a region that will produce effective moves (note that probability of placing in the inner region is the furthest from the center)? Currently defaults to 1.0nm from the centroid of the ligand (want this to be ligand based, to be generic), probably in practice take the max pair wise distance of the ligands and add a padding (~0.4nm).
  * Select ligand atoms that are 'buried' in the protein to define sphere where we think it is important, unclear how to define
  *  Randomize the center of the sphere/radius (no API available short of reconstructing the entire class)

### Todo

- [x] Add a test with a 3 atom ligand (including dummy atoms)