### PR TITLE
Minimize InitialStates only considering fully interacting atoms for the min_cutoff threshold

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -61,7 +61,9 @@ def prepare_single_topology_initial_state(st: SingleTopology, host_config: Optio
     host = None
     if host_config is not None:
         host = rbfe.setup_optimized_host(st, host_config)
-    initial_state = rbfe.setup_initial_states(st, host, temperature, [lamb], seed=2022)[0]
+    initial_state = rbfe.setup_initial_states(
+        st, host, temperature, [lamb], seed=2022, min_cutoff=0.7 if host_config is not None else None
+    )[0]
     return initial_state
 
 

--- a/tests/test_benchmark_free_energy.py
+++ b/tests/test_benchmark_free_energy.py
@@ -80,7 +80,9 @@ def setup_hif2a_single_topology_leg(host_name: str, n_windows: int, lambda_endpo
 
     lambdas = np.linspace(lambda_endpoints[0], lambda_endpoints[1], n_windows)
 
-    initial_states = setup_initial_states(single_topology, host, DEFAULT_TEMP, lambdas, seed=2023, min_cutoff=0.7)
+    initial_states = setup_initial_states(
+        single_topology, host, DEFAULT_TEMP, lambdas, seed=2023, min_cutoff=0.7 if host is not None else None
+    )
 
     n_frames = 500 // n_windows
 

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -273,7 +273,7 @@ def hif2a_ligand_pair_single_topology_lam0_state():
 
 
 @pytest.mark.parametrize("seed", [2024])
-@pytest.mark.parametrize("host_name", ["solvent", "complex"])
+@pytest.mark.parametrize("host_name", [None, "solvent", "complex"])
 def test_initial_state_interacting_ligand_atoms(host_name, seed):
     lambdas = np.linspace(0.0, 1.0, 4)
     forcefield = Forcefield.load_default()
@@ -305,7 +305,6 @@ def test_initial_state_interacting_ligand_atoms(host_name, seed):
         single_topology, host, DEFAULT_TEMP, lambdas, seed=seed, min_cutoff=0.7 if host_name is not None else None
     )
 
-    # print(mol_a_atoms)
     for state in initial_states:
         mol_a_atoms = state.ligand_idxs[single_topology.c_flags != 2]
         mol_b_atoms = state.ligand_idxs[single_topology.c_flags != 1]

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -309,13 +309,13 @@ def test_initial_state_interacting_ligand_atoms(host_name, seed):
         mol_a_atoms = state.ligand_idxs[single_topology.c_flags != AtomMapFlags.MOL_B]
         mol_b_atoms = state.ligand_idxs[single_topology.c_flags != AtomMapFlags.MOL_A]
         core_atoms = state.ligand_idxs[single_topology.c_flags == AtomMapFlags.CORE]
-        interacting_atom_indices = state.get_interacting_ligand_atom_indices()
+        assert state.interacting_atoms is not None
         if state.lamb == 0.0:
-            assert set(interacting_atom_indices) == set(mol_a_atoms)
+            assert set(state.interacting_atoms) == set(mol_a_atoms)
         elif state.lamb == 1.0:
-            assert set(interacting_atom_indices) == set(mol_b_atoms)
+            assert set(state.interacting_atoms) == set(mol_b_atoms)
         else:
-            assert set(interacting_atom_indices) == set(core_atoms)
+            assert set(state.interacting_atoms) == set(core_atoms)
 
 
 @pytest.mark.nocuda

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -30,7 +30,7 @@ from timemachine.fe.free_energy import (
     sample,
 )
 from timemachine.fe.rbfe import Host, setup_initial_state, setup_initial_states, setup_optimized_host
-from timemachine.fe.single_topology import SingleTopology
+from timemachine.fe.single_topology import AtomMapFlags, SingleTopology
 from timemachine.fe.stored_arrays import StoredArrays
 from timemachine.fe.system import convert_omm_system
 from timemachine.ff import Forcefield
@@ -306,9 +306,9 @@ def test_initial_state_interacting_ligand_atoms(host_name, seed):
     )
 
     for state in initial_states:
