### PR TITLE
Avoid writing frames to disk only to be read into memory immediately

### DIFF
--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, replace
 from functools import cache
-from typing import Callable, List, Optional, Sequence, Tuple, Union
+from typing import Callable, Iterator, List, Optional, Sequence, Tuple
 from warnings import warn
 
 import jax
@@ -542,7 +542,7 @@ def get_context(initial_state: InitialState, md_params: Optional[MDParams] = Non
 
 def sample_with_context_iter(
     ctxt: Context, md_params: MDParams, temperature: float, ligand_idxs: NDArray, max_buffer_frames: int
-) -> Tuple[NDArray, NDArray, NDArray]:
+) -> Iterator[Tuple[NDArray, NDArray, NDArray]]:
     # burn-in
     if md_params.n_eq_steps:
         # Set barostat interval to 15 for equilibration, then back to the original interval for production
@@ -1166,7 +1166,7 @@ def run_sims_hrex(
 
     for iteration, n_frames_iter in enumerate(batches(md_params.n_frames, n_frames_per_iter), 1):
 
-        def sample_replica(xvb: CoordsVelBox, state_idx: StateIdx) -> Trajectory:
+        def sample_replica(xvb: CoordsVelBox, state_idx: StateIdx) -> List[Tuple[NDArray, NDArray, NDArray]]:
             context.set_x_t(xvb.coords)
             context.set_v_t(xvb.velocities)
             context.set_box(xvb.box)

--- a/timemachine/fe/stored_arrays.py
+++ b/timemachine/fe/stored_arrays.py
@@ -115,12 +115,13 @@ class StoredArrays(Sequence[NDArray]):
         >>> StoredArrays.load(fc) == sa
         True
         """
-        for idx, chunk in enumerate(self._chunks()):
-            serialized_array = serialize_array(np.array(chunk))
-            path = self.get_chunk_path(prefix, idx)
-            if client.exists(str(path)):
-                raise FileExistsError(f"file already exists: {path}")
-            client.store(str(path), serialized_array)
+        for idx, _ in enumerate(self._chunk_sizes):
+            dest_path = self.get_chunk_path(prefix, idx)
+            if client.exists(str(dest_path)):
+                raise FileExistsError(f"file already exists: {dest_path}")
+            src_path = self._get_chunk_path(idx)
+            with open(src_path, "rb") as ifs:
+                client.store_stream(str(dest_path), ifs)
 
     @classmethod
     def load(cls: Type[_T], client: AbstractFileClient, prefix: Path = Path(".")) -> _T:


### PR DESCRIPTION
* This is more of a proof of concept, but looks like we can get another 10% for vacuum simulations in HREX by not writing the windows to disk until we have evaluated them, else we write them to disk then immediately read them into memory.
* The more complete way to do this would be to be able to more precisely control if the Trajectory is backed by disk or by memory