### PR TITLE
Remove HREX replica-state distribution convergence plot

### DIFF
--- a/examples/water_sampling_hrex.py
+++ b/examples/water_sampling_hrex.py
@@ -12,7 +12,6 @@ from timemachine.constants import DEFAULT_TEMP
 from timemachine.fe.free_energy import HREXParams, InitialState, MDParams, SimulationResult
 from timemachine.fe.plots import (
     plot_hrex_replica_state_distribution,
-    plot_hrex_replica_state_distribution_convergence,
     plot_hrex_replica_state_distribution_heatmap,
     plot_hrex_swap_acceptance_rates_convergence,
     plot_hrex_transition_matrix,
@@ -180,11 +179,6 @@ def test_hrex():
     plot_and_save(
         plot_hrex_replica_state_distribution,
         "plot_hrex_replica_state_distribution.png",
-        sim_res.hrex_diagnostics.cumulative_replica_state_counts,
-    )
-    plot_and_save(
-        plot_hrex_replica_state_distribution_convergence,
-        "plot_hrex_replica_state_distribution_convergence.png",
         sim_res.hrex_diagnostics.cumulative_replica_state_counts,
     )
     plot_and_save(

--- a/tests/hrex/test_hrex_1d.py
+++ b/tests/hrex/test_hrex_1d.py
@@ -11,7 +11,6 @@ from scipy.special import logsumexp
 
 from timemachine.fe.plots import (
     plot_hrex_replica_state_distribution,
-    plot_hrex_replica_state_distribution_convergence,
     plot_hrex_replica_state_distribution_heatmap,
     plot_hrex_swap_acceptance_rates_convergence,
     plot_hrex_transition_matrix,
@@ -278,7 +277,6 @@ def plot_hrex_diagnostics(diagnostics: HREXDiagnostics):
     plot_hrex_transition_matrix(diagnostics.transition_matrix)
     plot_hrex_replica_state_distribution(diagnostics.cumulative_replica_state_counts)
     plot_hrex_replica_state_distribution_heatmap(diagnostics.cumulative_replica_state_counts)
-    plot_hrex_replica_state_distribution_convergence(diagnostics.cumulative_replica_state_counts)
 
 
 @pytest.mark.parametrize("num_states", [5])

--- a/tests/hrex/test_hrex_rbfe.py
+++ b/tests/hrex/test_hrex_rbfe.py
@@ -18,7 +18,6 @@ from timemachine.fe.free_energy import (
     sample_with_context,
 )
 from timemachine.fe.plots import (
-    plot_hrex_replica_state_distribution_convergence,
     plot_hrex_replica_state_distribution_heatmap,
     plot_hrex_swap_acceptance_rates_convergence,
     plot_hrex_transition_matrix,
@@ -121,7 +120,6 @@ def test_hrex_rbfe_hif2a(hif2a_single_topology_leg):
     assert result.hrex_plots
     assert result.hrex_plots.transition_matrix_png
     assert result.hrex_plots.swap_acceptance_rates_convergence_png
-    assert result.hrex_plots.replica_state_distribution_convergence_png
     assert result.hrex_plots.replica_state_distribution_heatmap_png
 
 
@@ -129,7 +127,6 @@ def plot_hrex_rbfe_hif2a(result: SimulationResult):
     assert result.hrex_diagnostics
     plot_hrex_swap_acceptance_rates_convergence(result.hrex_diagnostics.cumulative_swap_acceptance_rates)
     plot_hrex_transition_matrix(result.hrex_diagnostics.transition_matrix)
-    plot_hrex_replica_state_distribution_convergence(result.hrex_diagnostics.cumulative_replica_state_counts)
     plot_hrex_replica_state_distribution_heatmap(result.hrex_diagnostics.cumulative_replica_state_counts)
     plt.show()
 

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -31,14 +31,7 @@ from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, custom_ops
 from timemachine.lib.custom_ops import Context
 from timemachine.md.barostat.utils import compute_box_center, get_bond_list, get_group_indices
 from timemachine.md.exchange.exchange_mover import get_water_idxs
-from timemachine.md.hrex import (
-    HREX,
-    HREXDiagnostics,
-    HREXPlots,
-    ReplicaIdx,
-    StateIdx,
-    get_swap_attempts_per_iter_heuristic,
-)
+from timemachine.md.hrex import HREX, HREXDiagnostics, ReplicaIdx, StateIdx, get_swap_attempts_per_iter_heuristic
 from timemachine.md.states import CoordsVelBox
 from timemachine.potentials import BoundPotential, HarmonicBond, NonbondedInteractionGroup, SummedPotential
 from timemachine.utils import batches, pairwise_transform_and_combine
@@ -174,6 +167,14 @@ class PairBarPlots:
     dG_errs_png: bytes
     overlap_summary_png: bytes
     overlap_detail_png: bytes
+
+
+@dataclass
+class HREXPlots:
+    transition_matrix_png: bytes
+    swap_acceptance_rates_convergence_png: bytes
+    replica_state_distribution_convergence_png: bytes
+    replica_state_distribution_heatmap_png: bytes
 
 
 @dataclass

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -173,7 +173,6 @@ class PairBarPlots:
 class HREXPlots:
     transition_matrix_png: bytes
     swap_acceptance_rates_convergence_png: bytes
-    replica_state_distribution_convergence_png: bytes
     replica_state_distribution_heatmap_png: bytes
 
 

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -452,45 +452,6 @@ def plot_hrex_replica_state_distribution_heatmap(
     fig.colorbar(p, label="fraction of iterations", format=lambda x, _: format_cbar_tick(x))
 
 
-def plot_hrex_replica_state_distribution_convergence(cumulative_replica_state_counts: NDArray, ncols: int = 4):
-    """Plot distribution of states as a function of iteration for each replica."""
-    n_iters, n_states, _ = cumulative_replica_state_counts.shape
-
-    # (replica, iter, state) -> int
-    count_by_state_by_iter_by_replica = np.moveaxis(cumulative_replica_state_counts, 2, 0)
-
-    ncols = min(n_states, ncols)
-    nrows = (n_states + ncols - 1) // ncols
-    fig, axs = plt.subplots(ncols=ncols, nrows=nrows, figsize=(13, 10), sharex=True, sharey=True, squeeze=False)
-
-    # (replica, state) pairs with no observations will be colored white
-    cmap = plt.get_cmap("viridis_r")
-    cmap.set_bad("white")
-
-    for replica_idx, (count_by_state_by_iter, ax) in enumerate(zip(count_by_state_by_iter_by_replica, axs.flat)):
-        p = ax.pcolormesh(np.arange(n_iters) + 1, np.arange(n_states), np.log10(count_by_state_by_iter.T), cmap=cmap)
-        ax.set_title(f"replica = {replica_idx}")
-
-    for ax in axs[-1, :]:
-        ax.set_xlabel("iteration")
-        ax.xaxis.get_major_locator().set_params(integer=True)
-
-    for ax in axs[:, 0]:
-        ax.set_ylabel("state")
-        ax.yaxis.get_major_locator().set_params(integer=True)
-
-    # don't draw axes for empty subplots in last row
-    n_remaining = n_states % ncols
-    if n_remaining:
-        n_empty = ncols - n_remaining
-        for ax in axs.flat[-n_empty:]:
-            ax.set_visible(False)
-
-    fig.subplots_adjust(right=0.8, hspace=0.2, wspace=0.2)
-    cbar_ax = fig.add_axes((0.85, 0.15, 0.02, 0.7))
-    fig.colorbar(p, cax=cbar_ax, label=r"$\log_{10}$(number of iterations)")
-
-
 def plot_as_png_fxn(f, *args, **kwargs) -> bytes:
     """
     Given a function which generates a plot, return the plot as png bytes.

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -328,11 +328,7 @@ def plot_fwd_reverse_predictions(
     return plot_png
 
 
-def plot_chiral_restraint_energies(
-    chiral_energies: NDArray,
-    annotate_threshold: int = DEFAULT_HEATMAP_ANNOTATE_THRESHOLD,
-    figsize: Tuple[float, float] = (13, 10),
-):
+def plot_chiral_restraint_energies(chiral_energies: NDArray, figsize: Tuple[float, float] = (13, 10)):
     """Plot matrix of chiral restraint energies as a heatmap.
 
     For use with the outputs of timemachine.fe.chiral_utils.make_chiral_flip_heatmaps.

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -27,7 +27,6 @@ from timemachine.fe.free_energy import (
 )
 from timemachine.fe.plots import (
     plot_as_png_fxn,
-    plot_hrex_replica_state_distribution_convergence,
     plot_hrex_replica_state_distribution_heatmap,
     plot_hrex_swap_acceptance_rates_convergence,
     plot_hrex_transition_matrix,
@@ -677,9 +676,6 @@ def estimate_relative_free_energy_bisection_hrex_impl(
             swap_acceptance_rates_convergence_png=plot_as_png_fxn(
                 plot_hrex_swap_acceptance_rates_convergence, diagnostics.cumulative_swap_acceptance_rates
             ),
-            replica_state_distribution_convergence_png=plot_as_png_fxn(
-                plot_hrex_replica_state_distribution_convergence, diagnostics.cumulative_replica_state_counts
-            ),
             replica_state_distribution_heatmap_png=plot_as_png_fxn(
                 plot_hrex_replica_state_distribution_heatmap, diagnostics.cumulative_replica_state_counts
             ),
@@ -952,10 +948,6 @@ def run_edge_and_save_results(
                 complex_res.hrex_plots.swap_acceptance_rates_convergence_png,
             )
             file_client.store(
-                f"{edge_prefix}_complex_hrex_replica_state_distribution_convergence.png",
-                complex_res.hrex_plots.replica_state_distribution_convergence_png,
-            )
-            file_client.store(
                 f"{edge_prefix}_complex_hrex_replica_state_distribution_heatmap.png",
                 complex_res.hrex_plots.replica_state_distribution_heatmap_png,
             )
@@ -976,10 +968,6 @@ def run_edge_and_save_results(
             file_client.store(
                 f"{edge_prefix}_solvent_hrex_swap_acceptance_rates_convergence.png",
                 solvent_res.hrex_plots.swap_acceptance_rates_convergence_png,
-            )
-            file_client.store(
-                f"{edge_prefix}_solvent_hrex_replica_state_distribution_convergence.png",
-                solvent_res.hrex_plots.replica_state_distribution_convergence_png,
             )
             file_client.store(
                 f"{edge_prefix}_solvent_hrex_replica_state_distribution_heatmap.png",

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -384,14 +384,6 @@ class HREXDiagnostics:
         return get_normalized_kl_divergence(self.replica_idx_by_state_by_iter)
 
 
-@dataclass
-class HREXPlots:
-    transition_matrix_png: bytes
-    swap_acceptance_rates_convergence_png: bytes
-    replica_state_distribution_convergence_png: bytes
-    replica_state_distribution_heatmap_png: bytes
-
-
 def get_swap_attempts_per_iter_heuristic(n_states: int) -> int:
     """Heuristic for number of swap attempts per iteration derived from [1].
 


### PR DESCRIPTION
* Removes `plot_hrex_replica_state_distribution_convergence` from `timemachine.fe.plots`. This plot has never been particularly useful, and the current implementation uses a lot of memory (~300 MB according to local profiling).
* Miscellaneous organization/cleanup
  - moves `HREXPlots` to `timemachine.fe.free_energy` alongside `PairBarPlots` (there's no plotting code in `timemachine.md.hrex`, and the abstractions in the latter are higher-level than the plots, e.g. not assuming a 1-d chain of states)
  - removes an unused argument from `plot_chiral_restraint_energies`

**NOTE**: merging this will require downstream changes

Example of the removed plot:
![image](https://github.com/proteneer/timemachine/assets/319411/1d6b8067-ead3-4288-b5c2-e90dacd154f5)
