### PR TITLE
Avoid repeatedly instantiating potentials

### DIFF
--- a/tests/test_benchmark_free_energy.py
+++ b/tests/test_benchmark_free_energy.py
@@ -1,10 +1,13 @@
 import time
+from argparse import ArgumentParser
+from collections import defaultdict
 from dataclasses import replace
 from functools import partial
 from importlib import resources
 from itertools import product
 from typing import Callable, Optional, Tuple, TypeVar
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
@@ -44,8 +47,14 @@ hif2a_single_topology_leg_params = {
 )
 def hif2a_single_topology_leg(request):
     host_name, n_windows = request.param
+    return setup_hif2a_single_topology_leg(host_name, n_windows, (0.0, 0.2))
+
+
+def setup_hif2a_single_topology_leg(host_name: str, n_windows: int, lambda_endpoints: Tuple[float, float]):
     forcefield = Forcefield.load_default()
     host_config: Optional[HostConfig] = None
+    assert len(lambda_endpoints) == 2
+    assert lambda_endpoints[0] < lambda_endpoints[1]
 
     if host_name == "complex":
         with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as protein_path:
@@ -63,22 +72,23 @@ def hif2a_single_topology_leg(request):
     single_topology = SingleTopology(mol_a, mol_b, core, forcefield)
     host = setup_optimized_host(single_topology, host_config) if host_config else None
 
-    lambdas = np.linspace(0.0, 0.2, n_windows)
+    lambdas = np.linspace(lambda_endpoints[0], lambda_endpoints[1], n_windows)
 
     initial_states = setup_initial_states(single_topology, host, DEFAULT_TEMP, lambdas, seed=2023, min_cutoff=0.7)
 
-    return single_topology, host, host_name, n_windows, initial_states
+    n_frames = 500 // n_windows
+
+    return single_topology, host, host_name, n_frames, n_windows, initial_states
 
 
 @pytest.mark.nightly(reason="Slow")
 @pytest.mark.parametrize("enable_water_sampling", [False, True])
 @pytest.mark.parametrize("mode", ["sequential", "bisection", "hrex"])
 def test_benchmark_hif2a_single_topology(hif2a_single_topology_leg, mode, enable_water_sampling):
-    single_topology, host, host_name, n_windows, initial_states = hif2a_single_topology_leg
+    single_topology, host, host_name, n_frames, n_windows, initial_states = hif2a_single_topology_leg
     if host_name != "complex" and enable_water_sampling:
         pytest.skip("Water sampling disabled outside of complex")
 
-    n_frames = 500 // n_windows
     md_params = MDParams(n_frames=n_frames, n_eq_steps=1, steps_per_frame=400, seed=2023)
     if enable_water_sampling:
         md_params = replace(md_params, water_sampling_params=WaterSamplingParams())
