### PR TITLE
Hardcode n_frames_per_iter to 1

### DIFF
--- a/examples/biphenyl_torsion_sampling_hrex.py
+++ b/examples/biphenyl_torsion_sampling_hrex.py
@@ -146,7 +146,7 @@ def sample_biphenyl_hrex(
         n_eq_steps=100_000 if solvent else 10_000,
         steps_per_frame=400,
         seed=seed,
-        hrex_params=HREXParams(n_frames_bisection=n_frames_bisection, n_frames_per_iter=1),
+        hrex_params=HREXParams(n_frames_bisection=n_frames_bisection),
     )
     assert md_params.hrex_params
 
@@ -228,7 +228,6 @@ def sample_biphenyl_hrex(
     _, trajectories_by_state_hrex, diagnostics = run_sims_hrex(
         initial_states_hrex,
         replace(md_params, n_eq_steps=0),  # using pre-equilibrated samples
-        n_frames_per_iter=md_params.hrex_params.n_frames_per_iter,
     )
 
     def get_torsion_angle_traj(frames: NDArray) -> NDArray:

--- a/examples/water_sampling_hrex.py
+++ b/examples/water_sampling_hrex.py
@@ -146,7 +146,7 @@ def test_hrex():
     lambda_max = 0.4
     n_windows = 48
 
-    hrex_params = HREXParams(n_frames_bisection=min(1000, args.n_frames), n_frames_per_iter=1)
+    hrex_params = HREXParams(n_frames_bisection=min(1000, args.n_frames))
     mdp = MDParams(n_frames=args.n_frames, n_eq_steps=10_000, steps_per_frame=400, seed=2023, hrex_params=hrex_params)
     print("hrex_params:", hrex_params)
     sim_res = estimate_relative_free_energy_hrex_bb(

--- a/tests/test_benchmark_free_energy.py
+++ b/tests/test_benchmark_free_energy.py
@@ -103,7 +103,6 @@ def run_benchmark_hif2a_single_topology(hif2a_single_topology_leg, mode, enable_
             run_sims_hrex,
             initial_states,
             replace(md_params, hrex_params=DEFAULT_HREX_PARAMS.hrex_params),
-            n_frames_per_iter=1,
             print_diagnostics_interval=None,
         )
     elif mode == "sequential":

--- a/tests/test_hrex_rbfe.py
+++ b/tests/test_hrex_rbfe.py
@@ -75,7 +75,7 @@ def test_hrex_rbfe_hif2a(hif2a_single_topology_leg, seed):
         n_eq_steps=10_000,
         steps_per_frame=400,
         seed=seed,
-        hrex_params=HREXParams(n_frames_bisection=100, n_frames_per_iter=1),
+        hrex_params=HREXParams(n_frames_bisection=100),
         water_sampling_params=WaterSamplingParams(interval=400, n_proposals=1000) if host_name == "complex" else None,
     )
     n_windows = 5
@@ -182,7 +182,7 @@ def test_hrex_rbfe_reproducibility(hif2a_single_topology_leg, seed):
         n_eq_steps=10,
         steps_per_frame=400,
         seed=seed,
-        hrex_params=HREXParams(n_frames_bisection=1, n_frames_per_iter=1),
+        hrex_params=HREXParams(n_frames_bisection=1),
     )
 
     run = lambda seed: estimate_relative_free_energy_bisection_hrex(

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -80,12 +80,11 @@ def run_triple(mol_a, mol_b, core, forcefield, md_params: MDParams, protein_path
 
         if isinstance(sim_res, HREXSimulationResult):
             assert md_params.hrex_params
-            n_hrex_iters = md_params.n_frames // md_params.hrex_params.n_frames_per_iter
 
-            assert len(sim_res.hrex_diagnostics.fraction_accepted_by_pair_by_iter) == n_hrex_iters
+            assert len(sim_res.hrex_diagnostics.fraction_accepted_by_pair_by_iter) == md_params.n_frames
             assert all(len(fs) == n_windows - 1 for fs in sim_res.hrex_diagnostics.fraction_accepted_by_pair_by_iter)
 
-            assert len(sim_res.hrex_diagnostics.replica_idx_by_state_by_iter) == n_hrex_iters
+            assert len(sim_res.hrex_diagnostics.replica_idx_by_state_by_iter) == md_params.n_frames
             assert all(len(fs) == n_windows for fs in sim_res.hrex_diagnostics.replica_idx_by_state_by_iter)
 
         def check_pair_bar_result(res: PairBarResult):
@@ -180,7 +179,7 @@ def test_run_hif2a_test_system(estimate_relative_free_energy_fn):
         n_eq_steps=1000,
         steps_per_frame=100,
         seed=2023,
-        hrex_params=HREXParams(n_frames_per_iter=1),
+        hrex_params=HREXParams(),
     )
 
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as protein_path:

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -1184,7 +1184,10 @@ def run_sims_hrex(
         replica_idx_by_state_by_iter.append(hrex.replica_idx_by_state)
 
         hrex, fraction_accepted_by_pair = hrex.attempt_neighbor_swaps_fast(
-            neighbor_pairs, log_q_kl, n_swap_attempts_per_iter, md_params.seed + current_frame
+            neighbor_pairs,
+            log_q_kl,
+            n_swap_attempts_per_iter,
+            md_params.seed + current_frame + 1,  # NOTE: "+ 1" is for bitwise compatibility with previous version
         )
 
         if len(initial_states) == 2:

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -59,6 +59,9 @@ class HREXParams:
     n_frames_bisection: int
         Number of frames to sample using MD during the initial bisection phase used to determine lambda spacing
 
+    n_frames_per_iter: int
+        DEPRECATED, must be set to 1. Number of frames to sample using MD per HREX iteration.
+
     max_delta_states: int or None
         If given, number of neighbor states on either side of a given replica's initial state for which to compute
         potentials. This determines the maximum number of states that a replica can move from its initial state during
@@ -66,10 +69,12 @@ class HREXParams:
     """
 
     n_frames_bisection: int = 100
+    n_frames_per_iter: int = 1
     max_delta_states: Optional[int] = 4
 
     def __post_init__(self):
         assert self.n_frames_bisection > 0
+        assert self.n_frames_per_iter == 1, "n_frames_per_iter must be 1"
         assert self.max_delta_states is None or self.max_delta_states > 0
 
 

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -59,9 +59,6 @@ class HREXParams:
     n_frames_bisection: int
         Number of frames to sample using MD during the initial bisection phase used to determine lambda spacing
 
-    n_frames_per_iter: int
-        Number of frames to sample using MD per HREX iteration.
-
     max_delta_states: int or None
         If given, number of neighbor states on either side of a given replica's initial state for which to compute
         potentials. This determines the maximum number of states that a replica can move from its initial state during
@@ -69,12 +66,10 @@ class HREXParams:
     """
 
     n_frames_bisection: int = 100
-    n_frames_per_iter: int = 1
     max_delta_states: Optional[int] = 4
 
     def __post_init__(self):
         assert self.n_frames_bisection > 0
-        assert self.n_frames_per_iter > 0
         assert self.max_delta_states is None or self.max_delta_states > 0
 
 
@@ -1001,7 +996,6 @@ def compute_potential_matrix(
 def run_sims_hrex(
     initial_states: Sequence[InitialState],
     md_params: MDParams,
-    n_frames_per_iter: int,
     n_swap_attempts_per_iter: Optional[int] = None,
     print_diagnostics_interval: Optional[int] = 10,
 ) -> Tuple[PairBarResult, List[Trajectory], HREXDiagnostics]:
@@ -1017,9 +1011,6 @@ def run_sims_hrex(
 
     md_params: MDParams
         MD parameters
-
-    n_frames_per_iter: int
-        Number of frames to sample using MD per iteration
 
     n_swap_attempts_per_iter: int or None, optional
         Number of nearest-neighbor swaps to attempt per iteration. Defaults to len(initial_states) ** 4.
@@ -1154,11 +1145,11 @@ def run_sims_hrex(
 
     if (
         md_params.water_sampling_params is not None
-        and md_params.steps_per_frame * n_frames_per_iter > md_params.water_sampling_params.interval
+        and md_params.steps_per_frame > md_params.water_sampling_params.interval
     ):
         warn("Not running any water sampling, too few steps of MD for the water sampling interval")
 
-    for iteration, n_frames_iter in enumerate(batches(md_params.n_frames, n_frames_per_iter), 1):
+    for current_frame in range(md_params.n_frames):
 
         def sample_replica(xvb: CoordsVelBox, state_idx: StateIdx) -> Trajectory:
             context.set_x_t(xvb.coords)
@@ -1168,7 +1159,7 @@ def run_sims_hrex(
             params = params_by_state[state_idx]
             bound_potentials[0].set_params(params)
 
-            current_step = (iteration - 1) * n_frames_per_iter * md_params.steps_per_frame
+            current_step = current_frame * md_params.steps_per_frame
             # Setup the MC movers of the Context
             for mover in context.get_movers():
                 if md_params.water_sampling_params is not None and isinstance(mover, WATER_SAMPLER_MOVERS):
@@ -1178,7 +1169,7 @@ def run_sims_hrex(
                 mover.set_step(current_step)
 
             md_params_replica = replace(
-                md_params, n_frames=n_frames_iter, n_eq_steps=0, seed=np.random.randint(np.iinfo(np.int32).max)
+                md_params, n_frames=1, n_eq_steps=0, seed=np.random.randint(np.iinfo(np.int32).max)
             )
 
             return sample_with_context(context, md_params_replica, temperature, ligand_idxs, max_buffer_frames=100)
@@ -1193,7 +1184,7 @@ def run_sims_hrex(
         replica_idx_by_state_by_iter.append(hrex.replica_idx_by_state)
 
         hrex, fraction_accepted_by_pair = hrex.attempt_neighbor_swaps_fast(
-            neighbor_pairs, log_q_kl, n_swap_attempts_per_iter, md_params.seed + iteration
+            neighbor_pairs, log_q_kl, n_swap_attempts_per_iter, md_params.seed + current_frame
         )
 
         if len(initial_states) == 2:
@@ -1204,7 +1195,7 @@ def run_sims_hrex(
 
         fraction_accepted_by_pair_by_iter.append(fraction_accepted_by_pair)
 
-        if print_diagnostics_interval and iteration % print_diagnostics_interval == 0:
+        if print_diagnostics_interval and (current_frame + 1) % print_diagnostics_interval == 0:
 
             def get_swap_acceptance_rates(fraction_accepted_by_pair):
                 return [
@@ -1221,7 +1212,7 @@ def run_sims_hrex(
             def format_rates(rs):
                 return " | ".join(format_rate(r) for r in rs)
 
-            print("Completed HREX iteration", iteration)
+            print("Frame ", current_frame)
             print("Acceptance rates (inst.)   :", format_rates(instantaneous_swap_acceptance_rates))
             print("Acceptance rates (average) :", format_rates(average_swap_acceptance_rates))
             print("Final replica permutation  :", hrex.replica_idx_by_state)

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -51,7 +51,7 @@ MAX_SEED_VALUE = 10000
 
 DEFAULT_MD_PARAMS = MDParams(n_frames=1000, n_eq_steps=10_000, steps_per_frame=400, seed=2023, hrex_params=None)
 
-DEFAULT_HREX_PARAMS = replace(DEFAULT_MD_PARAMS, hrex_params=HREXParams(n_frames_bisection=100, n_frames_per_iter=1))
+DEFAULT_HREX_PARAMS = replace(DEFAULT_MD_PARAMS, hrex_params=HREXParams(n_frames_bisection=100))
 
 
 @dataclass
@@ -667,7 +667,6 @@ def estimate_relative_free_energy_bisection_hrex_impl(
         pair_bar_result, trajectories_by_state, diagnostics = run_sims_hrex(
             initial_states_hrex,
             replace(md_params, n_eq_steps=0),  # using pre-equilibrated samples
-            n_frames_per_iter=md_params.hrex_params.n_frames_per_iter,
         )
 
         plots = make_pair_bar_plots(pair_bar_result, temperature, combined_prefix)


### PR DESCRIPTION
## Motivation

* Methods to extract trajectories by replica currently assume `n_frames_per_iter==1` and will break otherwise
* Since HREX now has minimal overhead, there's no clear use case for performing HREX moves less frequently than once per frame
* Hardcoding `n_frames_per_iter = 1` allows removing some subtle logic that exists to handle edge cases