### PR TITLE
Switch to uint32 rather than int_ to avoid warning

### DIFF
--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -118,7 +118,7 @@ def _run_neighbor_swaps(
         return (result, None)
 
     n_pairs, _ = neighbor_pairs.shape
-    init = (replica_idx_by_state, jnp.zeros(n_pairs, jnp.int_), jnp.zeros(n_pairs, jnp.int_))
+    init = (replica_idx_by_state, jnp.zeros(n_pairs, jnp.uint32), jnp.zeros(n_pairs, jnp.uint32))
 
     (replica_idx_by_state, proposed, accepted), _ = jax.lax.scan(run_neighbor_swap, init, (pair_idxs, uniform_samples))
 


### PR DESCRIPTION
When running the new HREX code in 32 bit (without enabling 64 bit for jax) there is a warning. This changes the zeros to uint32s to avoid the warning.