### PR TITLE
Adds normalized kl divergence metric

### DIFF
--- a/tests/hrex/test_hrex.py
+++ b/tests/hrex/test_hrex.py
@@ -149,3 +149,23 @@ def test_normalized_kl_divergence_with_bottleneck(n_windows, frames):
     hrex_matrix = simulate_bottlenecked_hrex(n_windows, frames)
     res = get_normalized_kl_divergence(hrex_matrix)
     assert res >= 0.5
+
+
+@pytest.mark.parametrize("seed", [2024])
+@pytest.mark.parametrize("iterations", [10])
+@pytest.mark.parametrize("n_windows,frames", [(5, 2000), (16, 2000), (48, 2000)])
+def test_normalized_kl_divergence_relative_values(iterations, n_windows, frames, seed):
+    """Ensure that the mean of multiple replicates of normalized KL divergence produce the right ordering.
+
+    Perfect sampling should have the lowest value, followed by slow mixing followed up by bottle necked mixing"""
+    np.random.seed(seed)
+    perfect_mixing_kl = []
+    slow_mixing_kl = []
+    bottlenecked_kl = []
+    for _ in range(iterations):
+        perfect_mixing_kl.append(get_normalized_kl_divergence(simulate_perfect_mixing_hrex(n_windows, frames)))
+        bottlenecked_kl.append(get_normalized_kl_divergence(simulate_bottlenecked_hrex(n_windows, frames)))
+        slow_mixing_kl.append(get_normalized_kl_divergence(simulate_slow_mixing_hrex(n_windows, frames)))
+
+    assert np.mean(perfect_mixing_kl) < np.mean(slow_mixing_kl)
+    assert np.mean(slow_mixing_kl) < np.mean(bottlenecked_kl)

--- a/tests/hrex/test_hrex.py
+++ b/tests/hrex/test_hrex.py
@@ -1,9 +1,13 @@
+from typing import List
+
 import hypothesis.strategies as st
 import numpy as np
 import pytest
 from hypothesis import given, seed
 
