### PR TITLE
Improve performance of HREX swap moves

### DIFF
--- a/tests/hrex/test_hrex_1d.py
+++ b/tests/hrex/test_hrex_1d.py
@@ -282,7 +282,8 @@ def plot_hrex_diagnostics(diagnostics: HREXDiagnostics):
 @pytest.mark.parametrize("swaps", [50_000])
 @pytest.mark.parametrize("seed", range(5))
 def test_batched_mixture_of_moves(num_states, seed, swaps):
-    replicas = np.random.uniform(size=num_states)
+    np.random.seed(seed)
+    replicas = sorted(np.random.uniform(size=num_states))
     states = [gaussian(loc, 0.3) for loc in replicas]
     state_idxs = [StateIdx(i) for i, _ in enumerate(states)]
     replica_idxs = [ReplicaIdx(i) for i, _ in enumerate(replicas)]
@@ -303,7 +304,6 @@ def test_batched_mixture_of_moves(num_states, seed, swaps):
             replica_idxs = move.move(replica_idxs)
         return move
 
-    np.random.seed(seed)
     move_seq = run_sequential_swaps(replica_idxs)
 
     move_batched = MixtureOfMoves(neighbor_swaps)

--- a/tests/hrex/test_hrex_1d.py
+++ b/tests/hrex/test_hrex_1d.py
@@ -112,7 +112,7 @@ def run_hrex_with_local_proposal(
         )
 
         def log_q(replica_idx: ReplicaIdx, state_idx: StateIdx) -> float:
-            return log_q_matrix[replica_idx, state_idx]
+            return log_q_matrix[replica_idx, state_idx].item()
 
         return log_q
 

--- a/tests/hrex/test_hrex_1d.py
+++ b/tests/hrex/test_hrex_1d.py
@@ -268,7 +268,7 @@ def test_hrex_gaussian_mixture(seed):
         return scipy.stats.ks_2samp(samples[tau::tau], target_samples).pvalue
 
     assert compute_ks_pvalue(local_samples) == pytest.approx(0.0, abs=1e-10)  # local sampling alone is insufficient
-    assert compute_ks_pvalue(hrex_samples) > 0.01
+    assert compute_ks_pvalue(hrex_samples) > 0.005
 
     final_swap_acceptance_rates = diagnostics.cumulative_swap_acceptance_rates[-1]
     assert final_swap_acceptance_rates[0] > 0.2

--- a/tests/hrex/test_hrex_rbfe.py
+++ b/tests/hrex/test_hrex_rbfe.py
@@ -31,11 +31,7 @@ from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topolo
 DEBUG = False
 
 
-@pytest.fixture(
-    scope="module", params=[None, "solvent", pytest.param("complex", marks=pytest.mark.nightly(reason="slow"))]
-)
-def hif2a_single_topology_leg(request):
-    host_name = request.param
+def get_hif2a_single_topology_leg(host_name: str | None):
     forcefield = Forcefield.load_default()
     host_config: Optional[HostConfig] = None
 
@@ -55,6 +51,13 @@ def hif2a_single_topology_leg(request):
     forcefield = Forcefield.load_default()
 
     return mol_a, mol_b, core, forcefield, host_config
