### PR TITLE
Speed up and refactor chiral checks

### DIFF
--- a/examples/relative_free_energy.py
+++ b/examples/relative_free_energy.py
@@ -6,9 +6,9 @@ from rdkit import Chem
 
 from timemachine.constants import DEFAULT_ATOM_MAPPING_KWARGS
 from timemachine.fe import atom_mapping, cif_writer
+from timemachine.fe.atom_map_mixin import AtomMapMixin
 from timemachine.fe.free_energy import HREXParams, MDParams, WaterSamplingParams
 from timemachine.fe.rbfe import run_complex, run_solvent
-from timemachine.fe.single_topology import AtomMapMixin
 from timemachine.fe.utils import plot_atom_mapping_grid, read_sdf
 from timemachine.ff import Forcefield
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology

--- a/tests/test_chiral_restraints.py
+++ b/tests/test_chiral_restraints.py
@@ -8,10 +8,10 @@ from rdkit import Chem
 
 from timemachine.constants import DEFAULT_CHIRAL_ATOM_RESTRAINT_K, DEFAULT_CHIRAL_BOND_RESTRAINT_K
 from timemachine.fe import topology, utils
+from timemachine.fe.atom_map_mixin import AtomMapMixin
 from timemachine.fe.chiral_utils import make_chiral_flip_heatmaps
 from timemachine.fe.free_energy import HREXParams
 from timemachine.fe.rbfe import DEFAULT_HREX_PARAMS, run_solvent, run_vacuum
-from timemachine.fe.single_topology import AtomMapMixin
 from timemachine.fe.system import simulate_system
 from timemachine.ff import Forcefield
 from timemachine.potentials import chiral_restraints

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -13,6 +13,7 @@ from scipy.optimize import check_grad, minimize
 
 from timemachine.constants import DEFAULT_TEMP
 from timemachine.fe import free_energy, topology, utils