-from timemachine.md.hrex import ReplicaIdx, get_samples_by_iter_by_replica
+from timemachine.md.hrex import ReplicaIdx, get_normalized_kl_divergence, get_samples_by_iter_by_replica
+
+pytestmark = [pytest.mark.nogpu]
 
 
 @given(
@@ -40,3 +44,105 @@ def test_get_samples_by_iter_by_replica_invalid_args():
         get_samples_by_iter_by_replica([[1], [2, 3]], [[ReplicaIdx(0)], [ReplicaIdx(0)]])
     with pytest.raises(AssertionError):
         get_samples_by_iter_by_replica([[1, 2], [3, 4]], [[ReplicaIdx(0)], [ReplicaIdx(0), ReplicaIdx(1)]])
+
+
+def simulate_perfect_mixing_hrex(num_states: int, num_frames: int) -> List[List[int]]:
+    """assume every step of HREX perfectly mixed all replicas"""
+    rng = np.random.default_rng(num_states)
+    inds = np.arange(num_states)
+    traj = []
+    for _ in range(num_frames):
+        rng.shuffle(inds)
+        traj.append(np.array(inds).tolist())
+    return traj
+
+
+def simulate_slow_mixing_hrex(num_states: int, num_frames: int) -> List[List[int]]:
+    """assume every step of HREX only succeeds in making K nearest-neighbor swaps"""
+    traj = [np.arange(num_states).tolist()]
+    for _ in range(num_frames - 1):
+        current_state = np.array(traj[-1])
+        for _ in range(num_states):
+            i = np.random.randint(num_states - 1)
+            j = i + 1
+
+            x_i = current_state[i]
+            x_j = current_state[j]
+
+            current_state[j] = x_i
+            current_state[i] = x_j
+
+        traj.append(current_state.tolist())
+    return traj
+
+
+def simulate_bottlenecked_hrex(num_states: int, num_frames: int) -> List[List[int]]:
+    """simulate_slow_mixing_hrex, but there's a state near K/2 that never swaps with neighbors"""
+    traj = [np.arange(num_states).tolist()]
+
+    bottleneck_i = int(round(num_states / 2))
+    for _ in range(num_frames - 1):
+        current_state = np.array(traj[-1])
+        for _ in range(num_states):
+            i = np.random.randint(num_states - 1)
+            j = i + 1
+
+            if i != bottleneck_i:
+                x_i = current_state[i]
+                x_j = current_state[j]
+
+                current_state[j] = x_i
+                current_state[i] = x_j
+
+        traj.append(current_state.tolist())
+    return traj
+
+
+def simulate_no_mixing_hrex(num_states: int, num_frames: int) -> List[List[int]]:
+    traj = [np.arange(num_states).tolist()] * num_frames
+    return traj
+
+
+@pytest.mark.parametrize("n_windows,frames", [(3, 2000), (16, 2000), (48, 2000)])
+@pytest.mark.parametrize(
+    "simulator",
+    [
+        simulate_perfect_mixing_hrex,
+        simulate_perfect_mixing_hrex,
+        simulate_slow_mixing_hrex,
+        simulate_bottlenecked_hrex,
+        simulate_no_mixing_hrex,
+    ],
+)
+def test_normalized_kl_divergence(simulator, n_windows, frames):
+    """Verify that given any of the expected hrex simulations produces values that are greater than 0.0"""
+    hrex_matrix = simulator(n_windows, frames)
+    res = get_normalized_kl_divergence(hrex_matrix)
+    assert res >= 0.0
+
+
+@pytest.mark.parametrize("n_windows,frames", [(16, 2000), (48, 2000)])
+def test_normalized_kl_divergence_perfect_mixing(n_windows, frames):
+    hrex_matrix = simulate_perfect_mixing_hrex(n_windows, frames)
+    res = get_normalized_kl_divergence(hrex_matrix)
+    assert res >= 0.0
+    np.testing.assert_allclose(res, 0.0, atol=0.015)
+
+
+@pytest.mark.parametrize("n_windows,frames", [(16, 2000), (48, 2000)])
+def test_normalized_kl_divergence_no_mixing(n_windows, frames):
+    """With no mixing at all, the kl divergence becomes larger than 1.0 and continues to grow with the number of windows
+
+    Verify that values are greater than one in this case.
+    """
+    hrex_matrix = simulate_no_mixing_hrex(n_windows, frames)
+    res = get_normalized_kl_divergence(hrex_matrix)
+    assert res >= 1.0
+
+
+@pytest.mark.parametrize("n_windows,frames", [(16, 2000), (48, 2000)])
+def test_normalized_kl_divergence_with_bottleneck(n_windows, frames):
+    """With a bottleneck, expect the divergence to be between 0.5 and 1.0"""
+    hrex_matrix = simulate_bottlenecked_hrex(n_windows, frames)
+    res = get_normalized_kl_divergence(hrex_matrix)
+    assert res <= 1.0 and res >= 0.5

--- a/tests/hrex/test_hrex_rbfe.py
+++ b/tests/hrex/test_hrex_rbfe.py
@@ -114,6 +114,9 @@ def test_hrex_rbfe_hif2a(hif2a_single_topology_leg):
     final_replica_state_counts = result.hrex_diagnostics.cumulative_replica_state_counts[-1]
     assert np.any(np.all(final_replica_state_counts > 0, axis=0))
 
+    assert isinstance(result.hrex_diagnostics.relaxation_time, float)
+    assert result.hrex_diagnostics.normalized_kl_divergence >= 0.0
+
     # Check plots were generated
     assert result.hrex_plots
     assert result.hrex_plots.transition_matrix_png

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -260,7 +260,7 @@ def get_normalized_kl_divergence(replica_idx_by_state_by_iter: Sequence[Sequence
     count_by_replica_by_state = cumulative_counts[-1]
     fraction_by_replica_by_state = count_by_replica_by_state / n_iters
 
-    return -np.mean(entropy(fraction_by_replica_by_state)) + np.log(n_states)
+    return -np.mean(entropy(fraction_by_replica_by_state, axis=0)) + np.log(n_states)
 
 
 def get_cumulative_replica_state_counts(replica_idx_by_state_by_iter: Sequence[Sequence[ReplicaIdx]]) -> NDArray:

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -7,6 +7,7 @@ import numpy as np
 from jax import Array
 from jax.typing import ArrayLike
 from numpy.typing import NDArray
+from scipy.special import rel_entr
 
 from timemachine.md.moves import MixtureOfMoves, MonteCarloMove
 from timemachine.utils import batches, not_ragged
@@ -238,6 +239,26 @@ class HREX(Generic[Replica]):
         return [(StateIdx(i), self.replicas[replica_idx]) for i, replica_idx in enumerate(self.replica_idx_by_state)]
 
 
+def get_normalized_kl_divergence(replica_idx_by_state_by_iter: Sequence[Sequence[ReplicaIdx]]) -> float:
+    """Heuristic for the how uniformly windows were sampled within an HREX simulation.
+    Based on Eq. 5 from [1], but after summing up the divergences of each state, take the mean
+    so that it is possible to compare the values between simulations of different numbers of windows.
+
+    A value closer to 0.0 indicates more uniforming sampling.
+
+    References
+    ----------
+    [1]: https://doi.org/10.1021/acs.jctc.0c00660, https://chemrxiv.org/engage/chemrxiv/article-details/60c74d2e702a9b007018b7ef
+    """
+    cumulative_counts = get_cumulative_replica_state_counts(replica_idx_by_state_by_iter)
+    n_iters, n_states, n_replicas = cumulative_counts.shape
+    count_by_replica_by_state = cumulative_counts[-1]
+    fraction_by_replica_by_state = count_by_replica_by_state / n_iters
+    uniform_dist = np.ones_like(fraction_by_replica_by_state) / n_states
+    # No need to add eps to the fraction_by_replica_state, as kel_entr returns a KL of 0 in that case
+    return np.sum(rel_entr(fraction_by_replica_by_state, uniform_dist)) / n_states
+
+
 def get_cumulative_replica_state_counts(replica_idx_by_state_by_iter: Sequence[Sequence[ReplicaIdx]]) -> NDArray:
     """Given a mapping of state index to replica index by iteration, returns an array of cumulative counts by iteration, replica, and state.
 
@@ -351,8 +372,12 @@ class HREXDiagnostics:
         return estimate_transition_matrix(self.replica_idx_by_state_by_iter)
 
     @property
-    def relaxation_time(self):
+    def relaxation_time(self) -> float:
         return estimate_relaxation_time(self.transition_matrix)
+
+    @property
+    def normalized_kl_divergence(self) -> float:
+        return get_normalized_kl_divergence(self.replica_idx_by_state_by_iter)
 
 
 @dataclass

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -7,7 +7,7 @@ import numpy as np
 from jax import Array
 from jax.typing import ArrayLike
 from numpy.typing import NDArray
-from scipy.special import rel_entr
+from scipy.stats import entropy
 
 from timemachine.md.moves import MixtureOfMoves, MonteCarloMove
 from timemachine.utils import batches, not_ragged
@@ -240,23 +240,27 @@ class HREX(Generic[Replica]):
 
 
 def get_normalized_kl_divergence(replica_idx_by_state_by_iter: Sequence[Sequence[ReplicaIdx]]) -> float:
-    """Heuristic for the how uniformly windows were sampled within an HREX simulation.
+    r"""Heuristic for the how uniformly windows were sampled within an HREX simulation.
     Based on Eq. 5 from [1], but after summing up the divergences of each state, take the mean
     so that it is possible to compare the values between simulations of different numbers of windows.
 
-    A value closer to 0.0 indicates more uniforming sampling.
+    A value closer to 0.0 indicates more uniform sampling.
 
     References
     ----------
     [1]: https://doi.org/10.1021/acs.jctc.0c00660, https://chemrxiv.org/engage/chemrxiv/article-details/60c74d2e702a9b007018b7ef
+
+    Notes
+    -----
+    * Avoid having to generate a uniform distribution by using the identity
+      $\sum_i p_i \log (p_i / u_i) =  \sum_i p_i \log p_i + \log N = -H_p + \log N$, where $H_p$ is the entropy of $p$
     """
     cumulative_counts = get_cumulative_replica_state_counts(replica_idx_by_state_by_iter)
     n_iters, n_states, n_replicas = cumulative_counts.shape
     count_by_replica_by_state = cumulative_counts[-1]
     fraction_by_replica_by_state = count_by_replica_by_state / n_iters
-    uniform_dist = np.ones_like(fraction_by_replica_by_state) / n_states
-    # No need to add eps to the fraction_by_replica_state, as kel_entr returns a KL of 0 in that case
-    return np.sum(rel_entr(fraction_by_replica_by_state, uniform_dist)) / n_states
+
+    return -np.mean(entropy(fraction_by_replica_by_state)) + np.log(n_states)
 
 
 def get_cumulative_replica_state_counts(replica_idx_by_state_by_iter: Sequence[Sequence[ReplicaIdx]]) -> NDArray:


### PR DESCRIPTION
Had previously looked at the KL Divergence for detecting bottlenecks in HREX and it seemed to grow unbounded with the number of windows, which is a problem when wanting to compare edges with different number of windows. Normalizing it appears to do the right thing

## Unnormalized
![image](https://github.com/proteneer/timemachine/assets/5840832/4e074224-f80b-4044-adf6-76c6c31df31d)

## Normalized
![image](https://github.com/proteneer/timemachine/assets/5840832/6e9d905c-a437-41a7-a4d6-e9dffe29079f)
