### PR TITLE
Adds a margin parameter to builders to ensure boxes are correctly dimensioned everywhere

### DIFF
--- a/attic/training/parameter_changes.py
+++ b/attic/training/parameter_changes.py
@@ -28,7 +28,6 @@ def get_solvent_phase_system_parameter_changes(mol, ff0, ff1, box_width=3.0, mar
     if ff0.water_ff != ff1.water_ff:
         raise RuntimeError(f"Can not alchemically change the water model: {ff0.water_ff} != {ff1.water_ff}")
     water_system, water_coords, water_box, water_topology = builders.build_water_system(box_width, ff0.water_ff)
-    water_box = water_box + np.eye(3) * margin  # add a small margin around the box for stability
 
     top = topology.RelativeFreeEnergyForcefield(mol, ff0, ff1)
     afe = free_energy.AbsoluteFreeEnergy(mol, top)

--- a/tests/common.py
+++ b/tests/common.py
@@ -452,7 +452,6 @@ def check_split_ixns(
         complex_system, host_conf, box, _, num_water_atoms = build_protein_system(
             str(path_to_pdb), ffs.ref.protein_ff, ffs.ref.water_ff
         )
-        box += np.diag([0.1, 0.1, 0.1])
 
     coords0 = np.concatenate([host_conf, ligand_conf])
     num_protein_atoms = host_conf.shape[0] - num_water_atoms

--- a/tests/nonbonded/test_nonbonded_mol_energy.py
+++ b/tests/nonbonded/test_nonbonded_mol_energy.py
@@ -69,7 +69,6 @@ def test_nonbonded_mol_energy_matches_exchange_mover_batch_U(num_mols, precision
     energies as the reference jax version in the BDExchangeMover"""
     ff = Forcefield.load_default()
     system, conf, box, _ = builders.build_water_system(5.0, ff.water_ff)
-    box += np.eye(3) * 0.1
     bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     nb = next(bp for bp in bps if isinstance(bp.potential, Nonbonded))
     bond_pot = next(bp for bp in bps if isinstance(bp.potential, HarmonicBond)).potential

--- a/tests/test_benchmark_free_energy.py
+++ b/tests/test_benchmark_free_energy.py
@@ -67,11 +67,9 @@ def setup_hif2a_single_topology_leg(host_name: str, n_windows: int, lambda_endpo
             host_sys, host_conf, box, _, num_water_atoms = builders.build_protein_system(
                 str(protein_path), forcefield.protein_ff, forcefield.water_ff
             )
-            box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
         host_config = HostConfig(host_sys, host_conf, box, num_water_atoms)
     elif host_name == "solvent":
         host_sys, host_conf, box, _ = builders.build_water_system(4.0, forcefield.water_ff)
-        box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
         host_config = HostConfig(host_sys, host_conf, box, host_conf.shape[0])
 
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()

--- a/tests/test_cuda_bd_exchange_mover.py
+++ b/tests/test_cuda_bd_exchange_mover.py
@@ -260,7 +260,6 @@ def test_sampling_single_water_in_bulk(
     """Sample a single water in a box of water. Useful to verify that we are hitting the tail end of buffers"""
     ff = Forcefield.load_default()
     system, conf, box, _ = builders.build_water_system(2.5, ff.water_ff)
-    box += np.diag([0.1, 0.1, 0.1])
     bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     nb = next(bp for bp in bps if isinstance(bp.potential, Nonbonded))
@@ -312,7 +311,6 @@ def test_sampling_single_water_in_bulk(
 def test_bias_deletion_bulk_water_with_context(precision, seed, batch_size):
     ff = Forcefield.load_default()
     system, conf, box, _ = builders.build_water_system(4.0, ff.water_ff)
-    box += np.diag([0.1, 0.1, 0.1])
     bps, masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     nb = next(bp for bp in bps if isinstance(bp.potential, Nonbonded))
     bond_pot = next(bp for bp in bps if isinstance(bp.potential, HarmonicBond)).potential
@@ -543,7 +541,6 @@ def test_moves_in_a_water_box(
     """Verify that the log acceptance probability between the reference and cuda implementation agree"""
     ff = Forcefield.load_default()
     system, conf, box, _ = builders.build_water_system(box_size, ff.water_ff)
-    box += np.diag([0.1, 0.1, 0.1])
     bps, masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     nb = next(bp for bp in bps if isinstance(bp.potential, Nonbonded))
@@ -779,7 +776,6 @@ def hif2a_complex():
     ff = Forcefield.load_default()
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as path_to_pdb:
         complex_system, conf, box, _, _ = builders.build_protein_system(str(path_to_pdb), ff.protein_ff, ff.water_ff)
-    box += np.diag([0.1, 0.1, 0.1])
     bps, masses = openmm_deserializer.deserialize_system(complex_system, cutoff=1.2)
     bond_pot = next(bp for bp in bps if isinstance(bp.potential, HarmonicBond)).potential
 
@@ -892,7 +888,6 @@ def hif2a_rbfe_state() -> InitialState:
         complex_system, complex_conf, box, _, num_water_atoms = builders.build_protein_system(
             str(path_to_pdb), ff.protein_ff, ff.water_ff
         )
-    box += np.diag([0.1, 0.1, 0.1])
     host_config = HostConfig(complex_system, complex_conf, box, num_water_atoms)
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     st = SingleTopology(mol_a, mol_b, core, ff)

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -379,7 +379,6 @@ def brd4_rbfe_state() -> InitialState:
         complex_system, complex_conf, box, _, num_water_atoms = builders.build_protein_system(
             str(pdb_path), ff.protein_ff, ff.water_ff
         )
-    box += np.diag([0.1, 0.1, 0.1])
     with resources.path("timemachine.datasets.water_exchange", "brd4_pair.sdf") as ligand_path:
         mols = read_sdf(ligand_path)
     mol_a = mols[0]
@@ -426,7 +425,6 @@ def test_targeted_insertion_buckyball_edge_cases(radius, moves, precision, rtol,
     host_sys, host_conf, host_box, host_topology, num_water_atoms = builders.build_protein_system(
         str(host_pdb), ff.protein_ff, ff.water_ff
     )
-    host_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     host_config = HostConfig(host_sys, host_conf, host_box, num_water_atoms)
 
     bt = BaseTopology(mol, ff)
@@ -664,7 +662,6 @@ def test_targeted_insertion_buckyball_determinism(radius, proposals_per_move, ba
     host_sys, host_conf, host_box, host_topology, num_water_atoms = builders.build_protein_system(
         str(host_pdb), ff.protein_ff, ff.water_ff
     )
-    host_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     host_config = HostConfig(host_sys, host_conf, host_box, num_water_atoms)
 
     bt = BaseTopology(mol, ff)

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -285,11 +285,9 @@ def test_initial_state_interacting_ligand_atoms(host_name, seed):
             host_sys, host_conf, box, _, num_water_atoms = builders.build_protein_system(
                 str(protein_path), forcefield.protein_ff, forcefield.water_ff
             )
-            box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
         host_config = HostConfig(host_sys, host_conf, box, num_water_atoms)
     elif host_name == "solvent":
         host_sys, host_conf, box, _ = builders.build_water_system(4.0, forcefield.water_ff)
-        box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
         host_config = HostConfig(host_sys, host_conf, box, host_conf.shape[0])
 
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()

--- a/tests/test_hrex_rbfe.py
+++ b/tests/test_hrex_rbfe.py
@@ -41,11 +41,9 @@ def get_hif2a_single_topology_leg(host_name: str | None):
             host_sys, host_conf, box, _, num_water_atoms = builders.build_protein_system(
                 str(protein_path), forcefield.protein_ff, forcefield.water_ff
             )
-            box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
         host_config = HostConfig(host_sys, host_conf, box, num_water_atoms)
     elif host_name == "solvent":
         host_sys, host_conf, box, _ = builders.build_water_system(4.0, forcefield.water_ff)
-        box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
         host_config = HostConfig(host_sys, host_conf, box, host_conf.shape[0])
 
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -110,7 +110,6 @@ def test_local_minimize_water_box():
 
     system, x0, box0, _ = builders.build_water_system(4.0, ff.water_ff)
     host_fns, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
-    box0 += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes at the boundary
 
     val_and_grad_fn = minimizer.get_val_and_grad_fn(host_fns, box0)
 

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -35,7 +35,6 @@ def run_bitwise_reproducibility(mol_a, mol_b, core, forcefield, md_params, estim
     box_width = 4.0
     n_windows = 3
     solvent_sys, solvent_conf, solvent_box, _ = builders.build_water_system(box_width, forcefield.water_ff)
-    solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
 
     solvent_res = estimate_relative_free_energy_fn(
@@ -123,7 +122,6 @@ def run_triple(mol_a, mol_b, core, forcefield, md_params: MDParams, protein_path
 
     box_width = 4.0
     solvent_sys, solvent_conf, solvent_box, _ = builders.build_water_system(box_width, forcefield.water_ff)
-    solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
     solvent_res = estimate_relative_free_energy_fn(
         mol_a,
@@ -143,7 +141,6 @@ def run_triple(mol_a, mol_b, core, forcefield, md_params: MDParams, protein_path
     complex_sys, complex_conf, complex_box, _, num_water_atoms = builders.build_protein_system(
         protein_path, forcefield.protein_ff, forcefield.water_ff
     )
-    complex_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     complex_host_config = HostConfig(complex_sys, complex_conf, complex_box, num_water_atoms)
     complex_res = estimate_relative_free_energy_fn(
         mol_a,

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -868,7 +868,6 @@ def test_nonbonded_intra_split_bitwise_identical(precision, lamb):
         complex_system, complex_coords, box, _, num_water_atoms = build_protein_system(
             str(path_to_pdb), ff.protein_ff, ff.water_ff
         )
-        box += np.diag([0.1, 0.1, 0.1])
 
     host_bps, host_masses = openmm_deserializer.deserialize_system(complex_system, cutoff=1.2)
     host_system = convert_bps_into_system(host_bps)

--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -49,7 +49,6 @@ def run_edge(mol_a, mol_b, protein_path, n_windows):
     # solvent
     box_width = 4.0
     solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(box_width, ff.water_ff)
-    solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
     solvent_host = setup_optimized_host(st, solvent_host_config)
     initial_states = setup_initial_states(st, solvent_host, DEFAULT_TEMP, lambda_schedule, seed)
@@ -67,7 +66,6 @@ def run_edge(mol_a, mol_b, protein_path, n_windows):
     complex_sys, complex_conf, complex_box, complex_top, num_water_atoms = builders.build_protein_system(
         protein_path, ff.protein_ff, ff.water_ff
     )
-    complex_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     complex_host_config = HostConfig(complex_sys, complex_conf, complex_box, num_water_atoms)
     complex_host = setup_optimized_host(st, complex_host_config)
     initial_states = setup_initial_states(st, complex_host, DEFAULT_TEMP, lambda_schedule, seed)
@@ -171,7 +169,6 @@ def test_min_cutoff_failure(pair, seed, n_windows):
     lambda_grid = np.linspace(0.0, 1.0, n_windows)
 
     solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(box_width, ff.water_ff)
-    solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
     solvent_host = setup_optimized_host(st, solvent_host_config)
     ligand_idxs = np.arange(st.get_num_atoms()) + solvent_host.conf.shape[0]

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -322,7 +322,6 @@ def run_solvent(
 ) -> Tuple[SimulationResult, app.topology.Topology, HostConfig]:
     box_width = 4.0
     solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(box_width, forcefield.water_ff)
-    solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes, deboggle later
     solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
     solvent_res = estimate_absolute_free_energy(
         mol,

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -883,7 +883,6 @@ def run_solvent(
         warnings.warn("Solvent simulations don't benefit from water sampling, disabling")
     box_width = 4.0
     solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(box_width, forcefield.water_ff)
-    solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes, deboggle later
     solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
     solvent_res = estimate_relative_free_energy_bisection_or_hrex(
         mol_a,
@@ -914,7 +913,6 @@ def run_complex(
     complex_sys, complex_conf, complex_box, complex_top, nwa = builders.build_protein_system(
         protein, forcefield.protein_ff, forcefield.water_ff
     )
-    complex_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes, deboggle later
     complex_host_config = HostConfig(complex_sys, complex_conf, complex_box, nwa)
     complex_res = estimate_relative_free_energy_bisection_or_hrex(
         mol_a,

--- a/timemachine/md/enhanced.py
+++ b/timemachine/md/enhanced.py
@@ -431,7 +431,6 @@ def get_solvent_phase_system(mol, ff, lamb: float, box_width=3.0, margin=0.5, mi
 
     # construct water box
     water_system, water_coords, water_box, water_topology = builders.build_water_system(box_width, ff.water_ff)
-    water_box = water_box + np.eye(3) * margin  # add a small margin around the box for stability
     host_config = HostConfig(water_system, water_coords, water_box, water_coords.shape[0])
 
     # construct alchemical system


### PR DESCRIPTION
* Originally intended to use the addSolvent(padding) option, but that is not well suited to our solvent use case (we don't add the ligands into the topology) and also **in the complex using it appears to triple the number of waters (7k -> 21k). The latter of which may indicate an issue with our current set up**
* The values picked are empirically, pretty similar to what we were using before

I looked at the following plots, just increasing the padding slightly until the forces tapered off. Has been suggested by @maxentile  to bisect on the right box volume, which may be the better way of approaching this.
## 4nm Solvent
![solvent_padding_impact_on_max_force](https://github.com/user-attachments/assets/99da870e-2186-4186-ba30-ec50990cd886)

## Hif2a Complex
![complex_padding_impact_on_max_force](https://github.com/user-attachments/assets/43114848-4f7b-4620-bcfb-8c65d8514932)


