### PR TITLE
Add additional dependencies for mypy in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,13 @@ repos:
     rev: v1.5.1
     hooks:
     -   id: mypy
+        # include dependencies that export types (i.e. have a py.typed file in the root module) so that they can be used
+        # by mypy in pre-commit
         additional_dependencies:
+          - "jax==0.4.14"
           - "numpy==1.23.5"
+          - "scipy==1.10.1"
+          - "matplotlib==3.7.1"
 
         # Exclude custom_ops.py to work around clash with stub file when typechecking
         exclude: '^timemachine/lib/custom_ops.py$'


### PR DESCRIPTION
Currently mypy, when run via pre-commit, treats imports from jax and other libraries as having type `Any`, resulting in it failing to catch some type errors. This is due to the combination of 1) pre-commit running checks in isolated environments without dependencies installed by default, and 2) the mypy pre-commit hook automatically passing `--ignore-missing-imports` in the mypy invocation. See this [issue comment](https://github.com/python/mypy/issues/13916#issue-1412194622) for more details.

This PR:
1. Adds the remaining dependencies that export types to `additional_dependencies` for mypy in the pre-commit configuration
2. Fixes any newly-exposed type errors