### PR TITLE
Fix off-by-one misalignment of permutations and frames in HREX output

### DIFF
--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -1152,6 +1152,8 @@ def run_sims_hrex(
         U_kl = compute_potential_matrix(potential, hrex, params_by_state, md_params.hrex_params.max_delta_states)
         log_q_kl = -U_kl / (BOLTZ * temperature)
 
+        replica_idx_by_state_by_iter.append(hrex.replica_idx_by_state)
+
         hrex, fraction_accepted_by_pair = hrex.attempt_neighbor_swaps_fast(
             neighbor_pairs, log_q_kl, n_swap_attempts_per_iter, md_params.seed + iteration
         )
@@ -1162,7 +1164,6 @@ def run_sims_hrex(
         for samples, samples_iter in zip(samples_by_state, samples_by_state_iter):
             samples.extend(samples_iter)
 
-        replica_idx_by_state_by_iter.append(hrex.replica_idx_by_state)
         fraction_accepted_by_pair_by_iter.append(fraction_accepted_by_pair)
 
         if print_diagnostics_interval and iteration % print_diagnostics_interval == 0:


### PR DESCRIPTION
Currently, `replica_idx_by_state_by_iter[i]` gives the permutation of replicas corresponding to the i+1st frame. This leads to confusion and potential bugs in analyses that try to correlate permutations and frames, e.g. to extract replica trajectories. (This also means that we confusingly store a final permutation that wasn't actually sampled by MD).

This PR fixes the off-by-one misalignment so that `replica_idx_by_state_by_iter[i]` gives the permutation of replicas corresponding to `frames[i]`.

Note, this does not affect the correctness of free energy calculations, or significantly affect existing diagnostic plots in timemachine.