### PR TITLE
Fix nightly test

### DIFF
--- a/tests/test_benchmark_free_energy.py
+++ b/tests/test_benchmark_free_energy.py
@@ -20,7 +20,12 @@ from timemachine.fe.free_energy import (
     run_sims_hrex,
     run_sims_sequential,
 )
-from timemachine.fe.rbfe import setup_initial_states, setup_optimized_host, setup_optimized_initial_state
+from timemachine.fe.rbfe import (
+    DEFAULT_HREX_PARAMS,
+    setup_initial_states,
+    setup_optimized_host,
+    setup_optimized_initial_state,
+)
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.ff import Forcefield
 from timemachine.md import builders
@@ -96,7 +101,7 @@ def run_benchmark_hif2a_single_topology(hif2a_single_topology_leg, mode, enable_
         run = partial(
             run_sims_hrex,
             initial_states,
-            md_params,
+            replace(md_params, hrex_params=DEFAULT_HREX_PARAMS.hrex_params),
             n_frames_per_iter=1,
             print_diagnostics_interval=None,
         )

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -1001,6 +1001,8 @@ def run_sims_hrex(
         HREX statistics (e.g. swap rates, replica-state distribution)
     """
 
+    assert md_params.hrex_params is not None
+
     # TODO: to support replica exchange with variable temperatures,
     #  consider modifying sample fxn to rescale velocities by sqrt(T_new/T_orig)
     def assert_ensembles_compatible(state_a: InitialState, state_b: InitialState):
@@ -1147,7 +1149,6 @@ def run_sims_hrex(
             return CoordsVelBox(traj.frames[-1], traj.final_velocities, traj.boxes[-1])
 
         hrex, samples_by_state_iter = hrex.sample_replicas(sample_replica, replica_from_samples)
-        assert md_params.hrex_params is not None
         U_kl = compute_potential_matrix(potential, hrex, params_by_state, md_params.hrex_params.max_delta_states)
         log_q_kl = -U_kl / (BOLTZ * temperature)
 


### PR DESCRIPTION
Fixes a nightly test failure introduced by #1309.

* Add `hrex_params` to `params` in call to `run_sims_hrex`. As of #1309, `run_sims_hrex` asserts that `hrex_params` is not `None` because it uses the `max_delta_states` parameter.