-        mol_a_atoms = state.ligand_idxs[single_topology.c_flags != 2]
-        mol_b_atoms = state.ligand_idxs[single_topology.c_flags != 1]
-        core_atoms = state.ligand_idxs[single_topology.c_flags == 0]
+        mol_a_atoms = state.ligand_idxs[single_topology.c_flags != AtomMapFlags.MOL_B]
+        mol_b_atoms = state.ligand_idxs[single_topology.c_flags != AtomMapFlags.MOL_A]
+        core_atoms = state.ligand_idxs[single_topology.c_flags == AtomMapFlags.CORE]
         interacting_atom_indices = state.get_interacting_ligand_atom_indices()
         if state.lamb == 0.0:
             assert set(interacting_atom_indices) == set(mol_a_atoms)

--- a/tests/test_hrex_rbfe.py
+++ b/tests/test_hrex_rbfe.py
@@ -97,6 +97,7 @@ def test_hrex_rbfe_hif2a(hif2a_single_topology_leg, seed):
             md_params,
             lambda_interval=(0.0, 0.15),
             n_windows=n_windows,
+            min_cutoff=0.7 if host_name is not None else None,
         )
 
     # Check that memory usage is not increasing

--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -175,6 +175,7 @@ def test_min_cutoff_failure(pair, seed, n_windows):
     solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
     solvent_host = setup_optimized_host(st, solvent_host_config)
     ligand_idxs = np.arange(st.get_num_atoms()) + solvent_host.conf.shape[0]
+    expected_moved = ligand_idxs[st.c_flags != 2]
     with pytest.raises(AssertionError) as res:
         setup_initial_states(st, solvent_host, DEFAULT_TEMP, lambda_grid, seed, min_cutoff=min_cutoff)
-    assert f"moved atoms {ligand_idxs.tolist()} >" in str(res.value)
+    assert f"moved atoms {expected_moved.tolist()} >" in str(res.value)

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -24,7 +24,6 @@ from timemachine.fe.plots import (
     plot_overlap_summary_figure,
 )
 from timemachine.fe.protocol_refinement import greedy_bisection_step
-from timemachine.fe.single_topology import AtomMapFlags, AtomMapMixin
 from timemachine.fe.stored_arrays import StoredArrays
 from timemachine.fe.utils import get_mol_masses, get_romol_conf
 from timemachine.ff import ForcefieldParams
@@ -155,35 +154,12 @@ class InitialState:
     lamb: float
     ligand_idxs: NDArray
     protein_idxs: NDArray
-    # Expected to be set in the case of Relative Free Energies
-    atom_map: Optional[AtomMapMixin] = None
+    # The atoms that are in the 4d plane defined by w_coord == 0.0
+    interacting_atoms: Optional[NDArray] = None
 
     def __post_init__(self):
         assert self.ligand_idxs.dtype == np.int32 or self.ligand_idxs.dtype == np.int64
         assert self.protein_idxs.dtype == np.int32 or self.protein_idxs.dtype == np.int64
-
-    def get_interacting_ligand_atom_indices(self) -> NDArray:
-        """Returns the ligand atom indices that are fully interacting at the specific lambda.
-
-        Currently implemented by looking at the atoms in the atom_map object and either return
-        the endstates for lambda == 0.0 and lambda == 1.0 and for all other values the core atoms.
-
-        Note
-        ----
-        * Raises an exception if no atom map object is provided
-
-        Return
-        ------
-        np.ndarray
-            Contains the indices of the ligand that are not considered dummy atoms at the lambda value.
-        """
-        assert self.atom_map is not None, "No atom map provided, unable to provide interacting atom indices"
-        if self.lamb == 0.0:
-            return self.ligand_idxs[self.atom_map.c_flags != AtomMapFlags.MOL_B]
-        elif self.lamb == 1.0:
-            return self.ligand_idxs[self.atom_map.c_flags != AtomMapFlags.MOL_A]
-        else:
-            return self.ligand_idxs[self.atom_map.c_flags == AtomMapFlags.CORE]
 
 
 @dataclass

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -155,6 +155,7 @@ class InitialState:
     lamb: float
     ligand_idxs: NDArray
     protein_idxs: NDArray
