### PR TITLE
Improves performance of Local MD potentials

### DIFF
--- a/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
@@ -8,7 +8,13 @@ template <typename RealType>
 RealType __device__ __forceinline__ compute_flat_bottom_energy(RealType k, RealType r, RealType rmin, RealType rmax) {
     RealType r_gt_rmax = static_cast<RealType>(r > rmax);
     RealType r_lt_rmin = static_cast<RealType>(r < rmin);
-    return (k / 4) * (r_lt_rmin * (pow(r - rmin, 4)) + r_gt_rmax * (pow(r - rmax, 4)));
+    RealType d_rmin_2 = (r - rmin) * (r - rmin);
+    RealType d_rmin_4 = d_rmin_2 * d_rmin_2;
+
+    RealType d_rmax_2 = (r - rmax) * (r - rmax);
+    RealType d_rmax_4 = d_rmax_2 * d_rmax_2;
+
+    return (k / static_cast<RealType>(4.0)) * ((r_lt_rmin * d_rmin_4) + (r_gt_rmax * d_rmax_4));
 }
 
 template <typename RealType>
@@ -98,6 +104,7 @@ void __global__ k_flat_bottom_bond(
     // compute common subexpressions involving distance, displacements
     RealType dx[3];
     RealType r2 = 0;
+#pragma unroll
     for (int d = 0; d < 3; d++) {
         double delta = coords[src_idx * 3 + d] - coords[dst_idx * 3 + d];
         delta -= box[d * 3 + d] * nearbyint(delta / box[d * 3 + d]);
@@ -115,39 +122,48 @@ void __global__ k_flat_bottom_bond(
         // Always set the energy buffer value to ensure buffer is initialized
         u[b_idx] = FLOAT_TO_FIXED_ENERGY<RealType>(u_real);
     }
-
-    if (du_dp) {
-        // compute parameter derivatives
-        RealType du_dk_real = (r_gt_rmax * (pow(r - rmax, 4) / 4)) + (r_lt_rmin * (pow(r - rmin, 4) / 4));
-        RealType du_drmin_real = r_lt_rmin * (-k * pow(r - rmin, 3));
-        RealType du_drmax_real = r_gt_rmax * (-k * pow(r - rmax, 3));
-
-        // cast float -> fixed
-        auto du_dk = FLOAT_TO_FIXED_BONDED<RealType>(du_dk_real);
-        auto du_drmin = FLOAT_TO_FIXED_BONDED<RealType>(du_drmin_real);
-        auto du_drmax = FLOAT_TO_FIXED_BONDED<RealType>(du_drmax_real);
-
-        // increment du_dp array
-        atomicAdd(du_dp + k_idx, du_dk);
-        atomicAdd(du_dp + rmin_idx, du_drmin);
-        atomicAdd(du_dp + rmax_idx, du_drmax);
-    }
-
-    if (du_dx) {
-        RealType du_dr = k * ((r_gt_rmax * pow(r - rmax, 3)) + (r_lt_rmin * pow(r - rmin, 3)));
-
-        for (int d = 0; d < 3; d++) {
-            // compute du/dcoords
-            RealType du_dsrc_real = du_dr * dx[d] / r;
-            RealType du_ddst_real = -du_dsrc_real;
+    if (du_dp || du_dx) {
+        RealType d_r_min = r - rmin;
+        RealType d_r_max = r - rmax;
+        RealType d_rmin_3 = d_r_min * d_r_min * d_r_min;
+        RealType d_rmax_3 = d_r_max * d_r_max * d_r_max;
+        if (du_dp) {
+            // compute parameter derivatives
+            RealType du_dk_real =
+                (r_gt_rmax * ((d_rmax_3 * d_r_max) / static_cast<RealType>(4)) +
+                 (r_lt_rmin * ((d_rmin_3 * d_r_min) / static_cast<RealType>(4))));
+            RealType du_drmin_real = r_lt_rmin * (-k * d_rmin_3);
+            RealType du_drmax_real = r_gt_rmax * (-k * d_rmax_3);
 
             // cast float -> fixed
-            auto du_dsrc = FLOAT_TO_FIXED_BONDED<RealType>(du_dsrc_real);
-            auto du_ddst = FLOAT_TO_FIXED_BONDED<RealType>(du_ddst_real);
+            unsigned long long du_dk = FLOAT_TO_FIXED_BONDED<RealType>(du_dk_real);
+            unsigned long long du_drmin = FLOAT_TO_FIXED_BONDED<RealType>(du_drmin_real);
+            unsigned long long du_drmax = FLOAT_TO_FIXED_BONDED<RealType>(du_drmax_real);
 
-            // increment du_dx array
-            atomicAdd(du_dx + src_idx * 3 + d, du_dsrc);
-            atomicAdd(du_dx + dst_idx * 3 + d, du_ddst);
+            // increment du_dp array
+            atomicAdd(du_dp + k_idx, du_dk);
+            atomicAdd(du_dp + rmin_idx, du_drmin);
+            atomicAdd(du_dp + rmax_idx, du_drmax);
+        }
+
+        if (du_dx) {
+            RealType du_dr = k * ((r_gt_rmax * d_rmax_3) + (r_lt_rmin * d_rmin_3));
+
+            RealType inv_r = 1 / r;
+#pragma unroll
+            for (int d = 0; d < 3; d++) {
+                // compute du/dcoords
+                RealType du_dsrc_real = du_dr * dx[d] * inv_r;
+                RealType du_ddst_real = -du_dsrc_real;
+
+                // cast float -> fixed
+                unsigned long long du_dsrc = FLOAT_TO_FIXED_BONDED<RealType>(du_dsrc_real);
+                unsigned long long du_ddst = FLOAT_TO_FIXED_BONDED<RealType>(du_ddst_real);
+
+                // increment du_dx array
+                atomicAdd(du_dx + src_idx * 3 + d, du_dsrc);
+                atomicAdd(du_dx + dst_idx * 3 + d, du_ddst);
+            }
         }
     }
 }

--- a/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
@@ -12,7 +12,8 @@ RealType __device__ __forceinline__ compute_flat_bottom_energy(RealType k, RealT
     RealType d_rmin_2 = d_rmin * d_rmin;
     RealType d_rmin_4 = d_rmin_2 * d_rmin_2;
 
-    RealType d_rmax_2 = (r - rmax) * (r - rmax);
+    RealType d_rmax = r - rmax;
+    RealType d_rmax_2 = d_rmax * d_rmax;
     RealType d_rmax_4 = d_rmax_2 * d_rmax_2;
 
     return (k / static_cast<RealType>(4.0)) * ((r_lt_rmin * d_rmin_4) + (r_gt_rmax * d_rmax_4));

--- a/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_flat_bottom_bond.cuh
@@ -8,7 +8,8 @@ template <typename RealType>
 RealType __device__ __forceinline__ compute_flat_bottom_energy(RealType k, RealType r, RealType rmin, RealType rmax) {
     RealType r_gt_rmax = static_cast<RealType>(r > rmax);
     RealType r_lt_rmin = static_cast<RealType>(r < rmin);
-    RealType d_rmin_2 = (r - rmin) * (r - rmin);
+    RealType d_rmin = r - rmin;
+    RealType d_rmin_2 = d_rmin * d_rmin;
     RealType d_rmin_4 = d_rmin_2 * d_rmin_2;
 
     RealType d_rmax_2 = (r - rmax) * (r - rmax);

--- a/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
@@ -47,6 +47,7 @@ void __global__ k_log_flat_bottom_bond(
     // compute common subexpressions involving distance, displacements
     RealType dx[3];
     RealType r2 = 0;
+#pragma unroll
     for (int d = 0; d < 3; d++) {
         double delta = coords[src_idx * 3 + d] - coords[dst_idx * 3 + d];
         delta -= box[d * 3 + d] * nearbyint(delta / box[d * 3 + d]);
@@ -68,40 +69,47 @@ void __global__ k_log_flat_bottom_bond(
         u[b_idx] = FLOAT_TO_FIXED_ENERGY<RealType>(u_real);
     }
 
-    RealType prefactor = -exp(-beta * nrg) / (1 - exp(-beta * nrg));
+    RealType prefactor = -exp(-beta * nrg) / (static_cast<RealType>(1) - exp(-beta * nrg));
 
-    if (du_dp) {
-        // compute parameter derivatives
-        RealType du_dk_real = (r_gt_rmax * (pow(r - rmax, 4) / 4)) + (r_lt_rmin * (pow(r - rmin, 4) / 4));
-        RealType du_drmin_real = r_lt_rmin * (-k * pow(r - rmin, 3));
-        RealType du_drmax_real = r_gt_rmax * (-k * pow(r - rmax, 3));
-
-        // cast float -> fixed
-        auto du_dk = FLOAT_TO_FIXED_BONDED<RealType>(du_dk_real * prefactor);
-        auto du_drmin = FLOAT_TO_FIXED_BONDED<RealType>(du_drmin_real * prefactor);
-        auto du_drmax = FLOAT_TO_FIXED_BONDED<RealType>(du_drmax_real * prefactor);
-
-        // increment du_dp array
-        atomicAdd(du_dp + k_idx, du_dk);
-        atomicAdd(du_dp + rmin_idx, du_drmin);
-        atomicAdd(du_dp + rmax_idx, du_drmax);
-    }
-
-    if (du_dx) {
-        RealType du_dr = k * ((r_gt_rmax * pow(r - rmax, 3)) + (r_lt_rmin * pow(r - rmin, 3)));
-
-        for (int d = 0; d < 3; d++) {
-            // compute du/dcoords
-            RealType du_dsrc_real = du_dr * dx[d] / r;
-            RealType du_ddst_real = -du_dsrc_real;
+    if (du_dp || du_dx) {
+        RealType d_r_min = r - rmin;
+        RealType d_r_max = r - rmax;
+        RealType d_rmin_3 = d_r_min * d_r_min * d_r_min;
+        RealType d_rmax_3 = d_r_max * d_r_max * d_r_max;
+        if (du_dp) {
+            // compute parameter derivatives
+            RealType du_dk_real = (r_gt_rmax * ((d_rmax_3 * d_r_max) / static_cast<RealType>(4))) +
+                                  (r_lt_rmin * ((d_rmin_3 * d_r_min) / static_cast<RealType>(4)));
+            RealType du_drmin_real = r_lt_rmin * (-k * d_rmin_3);
+            RealType du_drmax_real = r_gt_rmax * (-k * d_rmax_3);
 
             // cast float -> fixed
-            auto du_dsrc = FLOAT_TO_FIXED_BONDED<RealType>(prefactor * du_dsrc_real);
-            auto du_ddst = FLOAT_TO_FIXED_BONDED<RealType>(prefactor * du_ddst_real);
+            unsigned long long du_dk = FLOAT_TO_FIXED_BONDED<RealType>(du_dk_real * prefactor);
+            unsigned long long du_drmin = FLOAT_TO_FIXED_BONDED<RealType>(du_drmin_real * prefactor);
+            unsigned long long du_drmax = FLOAT_TO_FIXED_BONDED<RealType>(du_drmax_real * prefactor);
 
-            // increment du_dx array
-            atomicAdd(du_dx + src_idx * 3 + d, du_dsrc);
-            atomicAdd(du_dx + dst_idx * 3 + d, du_ddst);
+            // increment du_dp array
+            atomicAdd(du_dp + k_idx, du_dk);
+            atomicAdd(du_dp + rmin_idx, du_drmin);
+            atomicAdd(du_dp + rmax_idx, du_drmax);
+        }
+
+        if (du_dx) {
+            RealType du_dr = k * ((r_gt_rmax * d_rmax_3) + (r_lt_rmin * d_rmin_3));
+#pragma unroll
+            for (int d = 0; d < 3; d++) {
+                // compute du/dcoords
+                RealType du_dsrc_real = du_dr * dx[d] / r;
+                RealType du_ddst_real = -du_dsrc_real;
+
+                // cast float -> fixed
+                unsigned long long du_dsrc = FLOAT_TO_FIXED_BONDED<RealType>(prefactor * du_dsrc_real);
+                unsigned long long du_ddst = FLOAT_TO_FIXED_BONDED<RealType>(prefactor * du_ddst_real);
+
+                // increment du_dx array
+                atomicAdd(du_dx + src_idx * 3 + d, du_dsrc);
+                atomicAdd(du_dx + dst_idx * 3 + d, du_ddst);
+            }
         }
     }
 }

--- a/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
+++ b/timemachine/cpp/src/kernels/k_log_flat_bottom_bond.cuh
@@ -69,7 +69,8 @@ void __global__ k_log_flat_bottom_bond(
         u[b_idx] = FLOAT_TO_FIXED_ENERGY<RealType>(u_real);
     }
 
-    RealType prefactor = -exp(-beta * nrg) / (static_cast<RealType>(1) - exp(-beta * nrg));
+    RealType prefactor = -exp(-beta * nrg);
+    prefactor = prefactor / (static_cast<RealType>(1) + prefactor);
 
     if (du_dp || du_dx) {
         RealType d_r_min = r - rmin;
@@ -96,10 +97,11 @@ void __global__ k_log_flat_bottom_bond(
 
         if (du_dx) {
             RealType du_dr = k * ((r_gt_rmax * d_rmax_3) + (r_lt_rmin * d_rmin_3));
+            RealType inv_r = 1 / r;
 #pragma unroll
             for (int d = 0; d < 3; d++) {
                 // compute du/dcoords
-                RealType du_dsrc_real = du_dr * dx[d] / r;
+                RealType du_dsrc_real = du_dr * dx[d] * inv_r;
                 RealType du_ddst_real = -du_dsrc_real;
 
                 // cast float -> fixed

--- a/timemachine/cpp/src/local_md_potentials.cu
+++ b/timemachine/cpp/src/local_md_potentials.cu
@@ -55,7 +55,7 @@ LocalMDPotentials::LocalMDPotentials(
         default_bonds[i * 2 + 1] = i + 1;
     }
     std::vector<double> default_params(N_ * 3);
-    free_restraint_ = std::shared_ptr<FlatBottomBond<double>>(new FlatBottomBond<double>(default_bonds));
+    free_restraint_ = std::shared_ptr<FlatBottomBond<float>>(new FlatBottomBond<float>(default_bonds));
     // Construct a bound potential with 0 params
     bound_free_restraint_ = std::shared_ptr<BoundPotential>(new BoundPotential(free_restraint_, default_params));
 
@@ -71,8 +71,8 @@ LocalMDPotentials::LocalMDPotentials(
     all_potentials_.push_back(bound_free_restraint_);
     all_potentials_.push_back(ixn_group_);
     if (!freeze_reference) {
-        frozen_restraint_ = std::shared_ptr<LogFlatBottomBond<double>>(
-            new LogFlatBottomBond<double>(default_bonds, 1 / (temperature * BOLTZ)));
+        frozen_restraint_ = std::shared_ptr<LogFlatBottomBond<float>>(
+            new LogFlatBottomBond<float>(default_bonds, 1 / (temperature * BOLTZ)));
         bound_frozen_restraint_ =
             std::shared_ptr<BoundPotential>(new BoundPotential(frozen_restraint_, default_params));
         all_potentials_.push_back(bound_frozen_restraint_);

--- a/timemachine/cpp/src/local_md_potentials.hpp
+++ b/timemachine/cpp/src/local_md_potentials.hpp
@@ -57,11 +57,11 @@ private:
     std::shared_ptr<BoundPotential> ixn_group_;
     std::shared_ptr<BoundPotential> nonbonded_bp_;
     // Restraint for the free particles to the reference particle
-    std::shared_ptr<FlatBottomBond<double>> free_restraint_;
+    std::shared_ptr<FlatBottomBond<float>> free_restraint_;
     std::shared_ptr<BoundPotential> bound_free_restraint_;
 
     // Restraint for the frozen particles to the reference particle
-    std::shared_ptr<LogFlatBottomBond<double>> frozen_restraint_;
+    std::shared_ptr<LogFlatBottomBond<float>> frozen_restraint_;
     std::shared_ptr<BoundPotential> bound_frozen_restraint_;
 
     DeviceBuffer<int> d_restraint_pairs_;


### PR DESCRIPTION
* Believe this was originally due to flaky tests, but was resolved with https://github.com/proteneer/timemachine/pull/1275
* Removes the `pow` calls in the flat bottom kernel. Makes for a 2x speed up of the kernel, though doesn't appear to matter much for the benchmarks.
* Nightlies all pass


## Kernel Timings

Kernels are 2x faster with the removal of the `pow` calls, both in float/double.

Ran `pytest -k flat_bottom_bond` to generate the timings

### Master
```
CUDA Kernel Statistics:

 Time (%)  Total Time (ns)  Instances  Avg (ns)  Med (ns)  Min (ns)  Max (ns)  StdDev (ns)                                                  Name                                                
 --------  ---------------  ---------  --------  --------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
     24.0          385,152         20  19,257.6  19,552.5    10,400    25,185      4,918.7  void timemachine::k_log_flat_bottom_bond<double>(int, const double *, const double *, const double …
     23.1          370,527         20  18,526.4  18,959.5    10,080    25,119      4,813.2  void timemachine::k_log_flat_bottom_bond<float>(int, const double *, const double *, const double *…
     22.4          359,233         20  17,961.7  18,096.0     4,288    28,096      7,806.7  void timemachine::k_flat_bottom_bond<double>(int, const double *, const double *, const double *, c…
     20.7          332,351         20  16,617.6  17,088.0     3,680    25,376      7,374.3  void timemachine::k_flat_bottom_bond<float>(int, const double *, const double *, const double *, co…
      9.6          154,459         48   3,217.9   3,168.0     3,135     3,776        130.7  void timemachine::k_accumulate_energy<(unsigned int)512>(int, const __int128 *, __int128 *)      
```

### PR
```
CUDA Kernel Statistics:

 Time (%)  Total Time (ns)  Instances  Avg (ns)  Med (ns)  Min (ns)  Max (ns)  StdDev (ns)                                                  Name                                                
 --------  ---------------  ---------  --------  --------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
     26.9          178,465         20   8,923.3   9,824.0     5,472    11,264      2,239.2  void timemachine::k_log_flat_bottom_bond<double>(int, const double *, const double *, const double …
     23.3          154,113         48   3,210.7   3,137.0     3,135     3,776        149.7  void timemachine::k_accumulate_energy<(unsigned int)512>(int, const __int128 *, __int128 *)         
     22.4          148,032         20   7,401.6   8,864.0     4,608     9,472      2,120.3  void timemachine::k_log_flat_bottom_bond<float>(int, const double *, const double *, const double *…
     15.1          100,256         20   5,012.8   5,056.0     4,256     6,368        582.1  void timemachine::k_flat_bottom_bond<double>(int, const double *, const double *, const double *, c…
     12.3           81,345         20   4,067.3   4,064.0     3,744     4,512        216.0  void timemachine::k_flat_bottom_bond<float>(int, const double *, const double *, const double *, co…
```

## Benchmarks
Only showing the local MD benchmarks as these changes only impacts local MD performance. Seems to be pretty much a wash when run in local MD, which appears to be due to the fact that this was never a bottleneck for local MD.

It appears that the local MD benchmarks are not converged. Looking at the output of `nsys` shows that the total run time of the flat bottom restraint went from 2.9% to 1.4% of the total runtime. Think that the other kernels (and perhaps set up time) is where the overhead is.

Run on A10, Cuda Arch 8.6

### Master
```
hif2a-rbfe-local: N=8840 speed: 1335.10ns/day dt: 2.5fs (ran 100000 steps in 16.18s)
solvent-rbfe-local: N=6317 speed: 1468.79ns/day dt: 2.5fs (ran 100000 steps in 14.71s)
```

### PR
```
hif2a-rbfe-local: N=8840 speed: 1331.59ns/day dt: 2.5fs (ran 100000 steps in 16.23s)
solvent-rbfe-local: N=6317 speed: 1435.01ns/day dt: 2.5fs (ran 100000 steps in 15.06s)
```