+from timemachine.fe.atom_map_mixin import AtomMapFlags
 from timemachine.fe.bar import ukln_to_ukn
 from timemachine.fe.free_energy import (
     BarResult,
@@ -33,7 +34,7 @@ from timemachine.fe.free_energy import (
     trajectories_by_replica_to_by_state,
 )
 from timemachine.fe.rbfe import Host, setup_initial_state, setup_initial_states, setup_optimized_host
-from timemachine.fe.single_topology import AtomMapFlags, SingleTopology
+from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.stored_arrays import StoredArrays
 from timemachine.fe.system import convert_omm_system
 from timemachine.ff import Forcefield

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -20,6 +20,7 @@ from timemachine.constants import (
     DEFAULT_CHIRAL_BOND_RESTRAINT_K,
 )
 from timemachine.fe import atom_mapping, single_topology
+from timemachine.fe.chiral_utils import ChiralConversionError, verify_chiral_consistency_of_core
 from timemachine.fe.dummy import MultipleAnchorWarning
 from timemachine.fe.free_energy import HostConfig
 from timemachine.fe.interpolate import (
@@ -30,7 +31,6 @@ from timemachine.fe.interpolate import (
 )
 from timemachine.fe.single_topology import (
     ChargePertubationError,
-    ChiralConversionError,
     CoreBondChangeWarning,
     SingleTopology,
     canonicalize_improper_idxs,
@@ -40,7 +40,6 @@ from timemachine.fe.single_topology import (
     interpolate_harmonic_force_constant,
     interpolate_w_coord,
     setup_dummy_interactions_from_ff,
-    verify_chiral_consistency_of_core,
 )
 from timemachine.fe.system import convert_bps_into_system, minimize_scipy, simulate_system
 from timemachine.fe.utils import get_mol_name, get_romol_conf, read_sdf

--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -5,8 +5,9 @@ import pytest
 
 from timemachine.constants import DEFAULT_ATOM_MAPPING_KWARGS, DEFAULT_TEMP
 from timemachine.fe import atom_mapping, cif_writer, utils
+from timemachine.fe.atom_map_mixin import AtomMapMixin
 from timemachine.fe.rbfe import HostConfig, setup_initial_states, setup_optimized_host
-from timemachine.fe.single_topology import AtomMapMixin, SingleTopology
+from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.utils import get_mol_name, read_sdf
 from timemachine.ff import Forcefield
 from timemachine.md import builders

--- a/timemachine/fe/atom_map_mixin.py
+++ b/timemachine/fe/atom_map_mixin.py
@@ -1,0 +1,88 @@
+from enum import IntEnum
+
+import numpy as np
+
+
+class AtomMapFlags(IntEnum):
+    CORE = 0
+    MOL_A = 1
+    MOL_B = 2
+
+
+class AtomMapMixin:
+    """
+    A Mixin class containing the atom_mapping information. This Mixin sets up the following
+    members:
+
+    self.mol_a
+    self.mol_b
+    self.core
+    self.a_to_c
+    self.b_to_c
+    self.c_to_a
+    self.c_to_b
+    self.c_flags
+    """
+
+    def __init__(self, mol_a, mol_b, core):
+        assert core.shape[1] == 2
+        assert mol_a is not None
+        assert mol_b is not None
+
+        self.mol_a = mol_a
+        self.mol_b = mol_b
+        self.core = core
+        assert mol_a is not None
+        assert mol_b is not None
+        assert core.shape[1] == 2
+
+        # map into idxs in the combined molecule
+
+        self.a_to_c = np.arange(mol_a.GetNumAtoms(), dtype=np.int32)  # identity
+        self.b_to_c = np.zeros(mol_b.GetNumAtoms(), dtype=np.int32) - 1
+
+        # mark membership:
+        # AtomMapFlags.CORE: Core
+        # AtomMapFlags.MOL_A: R_A (default)
+        # AtomMapFlags.MOL_B: R_B
+        self.c_flags = np.ones(self.get_num_atoms(), dtype=np.int32) * AtomMapFlags.MOL_A
+        # test for uniqueness in core idxs for each mol
+        assert len(set(tuple(core[:, 0]))) == len(core[:, 0])
+        assert len(set(tuple(core[:, 1]))) == len(core[:, 1])
+
+        for a, b in core:
+            self.c_flags[a] = AtomMapFlags.CORE
+            self.b_to_c[b] = a
+
+        iota = self.mol_a.GetNumAtoms()
+        for b_idx, c_idx in enumerate(self.b_to_c):
+            if c_idx == -1:
+                self.b_to_c[b_idx] = iota
+                self.c_flags[iota] = AtomMapFlags.MOL_B
+                iota += 1
+
+        # setup reverse mappings
+        self.c_to_a = {v: k for k, v in enumerate(self.a_to_c)}
+        self.c_to_b = {v: k for k, v in enumerate(self.b_to_c)}
+
+    def get_num_atoms(self):
+        """
+        Get the total number of atoms in the alchemical hybrid.
+
+        Returns
+        -------
+        int
+            Total number of atoms.
+        """
+        return self.mol_a.GetNumAtoms() + self.mol_b.GetNumAtoms() - len(self.core)
+
+    def get_num_dummy_atoms(self):
+        """
+        Get the total number of dummy atoms in the alchemical hybrid.
+
+        Returns
+        -------
+        int
+            Total number of atoms.
+        """
+        return self.mol_a.GetNumAtoms() + self.mol_b.GetNumAtoms() - len(self.core) - len(self.core)

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -14,7 +14,12 @@ from rdkit.Chem.rdchem import BondType
 from timemachine.constants import DEFAULT_CHIRAL_ATOM_RESTRAINT_K, DEFAULT_CHIRAL_BOND_RESTRAINT_K
 from timemachine.fe import topology
 from timemachine.fe.atom_map_mixin import AtomMapMixin
-from timemachine.fe.dummy import canonicalize_bond
+from timemachine.fe.dummy import (
+    canonicalize_bond,
+    convert_bond_list_to_nx,
+    generate_dummy_group_assignments,
+    get_romol_bonds,
+)
 from timemachine.fe.utils import get_romol_conf, recursive_map
 from timemachine.graph_utils import convert_to_nx, enumerate_simple_paths
 from timemachine.potentials import BoundPotential, ChiralAtomRestraint, ChiralBondRestraint, HarmonicBond
@@ -549,8 +554,6 @@ def setup_end_state_harmonic_bond_and_chiral_potentials(
     """
     all_dummy_bond_idxs, all_dummy_bond_params = [], []
     all_dummy_chiral_atom_idxs, all_dummy_chiral_atom_params = [], []
-
-    from timemachine.fe.dummy import convert_bond_list_to_nx, generate_dummy_group_assignments, get_romol_bonds
 
     bonds_b = get_romol_bonds(mol_b)
     bond_graph_b = convert_bond_list_to_nx(bonds_b)

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -1,18 +1,23 @@
 import itertools
+import warnings
 from enum import Enum
 from functools import partial
-from typing import Callable, Iterator, List, Mapping, Sequence, Set, Tuple
+from typing import Callable, Collection, Iterator, List, Mapping, Sequence, Set, Tuple
 
+import networkx as nx
 import numpy as np
 from jax import jit
 from numpy.typing import NDArray
 from rdkit import Chem
 from rdkit.Chem.rdchem import BondType
 
-from timemachine.constants import DEFAULT_CHIRAL_ATOM_RESTRAINT_K
+from timemachine.constants import DEFAULT_CHIRAL_ATOM_RESTRAINT_K, DEFAULT_CHIRAL_BOND_RESTRAINT_K
+from timemachine.fe import topology
+from timemachine.fe.atom_map_mixin import AtomMapMixin
 from timemachine.fe.dummy import canonicalize_bond
-from timemachine.fe.utils import get_romol_conf
+from timemachine.fe.utils import get_romol_conf, recursive_map
 from timemachine.graph_utils import convert_to_nx, enumerate_simple_paths
+from timemachine.potentials import BoundPotential, ChiralAtomRestraint, ChiralBondRestraint, HarmonicBond
 from timemachine.potentials.chiral_restraints import U_chiral_atom_batch, pyramidal_volume, torsion_volume
 
 FourTuple = Tuple[int, int, int, int]
@@ -484,3 +489,338 @@ def make_chiral_flip_heatmaps(simulation_result, atom_map):
     assert mol_a_chiral_conflicts.shape == (len(simulation_result.frames), len(simulation_result.frames[0]))
 
     return mol_a_chiral_conflicts, mol_b_chiral_conflicts
+
+
+def get_num_connected_components(num_atoms: int, bonds: Collection[Tuple[int, int]]) -> int:
+    g = nx.Graph()
+    g.add_nodes_from(range(num_atoms))
+    g.add_edges_from(bonds)
+    return len(list(nx.connected_components(g)))
+
+
+def canonicalize_chiral_atom_idxs(idxs):
+    i, j, k, l = idxs
+    rotations = [(j, k, l), (l, j, k), (k, l, j)]
+    jj, kk, ll = min(rotations)
+    return i, jj, kk, ll
+
+
+def setup_end_state_harmonic_bond_and_chiral_potentials(
+    ff, mol_a, mol_b, core, a_to_c, b_to_c
+) -> Tuple[BoundPotential[HarmonicBond], BoundPotential[ChiralAtomRestraint], BoundPotential[ChiralBondRestraint]]:
+    """
+    Setup end-state potentials to verify chiral correctness for mol_a with dummy atoms of mol_b attached. The mapped indices will correspond
+    to the alchemical molecule with dummy atoms. Note that the bond, chiral atom and chiral bond idxs are canonicalized.
+
+    This code is identical to setup_end_state, but only handles chiral potentials to be used to quickly verify
+    core mappings in verify_chiral_consistency_of_core
+
+    Parameters
+    ----------
+    ff: forcefield.Forcefield
+        Forcefield used to parameterize the molecule
+
+    mol_a: Chem.Mol
+        Fully interacting molecule
+
+    mol_b: Chem.Mol
+        Molecule providing the dummy atoms.
+
+    core: list of 2-tuples
+        Each pair is an atom mapping from mol_a into mol_b
+
+    a_to_c: dict or array, supports []
+        mapping from a into a common core idx
+
+    b_to_c: dict or array, supports []
+        mapping from b into a common core idx
+
+    Returns
+    -------
+    Tuple of bound HarmonicBond, ChiralAtomRestraint and ChiralBondRestraint
+        The potentials involved in checking the correctness and validity of chirality at endstates.
+
+    """
+    all_dummy_bond_idxs, all_dummy_bond_params = [], []
+    all_dummy_chiral_atom_idxs, all_dummy_chiral_atom_params = [], []
+
+    from timemachine.fe.dummy import convert_bond_list_to_nx, generate_dummy_group_assignments, get_romol_bonds
+
+    bonds_b = get_romol_bonds(mol_b)
+    bond_graph_b = convert_bond_list_to_nx(bonds_b)
+    dummy_group_assignments = generate_dummy_group_assignments(bond_graph_b, core[:, 1])
+
+    # pick an arbitrary one
+    # later on, iterate over multiple ones.
+    dga = next(dummy_group_assignments)
+
+    for anchor, dg in dga.items():
+        all_idxs, all_params = setup_dummy_bond_and_chiral_interactions_from_ff(
+            ff, mol_b, dg, anchor, core[:, 1], DEFAULT_CHIRAL_ATOM_RESTRAINT_K, DEFAULT_CHIRAL_BOND_RESTRAINT_K
+        )
+        # append idxs
+        all_dummy_bond_idxs.extend(all_idxs[0])
+        all_dummy_chiral_atom_idxs.extend(all_idxs[1])
+        # append params
+        all_dummy_bond_params.extend(all_params[0])
+        all_dummy_chiral_atom_params.extend(all_params[1])
+
+    # generate parameters for mol_a
+    mol_a_top = topology.BaseTopology(mol_a, ff)
+    mol_a_bond_params, mol_a_hb = mol_a_top.parameterize_harmonic_bond(ff.hb_handle.params)
+    mol_a_chiral_atom, mol_a_chiral_bond = mol_a_top.setup_chiral_restraints(
+        DEFAULT_CHIRAL_ATOM_RESTRAINT_K, DEFAULT_CHIRAL_BOND_RESTRAINT_K
+    )
+
+    mol_a_bond_params = mol_a_bond_params.tolist()
+
+    mol_a_bond_idxs = recursive_map(mol_a_hb.idxs, a_to_c)
+    mol_a_chiral_atom_idxs = recursive_map(mol_a_chiral_atom.potential.idxs, a_to_c)
+    mol_a_chiral_bond_idxs = recursive_map(mol_a_chiral_bond.potential.idxs, a_to_c)
+
+    all_dummy_bond_idxs = recursive_map(all_dummy_bond_idxs, b_to_c)
+    all_dummy_chiral_atom_idxs = recursive_map(all_dummy_chiral_atom_idxs, b_to_c)
+
+    # parameterize the combined molecule
+    mol_c_bond_idxs = mol_a_bond_idxs + all_dummy_bond_idxs
+    mol_c_bond_params = mol_a_bond_params + all_dummy_bond_params
+
+    # process chiral volumes, turning off ones at the end-state that have a missing bond.
+    canon_mol_a_bond_idxs_set = set([canonicalize_bond(x) for x in mol_a_bond_idxs])
+    # assert presence of bonds
+    for c, i, j, k in mol_a_chiral_atom_idxs:
+        ci = canonicalize_bond((c, i))
+        cj = canonicalize_bond((c, j))
+        ck = canonicalize_bond((c, k))
+        assert ci in canon_mol_a_bond_idxs_set
+        assert cj in canon_mol_a_bond_idxs_set
+        assert ck in canon_mol_a_bond_idxs_set
+
+    canon_mol_c_bond_idxs_set = set([canonicalize_bond(x) for x in mol_c_bond_idxs])
+
+    # Chiral atom restraint c,i,j,k requires that all bonds ci, cj, ck be present at the
+    # end-state in order to be numerically stable under small perturbations due to normalization
+    # along the bond lengths. However, the angle terms defining icj, ick, and jck can be
+    # either 0 or 180, since the normalized chiral volume is still smooth wrt perturbations
+    all_proper_dummy_chiral_atom_idxs = []
+    all_proper_dummy_chiral_atom_params = []
+    for (c, i, j, k), p in zip(all_dummy_chiral_atom_idxs, all_dummy_chiral_atom_params):
+        ci = canonicalize_bond((c, i))
+        cj = canonicalize_bond((c, j))
+        ck = canonicalize_bond((c, k))
+        if ci in canon_mol_c_bond_idxs_set and cj in canon_mol_c_bond_idxs_set and ck in canon_mol_c_bond_idxs_set:
+            all_proper_dummy_chiral_atom_idxs.append((c, i, j, k))
+            all_proper_dummy_chiral_atom_params.append(p)
+        else:
+            warnings.warn(f"Chiral Volume {c,i,j,k} has a disabled bond, turning off.")
+
+    mol_c_chiral_atom_idxs = list(mol_a_chiral_atom_idxs) + list(all_proper_dummy_chiral_atom_idxs)
+    mol_c_chiral_atom_params = np.concatenate([mol_a_chiral_atom.params, all_proper_dummy_chiral_atom_params])
+
+    # canonicalize bonds
+    mol_c_bond_idxs_canon = np.array([canonicalize_bond(idxs) for idxs in mol_c_bond_idxs])
+    bond_potential = HarmonicBond(mol_c_bond_idxs_canon).bind(np.array(mol_c_bond_params))
+
+    # chiral atoms need special code for canonicalization, since triple product is invariant
+    # under rotational symmetry (but not something like swap symmetry)
+    canon_chiral_atom_idxs = []
+    for idxs in mol_c_chiral_atom_idxs:
+        canon_chiral_atom_idxs.append(canonicalize_chiral_atom_idxs(idxs))
+
+    chiral_atom_idxs = np.array(canon_chiral_atom_idxs, dtype=np.int32).reshape((-1, 4))
+    mol_c_chiral_bond_idxs_canon = [canonicalize_bond(idxs) for idxs in mol_a_chiral_bond_idxs]
+    chiral_bond_idxs = np.array(mol_c_chiral_bond_idxs_canon, dtype=np.int32).reshape((-1, 4))
+    chiral_bond_signs = np.array(mol_a_chiral_bond.potential.signs)
+
+    chiral_atom_potential = ChiralAtomRestraint(chiral_atom_idxs).bind(mol_c_chiral_atom_params)
+    chiral_bond_potential = ChiralBondRestraint(chiral_bond_idxs, chiral_bond_signs).bind(mol_a_chiral_bond.params)
+
+    num_atoms = mol_a.GetNumAtoms() + mol_b.GetNumAtoms() - len(core)
+    assert (
+        get_num_connected_components(num_atoms, bond_potential.potential.idxs) == 1
+    ), "hybrid molecule has multiple connected components"
+    return bond_potential, chiral_atom_potential, chiral_bond_potential
+
+
+def setup_dummy_bond_and_chiral_interactions_from_ff(
+    ff, mol, dummy_group, root_anchor_atom, core_atoms, chiral_atom_k, chiral_bond_k
+):
+    """
+    Setup interactions involving atoms in a given dummy group.
+    """
+    top = topology.BaseTopology(mol, ff)
+
+    bond_params, hb = top.parameterize_harmonic_bond(ff.hb_handle.params)
+    chiral_atom_potential, _ = top.setup_chiral_restraints(chiral_atom_k, chiral_bond_k)
+    chiral_atom_idxs = chiral_atom_potential.potential.idxs
+    chiral_atom_params = chiral_atom_potential.params
+
+    return setup_dummy_bond_and_chiral_interactions(
+        hb.idxs,
+        bond_params,
+        chiral_atom_idxs,
+        chiral_atom_params,
+        dummy_group,
+        root_anchor_atom,
+        core_atoms,
+    )
+
+
+def setup_dummy_bond_and_chiral_interactions(
+    bond_idxs,
+    bond_params,
+    chiral_atom_idxs,
+    chiral_atom_params,
+    dummy_group,
+    root_anchor_atom,
+    core_atoms,
+):
+    assert root_anchor_atom in core_atoms
+
+    dummy_bond_idxs = []
+    dummy_bond_params = []
+    dummy_chiral_atom_idxs = []
+    dummy_chiral_atom_params = []
+
+    # dummy_group may be a set in certain cases, so sanity check.
+
+    assert len(dummy_group) == len(list(dummy_group))
+    dummy_group = list(dummy_group)
+
+    # dummy group and anchor
+    dga = dummy_group + [root_anchor_atom]
+
+    # copy interactions that involve only root_anchor_atom
+    for idxs, params in zip(bond_idxs, bond_params):
+        if all([a in dga for a in idxs]):
+            dummy_bond_idxs.append(tuple([int(x) for x in idxs]))  # tuples are hashable etc.
+            dummy_bond_params.append(params)
+
+    # certain configuration of chiral states are symmetrizable
+    # . means a bond involving at least 1 dummy atom
+    # | means a bond involving only core atoms
+    #
+    #        all allowed geometries              |  disallowed geometry
+    #     center is core     center is not core  |
+    #    d      c      c      d      d      d    |    c      c
+    #    .      |      |      .      .      .    |    .      |
+    #    c      c      c      d      d      d    |    d      c
+    #   . .    . .    / .    . .    . .    . .   |   . .    / \
+    #  d   d  d   d  c   d  c   d  c   c  d   d  |  c   c  c   c (only core)
+    dgc = dummy_group + list(core_atoms)
+    for idxs, params in zip(chiral_atom_idxs, chiral_atom_params):
+        center, i, j, k = idxs
+        if all([a in dgc for a in idxs]):
+            # non center dummy atom count
+            ncda_count = sum([a in dummy_group for a in (i, j, k)])
+            if ncda_count == 1 or ncda_count == 2 or ncda_count == 3:
+                assert not all(a in core_atoms for a in idxs)
+                dummy_chiral_atom_idxs.append(tuple(int(x) for x in idxs))
+                dummy_chiral_atom_params.append(params)
+
+    bonded_idxs = (dummy_bond_idxs, dummy_chiral_atom_idxs)
+    bonded_params = (dummy_bond_params, dummy_chiral_atom_params)
+    return bonded_idxs, bonded_params
+
+
+def verify_chiral_consistency_of_core(mol_a: Chem.Mol, mol_b: Chem.Mol, core: NDArray, forcefield):
+    """Verify that a core and forcefield would allow for valid chiral endstates.
+
+    Refer to `assert_chiral_consistency_and_validity` for definitions of consistency and validity.
+
+    Raises
+    ------
+        ChiralConversionError
+            If chiral end states are incompatible for the given core and forcefield.
+    """
+    atom_map = AtomMapMixin(mol_a, mol_b, core)
+    bond_pot_src, chiral_atom_pot_src, _ = setup_end_state_harmonic_bond_and_chiral_potentials(
+        forcefield, mol_a, mol_b, core, atom_map.a_to_c, atom_map.b_to_c
+    )
+    bond_pot_dest, chiral_atom_pot_dest, _ = setup_end_state_harmonic_bond_and_chiral_potentials(
+        forcefield, mol_b, mol_a, core[:, ::-1], atom_map.b_to_c, atom_map.a_to_c
+    )
+    assert_chiral_consistency_and_validity(
+        atom_map,
+        chiral_atom_pot_src.potential.idxs,
+        chiral_atom_pot_dest.potential.idxs,
+        bond_pot_src.potential.idxs,
+        bond_pot_dest.potential.idxs,
+    )
+
+
+def get_neighbors(atom, bond_idxs) -> List[int]:
+    nbs = []
+    for i, j in bond_idxs:
+        if i == atom:
+            nbs.append(j)
+        elif j == atom:
+            nbs.append(i)
+    return nbs
+
+
+class ChiralConversionError(RuntimeError):
+    pass
+
+
+def check_chiral_validity(src_chiral_centers_in_mol_c, dst_chiral_restr_idx_set, src_bond_idxs):
+    """Raise error unless, for every chiral center, at least 1 chiral volume is defined in both end-states."""
+
+    for c in src_chiral_centers_in_mol_c:
+        nbs = get_neighbors(c, src_bond_idxs)
+        if len(nbs) == 4:
+            i, j, k, l = nbs
+            # (ytz): the ordering of i,j,k,l is random if we're reading directly from the mol graph,
+            # which can be inconsistent with the ordering used in the chiral volume definition.
+            nb_subsets = [(i, j, k), (i, j, l), (i, k, l), (j, k, l)]  # 4-choose-3 subsets
+            flags = [dst_chiral_restr_idx_set.defines((c, ii, jj, kk)) for (ii, jj, kk) in nb_subsets]
+
+            if sum(flags) == 0:
+                raise ChiralConversionError(f"len(nbs) == 4 {c, i, j, k, l}")
+
+        if len(nbs) == 3:
+            i, j, k = nbs
+            flag_0 = dst_chiral_restr_idx_set.defines((c, i, j, k))
+            if not flag_0:
+                raise ChiralConversionError(f"len(nbs) == 3 {c, i, j, k}")
+
+
+def assert_chiral_consistency_and_validity(
+    atom_map: AtomMapMixin,
+    src_chiral_idxs,
+    dst_chiral_idxs,
+    src_bond_idxs: NDArray,
+    dst_bond_idxs: NDArray,
+):
+    """
+    Assert that the given the two end states chiral and bond idxs it would be both consistent and valid.
+
+    consistency: if there are no inversions at the end-states between chiral atoms and bonds are present
+    validity: if we can directly turn on the chiral volumes (after bonds) without staggering angles
+    """
+
+    for c, i, j, k in src_chiral_idxs:
+        assert canonicalize_bond((c, i)) in src_bond_idxs
+        assert canonicalize_bond((c, j)) in src_bond_idxs
+        assert canonicalize_bond((c, k)) in src_bond_idxs
+
+    for c, i, j, k in dst_chiral_idxs:
+        assert canonicalize_bond((c, i)) in dst_bond_idxs
+        assert canonicalize_bond((c, j)) in dst_bond_idxs
+        assert canonicalize_bond((c, k)) in dst_bond_idxs
+
+    src_chiral_restr_idx_set = ChiralRestrIdxSet(src_chiral_idxs)
+    dst_chiral_restr_idx_set = ChiralRestrIdxSet(dst_chiral_idxs)
+
+    # ensure that we don't have any chiral inversions between src and dst end states
+    assert len(src_chiral_restr_idx_set.allowed_set.intersection(dst_chiral_restr_idx_set.disallowed_set)) == 0
+    assert len(dst_chiral_restr_idx_set.allowed_set.intersection(src_chiral_restr_idx_set.disallowed_set)) == 0
+
+    chiral_centers_in_mol_a = find_chiral_atoms(atom_map.mol_a)
+    chiral_centers_in_mol_b = find_chiral_atoms(atom_map.mol_b)
+
+    src_chiral_centers_in_mol_c = [atom_map.a_to_c[x] for x in chiral_centers_in_mol_a]
+    dst_chiral_centers_in_mol_c = [atom_map.b_to_c[x] for x in chiral_centers_in_mol_b]
+
+    check_chiral_validity(src_chiral_centers_in_mol_c, dst_chiral_restr_idx_set, src_bond_idxs)
+    check_chiral_validity(dst_chiral_centers_in_mol_c, src_chiral_restr_idx_set, dst_bond_idxs)

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -30,6 +30,10 @@ class ChiralCheckMode(Enum):
     UNDEFINED = 2
 
 
+class ChiralConversionError(RuntimeError):
+    pass
+
+
 def setup_chiral_atom_restraints(mol, conf, a_idx):
     """
     Setup chiral atom restraints for the molecule at a_idx by inspecting the
@@ -430,7 +434,7 @@ def xs_ab_from_xs(xs: NDArray, atom_map):
     ----------
     xs: An array of coordinates
         Coordinates containing the alchemical molecule constructed for RBFE
-    atom_map: timemachine.fe.single_topology.AtomMapMixin
+    atom_map: timemachine.fe.atom_map_mixin.AtomMapMixin
         Contains the atom map between the two end state molecules
 
     Returns
@@ -461,7 +465,7 @@ def make_chiral_flip_heatmaps(simulation_result, atom_map):
     simulation_result: timemachine.fe.free_energy.SimulationResult
         Containing all of the frames that make up a simulation_result, may contain intermediate windows
 
-    atom_map: timemachine.fe.single_topology.AtomMapMixin
+    atom_map: timemachine.fe.atom_map_mixin.AtomMapMixin
         Contains the atom map between the two end state molecules
 
     Returns
@@ -505,6 +509,8 @@ def canonicalize_chiral_atom_idxs(idxs):
     return i, jj, kk, ll
 
 
+# (ytz): TODO: Refactor this so the HarmonicBond setup is done in single_topology.py in the future and
+# isolate functionality in this module to chirality-specific tasks.
 def setup_end_state_harmonic_bond_and_chiral_potentials(
     ff, mol_a, mol_b, core, a_to_c, b_to_c
 ) -> Tuple[BoundPotential[HarmonicBond], BoundPotential[ChiralAtomRestraint], BoundPotential[ChiralBondRestraint]]:
@@ -757,10 +763,6 @@ def get_neighbors(atom, bond_idxs) -> List[int]:
         elif j == atom:
             nbs.append(i)
     return nbs
-
-
-class ChiralConversionError(RuntimeError):
-    pass
 
 
 def check_chiral_validity(src_chiral_centers_in_mol_c, dst_chiral_restr_idx_set, src_bond_idxs):

--- a/timemachine/fe/cif_writer.py
+++ b/timemachine/fe/cif_writer.py
@@ -3,7 +3,7 @@ from openmm import app
 from openmm.app import PDBxFile
 from rdkit import Chem
 
-from timemachine.fe.single_topology import AtomMapMixin
+from timemachine.fe.atom_map_mixin import AtomMapMixin
 
 
 def convert_single_topology_mols(coords: np.ndarray, atom_map: AtomMapMixin) -> np.ndarray:

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -12,6 +12,7 @@ from rdkit import Chem
 
 from timemachine.constants import DEFAULT_ATOM_MAPPING_KWARGS, DEFAULT_PRESSURE, DEFAULT_TEMP
 from timemachine.fe import atom_mapping, model_utils
+from timemachine.fe.atom_map_mixin import AtomMapFlags
 from timemachine.fe.free_energy import (
     HostConfig,
     HREXParams,
@@ -33,7 +34,7 @@ from timemachine.fe.plots import (
     plot_hrex_swap_acceptance_rates_convergence,
     plot_hrex_transition_matrix,
 )
-from timemachine.fe.single_topology import AtomMapFlags, SingleTopology
+from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.system import VacuumSystem, convert_omm_system
 from timemachine.fe.utils import bytes_to_id, get_mol_name, get_romol_conf
 from timemachine.ff import Forcefield

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1,5 +1,4 @@
 import warnings
-from enum import IntEnum
 from functools import partial
 from typing import Callable, Collection, Dict, FrozenSet, List, Optional, Tuple, TypeVar, Union, cast
 
@@ -11,6 +10,7 @@ from rdkit import Chem
 
 from timemachine.constants import DEFAULT_CHIRAL_ATOM_RESTRAINT_K, DEFAULT_CHIRAL_BOND_RESTRAINT_K
 from timemachine.fe import interpolate, model_utils, topology, utils
+from timemachine.fe.atom_map_mixin import AtomMapMixin
 from timemachine.fe.chiral_utils import (
     assert_chiral_consistency_and_validity,
     setup_dummy_bond_and_chiral_interactions,
@@ -693,91 +693,6 @@ def interpolate_w_coord(w0: float | jax.Array, w1: float | jax.Array, lamb: floa
         interpolate.linear_interpolation(w0, w1, jnp.interp(lamb, x, lambdas)),
         interpolate.linear_interpolation(w1, w0, jnp.interp(1.0 - lamb, x, lambdas)),
     )
-
-
-class AtomMapFlags(IntEnum):
-    CORE = 0
-    MOL_A = 1
-    MOL_B = 2
-
-
-class AtomMapMixin:
-    """
-    A Mixin class containing the atom_mapping information. This Mixin sets up the following
-    members:
-
-    self.mol_a
-    self.mol_b
-    self.core
-    self.a_to_c
-    self.b_to_c
-    self.c_to_a
-    self.c_to_b
-    self.c_flags
-    """
-
-    def __init__(self, mol_a, mol_b, core):
-        assert core.shape[1] == 2
-        assert mol_a is not None
-        assert mol_b is not None
-
-        self.mol_a = mol_a
-        self.mol_b = mol_b
-        self.core = core
-        assert mol_a is not None
-        assert mol_b is not None
-        assert core.shape[1] == 2
-
-        # map into idxs in the combined molecule
-
-        self.a_to_c = np.arange(mol_a.GetNumAtoms(), dtype=np.int32)  # identity
-        self.b_to_c = np.zeros(mol_b.GetNumAtoms(), dtype=np.int32) - 1
-
-        # mark membership:
-        # AtomMapFlags.CORE: Core
-        # AtomMapFlags.MOL_A: R_A (default)
-        # AtomMapFlags.MOL_B: R_B
-        self.c_flags = np.ones(self.get_num_atoms(), dtype=np.int32) * AtomMapFlags.MOL_A
-        # test for uniqueness in core idxs for each mol
-        assert len(set(tuple(core[:, 0]))) == len(core[:, 0])
-        assert len(set(tuple(core[:, 1]))) == len(core[:, 1])
-
-        for a, b in core:
-            self.c_flags[a] = AtomMapFlags.CORE
-            self.b_to_c[b] = a
-
-        iota = self.mol_a.GetNumAtoms()
-        for b_idx, c_idx in enumerate(self.b_to_c):
-            if c_idx == -1:
-                self.b_to_c[b_idx] = iota
-                self.c_flags[iota] = AtomMapFlags.MOL_B
-                iota += 1
-
-        # setup reverse mappings
-        self.c_to_a = {v: k for k, v in enumerate(self.a_to_c)}
-        self.c_to_b = {v: k for k, v in enumerate(self.b_to_c)}
-
-    def get_num_atoms(self):
-        """
-        Get the total number of atoms in the alchemical hybrid.
-
-        Returns
-        -------
-        int
-            Total number of atoms.
-        """
-        return self.mol_a.GetNumAtoms() + self.mol_b.GetNumAtoms() - len(self.core)
-
-    def get_num_dummy_atoms(self):
-        """
-        Get the total number of dummy atoms in the alchemical hybrid.
-
-        Returns
-        -------
-        int
-            Total number of atoms.
-        """
-        return self.mol_a.GetNumAtoms() + self.mol_b.GetNumAtoms() - len(self.core) - len(self.core)
 
 
 _Bonded = TypeVar("_Bonded", bound=Union[ChiralAtomRestraint, HarmonicAngleStable, HarmonicBond, PeriodicTorsion])

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1,23 +1,26 @@
 import warnings
-from collections.abc import Iterable
 from enum import IntEnum
 from functools import partial
 from typing import Callable, Collection, Dict, FrozenSet, List, Optional, Tuple, TypeVar, Union, cast
 
 import jax
 import jax.numpy as jnp
-import networkx as nx
 import numpy as np
 from numpy.typing import NDArray
 from rdkit import Chem
 
 from timemachine.constants import DEFAULT_CHIRAL_ATOM_RESTRAINT_K, DEFAULT_CHIRAL_BOND_RESTRAINT_K
-from timemachine.fe import chiral_utils, interpolate, model_utils, topology, utils
-from timemachine.fe.chiral_utils import ChiralRestrIdxSet
+from timemachine.fe import interpolate, model_utils, topology, utils
+from timemachine.fe.chiral_utils import (
+    assert_chiral_consistency_and_validity,
+    setup_dummy_bond_and_chiral_interactions,
+    setup_end_state_harmonic_bond_and_chiral_potentials,
+)
 from timemachine.fe.dummy import canonicalize_bond, generate_anchored_dummy_group_assignments
 from timemachine.fe.lambda_schedule import construct_pre_optimized_relative_lambda_schedule
 from timemachine.fe.system import HostGuestSystem, VacuumSystem
 from timemachine.fe.topology import get_ligand_ixn_pots_params
+from timemachine.fe.utils import recursive_map
 from timemachine.potentials import (
     BoundPotential,
     ChiralAtomRestraint,
@@ -41,26 +44,6 @@ class MissingAngleError(RuntimeError):
 
 class ChargePertubationError(RuntimeError):
     pass
-
-
-class ChiralConversionError(RuntimeError):
-    pass
-
-
-def recursive_map(items, mapping):
-    """recursively replace items in a list of tuple
-    mapping = np.arange(100)[::-1]
-    items = [[0,2,3], [5,1,[2,5,6]], 3]
-    result = recursive_map(items, mapping)
-    # ((99, 97, 96), (94, 98, (97, 94, 93)), 96)
-    """
-    if isinstance(items, Iterable):
-        res = []
-        for item in items:
-            res.append(recursive_map(item, mapping))
-        return tuple(res)
-    else:
-        return mapping[items]
 
 
 def setup_dummy_interactions_from_ff(
@@ -95,87 +78,6 @@ def setup_dummy_interactions_from_ff(
         nbr_anchor_atom,
         core_atoms,
     )
-
-
-def setup_dummy_bond_and_chiral_interactions_from_ff(
-    ff, mol, dummy_group, root_anchor_atom, core_atoms, chiral_atom_k, chiral_bond_k
-):
-    """
-    Setup interactions involving atoms in a given dummy group.
-    """
-    top = topology.BaseTopology(mol, ff)
-
-    bond_params, hb = top.parameterize_harmonic_bond(ff.hb_handle.params)
-    chiral_atom_potential, _ = top.setup_chiral_restraints(chiral_atom_k, chiral_bond_k)
-    chiral_atom_idxs = chiral_atom_potential.potential.idxs
-    chiral_atom_params = chiral_atom_potential.params
-
-    return setup_dummy_bond_and_chiral_interactions(
-        hb.idxs,
-        bond_params,
-        chiral_atom_idxs,
-        chiral_atom_params,
-        dummy_group,
-        root_anchor_atom,
-        core_atoms,
-    )
-
-
-def setup_dummy_bond_and_chiral_interactions(
-    bond_idxs,
-    bond_params,
-    chiral_atom_idxs,
-    chiral_atom_params,
-    dummy_group,
-    root_anchor_atom,
-    core_atoms,
-):
-    assert root_anchor_atom in core_atoms
-
-    dummy_bond_idxs = []
-    dummy_bond_params = []
-    dummy_chiral_atom_idxs = []
-    dummy_chiral_atom_params = []
-
-    # dummy_group may be a set in certain cases, so sanity check.
-
-    assert len(dummy_group) == len(list(dummy_group))
-    dummy_group = list(dummy_group)
-
-    # dummy group and anchor
-    dga = dummy_group + [root_anchor_atom]
-
-    # copy interactions that involve only root_anchor_atom
-    for idxs, params in zip(bond_idxs, bond_params):
-        if all([a in dga for a in idxs]):
-            dummy_bond_idxs.append(tuple([int(x) for x in idxs]))  # tuples are hashable etc.
-            dummy_bond_params.append(params)
-
-    # certain configuration of chiral states are symmetrizable
-    # . means a bond involving at least 1 dummy atom
-    # | means a bond involving only core atoms
-    #
-    #        all allowed geometries              |  disallowed geometry
-    #     center is core     center is not core  |
-    #    d      c      c      d      d      d    |    c      c
-    #    .      |      |      .      .      .    |    .      |
-    #    c      c      c      d      d      d    |    d      c
-    #   . .    . .    / .    . .    . .    . .   |   . .    / \
-    #  d   d  d   d  c   d  c   d  c   c  d   d  |  c   c  c   c (only core)
-    dgc = dummy_group + list(core_atoms)
-    for idxs, params in zip(chiral_atom_idxs, chiral_atom_params):
-        center, i, j, k = idxs
-        if all([a in dgc for a in idxs]):
-            # non center dummy atom count
-            ncda_count = sum([a in dummy_group for a in (i, j, k)])
-            if ncda_count == 1 or ncda_count == 2 or ncda_count == 3:
-                assert not all(a in core_atoms for a in idxs)
-                dummy_chiral_atom_idxs.append(tuple(int(x) for x in idxs))
-                dummy_chiral_atom_params.append(params)
-
-    bonded_idxs = (dummy_bond_idxs, dummy_chiral_atom_idxs)
-    bonded_params = (dummy_bond_params, dummy_chiral_atom_params)
-    return bonded_idxs, bonded_params
 
 
 def setup_dummy_interactions(
@@ -357,157 +259,6 @@ def canonicalize_improper_idxs(idxs) -> Tuple[int, int, int, int]:
             break
 
     return (i, *cw_items[idx])
-
-
-def get_num_connected_components(num_atoms: int, bonds: Collection[Tuple[int, int]]) -> int:
-    g = nx.Graph()
-    g.add_nodes_from(range(num_atoms))
-    g.add_edges_from(bonds)
-    return len(list(nx.connected_components(g)))
-
-
-def canonicalize_chiral_atom_idxs(idxs):
-    i, j, k, l = idxs
-    rotations = [(j, k, l), (l, j, k), (k, l, j)]
-    jj, kk, ll = min(rotations)
-    return i, jj, kk, ll
-
-
-def setup_end_state_harmonic_bond_and_chiral_potentials(
-    ff, mol_a, mol_b, core, a_to_c, b_to_c
-) -> Tuple[BoundPotential[HarmonicBond], BoundPotential[ChiralAtomRestraint], BoundPotential[ChiralBondRestraint]]:
-    """
-    Setup end-state potentials to verify chiral correctness for mol_a with dummy atoms of mol_b attached. The mapped indices will correspond
-    to the alchemical molecule with dummy atoms. Note that the bond, chiral atom and chiral bond idxs are canonicalized.
-
-    This code is identical to setup_end_state, but only handles chiral potentials to be used to quickly verify
-    core mappings in verify_chiral_consistency_of_core
-
-    Parameters
-    ----------
-    ff: forcefield.Forcefield
-        Forcefield used to parameterize the molecule
-
-    mol_a: Chem.Mol
-        Fully interacting molecule
-
-    mol_b: Chem.Mol
-        Molecule providing the dummy atoms.
-
-    core: list of 2-tuples
-        Each pair is an atom mapping from mol_a into mol_b
-
-    a_to_c: dict or array, supports []
-        mapping from a into a common core idx
-
-    b_to_c: dict or array, supports []
-        mapping from b into a common core idx
-
-    Returns
-    -------
-    Tuple of bound HarmonicBond, ChiralAtomRestraint and ChiralBondRestraint
-        The potentials involved in checking the correctness and validity of chirality at endstates.
-
-    """
-    all_dummy_bond_idxs, all_dummy_bond_params = [], []
-    all_dummy_chiral_atom_idxs, all_dummy_chiral_atom_params = [], []
-
-    from timemachine.fe.dummy import convert_bond_list_to_nx, generate_dummy_group_assignments, get_romol_bonds
-
-    bonds_b = get_romol_bonds(mol_b)
-    bond_graph_b = convert_bond_list_to_nx(bonds_b)
-    dummy_group_assignments = generate_dummy_group_assignments(bond_graph_b, core[:, 1])
-
-    # pick an arbitrary one
-    # later on, iterate over multiple ones.
-    dga = next(dummy_group_assignments)
-
-    for anchor, dg in dga.items():
-        all_idxs, all_params = setup_dummy_bond_and_chiral_interactions_from_ff(
-            ff, mol_b, dg, anchor, core[:, 1], DEFAULT_CHIRAL_ATOM_RESTRAINT_K, DEFAULT_CHIRAL_BOND_RESTRAINT_K
-        )
-        # append idxs
-        all_dummy_bond_idxs.extend(all_idxs[0])
-        all_dummy_chiral_atom_idxs.extend(all_idxs[1])
-        # append params
-        all_dummy_bond_params.extend(all_params[0])
-        all_dummy_chiral_atom_params.extend(all_params[1])
-
-    # generate parameters for mol_a
-    mol_a_top = topology.BaseTopology(mol_a, ff)
-    mol_a_bond_params, mol_a_hb = mol_a_top.parameterize_harmonic_bond(ff.hb_handle.params)
-    mol_a_chiral_atom, mol_a_chiral_bond = mol_a_top.setup_chiral_restraints(
-        DEFAULT_CHIRAL_ATOM_RESTRAINT_K, DEFAULT_CHIRAL_BOND_RESTRAINT_K
-    )
-
-    mol_a_bond_params = mol_a_bond_params.tolist()
-
-    mol_a_bond_idxs = recursive_map(mol_a_hb.idxs, a_to_c)
-    mol_a_chiral_atom_idxs = recursive_map(mol_a_chiral_atom.potential.idxs, a_to_c)
-    mol_a_chiral_bond_idxs = recursive_map(mol_a_chiral_bond.potential.idxs, a_to_c)
-
-    all_dummy_bond_idxs = recursive_map(all_dummy_bond_idxs, b_to_c)
-    all_dummy_chiral_atom_idxs = recursive_map(all_dummy_chiral_atom_idxs, b_to_c)
-
-    # parameterize the combined molecule
-    mol_c_bond_idxs = mol_a_bond_idxs + all_dummy_bond_idxs
-    mol_c_bond_params = mol_a_bond_params + all_dummy_bond_params
-
-    # process chiral volumes, turning off ones at the end-state that have a missing bond.
-    canon_mol_a_bond_idxs_set = set([canonicalize_bond(x) for x in mol_a_bond_idxs])
-    # assert presence of bonds
-    for c, i, j, k in mol_a_chiral_atom_idxs:
-        ci = canonicalize_bond((c, i))
-        cj = canonicalize_bond((c, j))
-        ck = canonicalize_bond((c, k))
-        assert ci in canon_mol_a_bond_idxs_set
-        assert cj in canon_mol_a_bond_idxs_set
-        assert ck in canon_mol_a_bond_idxs_set
-
-    canon_mol_c_bond_idxs_set = set([canonicalize_bond(x) for x in mol_c_bond_idxs])
-
-    # Chiral atom restraint c,i,j,k requires that all bonds ci, cj, ck be present at the
-    # end-state in order to be numerically stable under small perturbations due to normalization
-    # along the bond lengths. However, the angle terms defining icj, ick, and jck can be
-    # either 0 or 180, since the normalized chiral volume is still smooth wrt perturbations
-    all_proper_dummy_chiral_atom_idxs = []
-    all_proper_dummy_chiral_atom_params = []
-    for (c, i, j, k), p in zip(all_dummy_chiral_atom_idxs, all_dummy_chiral_atom_params):
-        ci = canonicalize_bond((c, i))
-        cj = canonicalize_bond((c, j))
-        ck = canonicalize_bond((c, k))
-        if ci in canon_mol_c_bond_idxs_set and cj in canon_mol_c_bond_idxs_set and ck in canon_mol_c_bond_idxs_set:
-            all_proper_dummy_chiral_atom_idxs.append((c, i, j, k))
-            all_proper_dummy_chiral_atom_params.append(p)
-        else:
-            warnings.warn(f"Chiral Volume {c,i,j,k} has a disabled bond, turning off.")
-
-    mol_c_chiral_atom_idxs = list(mol_a_chiral_atom_idxs) + list(all_proper_dummy_chiral_atom_idxs)
-    mol_c_chiral_atom_params = np.concatenate([mol_a_chiral_atom.params, all_proper_dummy_chiral_atom_params])
-
-    # canonicalize bonds
-    mol_c_bond_idxs_canon = np.array([canonicalize_bond(idxs) for idxs in mol_c_bond_idxs])
-    bond_potential = HarmonicBond(mol_c_bond_idxs_canon).bind(np.array(mol_c_bond_params))
-
-    # chiral atoms need special code for canonicalization, since triple product is invariant
-    # under rotational symmetry (but not something like swap symmetry)
-    canon_chiral_atom_idxs = []
-    for idxs in mol_c_chiral_atom_idxs:
-        canon_chiral_atom_idxs.append(canonicalize_chiral_atom_idxs(idxs))
-
-    chiral_atom_idxs = np.array(canon_chiral_atom_idxs, dtype=np.int32).reshape((-1, 4))
-    mol_c_chiral_bond_idxs_canon = [canonicalize_bond(idxs) for idxs in mol_a_chiral_bond_idxs]
-    chiral_bond_idxs = np.array(mol_c_chiral_bond_idxs_canon, dtype=np.int32).reshape((-1, 4))
-    chiral_bond_signs = np.array(mol_a_chiral_bond.potential.signs)
-
-    chiral_atom_potential = ChiralAtomRestraint(chiral_atom_idxs).bind(mol_c_chiral_atom_params)
-    chiral_bond_potential = ChiralBondRestraint(chiral_bond_idxs, chiral_bond_signs).bind(mol_a_chiral_bond.params)
-
-    num_atoms = mol_a.GetNumAtoms() + mol_b.GetNumAtoms() - len(core)
-    assert (
-        get_num_connected_components(num_atoms, bond_potential.potential.idxs) == 1
-    ), "hybrid molecule has multiple connected components"
-    return bond_potential, chiral_atom_potential, chiral_bond_potential
 
 
 def setup_end_state(ff, mol_a, mol_b, core, a_to_c, b_to_c):
@@ -1030,105 +781,6 @@ class AtomMapMixin:
 
 
 _Bonded = TypeVar("_Bonded", bound=Union[ChiralAtomRestraint, HarmonicAngleStable, HarmonicBond, PeriodicTorsion])
-
-
-def get_neighbors(atom, bond_idxs) -> List[int]:
-    nbs = []
-    for i, j in bond_idxs:
-        if i == atom:
-            nbs.append(j)
-        elif j == atom:
-            nbs.append(i)
-    return nbs
-
-
-def check_chiral_validity(src_chiral_centers_in_mol_c, dst_chiral_restr_idx_set, src_bond_idxs):
-    """Raise error unless, for every chiral center, at least 1 chiral volume is defined in both end-states."""
-
-    for c in src_chiral_centers_in_mol_c:
-        nbs = get_neighbors(c, src_bond_idxs)
-        if len(nbs) == 4:
-            i, j, k, l = nbs
-            # (ytz): the ordering of i,j,k,l is random if we're reading directly from the mol graph,
-            # which can be inconsistent with the ordering used in the chiral volume definition.
-            nb_subsets = [(i, j, k), (i, j, l), (i, k, l), (j, k, l)]  # 4-choose-3 subsets
-            flags = [dst_chiral_restr_idx_set.defines((c, ii, jj, kk)) for (ii, jj, kk) in nb_subsets]
-
-            if sum(flags) == 0:
-                raise ChiralConversionError(f"len(nbs) == 4 {c, i, j, k, l}")
-
-        if len(nbs) == 3:
-            i, j, k = nbs
-            flag_0 = dst_chiral_restr_idx_set.defines((c, i, j, k))
-            if not flag_0:
-                raise ChiralConversionError(f"len(nbs) == 3 {c, i, j, k}")
-
-
-def assert_chiral_consistency_and_validity(
-    atom_map: AtomMapMixin,
-    src_chiral_idxs,
-    dst_chiral_idxs,
-    src_bond_idxs: NDArray,
-    dst_bond_idxs: NDArray,
-):
-    """
-    Assert that the given the two end states chiral and bond idxs it would be both consistent and valid.
-
-    consistency: if there are no inversions at the end-states between chiral atoms and bonds are present
-    validity: if we can directly turn on the chiral volumes (after bonds) without staggering angles
-    """
-
-    for c, i, j, k in src_chiral_idxs:
-        assert canonicalize_bond((c, i)) in src_bond_idxs
-        assert canonicalize_bond((c, j)) in src_bond_idxs
-        assert canonicalize_bond((c, k)) in src_bond_idxs
-
-    for c, i, j, k in dst_chiral_idxs:
-        assert canonicalize_bond((c, i)) in dst_bond_idxs
-        assert canonicalize_bond((c, j)) in dst_bond_idxs
-        assert canonicalize_bond((c, k)) in dst_bond_idxs
-
-    src_chiral_restr_idx_set = ChiralRestrIdxSet(src_chiral_idxs)
-    dst_chiral_restr_idx_set = ChiralRestrIdxSet(dst_chiral_idxs)
-
-    # ensure that we don't have any chiral inversions between src and dst end states
-    assert len(src_chiral_restr_idx_set.allowed_set.intersection(dst_chiral_restr_idx_set.disallowed_set)) == 0
-    assert len(dst_chiral_restr_idx_set.allowed_set.intersection(src_chiral_restr_idx_set.disallowed_set)) == 0
-
-    chiral_centers_in_mol_a = chiral_utils.find_chiral_atoms(atom_map.mol_a)
-    chiral_centers_in_mol_b = chiral_utils.find_chiral_atoms(atom_map.mol_b)
-
-    src_chiral_centers_in_mol_c = [atom_map.a_to_c[x] for x in chiral_centers_in_mol_a]
-    dst_chiral_centers_in_mol_c = [atom_map.b_to_c[x] for x in chiral_centers_in_mol_b]
-
-    check_chiral_validity(src_chiral_centers_in_mol_c, dst_chiral_restr_idx_set, src_bond_idxs)
-    check_chiral_validity(dst_chiral_centers_in_mol_c, src_chiral_restr_idx_set, dst_bond_idxs)
-
-
-def verify_chiral_consistency_of_core(mol_a: Chem.Mol, mol_b: Chem.Mol, core: NDArray, forcefield):
-    """Verify that a core and forcefield would allow for valid chiral endstates.
-
-    Refer to `assert_chiral_consistency_and_validity` for definitions of consistency and validity.
-
-    Raises
-    ------
-        ChiralConversionError
-            If chiral end states are incompatible for the given core and forcefield.
-    """
-    atom_map = AtomMapMixin(mol_a, mol_b, core)
-    bond_pot_src, chiral_atom_pot_src, _ = setup_end_state_harmonic_bond_and_chiral_potentials(
-        forcefield, mol_a, mol_b, core, atom_map.a_to_c, atom_map.b_to_c
-    )
-    bond_pot_dest, chiral_atom_pot_dest, _ = setup_end_state_harmonic_bond_and_chiral_potentials(
-        forcefield, mol_b, mol_a, core[:, ::-1], atom_map.b_to_c, atom_map.a_to_c
-    )
-    assert_chiral_consistency_and_validity(
-        atom_map,
-        chiral_atom_pot_src.potential.idxs,
-        chiral_atom_pot_dest.potential.idxs,
-        bond_pot_src.potential.idxs,
-        bond_pot_dest.potential.idxs,
-    )
 
 
 class SingleTopology(AtomMapMixin):

--- a/timemachine/fe/utils.py
+++ b/timemachine/fe/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+from collections.abc import Iterable
 from pathlib import Path
 from typing import List, Optional, Sequence, Union
 
@@ -408,6 +409,22 @@ def set_romol_conf(mol, new_coords: NDArray):
     conf = mol.GetConformer(0)
     for i, pos in enumerate(angstrom_coords):
         conf.SetAtomPosition(i, pos)
+
+
+def recursive_map(items, mapping):
+    """recursively replace items in a list of tuple
+    mapping = np.arange(100)[::-1]
+    items = [[0,2,3], [5,1,[2,5,6]], 3]
+    result = recursive_map(items, mapping)
+    # ((99, 97, 96), (94, 98, (97, 94, 93)), 96)
+    """
+    if isinstance(items, Iterable):
+        res = []
+        for item in items:
+            res.append(recursive_map(item, mapping))
+        return tuple(res)
+    else:
+        return mapping[items]
 
 
 def get_mol_masses(mol) -> NDArray:


### PR DESCRIPTION
This PR refactors a lot of the business logic associated with chirality checking into `chiral_utils.py` and out of `single_topology.py` - enabling it to be called from the `atom_mapping.py` code.

This PR also skips the logic for traversing angle anchoring atoms (and instead relying only on the bond anchor). This is roughly a 2x speed-up to the previous implementation for hif2a, can be larger or smaller depending on the system.