+    # Expected to be set in the case of Relative Free Energies
     atom_map: Optional[AtomMapMixin] = None
 
     def __post_init__(self):

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -24,7 +24,7 @@ from timemachine.fe.plots import (
     plot_overlap_summary_figure,
 )
 from timemachine.fe.protocol_refinement import greedy_bisection_step
-from timemachine.fe.single_topology import AtomMapMixin
+from timemachine.fe.single_topology import AtomMapFlags, AtomMapMixin
 from timemachine.fe.stored_arrays import StoredArrays
 from timemachine.fe.utils import get_mol_masses, get_romol_conf
 from timemachine.ff import ForcefieldParams
@@ -179,11 +179,11 @@ class InitialState:
         """
         assert self.atom_map is not None, "No atom map provided, unable to provide interacting atom indices"
         if self.lamb == 0.0:
-            return self.ligand_idxs[self.atom_map.c_flags != 2]
+            return self.ligand_idxs[self.atom_map.c_flags != AtomMapFlags.MOL_B]
         elif self.lamb == 1.0:
-            return self.ligand_idxs[self.atom_map.c_flags != 1]
+            return self.ligand_idxs[self.atom_map.c_flags != AtomMapFlags.MOL_A]
         else:
-            return self.ligand_idxs[self.atom_map.c_flags == 0]
+            return self.ligand_idxs[self.atom_map.c_flags == AtomMapFlags.CORE]
 
 
 @dataclass

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -169,7 +169,7 @@ def setup_initial_state(
     friction = 1.0
     intg = LangevinIntegrator(temperature, dt, friction, hmr_masses, run_seed)
 
-    return InitialState(potentials, intg, baro, x0, v0, box0, lamb, ligand_idxs, protein_idxs)
+    return InitialState(potentials, intg, baro, x0, v0, box0, lamb, ligand_idxs, protein_idxs, atom_map=st)
 
 
 def setup_optimized_host(st: SingleTopology, config: HostConfig) -> Host:

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -386,8 +386,9 @@ def optimize_coordinates(initial_states: List[InitialState], min_cutoff: Optiona
     # sanity check that no atom has moved more than `min_cutoff` nm away
     if min_cutoff is not None:
         for state, coords in zip(initial_states, all_xs):
-            # assert that ligand and protein atoms are not allowed to move more than min_cutoff
-            restricted_idxs = np.concatenate([state.ligand_idxs, state.protein_idxs])
+            non_dummy_atom_indices = state.get_interacting_ligand_atom_indices()
+            # assert that interacting ligand atoms and protein atoms are not allowed to move more than min_cutoff
+            restricted_idxs = np.concatenate([non_dummy_atom_indices, state.protein_idxs])
             displacement_distances = jax_utils.distance_on_pairs(
                 state.x0[restricted_idxs], coords[restricted_idxs], box=state.box0
             )


### PR DESCRIPTION
* Adds an optional field to `InitialState` to store the `AtomMapMixin` (or really the SingleTopology). Still allows unpickling older files since the field is optional.
* In the case of intermediate windows the dummy atoms can move all over the place and could see failures where min_cutoff assertion was triggered for non-interacting dummy atoms. 
* Sets min_cutoff == 0.0 for vacuum cases we had missed in the tests, to be consistent with `run_vacuum`.
* The definition of interacting atoms is entirely determined by the atom mapping

  * Had attempted to do this by looking at the parameters, but seems more error prone and was not immediately obvious how to handle NonbondedPairListPrecomputed parameters. 
