### PR TITLE
Avoid reading in an invalid sample, triggering an invalid memory access

### DIFF
--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -1,5 +1,7 @@
+import pickle
 from dataclasses import replace
 from importlib import resources
+from pathlib import Path
 from typing import List
 
 import numpy as np
@@ -1067,3 +1069,11 @@ def test_targeted_moves_with_complex_and_ligand_in_brd4(
             # If an unexpect error was raised, re-raise the error
             raise
     assert False, f"No moves were made after {iterations}"
+
+
+@pytest.mark.memcheck
+def test_targeted_insertion_invalid_sample_bug():
+    with open(Path(__file__).parent / "data" / "water_sampling_bug.pkl", "rb") as ifs:
+        state, md_params = pickle.load(ifs)
+    md_params = replace(md_params, n_eq_steps=10_000, steps_per_frame=10)
+    sample(state, md_params, 100)

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -1075,5 +1075,5 @@ def test_targeted_moves_with_complex_and_ligand_in_brd4(
 def test_targeted_insertion_invalid_sample_bug():
     with open(Path(__file__).parent / "data" / "water_sampling_bug.pkl", "rb") as ifs:
         state, md_params = pickle.load(ifs)
-    md_params = replace(md_params, n_eq_steps=10_000, steps_per_frame=10)
+    md_params = replace(md_params, n_eq_steps=2_000, steps_per_frame=10)
     sample(state, md_params, 100)

--- a/timemachine/cpp/src/kernels/k_exchange.cu
+++ b/timemachine/cpp/src/kernels/k_exchange.cu
@@ -759,19 +759,11 @@ void __global__ k_adjust_sample_idxs(
     const int local_inner_count = *inner_count;
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    while (idx < batch_size) {
-        if (idx + current_offset >= total_proposals) {
-            // The value here is not important, as the result will be ignored in subsequent kernels
-            // This is done to avoid the fact that the original sampled indices may contain invalid state
-            // thanks to the way the batching performed.
-            sample_idxs[idx] = 0;
-        } else {
-            const int target_inner = targeting_inner_volume[idx];
-            const int offset = target_inner == 1 ? local_inner_count : 0;
-            const int before = sample_idxs[idx];
-            sample_idxs[idx] = partitioned_indices[before + offset];
-            idx += gridDim.x * blockDim.x;
-        }
+    while (idx < batch_size && idx + current_offset < total_proposals) {
+        const int target_inner = targeting_inner_volume[idx];
+        const int offset = target_inner == 1 ? local_inner_count : 0;
+        const int before = sample_idxs[idx];
+        sample_idxs[idx] = partitioned_indices[before + offset];
         idx += gridDim.x * blockDim.x;
     }
 }

--- a/timemachine/cpp/src/kernels/k_exchange.cu
+++ b/timemachine/cpp/src/kernels/k_exchange.cu
@@ -761,7 +761,7 @@ void __global__ k_adjust_sample_idxs(
 
     while (idx < batch_size) {
         if (idx + current_offset >= total_proposals) {
-            // The value here is not important, as the result will be ignored in subsuequent kernels
+            // The value here is not important, as the result will be ignored in subsequent kernels
             // This is done to avoid the fact that the original sampled indices may contain invalid state
             // thanks to the way the batching performed.
             sample_idxs[idx] = 0;

--- a/timemachine/cpp/src/kernels/k_exchange.cu
+++ b/timemachine/cpp/src/kernels/k_exchange.cu
@@ -752,7 +752,7 @@ void __global__ k_adjust_sample_idxs(
     const int *__restrict__ noise_offset,           // [1]
     const int *__restrict__ targeting_inner_volume, // [batch_size]
     const int *__restrict__ inner_count,            // [1]
-    const int *__restrict__ partitioned_indices,    // [K]
+    const int *__restrict__ partitioned_indices,    // [num_samples]
     int *__restrict__ sample_idxs                   // [batch_size]
 ) {
     const int current_offset = *noise_offset;

--- a/timemachine/cpp/src/kernels/k_exchange.cu
+++ b/timemachine/cpp/src/kernels/k_exchange.cu
@@ -747,20 +747,31 @@ template void __global__ k_setup_destination_weights_for_targeted<double>(
 );
 
 void __global__ k_adjust_sample_idxs(
+    const int total_proposals,
     const int batch_size,
+    const int *__restrict__ noise_offset,           // [1]
     const int *__restrict__ targeting_inner_volume, // [batch_size]
     const int *__restrict__ inner_count,            // [1]
-    const int *__restrict__ partitioned_indices,    // [inner_count]
+    const int *__restrict__ partitioned_indices,    // [K]
     int *__restrict__ sample_idxs                   // [batch_size]
 ) {
-    const int local_inner_count = inner_count[0];
+    const int current_offset = *noise_offset;
+    const int local_inner_count = *inner_count;
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
     while (idx < batch_size) {
-        const int target_inner = targeting_inner_volume[idx];
-        const int offset = target_inner == 1 ? local_inner_count : 0;
-        const int before = sample_idxs[idx];
-        sample_idxs[idx] = partitioned_indices[before + offset];
+        if (idx + current_offset >= total_proposals) {
+            // The value here is not important, as the result will be ignored in subsuequent kernels
+            // This is done to avoid the fact that the original sampled indices may contain invalid state
+            // thanks to the way the batching performed.
+            sample_idxs[idx] = 0;
+        } else {
+            const int target_inner = targeting_inner_volume[idx];
+            const int offset = target_inner == 1 ? local_inner_count : 0;
+            const int before = sample_idxs[idx];
+            sample_idxs[idx] = partitioned_indices[before + offset];
+            idx += gridDim.x * blockDim.x;
+        }
         idx += gridDim.x * blockDim.x;
     }
 }

--- a/timemachine/cpp/src/kernels/k_exchange.cu
+++ b/timemachine/cpp/src/kernels/k_exchange.cu
@@ -747,31 +747,20 @@ template void __global__ k_setup_destination_weights_for_targeted<double>(
 );
 
 void __global__ k_adjust_sample_idxs(
-    const int total_proposals,
     const int batch_size,
-    const int *__restrict__ noise_offset,           // [1]
     const int *__restrict__ targeting_inner_volume, // [batch_size]
     const int *__restrict__ inner_count,            // [1]
-    const int *__restrict__ partitioned_indices,    // [K]
+    const int *__restrict__ partitioned_indices,    // [inner_count]
     int *__restrict__ sample_idxs                   // [batch_size]
 ) {
-    const int current_offset = *noise_offset;
-    const int local_inner_count = *inner_count;
+    const int local_inner_count = inner_count[0];
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
     while (idx < batch_size) {
-        if (idx + current_offset >= total_proposals) {
-            // The value here is not important, as the result will be ignored in subsuequent kernels
-            // This is done to avoid the fact that the original sampled indices may contain invalid state
-            // thanks to the way the batching performed.
-            sample_idxs[idx] = 0;
-        } else {
-            const int target_inner = targeting_inner_volume[idx];
-            const int offset = target_inner == 1 ? local_inner_count : 0;
-            const int before = sample_idxs[idx];
-            sample_idxs[idx] = partitioned_indices[before + offset];
-            idx += gridDim.x * blockDim.x;
-        }
+        const int target_inner = targeting_inner_volume[idx];
+        const int offset = target_inner == 1 ? local_inner_count : 0;
+        const int before = sample_idxs[idx];
+        sample_idxs[idx] = partitioned_indices[before + offset];
         idx += gridDim.x * blockDim.x;
     }
 }

--- a/timemachine/cpp/src/kernels/k_exchange.cuh
+++ b/timemachine/cpp/src/kernels/k_exchange.cuh
@@ -202,7 +202,7 @@ void __global__ k_setup_destination_weights_for_targeted(
 
 // k_adjust_sample_idxs is to to handle that in the TIBD exchange move the initial samples
 // are selected from either the inner or outer volume. So the indices will go from 0 -> len(inner) or len(outer)
-// depending on the region being sampled. All of the downstream code expect the sample idxs to be from 0 -> num_samples
+// depending on the region being sampled. All of the downstream code expect the sample idxs to be from 0 -> num_mols
 // This kernel simple adjusts the sample idxs to match that expectation.
 void __global__ k_adjust_sample_idxs(
     const int total_proposals,
@@ -210,7 +210,7 @@ void __global__ k_adjust_sample_idxs(
     const int *__restrict__ noise_offset,           // [1]
     const int *__restrict__ targeting_inner_volume, // [batch_size]
     const int *__restrict__ inner_count,            // [1]
-    const int *__restrict__ partitioned_indices,    // [num_samples]
+    const int *__restrict__ partitioned_indices,    // [num_mols]
     int *__restrict__ sample_idxs                   // [batch_size]
 );
 

--- a/timemachine/cpp/src/kernels/k_exchange.cuh
+++ b/timemachine/cpp/src/kernels/k_exchange.cuh
@@ -200,6 +200,10 @@ void __global__ k_setup_destination_weights_for_targeted(
     const RealType *__restrict__ weights,           // [num_target_mols]
     RealType *__restrict__ output_weights);
 
+// k_adjust_sample_idxs is to to handle that in the TIBD exchange move the initial samples
+// are selected from either the inner or outer volume. So the indices will go from 0 -> len(inner) or len(outer)
+// depending on the region being sampled. All of the downstream code expect the sample idxs to be from 0 -> num_samples
+// This kernel simple adjusts the sample idxs to match that expectation.
 void __global__ k_adjust_sample_idxs(
     const int total_proposals,
     const int batch_size,

--- a/timemachine/cpp/src/kernels/k_exchange.cuh
+++ b/timemachine/cpp/src/kernels/k_exchange.cuh
@@ -201,12 +201,10 @@ void __global__ k_setup_destination_weights_for_targeted(
     RealType *__restrict__ output_weights);
 
 void __global__ k_adjust_sample_idxs(
-    const int total_proposals,
     const int batch_size,
-    const int *__restrict__ noise_offset,           // [1]
     const int *__restrict__ targeting_inner_volume, // [batch_size]
     const int *__restrict__ inner_count,            // [1]
-    const int *__restrict__ partitioned_indices,    // [K]
+    const int *__restrict__ partitioned_indices,    // [inner_count]
     int *__restrict__ sample_idxs                   // [batch_size]
 );
 

--- a/timemachine/cpp/src/kernels/k_exchange.cuh
+++ b/timemachine/cpp/src/kernels/k_exchange.cuh
@@ -206,7 +206,7 @@ void __global__ k_adjust_sample_idxs(
     const int *__restrict__ noise_offset,           // [1]
     const int *__restrict__ targeting_inner_volume, // [batch_size]
     const int *__restrict__ inner_count,            // [1]
-    const int *__restrict__ partitioned_indices,    // [K]
+    const int *__restrict__ partitioned_indices,    // [num_samples]
     int *__restrict__ sample_idxs                   // [batch_size]
 );
 

--- a/timemachine/cpp/src/kernels/k_exchange.cuh
+++ b/timemachine/cpp/src/kernels/k_exchange.cuh
@@ -201,10 +201,12 @@ void __global__ k_setup_destination_weights_for_targeted(
     RealType *__restrict__ output_weights);
 
 void __global__ k_adjust_sample_idxs(
+    const int total_proposals,
     const int batch_size,
+    const int *__restrict__ noise_offset,           // [1]
     const int *__restrict__ targeting_inner_volume, // [batch_size]
     const int *__restrict__ inner_count,            // [1]
-    const int *__restrict__ partitioned_indices,    // [inner_count]
+    const int *__restrict__ partitioned_indices,    // [K]
     int *__restrict__ sample_idxs                   // [batch_size]
 );
 

--- a/timemachine/cpp/src/tibd_exchange_move.cu
+++ b/timemachine/cpp/src/tibd_exchange_move.cu
@@ -293,7 +293,9 @@ void TIBDExchangeMove<RealType>::move(
 
         // Selected an index from the src weights, need to remap the samples idx to the mol indices
         k_adjust_sample_idxs<<<sample_blocks, tpb, 0, stream>>>(
+            this->num_proposals_per_move_,
             this->batch_size_,
+            this->d_noise_offset_.data,
             d_targeting_inner_vol_.data,
             d_inner_mols_count_.data,
             d_partitioned_indices_.data,

--- a/timemachine/cpp/src/tibd_exchange_move.cu
+++ b/timemachine/cpp/src/tibd_exchange_move.cu
@@ -293,9 +293,7 @@ void TIBDExchangeMove<RealType>::move(
 
         // Selected an index from the src weights, need to remap the samples idx to the mol indices
         k_adjust_sample_idxs<<<sample_blocks, tpb, 0, stream>>>(
-            this->num_proposals_per_move_,
             this->batch_size_,
-            this->d_noise_offset_.data,
             d_targeting_inner_vol_.data,
             d_inner_mols_count_.data,
             d_partitioned_indices_.data,


### PR DESCRIPTION
* Doesn't impact correctness of water sampling.
* Happens when the number of proposals left is fewer than the batch size. In this case the samples that are selected for the idx in the batch are stale and may be sampling invalid states. In the case that the final mol (by idx) was selected and it was a targeted inner move then the index of the new sample would be out of bounds triggering a failure. A very rare occurrence which is why this was not caught initially.