+
+
+@pytest.fixture(
+    scope="module", params=[None, "solvent", pytest.param("complex", marks=pytest.mark.nightly(reason="slow"))]
+)
+def hif2a_single_topology_leg(request):
+    return get_hif2a_single_topology_leg(request.param)
 
 
 @pytest.mark.nightly(reason="Slow")

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -1005,14 +1005,6 @@ def run_sims_hrex(
         log_q = -U / (BOLTZ * temperature)
         return log_q
 
-    def get_log_q_fn(xvbs: List[CoordsVelBox]):
-        log_q_kl = compute_log_q_matrix(xvbs)
-
-        def log_q_fn(replica_idx: ReplicaIdx, state_idx: StateIdx) -> float:
-            return log_q_kl[replica_idx, state_idx]
-
-        return log_q_fn
-
     state_idxs = [StateIdx(i) for i, _ in enumerate(initial_states)]
     neighbor_pairs = list(zip(state_idxs, state_idxs[1:]))
 
@@ -1105,8 +1097,10 @@ def run_sims_hrex(
             return CoordsVelBox(traj.frames[-1], traj.final_velocities, traj.boxes[-1])
 
         hrex, samples_by_state_iter = hrex.sample_replicas(sample_replica, replica_from_samples)
-        log_q = get_log_q_fn(hrex.replicas)
-        hrex, fraction_accepted_by_pair = hrex.attempt_neighbor_swaps(neighbor_pairs, log_q, n_swap_attempts_per_iter)
+        log_q_kl = compute_log_q_matrix(hrex.replicas)
+        hrex, fraction_accepted_by_pair = hrex.attempt_neighbor_swaps_fast(
+            neighbor_pairs, log_q_kl, n_swap_attempts_per_iter
+        )
 
         if len(initial_states) == 2:
             fraction_accepted_by_pair = fraction_accepted_by_pair[1:]  # remove stats for identity move

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -998,7 +998,7 @@ def run_sims_hrex(
     if md_params.water_sampling_params is not None:
         water_params_by_state = np.array([get_water_sampler_params(initial_state) for initial_state in initial_states])
 
-    def compute_log_q_matrix(xvbs: List[CoordsVelBox]):
+    def compute_log_q_matrix(xvbs: List[CoordsVelBox]) -> NDArray:
         coords = np.array([xvb.coords for xvb in xvbs])
         boxes = np.array([xvb.box for xvb in xvbs])
         _, _, U = potential.execute_batch(coords, params_by_state, boxes, False, False, True)

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -70,7 +70,7 @@ def _run_neighbor_swaps(
         (n_pairs, 2) array representing allowed swaps
 
     log_q_kl : Array
-        (n_replicas, n_states) array with the (r, s) element giving the unnormalized probability of replica r in state s
+        (n_replicas, n_states) array with the (r, s) element giving the log unnormalized probability of replica r in state s
 
     pair_idxs : Array
         (n_swap_attempts,) array of indices of pairs for which to attempt swap moves
@@ -176,7 +176,7 @@ class HREX(Generic[Replica]):
             pairs of states between which to attempt swaps
 
         log_q : Callable[[ReplicaIdx, StateIdx], float]
-            function to compute the unnormalized probability of a given replica in a given state
+            function to compute the log unnormalized probability of a given replica in a given state
 
         n_swap_attempts : int
             number of individual swap attempts, each between a randomly-selected neighbor pair
@@ -208,7 +208,7 @@ class HREX(Generic[Replica]):
             pairs of states between which to attempt swaps
 
         log_q_kl : ArrayLike
-            (n_replicas, n_states) array with the (r, s) element giving the unnormalized probability of replica r in state s
+            (n_replicas, n_states) array with the (r, s) element giving the log unnormalized probability of replica r in state s
 
         n_swap_attempts : int
             number of individual swap attempts, each between a randomly-selected neighbor pair

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -200,7 +200,7 @@ class HREX(Generic[Replica]):
         """Run a batch of swap attempts.
 
         See :py:meth:`attempt_neighbor_swaps` for a (typically slower) reference version.
-        Note that these methods do not generate compatible random sequences.
+        Note that these methods do not generate identical random sequences.
 
         Parameters
         ----------

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -43,16 +43,12 @@ class NeighborSwapMove(MonteCarloMove[List[Replica]]):
 
 
 @jax.jit
-def run_neighbor_swaps(
+def _run_neighbor_swaps(
     keys: Array,
-    replica_idx_by_state: ArrayLike,
-    neighbor_pairs: ArrayLike,
-    log_q_kl: ArrayLike,
+    replica_idx_by_state: Array,
+    neighbor_pairs: Array,
+    log_q_kl: Array,
 ) -> Tuple[Array, Array, Array]:
-    replica_idx_by_state = jnp.asarray(replica_idx_by_state)
-    neighbor_pairs = jnp.asarray(neighbor_pairs)
-    log_q_kl = jnp.asarray(log_q_kl)
-
     def run_neighbor_swap(
         carry: Tuple[Array, Array, Array], key: PRNGKeyArray
     ) -> Tuple[Tuple[Array, Array, Array], None]:
@@ -142,8 +138,8 @@ class HREX(Generic[Replica]):
         key = jax.random.key(seed)
         keys = jax.random.split(key, n_swap_attempts)
 
-        replica_idx_by_state_, proposed, accepted = run_neighbor_swaps(
-            keys, jnp.asarray(self.replica_idx_by_state), jnp.asarray(neighbor_pairs), log_q_kl
+        replica_idx_by_state_, proposed, accepted = _run_neighbor_swaps(
+            keys, jnp.asarray(self.replica_idx_by_state), jnp.asarray(neighbor_pairs), jnp.asarray(log_q_kl)
         )
 
         replica_idx_by_state = replica_idx_by_state_.tolist()

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -120,7 +120,7 @@ def _run_neighbor_swaps(
 Samples = TypeVar("Samples")
 
 
-def get_jax_random_key() -> Array:
+def get_jax_random_key() -> PRNGKeyArray:
     """Return a JAX PRNG key initialized from global numpy random state"""
     seed = np.random.randint(np.iinfo(np.uint32).max)
     key = jax.random.key(seed)

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable, Generic, List, NewType, Optional, Sequence, Tuple, TypeVar
+from typing import Any, Callable, Generic, List, NewType, Optional, Sequence, Tuple, TypeVar
 
 import jax
 import jax.numpy as jnp
@@ -15,6 +15,8 @@ Replica = TypeVar("Replica")
 
 StateIdx = NewType("StateIdx", int)
 ReplicaIdx = NewType("ReplicaIdx", int)
+
+PRNGKeyArray = Any
 
 
 class NeighborSwapMove(MonteCarloMove[List[Replica]]):
@@ -51,7 +53,9 @@ def run_neighbor_swaps(
     neighbor_pairs = jnp.asarray(neighbor_pairs)
     log_q_kl = jnp.asarray(log_q_kl)
 
-    def run_neighbor_swap(carry: Tuple[Array, Array, Array], key: Array) -> Tuple[Tuple[Array, Array, Array], None]:
+    def run_neighbor_swap(
+        carry: Tuple[Array, Array, Array], key: PRNGKeyArray
+    ) -> Tuple[Tuple[Array, Array, Array], None]:
         replica_idx_by_state, proposed, accepted = carry
 
         key, subkey = jax.random.split(key)

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -92,7 +92,11 @@ def _run_neighbor_swaps(
 
         r_a = replica_idx_by_state[s_a]
         r_b = replica_idx_by_state[s_b]
-        log_q_diff = log_q_kl[r_a, s_b] + log_q_kl[r_b, s_a] - log_q_kl[r_a, s_a] - log_q_kl[r_b, s_b]
+
+        log_q_before = log_q_kl[r_a, s_a] + log_q_kl[r_b, s_b]
+        log_q_after = log_q_kl[r_a, s_b] + log_q_kl[r_b, s_a]
+
+        log_q_diff = log_q_after - log_q_before
 
         log_acceptance_probability = jnp.minimum(log_q_diff, 0.0)
         acceptance_probability = jnp.exp(log_acceptance_probability)

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -168,7 +168,7 @@ class HREX(Generic[Replica]):
         """Run a batch of swap attempts.
 
         See :py:meth:`attempt_neighbor_swaps_fast` for a more efficient implementation with a similar signature.
-        Note that these methods do not generate compatible random sequences.
+        Note that these methods do not generate identical random sequences.
 
         Parameters
         ----------

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -4,7 +4,7 @@ from typing import Callable, Generic, List, NewType, Optional, Sequence, Tuple, 
 import numpy as np
 from numpy.typing import NDArray
 
-from timemachine.md.moves import BatchedMixtureOfMoves, MonteCarloMove
+from timemachine.md.moves import MixtureOfMoves, MonteCarloMove
 from timemachine.utils import batches, not_ragged
 
 Replica = TypeVar("Replica")
@@ -69,11 +69,9 @@ class HREX(Generic[Replica]):
         log_q: Callable[[ReplicaIdx, StateIdx], float],
         n_swap_attempts: int,
     ) -> Tuple["HREX[Replica]", List[Tuple[int, int]]]:
-        move = BatchedMixtureOfMoves(
-            n_swap_attempts, [NeighborSwapMove(log_q, s_a, s_b) for s_a, s_b in neighbor_pairs]
-        )
+        move = MixtureOfMoves([NeighborSwapMove(log_q, s_a, s_b) for s_a, s_b in neighbor_pairs])
 
-        replica_idx_by_state = move.move(list(self.replica_idx_by_state))
+        replica_idx_by_state = move.move_n(list(self.replica_idx_by_state), n_swap_attempts)
 
         fraction_accepted_by_pair = list(zip(move.n_accepted_by_move, move.n_proposed_by_move))
 

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -385,7 +385,7 @@ def run_hrex(
 
     This implementation uses a method described in [1] (in section III.B.2) to generate effectively uncorrelated
     permutations by attempting many consecutive nearest-neighbor swap moves. By default, the number of swap moves is
-    determined as a function of the number of states (:math:`K`) as :math`N_{\text{swaps}} = K^4`, a heuristic also
+    determined as a function of the number of states (:math:`K`) as :math`N_{\text{swaps}} = K^3`, a heuristic also
     described in [1].
 
     References

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -120,6 +120,13 @@ def _run_neighbor_swaps(
 Samples = TypeVar("Samples")
 
 
+def get_jax_random_key() -> Array:
+    """Return a JAX PRNG key initialized from global numpy random state"""
+    seed = np.random.randint(np.iinfo(np.uint32).max)
+    key = jax.random.key(seed)
+    return key
+
+
 @dataclass(frozen=True)
 class HREX(Generic[Replica]):
     replicas: List[Replica]
@@ -207,9 +214,7 @@ class HREX(Generic[Replica]):
             Updated HREX state, list of (accepted, proposed) counts by neighbor pair
         """
 
-        # initialize jax rng key from numpy global rng state
-        seed = np.random.randint(np.iinfo(np.uint32).max)
-        key = jax.random.key(seed)
+        key = get_jax_random_key()
         keys = jax.random.split(key, n_swap_attempts)
 
         replica_idx_by_state_, proposed, accepted = _run_neighbor_swaps(

--- a/timemachine/md/moves.py
+++ b/timemachine/md/moves.py
@@ -24,6 +24,15 @@ class Move(Generic[_State], ABC):
     def move(self, _: _State) -> _State:
         ...
 
+    def move_n(self, x: _State, n: int) -> _State:
+        """Return the result of iterating the move n times.
+
+        Subclasses may override this to use a more efficient implementation, e.g. to generate random numbers in batch.
+        """
+        for _ in range(n):
+            x = self.move(x)
+        return x
+
     def sample_chain_iter(self, x: _State) -> Iterator[_State]:
         """Given an initial state, returns an iterator over an infinite sequence of samples"""
         while True:
@@ -31,7 +40,10 @@ class Move(Generic[_State], ABC):
             yield x
 
     def sample_chain(self, x: _State, n_samples: int) -> List[_State]:
-        """Given an initial state and number of samples, returns a finite sequence of samples"""
+        """Given an initial state and number of samples, returns a finite sequence of samples
+
+        Subclasses may override this to use a more efficient implementation, e.g. to generate random numbers in batch.
+        """
         return list(islice(self.sample_chain_iter(x), n_samples))
 
 
@@ -94,24 +106,21 @@ class MixtureOfMoves(CompoundMove[_State]):
         x = chosen_move.move(x)
         return x
 
-
-class BatchedMixtureOfMoves(MixtureOfMoves[_State]):
-    """Repeatedly sample from a uniform mixture of moves.
-
-    Has the same intended behavior as calling MixtureOfMoves multiple times. Added as a
-    performance optimization to avoid calling np.random.choice repeatedly, which can be expensive
-    as the number of moves gets large.
-    """
-
-    def __init__(self, batch_size: int, moves: Sequence[MonteCarloMove[_State]]):
-        self.batch_size = batch_size
-        super().__init__(moves)
-
-    def move(self, x) -> _State:
-        idxs = np.random.choice(len(self.moves), size=self.batch_size, replace=True)
+    def move_n(self, x: _State, n: int):
+        # Override default implementation to generate random selections in batch for efficiency
+        idxs = np.random.choice(len(self.moves), size=n, replace=True)
         for idx in idxs:
             x = self.moves[idx].move(x)
         return x
+
+    def sample_chain(self, x: _State, n_samples: int) -> List[_State]:
+        # Override default implementation to generate random selections in batch for efficiency
+        idxs = np.random.choice(len(self.moves), size=n_samples, replace=True)
+        samples = []
+        for idx in idxs:
+            x = self.moves[idx].move(x)
+            samples.append(x)
+        return samples
 
 
 class SequenceOfMoves(CompoundMove[_State]):


### PR DESCRIPTION
Investigations done as part of #1287 showed that the performance of HREX falls off rapidly for larger numbers of windows. This is particularly pronounced in vacuum, where the overhead of the HREX moves is large compared to sampling and computation of the $u_{kl}$ matrix. See the right-hand panel of the following figure:

<img width="500px" src="https://private-user-images.githubusercontent.com/5840832/323736023-9ca7a411-bf5e-4379-93a9-0211badc07ef.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTQxNDgxMTgsIm5iZiI6MTcxNDE0NzgxOCwicGF0aCI6Ii81ODQwODMyLzMyMzczNjAyMy05Y2E3YTQxMS1iZjVlLTQzNzktOTNhOS0wMjExYmFkYzA3ZWYucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDQyNiUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA0MjZUMTYxMDE4WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9ZDIwMTNiNzA0NDA0OGU2YzZkYzcxZmE5YzI3YjUwOWQyNWFkZDViNWMzMTNhMDU1MTMyOTE3NDcyMWUzNTVhYiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.AOCi5GfSoqY8_WfAA6SNzTdfB08qpQdtmB4FkFPQJ7A"></img>

The rapid dropoff in vacuum performance is largely due to the rapid growth (as $L^3$, according to the [heuristic](https://github.com/proteneer/timemachine/blob/70706e301ab99d8f3dd513ccd0af2235f8c89e82/timemachine/md/hrex.py#L220) we currently use) of the number of swap attempts per HREX iteration with $L$ windows. E.g. with 48 windows, we do $48^3 \approx 10^5$ swap attempts per iteration. Because a batch of swap attempts is currently implemented as an unoptimized pure-Python for loop, there should be significant room for performance improvement in the implementation.

This PR adds a specialized implementation of a batch of neighbor swap moves that generates random numbers in batches and leverages JAX's jit compilation for performance. Benchmarks show that this implementation is significantly more performant (~50-100x) for large numbers of windows, although the initial compilation does introduce a small amount of overhead with a small number of windows.

### HREX MD timings
100 frames, no water sampling. As expected, performance improvement is significant for vacuum and marginal for solvent (where sampling and $u_{kl}$ computation is much more significant)

![benchmarks](https://github.com/proteneer/timemachine/assets/319411/71bfe0b1-980d-4466-a11e-dd2dee001aa7)

### Profiling permutation moves
With 4 windows, the overhead of JIT compilation is significant:

- [master, 4 windows](https://github.com/proteneer/timemachine/assets/319411/eca94d75-0bc6-427a-883c-992901cf668e)
- [branch, 4 windows](https://github.com/proteneer/timemachine/assets/319411/5946fdda-d83b-4082-93f6-ae2cea35e9df)

With 48 windows, optimized version is ~10x faster:

- [master, 48 windows](https://github.com/proteneer/timemachine/assets/319411/24a0e544-6f51-4e78-8e4b-5879ee8516bb)
- [branch, 48 windows](https://github.com/proteneer/timemachine/assets/319411/d64a94ba-a2a6-4869-afa0-47b7022ec78f)

Time to run a single permutation move (consisting of $L^3$ swap attempts), for the current version ("ref") and the version in this PR ("fast"). The time to compute the $u_{kl}$ matrix ("u_kl") is shown for reference. Note: this does not include the initial JIT compilation time for the fast version, which only runs once for a given number of windows and takes about half a second.

![timings](https://github.com/proteneer/timemachine/assets/319411/8bff32e5-117b-4187-90a8-0a02eeefdbff)

### Other changes
- Removes `BatchedMixtureOfMoves` in favor of adding a method `move_n` to the base class. Subclasses can override the default definition of this and `sample_chain` to provide efficient implementations.

### TODO
- [x] Docstrings
- [ ] Update tests to also exercise reference version
- [ ] Test more directly comparing results of reference and fast version?