### PR TITLE
Perf/verify_chiral_consistency_of_core

### DIFF
--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -1442,7 +1442,7 @@ $$$$""",
         removeHs=False,
     )
 
-    ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
+    ff = Forcefield.load_from_file("placeholder_ff.py")
     core = np.array([[0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [6, 6]])
 
     with pytest.raises(ChiralConversionError):

--- a/timemachine/ff/make_placeholder_ff.py
+++ b/timemachine/ff/make_placeholder_ff.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+from timemachine.ff import Forcefield
+from timemachine.ff.handlers.bonded import (
+    HarmonicAngleHandler,
+    HarmonicBondHandler,
+    ImproperTorsionHandler,
+    ProperTorsionHandler,
+)
+from timemachine.ff.handlers.nonbonded import (
+    LennardJonesHandler,
+    LennardJonesIntraHandler,
+    LennardJonesSolventHandler,
+    SimpleChargeHandler,
+    SimpleChargeIntraHandler,
+    SimpleChargeSolventHandler,
+)
+
+# bonded
+placeholder_hb_handle = HarmonicBondHandler(smirks=["[*:1]~[*:2]"], params=np.array([[1e5, 1e-1]]), props=None)
+placeholder_ha_handle = HarmonicAngleHandler(
+    smirks=["[*:1]~[*:2]~[*:3]"], params=np.array([[1e2, np.pi / 2]]), props=None
+)
+placeholder_pt_handle = ProperTorsionHandler(
+    smirks=["[*:1]~[*:2]~[*:3]~[*:4]"], params=np.array([[1.0, 0.0, 1]]), props=None
+)
+placeholder_it_handle = ImproperTorsionHandler(
+    smirks=["[*:1]~[#6X3,#7X3:2](~[*:3])~[*:4]"], params=np.array([[1.0, np.pi, 2]]), props=None
+)
+
+# charge / chargeintra / chargesolvent
+_q_smirks = ["[*:1]"]
+_q_params = np.zeros(1)
+
+placeholder_q_handle = SimpleChargeHandler(smirks=_q_smirks, params=_q_params, props=None)
+placeholder_q_handle_intra = SimpleChargeIntraHandler(smirks=_q_smirks, params=_q_params, props=None)
+placeholder_q_handle_solv = SimpleChargeSolventHandler(smirks=_q_smirks, params=_q_params, props=None)
+
+# lj / ljintra / ljsolvent
+_lj_smirks = ["[*:1]"]
+_lj_params = np.array([[0.1, 1.0]])
+
+placeholder_lj_handle = LennardJonesHandler(smirks=_lj_smirks, params=_lj_params, props=None)
+placeholder_lj_handle_intra = LennardJonesIntraHandler(smirks=_lj_smirks, params=_lj_params, props=None)
+placeholder_lj_handle_solv = LennardJonesSolventHandler(smirks=_lj_smirks, params=_lj_params, props=None)
+
+# construct
+placeholder_ff = Forcefield(
+    hb_handle=placeholder_hb_handle,
+    ha_handle=placeholder_ha_handle,
+    pt_handle=placeholder_pt_handle,
+    it_handle=placeholder_it_handle,
+    q_handle=placeholder_q_handle,
+    q_handle_intra=placeholder_q_handle_intra,
+    q_handle_solv=placeholder_q_handle_solv,
+    lj_handle=placeholder_lj_handle,
+    lj_handle_intra=placeholder_lj_handle_intra,
+    lj_handle_solv=placeholder_lj_handle_solv,
+    protein_ff="amber99sbildn",
+    water_ff="amber14/tip3p",
+)
+
+# serialize
+with open("params/placeholder_ff.py", "w") as f:
+    f.write(placeholder_ff.serialize())

--- a/timemachine/ff/params/placeholder_ff.py
+++ b/timemachine/ff/params/placeholder_ff.py
@@ -1,0 +1,12 @@
+{'HarmonicAngle': {'patterns': [('[*:1]~[*:2]~[*:3]', 100.0, 1.5707963267948966)]},
+ 'HarmonicBond': {'patterns': [('[*:1]~[*:2]', 100000.0, 0.1)]},
+ 'ImproperTorsion': {'patterns': [('[*:1]~[#6X3,#7X3:2](~[*:3])~[*:4]', 1.0, 3.141592653589793, 2.0)]},
+ 'LennardJones': {'patterns': [('[*:1]', 0.1, 1.0)]},
+ 'LennardJonesIntra': {'patterns': [('[*:1]', 0.1, 1.0)]},
+ 'LennardJonesSolvent': {'patterns': [('[*:1]', 0.1, 1.0)]},
+ 'ProperTorsion': {'patterns': [('[*:1]~[*:2]~[*:3]~[*:4]', [1.0, 0.0, 1.0])]},
+ 'ProteinForcefield': 'amber99sbildn',
+ 'SimpleCharge': {'patterns': [('[*:1]', 0.0)]},
+ 'SimpleChargeIntra': {'patterns': [('[*:1]', 0.0)]},
+ 'SimpleChargeSolvent': {'patterns': [('[*:1]', 0.0)]},
+ 'WaterForcefield': 'amber14/tip3p'}

--- a/timemachine/ff/readme.md
+++ b/timemachine/ff/readme.md
@@ -36,3 +36,7 @@ Timemachine does not currently support the full OpenForceField definition. The f
 ## AM1BCC Charges
 
 The AM1BCC charges used as the basis for our CCC originally come from the [recharge](https://github.com/openforcefield/openff-recharge) project, a port of the original AM1BCC parameters by Christopher Bayly. The source of the charges comes directly from the charges defined [here](https://github.com/openforcefield/openff-recharge/blob/cf18f1920d35af0025ce90c4e1a7f7280b4bd76d/openff/recharge/data/bcc/original-am1-bcc.json).
+
+
+## Misc
+For some implementation purposes it may be convenient to produce a placeholder force field file that has the right slots, but is not necessarily chemically reasonable. `make_placeholder_ff.py` is a script that generates a forcefield .py file with a single generic type for each potential.


### PR DESCRIPTION
Implements the second option in https://github.com/proteneer/timemachine/pull/1315#discussion_r1621470240 , maybe ~10x faster on an example than using the `"smirnoff_1_1_0_sc.py"` file.

<details>

```python
from timemachine.fe.single_topology import verify_chiral_consistency_of_core
from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
from timemachine.ff import Forcefield

mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()

default_ff = Forcefield.load_default()
sc_ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
placeholder_ff = Forcefield.load_from_file("placeholder_ff.py")

# ~500ms
_ = verify_chiral_consistency_of_core(mol_a, mol_b, core, default_ff)

# ~500ms
_ = verify_chiral_consistency_of_core(mol_a, mol_b, core, sc_ff)

# ~30ms
_ = verify_chiral_consistency_of_core(mol_a, mol_b, core, placeholder_ff)
```

</details>

Adds a `"placeholder_ff.py"` file (with a single generic type per potential) to `ff/params` in case useful in similar contexts. (wherever it might be convenient to go through a `.parameterize(mol)` code path to get `potential.idxs` but `potential.params` would be unnecessary, and you want to minimize the number of unnecessary smarts queries.)

