### PR TITLE
Remove unnecessary array copy in `extract_trajectories_by_replica`

### DIFF
--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -284,7 +284,7 @@ class HREXSimulationResult(SimulationResult):
         # (states, frames, atoms, 3)
         trajs_by_state = np.array(
             [
-                np.concatenate([np.array(chunk)[:, atom_idxs] for chunk in state_traj.frames._chunks()], axis=0)
+                np.concatenate([chunk[:, atom_idxs] for chunk in state_traj.frames._chunks()], axis=0)
                 for state_traj in self.trajectories
             ]
         )

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -282,6 +282,8 @@ class HREXSimulationResult(SimulationResult):
         """
 
         # (states, frames, atoms, 3)
+        # NOTE: chunk[:, atom_idxs] below returns a copy (rather than a view) due to the use of "advanced indexing".
+        # This is important because otherwise we would try to store all of the whole-system frames in memory at once.
         trajs_by_state = np.array(
             [
                 np.concatenate([chunk[:, atom_idxs] for chunk in state_traj.frames._chunks()], axis=0)

--- a/timemachine/fe/stored_arrays.py
+++ b/timemachine/fe/stored_arrays.py
@@ -78,7 +78,7 @@ class StoredArrays(Sequence[NDArray]):
             np.array_equal(a, b, equal_nan=True) for a, b in zip(self, other)
         )
 
-    def _chunks(self) -> Iterator[List[NDArray]]:
+    def _chunks(self) -> Iterator[NDArray]:
         """Returns an iterator over chunks.
 
         Each chunk is a sequence of numpy arrays stored in a single .npy file

--- a/timemachine/fe/stored_arrays.py
+++ b/timemachine/fe/stored_arrays.py
@@ -81,7 +81,7 @@ class StoredArrays(Sequence[NDArray]):
     def _chunks(self) -> Iterator[NDArray]:
         """Returns an iterator over chunks.
 
-        Each chunk is a sequence of numpy arrays stored in a single .npy file
+        Each chunk is a numpy array stored in a single .npy file
         """
         for idx, _ in enumerate(self._chunk_sizes):
             yield np.load(self._get_chunk_path(idx))


### PR DESCRIPTION
Return type of `StoredArrays._chunks` is incorrect; `chunk` here is already an array