### PR TITLE
Test additional MCS pruning heuristics if `connected_core = True` 

### DIFF
--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -22,7 +22,7 @@ datasets = [
 
 
 @pytest.mark.nightly(reason="Slow")
-def test_connected_core_and_complete_rings_with_large_numbers_of_cores():
+def test_connected_core_with_large_numbers_of_cores():
     """The following tests that for two mols that have a large number of matching
     cores found prior to filtering out the molecules with disconnected cores and incomplete rings.
 
@@ -350,7 +350,6 @@ $$$$""",
         max_cores=1e6,  # This pair has 350k cores
         enforce_core_core=True,
         ring_matches_ring_only=False,
-        complete_rings=True,
         enforce_chiral=True,
         disallow_planar_torsion_flips=False,
         min_threshold=0,
@@ -390,7 +389,6 @@ def test_all_pairs(filepath):
                 max_cores=1000,
                 enforce_core_core=True,
                 ring_matches_ring_only=False,
-                complete_rings=False,
                 enforce_chiral=True,
                 disallow_planar_torsion_flips=False,
                 min_threshold=0,
@@ -420,59 +418,6 @@ def get_mol_by_name(mols, name):
             return m
 
     assert 0, "Mol not found"
-
-
-def test_complete_rings_only():
-    # this transformation has two ring changes:
-    # a 6->5 member ring size change and a unicycle to bicycle change
-    # we expect the MCS algorithm with complete rings only to map the single cycle core
-    mols = Chem.SDMolSupplier(datasets[0], removeHs=False)
-    mols = [m for m in mols]
-
-    mol_a = get_mol_by_name(mols, "43")
-    mol_b = get_mol_by_name(mols, "224")
-
-    all_cores = atom_mapping.get_cores(
-        mol_a,
-        mol_b,
-        ring_cutoff=0.1,
-        chain_cutoff=0.2,
-        max_visits=1e7,  # 10 million max nodes to visit
-        connected_core=True,
-        max_cores=1000,
-        enforce_core_core=True,
-        ring_matches_ring_only=True,
-        complete_rings=True,
-        enforce_chiral=True,
-        disallow_planar_torsion_flips=False,
-        min_threshold=0,
-    )
-
-    assert len(all_cores) == 1
-    core = all_cores[0]
-    np.testing.assert_array_equal(
-        np.array(
-            [
-                [1, 4],
-                [2, 5],
-                [3, 6],
-                [4, 7],
-                [5, 8],
-                [6, 9],
-                [7, 10],
-                [15, 12],
-                [16, 13],
-                [17, 14],
-                [18, 15],
-                [32, 18],
-                [19, 19],
-                [20, 20],
-                [26, 30],
-                [27, 31],
-            ]
-        ),
-        core,
-    )
 
 
 def tuples_to_set(arr):
@@ -579,7 +524,6 @@ $$$$""",
         max_cores=1000000,
         enforce_core_core=False,
         ring_matches_ring_only=False,
-        complete_rings=False,
         enforce_chiral=True,
         disallow_planar_torsion_flips=False,
         min_threshold=0,
@@ -602,7 +546,6 @@ $$$$""",
         max_cores=1000000,
         enforce_core_core=True,
         ring_matches_ring_only=False,
-        complete_rings=False,
         enforce_chiral=True,
         disallow_planar_torsion_flips=False,
         min_threshold=0,
@@ -627,7 +570,6 @@ $$$$""",
         max_cores=1000000,
         enforce_core_core=True,
         ring_matches_ring_only=False,
-        complete_rings=False,
         enforce_chiral=True,
         disallow_planar_torsion_flips=False,
         min_threshold=0,
@@ -759,7 +701,6 @@ def test_hif2a_failure():
         max_cores=1e6,
         enforce_core_core=True,
         ring_matches_ring_only=False,
-        complete_rings=True,
         enforce_chiral=True,
         disallow_planar_torsion_flips=False,
         min_threshold=0,
@@ -767,32 +708,38 @@ def test_hif2a_failure():
 
     expected_core = np.array(
         [
-            [24, 20],
-            [9, 9],
-            [26, 26],
-            [32, 31],
-            [6, 6],
+            [22, 15],
             [19, 12],
-            [4, 4],
-            [23, 19],
+            [3, 3],
             [2, 2],
-            [21, 14],
-            [27, 27],
+            [1, 1],
+            [18, 24],
+            [12, 21],
+            [11, 11],
+            [9, 9],
+            [8, 8],
+            [7, 7],
+            [6, 6],
+            [5, 5],
+            [4, 4],
+            [13, 22],
             [10, 10],
             [0, 0],
-            [3, 3],
-            [29, 16],
-            [25, 28],
-            [20, 13],
-            [1, 1],
-            [7, 7],
-            [22, 15],
-            [28, 17],
-            [36, 18],
-            [30, 29],
-            [5, 5],
+            [35, 33],
+            [33, 32],
+            [32, 31],
             [31, 30],
-            [8, 8],
+            [30, 29],
+            [25, 28],
+            [27, 27],
+            [26, 26],
+            [24, 20],
+            [23, 19],
+            [36, 18],
+            [28, 17],
+            [29, 16],
+            [21, 14],
+            [20, 13],
         ]
     )
 
@@ -817,7 +764,6 @@ def test_cyclohexane_stereo():
         max_cores=100000,
         enforce_core_core=True,
         ring_matches_ring_only=True,
-        complete_rings=False,
         enforce_chiral=True,
         disallow_planar_torsion_flips=False,
         min_threshold=0,
@@ -875,7 +821,6 @@ def test_chiral_atom_map():
         connected_core=True,
         max_cores=1e6,
         enforce_core_core=True,
-        complete_rings=False,
         disallow_planar_torsion_flips=False,
         ring_matches_ring_only=True,
         min_threshold=0,
@@ -913,7 +858,6 @@ def test_ring_matches_ring_only(ring_matches_ring_only):
         connected_core=True,
         max_cores=1e6,
         enforce_core_core=False,
-        complete_rings=False,
         enforce_chiral=False,
         disallow_planar_torsion_flips=False,
         min_threshold=0,
@@ -941,7 +885,6 @@ def test_max_visits_warning():
         max_cores=1000,
         enforce_core_core=True,
         ring_matches_ring_only=False,
-        complete_rings=False,
         enforce_chiral=True,
         disallow_planar_torsion_flips=False,
         min_threshold=0,
@@ -962,7 +905,6 @@ def test_max_cores_warning():
         connected_core=False,
         enforce_core_core=True,
         ring_matches_ring_only=False,
-        complete_rings=False,
         enforce_chiral=True,
         disallow_planar_torsion_flips=False,
         min_threshold=0,
@@ -981,7 +923,6 @@ def test_min_threshold():
         max_cores=1000,
         enforce_core_core=True,
         ring_matches_ring_only=False,
-        complete_rings=False,
         enforce_chiral=True,
         disallow_planar_torsion_flips=False,
         min_threshold=mol_a.GetNumAtoms(),

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -383,7 +383,7 @@ def test_all_pairs(filepath):
             all_cores = atom_mapping.get_cores(
                 mol_a,
                 mol_b,
-                ring_cutoff=0.2,
+                ring_cutoff=0.1,
                 chain_cutoff=0.2,
                 max_visits=1e7,  # 10 million max nodes to visit
                 connected_core=False,
@@ -412,8 +412,6 @@ def test_all_pairs(filepath):
             print(
                 f"{mol_a.GetProp('_Name')} -> {mol_b.GetProp('_Name')} has {len(all_cores)} cores of size {len(all_cores[0])}"
             )
-
-            # assert 0
 
 
 def get_mol_by_name(mols, name):

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -379,10 +379,11 @@ def test_all_pairs(filepath):
     mols = read_sdf(filepath)
     for idx, mol_a in enumerate(mols):
         for mol_b in mols[idx + 1 :]:
+            # print("Processing", get_mol_name(mol_a), "->", get_mol_name(mol_b))
             all_cores = atom_mapping.get_cores(
                 mol_a,
                 mol_b,
-                ring_cutoff=0.1,
+                ring_cutoff=0.2,
                 chain_cutoff=0.2,
                 max_visits=1e7,  # 10 million max nodes to visit
                 connected_core=False,
@@ -411,6 +412,8 @@ def test_all_pairs(filepath):
             print(
                 f"{mol_a.GetProp('_Name')} -> {mol_b.GetProp('_Name')} has {len(all_cores)} cores of size {len(all_cores[0])}"
             )
+
+            # assert 0
 
 
 def get_mol_by_name(mols, name):

--- a/tests/test_chiral_restraints.py
+++ b/tests/test_chiral_restraints.py
@@ -666,6 +666,14 @@ def make_chiral_flip_pair(well_aligned=True):
     mol_b_1 = mol_dict["B_1"]
     core_0 = get_cores(mol_a, mol_b_0, **DEFAULT_ATOM_MAPPING_KWARGS)[0]
     core_1 = get_cores(mol_a, mol_b_1, **DEFAULT_ATOM_MAPPING_KWARGS)[0]
+
+    from timemachine.fe.utils import plot_atom_mapping_grid
+
+    for core_idx, core in enumerate(core_0[:1]):
+        res = plot_atom_mapping_grid(mol_a, mol_b_0, core_0, num_rotations=5)
+        with open(f"atom_mapping_0_to_1_core_{core_idx}.svg", "w") as fh:
+            fh.write(res)
+
     assert len(core_0) == 10
     assert len(core_1) == 15
 

--- a/tests/test_chiral_restraints.py
+++ b/tests/test_chiral_restraints.py
@@ -6,13 +6,8 @@ import scipy
 from jax import numpy as jnp
 from rdkit import Chem
 
-from timemachine.constants import (
-    DEFAULT_ATOM_MAPPING_KWARGS,
-    DEFAULT_CHIRAL_ATOM_RESTRAINT_K,
-    DEFAULT_CHIRAL_BOND_RESTRAINT_K,
-)
+from timemachine.constants import DEFAULT_CHIRAL_ATOM_RESTRAINT_K, DEFAULT_CHIRAL_BOND_RESTRAINT_K
 from timemachine.fe import topology, utils
-from timemachine.fe.atom_mapping import get_cores
 from timemachine.fe.chiral_utils import make_chiral_flip_heatmaps
 from timemachine.fe.free_energy import HREXParams
 from timemachine.fe.rbfe import DEFAULT_HREX_PARAMS, run_solvent, run_vacuum
@@ -664,18 +659,28 @@ def make_chiral_flip_pair(well_aligned=True):
     mol_a = mol_dict["A"]
     mol_b_0 = mol_dict["B_0"]
     mol_b_1 = mol_dict["B_1"]
-    core_0 = get_cores(mol_a, mol_b_0, **DEFAULT_ATOM_MAPPING_KWARGS)[0]
-    core_1 = get_cores(mol_a, mol_b_1, **DEFAULT_ATOM_MAPPING_KWARGS)[0]
 
-    from timemachine.fe.utils import plot_atom_mapping_grid
-
-    for core_idx, core in enumerate(core_0[:1]):
-        res = plot_atom_mapping_grid(mol_a, mol_b_0, core_0, num_rotations=5)
-        with open(f"atom_mapping_0_to_1_core_{core_idx}.svg", "w") as fh:
-            fh.write(res)
-
-    assert len(core_0) == 10
-    assert len(core_1) == 15
+    # hard-coded core
+    core_0 = np.array([[6, 3], [4, 4], [5, 5], [3, 6], [15, 10], [14, 11], [12, 12], [13, 13], [11, 14], [10, 15]])
+    core_1 = np.array(
+        [
+            [0, 0],
+            [1, 1],
+            [2, 2],
+            [3, 3],
+            [4, 4],
+            [12, 5],
+            [6, 6],
+            [7, 7],
+            [9, 8],
+            [8, 9],
+            [10, 10],
+            [11, 11],
+            [5, 12],
+            [15, 14],
+            [14, 15],
+        ]
+    )
 
     if well_aligned:
         return AtomMapMixin(mol_a, mol_b_1, core_1)

--- a/timemachine/constants.py
+++ b/timemachine/constants.py
@@ -36,7 +36,6 @@ DEFAULT_ATOM_MAPPING_KWARGS = {
     "max_cores": 1e5,
     "enforce_core_core": True,
     "ring_matches_ring_only": True,
-    "complete_rings": False,
     "enforce_chiral": True,
     "disallow_planar_torsion_flips": True,
     "min_threshold": 0,

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -80,7 +80,6 @@ def get_cores_and_diagnostics(
 
     # we require that mol_a.GetNumAtoms() <= mol_b.GetNumAtoms()
     if mol_a.GetNumAtoms() > mol_b.GetNumAtoms():
-        print("Swapping")
         all_cores, mcs_diagnostics = _get_cores_impl(mol_b, mol_a, **core_kwargs)
         new_cores = []
         for core in all_cores:
@@ -435,29 +434,13 @@ def _get_cores_impl(
         max_visits,
         max_cores,
         enforce_core_core,
+        connected_core,
         min_threshold,
         filter_fxn=filter_fxn,
     )
 
     all_bond_cores = [_compute_bond_cores(mol_a, mol_b, marcs) for marcs in all_marcs]
-
-    if connected_core and complete_rings:
-        # 1) remove any disconnected components or lone atoms in the mapping
-        # so disconnected regions are not considered as part of the incomplete rings check.
-        # 2) deduplicate cores, to avoid checking incomplete rings on the same core
-        # 3) remove any incomplete rings
-        # 4) deduplicate cores, to avoid removing disconnections on the same core
-        # 5) remove any disconnections created by removing the incomplete rings.
-        all_cores, all_bond_cores = remove_disconnected_components(mol_a, mol_b, all_cores, all_bond_cores)
-        all_cores, all_bond_cores = _deduplicate_all_cores_and_bonds(all_cores, all_bond_cores)
-
-        all_cores, all_bond_cores = remove_incomplete_rings(mol_a, mol_b, all_cores, all_bond_cores)
-        all_cores, all_bond_cores = _deduplicate_all_cores_and_bonds(all_cores, all_bond_cores)
-
-        all_cores, all_bond_cores = remove_disconnected_components(mol_a, mol_b, all_cores, all_bond_cores)
-    elif connected_core and not complete_rings:
-        all_cores, all_bond_cores = remove_disconnected_components(mol_a, mol_b, all_cores, all_bond_cores)
-    elif not connected_core and complete_rings:
+    if complete_rings:
         all_cores, all_bond_cores = remove_incomplete_rings(mol_a, mol_b, all_cores, all_bond_cores)
 
     all_cores = remove_cores_smaller_than_largest(all_cores)

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -80,6 +80,7 @@ def get_cores_and_diagnostics(
 
     # we require that mol_a.GetNumAtoms() <= mol_b.GetNumAtoms()
     if mol_a.GetNumAtoms() > mol_b.GetNumAtoms():
+        print("Swapping")
         all_cores, mcs_diagnostics = _get_cores_impl(mol_b, mol_a, **core_kwargs)
         new_cores = []
         for core in all_cores:
@@ -363,7 +364,8 @@ def _get_cores_impl(
     disallow_planar_torsion_flips,
     min_threshold,
 ) -> Tuple[List[NDArray], mcgregor.MCSDiagnostics]:
-    mol_a, perm = reorder_atoms_by_degree(mol_a)  # UNINVERT
+    # mol_a, perm = reorder_atoms_by_degree(mol_a)  # UNINVERT
+    perm = np.arange(mol_a.GetNumAtoms())  # debug
 
     bonds_a = get_romol_bonds(mol_a)
     bonds_b = get_romol_bonds(mol_b)

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -363,8 +363,7 @@ def _get_cores_impl(
     disallow_planar_torsion_flips,
     min_threshold,
 ) -> Tuple[List[NDArray], mcgregor.MCSDiagnostics]:
-    # mol_a, perm = reorder_atoms_by_degree(mol_a)  # UNINVERT
-    perm = np.arange(mol_a.GetNumAtoms())  # debug
+    mol_a, perm = reorder_atoms_by_degree(mol_a)  # UNINVERT
 
     bonds_a = get_romol_bonds(mol_a)
     bonds_b = get_romol_bonds(mol_b)

--- a/timemachine/fe/mcgregor.py
+++ b/timemachine/fe/mcgregor.py
@@ -310,7 +310,7 @@ def _graph_is_disconnected(g, mapped_nodes, demapped_nodes, unvisited_nodes):
         sg_ccs = nx.connected_components(sg_all_possible)
         # see if all the mapped nodes belong to the same connected component
         for cc in sg_ccs:
-            if set(cc).intersection(mapped_nodes) == set(mapped_nodes):
+            if set(mapped_nodes).issubset(cc):
                 return False
         return True
     else:


### PR DESCRIPTION
This PR adds an additional pruning heuristics that checks and see if a given atom-mapping will result in a disconnected core.
The algorithm works as follows: 

1. Given a graph `G`, and a set of nodes `N` and edges `E`, partition `N` into three groups: `A` is mapped vertices, `B` is de-mapped vertices, and `C` is unvisited vertices. A de-mapped vertex is a vertex that has been visited but is explicitly omitted from the atom-mapping. 
2. Let `P` be the union of `A` and `C`. Note that this may form disconnected components.
3. Enumerate the connected components on the subgraph of `G` induced by `P`: `cc_1, cc_2, ...`
4. If `A` is entirely a subset of one of `cc_1, cc_2, etc`, then the atom-mapping can still be connected down-stream. Otherwise, `A` has already been fragmented into multiple connected components and the atom-mapping is guaranteed to result in a disconnected core. 