### PR TITLE
Correct docstring in get_cores

### DIFF
--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -931,7 +931,7 @@ def test_min_threshold():
         min_threshold=mol_a.GetNumAtoms(),
     )
 
-    with pytest.raises(NoMappingError, match="Unable to find mapping with at least 18 atoms"):
+    with pytest.raises(NoMappingError, match="Unable to find mapping with at least 18 edges"):
         atom_mapping.get_cores(mol_a, mol_b, **core_kwargs, max_visits=10000)
 
 

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -156,7 +156,7 @@ def get_cores(
         Filter out cores that would flip a mapped planar torsion (i.e. change the sign of the torsion volume)
 
     min_threshold: int
-        Number of atoms to require for a valid mapping
+        Number of edges to require for a valid mapping
 
     Returns
     -------

--- a/timemachine/fe/mcgregor.py
+++ b/timemachine/fe/mcgregor.py
@@ -265,7 +265,7 @@ def mcs(
     for idx in range(max_threshold):
         cur_threshold = max_threshold - idx
         if cur_threshold < min_threshold:
-            raise NoMappingError(f"Unable to find mapping with at least {min_threshold} atoms")
+            raise NoMappingError(f"Unable to find mapping with at least {min_threshold} edges")
         map_a_to_b = [UNMAPPED] * n_a
         map_b_to_a = [UNMAPPED] * n_b
         mcs_result = MCSResult()


### PR DESCRIPTION
* Bitten by this thinking it was atoms and not edges. Top level docs specify that it is edges

Introduced in https://github.com/proteneer/timemachine/pull/926 due to misunderstanding the code