@@ -133,4 +143,43 @@ def test_benchmark_hif2a_single_topology(hif2a_single_topology_leg, mode, enable
     ns = md_params.n_frames * md_params.steps_per_frame * dt_ns
     elapsed_days = elapsed_ns / 1e9 / 60 / 60 / 24
 
-    print(f"total ns/day: {n_windows * ns / elapsed_days:.1f}")
+    ns_per_day = n_windows * ns / elapsed_days
+
+    print(f"total ns/day: {ns_per_day:.1f}")
+    return ns_per_day
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("--leg", default="vacuum", choices=["vacuum", "solvent", "complex"])
+    parser.add_argument("--n_frames", default=100, type=int)
+    parser.add_argument("--modes", nargs="*", default=["sequential", "bisection", "hrex"])
+    parser.add_argument("--n_windows", nargs="*", type=int, default=[2, 4, 8, 16, 32, 48])
+    parser.add_argument("--water_sampling", action="store_true", default=False)
+    args = parser.parse_args()
+
+    if args.leg != "complex" and args.water_sampling:
+        print("Water sampling will not run outside of complex")
+
+    timings = defaultdict(list)
+    for windows in args.n_windows:
+        single_topology, host, host_name, _, _, initial_states = setup_hif2a_single_topology_leg(
+            args.leg, windows, (0.0, 1.0)
+        )
+        for mode in args.modes:
+            ns_per_day = test_benchmark_hif2a_single_topology(
+                (single_topology, host, host_name, args.n_frames, windows, initial_states), mode, args.water_sampling
+            )
+            timings[mode].append(ns_per_day)
+    fig, axes = plt.subplots(ncols=len(args.modes), sharey=True)
+    if len(args.modes) == 1:
+        axes = [axes]
+    fig.suptitle(f"Leg: {args.leg}, Frames {args.n_frames}, Water Sampling {args.water_sampling}")
+    for i, (ax, mode) in enumerate(zip(axes, args.modes)):
+        ax.set_title(mode)
+        ax.plot(args.n_windows, timings[mode], marker="x")
+        ax.set_xlabel("windows")
+        if i == 0:
+            ax.set_ylabel("ns/day")
+    fig.tight_layout()
+    plt.savefig(f"{args.leg}_{args.n_frames}_benchmarks.png", dpi=150)

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -400,8 +400,8 @@ def test_multiple_steps_local_consistency(freeze_reference):
     unbound_potentials, sys_params, masses, coords, box = get_solvent_phase_system(mol, ff, 0.0, minimize_energy=True)
     v0 = np.zeros_like(coords)
     bps = []
-    for p, bp in zip(sys_params, unbound_potentials):
-        bps.append(bp.bind(p).to_gpu(np.float32).bound_impl)
+    for p, pot in zip(sys_params, unbound_potentials):
+        bps.append(pot.bind(p).to_gpu(np.float32).bound_impl)
 
     reference_values = []
     for bp in bps:
@@ -442,9 +442,9 @@ def test_multiple_steps_local_consistency(freeze_reference):
     assert np.all(coords[frozen_idxs] == xs[-1][frozen_idxs])
 
     # Verify that the bound potentials haven't been changed, as local md modifies potentials
-    for ref_val, bp in zip(reference_values, bps):
+    for ref_val, pot in zip(reference_values, bps):
         ref_du_dx, ref_u = ref_val
-        test_du_dx, test_u = bp.execute(coords, box)
+        test_du_dx, test_u = pot.execute(coords, box)
         np.testing.assert_array_equal(ref_du_dx, test_du_dx)
         np.testing.assert_equal(ref_u, test_u)
         check_force_norm(-ref_du_dx)
@@ -507,8 +507,8 @@ def test_get_movers():
     unbound_potentials, sys_params, masses, coords, box = get_solvent_phase_system(mol, ff, 0.0, minimize_energy=False)
     v0 = np.zeros_like(coords)
     bps = []
-    for p, bp in zip(sys_params, unbound_potentials):
-        bps.append(bp.bind(p).to_gpu(np.float32).bound_impl)
+    for p, pot in zip(sys_params, unbound_potentials):
+        bps.append(pot.bind(p).to_gpu(np.float32).bound_impl)
 
     intg = LangevinIntegrator(temperature, dt, friction, masses, seed)
 
@@ -547,8 +547,8 @@ def test_multiple_steps_local_entire_system(freeze_reference):
     unbound_potentials, sys_params, masses, coords, box = get_solvent_phase_system(mol, ff, 0.0, minimize_energy=False)
     v0 = np.zeros_like(coords)
     bps = []
-    for p, bp in zip(sys_params, unbound_potentials):
-        bps.append(bp.bind(p).to_gpu(np.float32).bound_impl)
+    for p, pot in zip(sys_params, unbound_potentials):
+        bps.append(pot.bind(p).to_gpu(np.float32).bound_impl)
 
     # Select the molecule as the local idxs
     local_idxs = np.arange(len(coords) - mol.GetNumAtoms(), len(coords), dtype=np.int32)
@@ -770,8 +770,8 @@ def test_setup_context_with_references():
 
         weak_refs = []
         bps = []
-        for p, bp in zip(sys_params, unbound_potentials):
-            bound_impl = bp.bind(p).to_gpu(np.float32).bound_impl
+        for p, pot in zip(sys_params, unbound_potentials):
+            bound_impl = pot.bind(p).to_gpu(np.float32).bound_impl
             bps.append(bound_impl)
             weak_refs.append(weakref.ref(bound_impl))
 
@@ -898,8 +898,8 @@ def test_context_invalid_boxes():
     selection = rng.choice(host_idxs, size=40, replace=False)
 
     bps = []
-    for p, bp in zip(sys_params, unbound_potentials):
-        bound_impl = bp.bind(p).to_gpu(np.float32).bound_impl
+    for p, pot in zip(sys_params, unbound_potentials):
+        bound_impl = pot.bind(p).to_gpu(np.float32).bound_impl
         bps.append(bound_impl)
 
     intg = LangevinIntegrator(temperature, dt, friction, masses, seed)
@@ -946,11 +946,11 @@ def test_context_invalid_boxes_without_nonbonded_potentials():
     v0 = np.zeros_like(coords)
 
     bps = []
-    for p, bp in zip(sys_params, unbound_potentials):
+    for p, pot in zip(sys_params, unbound_potentials):
         # Skip the nonbonded all pairs, which is a SummedPotential, will result in no check
-        if isinstance(bp, SummedPotential):
+        if isinstance(pot, SummedPotential):
             continue
-        bound_impl = bp.bind(p).to_gpu(np.float32).bound_impl
+        bound_impl = pot.bind(p).to_gpu(np.float32).bound_impl
         bps.append(bound_impl)
 
     intg = LangevinIntegrator(temperature, dt, friction, masses, seed)

--- a/timemachine/fe/energy_decomposition.py
+++ b/timemachine/fe/energy_decomposition.py
@@ -44,7 +44,7 @@ def get_batch_u_fns(
 
     assert len(pots) == len(params)
     batch_u_fns: List[Batch_u_fn] = []
-    for p, bp in zip(params, pots):
+    for p, pot in zip(params, pots):
 
         def batch_u_fn(xs, boxes, pot_impl, pot_params):
             coords = np.array([x for x in xs])
@@ -61,7 +61,7 @@ def get_batch_u_fns(
             return us
 
         # extra functools.partial is needed to deal with closure jank
-        batch_u_fns.append(functools.partial(batch_u_fn, pot_impl=bp, pot_params=p[np.newaxis]))
+        batch_u_fns.append(functools.partial(batch_u_fn, pot_impl=pot, pot_params=p[np.newaxis]))
 
     return batch_u_fns
 

--- a/timemachine/fe/energy_decomposition.py
+++ b/timemachine/fe/energy_decomposition.py
@@ -1,12 +1,12 @@
 import functools
 from dataclasses import dataclass
-from typing import Callable, Generic, Iterable, List, Sequence, TypeVar
+from typing import Callable, Generic, List, Sequence, TypeVar
 
 import numpy as np
 from numpy.typing import NDArray
 
 from timemachine.constants import BOLTZ, DEFAULT_TEMP
-from timemachine.lib.custom_ops import BoundPotential
+from timemachine.lib.custom_ops import Potential
 
 Frames = TypeVar("Frames")
 Boxes = List[NDArray]
@@ -23,12 +23,17 @@ class EnergyDecomposedState(Generic[Frames]):
     batch_u_fns: Sequence[Batch_u_fn]  # u_fn : (frames, boxes) -> reduced_energies
 
 
-def get_batch_u_fns(bps: Iterable[BoundPotential], temperature: float = DEFAULT_TEMP) -> List[Batch_u_fn]:
+def get_batch_u_fns(
+    pots: Sequence[Potential],
+    params: Sequence[NDArray],
+    temperature: float = DEFAULT_TEMP,
+) -> List[Batch_u_fn]:
     """Get a list of functions that take in (coords, boxes), return reduced_potentials
 
     Parameters
     ----------
-    bps: list of bound potential impls
+    pots: list of potential impls
+    params: list of parameters to call potentials on
     temperature: float
 
     Returns
@@ -37,17 +42,26 @@ def get_batch_u_fns(bps: Iterable[BoundPotential], temperature: float = DEFAULT_
     """
     kBT = temperature * BOLTZ
 
+    assert len(pots) == len(params)
     batch_u_fns: List[Batch_u_fn] = []
-    for bp in bps:
+    for p, bp in zip(params, pots):
 
-        def batch_u_fn(xs, boxes, bp_impl):
+        def batch_u_fn(xs, boxes, pot_impl, pot_params):
             coords = np.array([x for x in xs])
-            _, Us = bp_impl.execute_batch(coords, np.array(boxes), compute_du_dx=False, compute_u=True)
-            us = Us / kBT
+            _, _, Us = pot_impl.execute_batch(
+                coords,
+                pot_params,
+                np.array(boxes),
+                compute_du_dx=False,
+                compute_du_dp=False,
+                compute_u=True,
+            )
+            # ravel the array to remove the params dimension
+            us = Us.ravel() / kBT
             return us
 
         # extra functools.partial is needed to deal with closure jank
-        batch_u_fns.append(functools.partial(batch_u_fn, bp_impl=bp))
+        batch_u_fns.append(functools.partial(batch_u_fn, pot_impl=bp, pot_params=p[np.newaxis]))
 
     return batch_u_fns
 

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -1145,10 +1145,9 @@ def run_sims_hrex(
     unbound_impls = potential.get_potentials()
 
     def make_energy_decomposed_state(
-        results: Tuple[StateIdx, StoredArrays, List[NDArray]]
+        results: Tuple[StoredArrays, List[NDArray], InitialState]
     ) -> EnergyDecomposedState[StoredArrays]:
-        state_idx, frames, boxes = results
-        initial_state = initial_states[state_idx]
+        frames, boxes, initial_state = results
         # Reuse the existing unbound potentials already constructed to make a batch Us fn
         return EnergyDecomposedState(
             frames,
@@ -1157,7 +1156,8 @@ def run_sims_hrex(
         )
 
     results_by_state = [
-        (StateIdx(state_idx), samples.frames, samples.boxes) for state_idx, samples in enumerate(samples_by_state)
+        (samples.frames, samples.boxes, initial_state)
+        for samples, initial_state in zip(samples_by_state, initial_states)
     ]
 
     bar_results = list(

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -15,12 +15,7 @@ from timemachine.fe.bar import (
     pair_overlap_from_ukln,
     works_from_ukln,
 )
-from timemachine.fe.energy_decomposition import (
-    Batch_u_fn,
-    EnergyDecomposedState,
-    compute_energy_decomposed_u_kln,
-    get_batch_u_fns,
-)
+from timemachine.fe.energy_decomposition import EnergyDecomposedState, compute_energy_decomposed_u_kln, get_batch_u_fns
 from timemachine.fe.plots import (
     plot_as_png_fxn,
     plot_dG_errs_figure,
@@ -48,7 +43,10 @@ from timemachine.md.states import CoordsVelBox
 from timemachine.potentials import BoundPotential, HarmonicBond, NonbondedInteractionGroup, SummedPotential
 from timemachine.utils import batches, pairwise_transform_and_combine
 
-WATER_SAMPLER_MOVERS = (custom_ops.TIBDExchangeMove_f32, custom_ops.TIBDExchangeMove_f64)
+WATER_SAMPLER_MOVERS = (
+    custom_ops.TIBDExchangeMove_f32,
+    custom_ops.TIBDExchangeMove_f64,
+)
 
 
 class HostConfig:
@@ -728,6 +726,7 @@ def run_sims_sequential(
     # u_kln matrix (2, 2, n_frames) for each pair of adjacent lambda windows and energy term
     u_kln_by_component_by_lambda = []
 
+    unbound_impls = [p.potential.to_gpu(np.float32).unbound_impl for p in initial_states[0].potentials]
     for initial_state in initial_states:
         # run simulation
         traj = sample(initial_state, md_params, max_buffer_frames=100)
@@ -736,8 +735,7 @@ def run_sims_sequential(
         # keep samples from any requested states in memory
         stored_trajectories.append(traj)
 
-        bound_impls = [p.to_gpu(np.float32).bound_impl for p in initial_state.potentials]
-        cur_batch_U_fns = get_batch_u_fns(bound_impls, temperature)
+        cur_batch_U_fns = get_batch_u_fns(unbound_impls, [p.params for p in initial_state.potentials], temperature)
 
         state = EnergyDecomposedState(traj.frames, traj.boxes, cur_batch_U_fns)
 
@@ -754,12 +752,6 @@ def run_sims_sequential(
     ]
 
     return PairBarResult(list(initial_states), bar_results), stored_trajectories
-
-
-def make_batch_u_fns(initial_state: InitialState, temperature: float) -> List[Batch_u_fn]:
-    assert initial_state.barostat is None or initial_state.barostat.temperature == temperature
-    bound_impls = [p.to_gpu(np.float32).bound_impl for p in initial_state.potentials]
-    return get_batch_u_fns(bound_impls, temperature)
 
 
 class MinOverlapWarning(UserWarning):
@@ -814,6 +806,8 @@ def run_sims_bisection(
     assert len(initial_lambdas) >= 2
     assert np.all(np.diff(initial_lambdas) > 0), "initial lambda schedule must be monotonically increasing"
 
+    lambdas = list(initial_lambdas)
+
     get_initial_state = cache(make_initial_state)
 
     @cache
@@ -822,13 +816,16 @@ def run_sims_bisection(
         traj = sample(initial_state, md_params, max_buffer_frames=100)
         return traj
 
+    # Set up a single set of unbound potentials for computing the batch U fns
+    unbound_impls = [p.potential.to_gpu(np.float32).unbound_impl for p in get_initial_state(lambdas[0]).potentials]
+
     # NOTE: we don't cache get_state to avoid holding BoundPotentials in memory since they
     # 1. can use significant GPU memory
     # 2. can be reconstructed relatively quickly
     def get_state(lamb: float) -> EnergyDecomposedState[StoredArrays]:
         initial_state = get_initial_state(lamb)
         traj = get_samples(lamb)
-        batch_u_fns = make_batch_u_fns(initial_state, temperature)
+        batch_u_fns = get_batch_u_fns(unbound_impls, [p.params for p in initial_state.potentials], temperature)
         return EnergyDecomposedState(traj.frames, traj.boxes, batch_u_fns)
 
     @cache
@@ -855,7 +852,6 @@ def run_sims_bisection(
         bar_results = [get_bar_result(lamb1, lamb2) for lamb1, lamb2 in zip(lambdas, lambdas[1:])]
         return PairBarResult(refined_initial_states, bar_results)
 
-    lambdas = list(initial_lambdas)
     result = compute_intermediate_result(lambdas)
     results = [result]
 
@@ -1141,19 +1137,25 @@ def run_sims_hrex(
             print("Final replica permutation  :", hrex.replica_idx_by_state)
             print()
 
+    # Use the unbound potentials associated with the summed potential once to compute the u_kln
+    # Avoids repeated creation of underlying GPU potentials
+    assert isinstance(potential, custom_ops.SummedPotential)
+    unbound_impls = potential.get_potentials()
+
     def make_energy_decomposed_state(
-        results: Tuple[StoredArrays, List[NDArray], InitialState]
+        results: Tuple[StateIdx, StoredArrays, List[NDArray]]
     ) -> EnergyDecomposedState[StoredArrays]:
-        frames, boxes, initial_state = results
+        state_idx, frames, boxes = results
+        initial_state = initial_states[state_idx]
+        # Reuse the existing unbound potentials already constructed to make a batch Us fn
         return EnergyDecomposedState(
             frames,
             boxes,
-            get_batch_u_fns([pot.to_gpu(np.float32).bound_impl for pot in initial_state.potentials], temperature),
+            get_batch_u_fns(unbound_impls, [p.params for p in initial_state.potentials], temperature),
         )
 
     results_by_state = [
-        (samples.frames, samples.boxes, initial_state)
-        for samples, initial_state in zip(samples_by_state, initial_states)
+        (StateIdx(state_idx), samples.frames, samples.boxes) for state_idx, samples in enumerate(samples_by_state)
     ]
 
     bar_results = list(

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -726,6 +726,7 @@ def run_sims_sequential(
     # u_kln matrix (2, 2, n_frames) for each pair of adjacent lambda windows and energy term
     u_kln_by_component_by_lambda = []
 
+    # NOTE: this assumes that states differ only in their parameters, but we do not check this!
     unbound_impls = [p.potential.to_gpu(np.float32).unbound_impl for p in initial_states[0].potentials]
     for initial_state in initial_states:
         # run simulation
@@ -817,6 +818,7 @@ def run_sims_bisection(
         return traj
 
     # Set up a single set of unbound potentials for computing the batch U fns
+    # NOTE: this assumes that states differ only in their parameters, but we do not check this!
     unbound_impls = [p.potential.to_gpu(np.float32).unbound_impl for p in get_initial_state(lambdas[0]).potentials]
 
     # NOTE: we don't cache get_state to avoid holding BoundPotentials in memory since they

--- a/timemachine/md/enhanced.py
+++ b/timemachine/md/enhanced.py
@@ -470,8 +470,8 @@ def equilibrate_solvent_phase(
     friction = 1.0
 
     bps = []
-    for p, bp in zip(params, potentials):
-        bps.append(bp.bind(p))
+    for p, pot in zip(params, potentials):
+        bps.append(pot.bind(p))
 
     all_impls = [bp.to_gpu(np.float32).bound_impl for bp in bps]
 


### PR DESCRIPTION
* Re-using the preallocated potentials appears to get us back some performance

# Benchmarks
The reference refers to what is currently on master, the comparison is this branch. Generated using the test here: https://github.com/proteneer/timemachine/blob/1b8f07f102cdeab76f5b7e2126dcd8ba7bfcc49e/tests/test_benchmark_free_energy.py#L76 with the additional change to run with 2, 4, 8, 16, 32 and 48 windows as well as making sure every window always ran 100 frames. 

Run on an A10 GPU with Cuda Arch 8.6. Only sampled once, but think the differences are significant even without replicates.

Also ran a small graph (bisection + hrex + water sampling) that was about 5% faster with this change. 

## Vacuum
Doesn't make a difference on vacuum simulations, presumably the cost of constructing potentials is cheap (no neighborlist notably, tiny systems, etc)

![image](https://github.com/proteneer/timemachine/assets/5840832/98841f4c-f223-4647-a7d7-18821221a01e)


## Solvent
Seems to make the biggest difference for bisection

![image](https://github.com/proteneer/timemachine/assets/5840832/9ebaaa47-affb-4c31-9ebf-b47be28c6633)

## Complex

### Without water sampling
![image](https://github.com/proteneer/timemachine/assets/5840832/71c0c484-81ee-4181-a313-1647104ef723)

### With water sampling
![image](https://github.com/proteneer/timemachine/assets/5840832/98e129dc-faae-4250-b02a-6db3ee182b39)


