### PR TITLE
Adds Nightly Memcheck job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -142,6 +142,24 @@ nightly-tests:
     when: on_success
     expire_in: 1 week
 
+nightly-memcheck-tests:
+  stage: test
+  image: $DOCKER_TAG
+  needs: ["lint"]
+  tags:
+    - gpu
+  rules:
+    - if: $NIGHTLY_TESTS
+  script:
+    - pip install .[test]
+    - make nightly_memcheck_tests
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-nightly-memcheck-tests"
+    paths:
+        - coverage/
+    when: on_success
+    expire_in: 1 week
+
 nightly-tests-nocuda:
   stage: test
   image: $DOCKER_TAG

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ nogpu_tests:
 
 .PHONY: memcheck_tests
 memcheck_tests:
-	compute-sanitizer --launch-timeout 120 --leak-check full --error-exitcode 1 pytest -m $(MEMCHECK_MARKER) $(PYTEST_CI_ARGS)
+	compute-sanitizer --launch-timeout 120 --leak-check full --error-exitcode 1 pytest -m '$(MEMCHECK_MARKER) and not $(NIGHTLY_MARKER)' $(PYTEST_CI_ARGS)
 
 .PHONY: unit_tests
 unit_tests:
@@ -51,6 +51,10 @@ unit_tests:
 .PHONY: nightly_tests
 nightly_tests:
 	pytest -m '$(NIGHTLY_MARKER) and not $(NOCUDA_MARKER) and not $(NOGPU_MARKER)' $(PYTEST_CI_ARGS)
+
+.PHONY: nightly_memcheck_tests
+nightly_memcheck_tests:
+	compute-sanitizer --launch-timeout 120 --leak-check full --error-exitcode 1 pytest -m '$(NIGHTLY_MARKER) and $(MEMCHECK_MARKER)' $(PYTEST_CI_ARGS)
 
 .PHONY: nocuda_nightly_tests
 nocuda_nightly_tests:

--- a/tests/test_cuda_bd_exchange_mover.py
+++ b/tests/test_cuda_bd_exchange_mover.py
@@ -186,7 +186,13 @@ def test_bd_exchange_get_set_params(precision):
 @pytest.mark.memcheck
 @pytest.mark.parametrize(
     "proposals_per_move,total_num_proposals,batch_size",
-    [(1, 1, 1), (1, 10, 1), (10, 10, 10), (1000, 10000, 1000), (1000, 10000, 333)],
+    [
+        (1, 1, 1),
+        (1, 10, 1),
+        (10, 10, 10),
+        pytest.param(1000, 10000, 1000, marks=pytest.mark.nightly(reason="slow")),
+        pytest.param(1000, 10000, 333, marks=pytest.mark.nightly(reason="slow")),
+    ],
 )
 @pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 5e-7, 5e-7), (np.float32, 1e-6, 2e-6)])
 @pytest.mark.parametrize("seed", [2023])
@@ -378,7 +384,10 @@ def test_bias_deletion_bulk_water_with_context(precision, seed, batch_size):
 
 
 @pytest.mark.memcheck
-@pytest.mark.parametrize("proposals_per_move, batch_size", [(1, 1), (10, 1), (2, 2), (100, 100), (1000, 333)])
+@pytest.mark.parametrize(
+    "proposals_per_move, batch_size",
+    [(1, 1), (10, 1), (2, 2), (100, 100), pytest.param(1000, 333, marks=pytest.mark.nightly(reason="slow"))],
+)
 @pytest.mark.parametrize("precision", [np.float64, np.float32])
 @pytest.mark.parametrize("seed", [2023])
 def test_bd_exchange_deterministic_moves(proposals_per_move, batch_size, precision, seed):

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -18,7 +18,10 @@ from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topolo
 pytestmark = [pytest.mark.memcheck]
 
 
-@pytest.mark.parametrize("precision,rtol,atol", [(np.float64, 1e-8, 1e-8), (np.float32, 1e-4, 1e-6)])
+@pytest.mark.parametrize(
+    "precision,rtol,atol",
+    [pytest.param(np.float64, 1e-8, 1e-8, marks=pytest.mark.nightly(reason="slow")), (np.float32, 1e-4, 1e-6)],
+)
 def test_deterministic_energies(precision, rtol, atol):
     """Verify that recomputing the energies of frames that have already had energies computed
     before, will produce the same bitwise identical energy.

--- a/tests/test_mtm.py
+++ b/tests/test_mtm.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import jax.random as jrandom
 import numpy as np
+import pytest
 
 from timemachine import testsystems
 from timemachine.constants import BOLTZ
@@ -23,6 +24,7 @@ def get_ff_am1ccc():
     return ff
 
 
+@pytest.mark.nightly
 def test_optimized_MTM():
     """
     Tests correctness of an optimized MTM in the condensed phase.


### PR DESCRIPTION
* Some of the memcheck tests are getting expensive and taking more time than the other jobs. Moved them to their own separate jobs where it seemed like the memcheck was not urgent
* Moved the optimized mtm test to nightly since it is relatively slow and we don't use this code much in practice
* Fixes up some warnings from pytest with the changes I had made in https://github.com/proteneer/timemachine/pull/1287/ that would have eventually turned into a pytest failure
* Reduces current CI from an hour 30 to about an hour 10. Nightlies stay around 6 hours