### PR TITLE
Refactor chiral restraint setup to avoid repeated work

### DIFF
--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -151,8 +151,8 @@ $$$$"""
     )
     chiral_atom_idxs = idxs[-1]
     chiral_atom_params = params[-1]
-    np.testing.assert_array_equal(chiral_atom_idxs, [])
-    np.testing.assert_array_equal(chiral_atom_params, [])
+    assert len(chiral_atom_idxs) == 0
+    assert len(chiral_atom_params) == 0
 
     dg_7 = []
     core_7 = [0, 1, 2, 3]
@@ -161,8 +161,15 @@ $$$$"""
     )
     chiral_atom_idxs = idxs[-1]
     chiral_atom_params = params[-1]
-    np.testing.assert_array_equal(chiral_atom_idxs, [])
-    np.testing.assert_array_equal(chiral_atom_params, [])
+    assert len(chiral_atom_idxs) == 0
+    assert len(chiral_atom_params) == 0
+
+
+def assert_bond_sets_equal(bonds_a, bonds_b):
+    def f(bonds):
+        return {tuple(idxs) for idxs in bonds}
+
+    return f(bonds_a) == f(bonds_b)
 
 
 @pytest.mark.nocuda
@@ -187,10 +194,10 @@ def test_phenol():
     )
     bond_idxs, angle_idxs, improper_idxs, chiral_atom_idxs = all_idxs
 
-    assert set(bond_idxs) == set([(5, 6), (6, 12)])
-    assert set(angle_idxs) == set([(5, 6, 12)])
-    assert set(improper_idxs) == set()
-    assert set(chiral_atom_idxs) == set()
+    assert_bond_sets_equal(bond_idxs, [(5, 6), (6, 12)])
+    assert_bond_sets_equal(angle_idxs, [(5, 6, 12)])
+    assert len(improper_idxs) == 0
+    assert len(chiral_atom_idxs) == 0
 
     # set [O,H] as the dummy group but allow an extra angle
     all_idxs, _ = setup_chiral_dummy_interactions_from_ff(
@@ -198,10 +205,10 @@ def test_phenol():
     )
     bond_idxs, angle_idxs, improper_idxs, chiral_atom_idxs = all_idxs
 
-    assert set(bond_idxs) == set([(5, 6), (6, 12)])
-    assert set(angle_idxs) == set([(5, 6, 12), (0, 5, 6)])
-    assert set(improper_idxs) == set()
-    assert set(chiral_atom_idxs) == set()
+    assert_bond_sets_equal(bond_idxs, [(5, 6), (6, 12)])
+    assert_bond_sets_equal(angle_idxs, [(5, 6, 12), (0, 5, 6)])
+    assert len(improper_idxs) == 0
+    assert len(chiral_atom_idxs) == 0
 
     dg_1 = [12]
     core_1 = list(all_atoms_set.difference(dg_1))
@@ -212,10 +219,10 @@ def test_phenol():
     )
     bond_idxs, angle_idxs, improper_idxs, chiral_atom_idxs = all_idxs
 
-    assert set(bond_idxs) == set([(6, 12)])
-    assert set(angle_idxs) == set()
-    assert set(improper_idxs) == set()
-    assert set(chiral_atom_idxs) == set()
+    assert_bond_sets_equal(bond_idxs, [(6, 12)])
+    assert len(angle_idxs) == 0
+    assert len(improper_idxs) == 0
+    assert len(chiral_atom_idxs) == 0
 
     # set [H] as the dummy group, with neighbor anchor atom
     all_idxs, _ = setup_chiral_dummy_interactions_from_ff(
@@ -223,10 +230,10 @@ def test_phenol():
     )
     bond_idxs, angle_idxs, improper_idxs, chiral_atom_idxs = all_idxs
 
-    assert set(bond_idxs) == set([(6, 12)])
-    assert set(angle_idxs) == set([(5, 6, 12)])
-    assert set(improper_idxs) == set()
-    assert set(chiral_atom_idxs) == set()
+    assert_bond_sets_equal(bond_idxs, [(6, 12)])
+    assert_bond_sets_equal(angle_idxs, [(5, 6, 12)])
+    assert len(improper_idxs) == 0
+    assert len(chiral_atom_idxs) == 0
 
     with pytest.raises(single_topology.MissingAngleError):
         all_idxs, _ = setup_chiral_dummy_interactions_from_ff(
@@ -254,16 +261,16 @@ def test_methyl_chiral_atom_idxs():
     )
     _, _, _, chiral_atom_idxs = all_idxs
 
-    expected_set = set(
+    expected_chiral_atom_idxs = [
         [
             (0, 1, 3, 4),
             (0, 3, 2, 4),
             (0, 2, 1, 4),
             (0, 1, 2, 3),
         ]
-    )
+    ]
 
-    assert set(chiral_atom_idxs) == expected_set
+    assert_bond_sets_equal(chiral_atom_idxs, expected_chiral_atom_idxs)
 
 
 @pytest.mark.nocuda

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -9,7 +9,7 @@ import networkx as nx
 import numpy as np
 import pytest
 from common import check_split_ixns, load_split_forcefields
-from hypothesis import assume, given, seed
+from hypothesis import assume, event, given, seed
 from rdkit import Chem
 from rdkit.Chem import AllChem
 
@@ -33,6 +33,8 @@ from timemachine.fe.single_topology import (
     CoreBondChangeWarning,
     DummyGroupAssignmentError,
     SingleTopology,
+    canonicalize_bonds,
+    canonicalize_chiral_atom_idxs,
     canonicalize_improper_idxs,
     cyclic_difference,
     handle_ring_opening_closing,
@@ -408,15 +410,12 @@ def test_charge_perturbation_is_invalid():
     assert str(e.value) == "mol a and mol b don't have the same charge: a: 0 b: 1"
 
 
-def assert_bond_idxs_are_canonical(all_idxs):
-    for idxs in all_idxs:
-        assert idxs[0] < idxs[-1]
+def bond_idxs_are_canonical(all_idxs):
+    return np.all(all_idxs[:, 0] < all_idxs[:, -1])
 
 
-def assert_chiral_atom_idxs_are_canonical(all_idxs):
-    for _, j, k, l in all_idxs:
-        assert (j, k, l) < (l, j, k)
-        assert (j, k, l) < (k, l, j)
+def chiral_atom_idxs_are_canonical(all_idxs):
+    return np.all((all_idxs[:, 1] < all_idxs[:, 2]) & (all_idxs[:, 1] < all_idxs[:, 3]))
 
 
 @pytest.mark.nogpu
@@ -457,12 +456,12 @@ def test_hif2a_end_state_stability(num_pairs_to_setup=25, num_pairs_to_simulate=
 
         for system in systems:
             # assert that the idxs are canonicalized.
-            assert_bond_idxs_are_canonical(system.bond.potential.idxs)
-            assert_bond_idxs_are_canonical(system.angle.potential.idxs)
-            assert_bond_idxs_are_canonical(system.torsion.potential.idxs)
-            assert_bond_idxs_are_canonical(system.nonbonded.potential.idxs)
-            assert_bond_idxs_are_canonical(system.chiral_bond.potential.idxs)
-            assert_chiral_atom_idxs_are_canonical(system.chiral_atom.potential.idxs)
+            assert bond_idxs_are_canonical(system.bond.potential.idxs)
+            assert bond_idxs_are_canonical(system.angle.potential.idxs)
+            assert bond_idxs_are_canonical(system.torsion.potential.idxs)
+            assert bond_idxs_are_canonical(system.nonbonded.potential.idxs)
+            assert bond_idxs_are_canonical(system.chiral_bond.potential.idxs)
+            assert chiral_atom_idxs_are_canonical(system.chiral_atom.potential.idxs)
             U_fn = jax.jit(system.get_U_fn())
             assert np.isfinite(U_fn(x0))
             x_min = minimize_scipy(U_fn, x0, seed=seed)
@@ -478,6 +477,46 @@ def test_hif2a_end_state_stability(num_pairs_to_setup=25, num_pairs_to_simulate=
                 assert np.all(np.isfinite(nrgs))
                 assert np.all(np.isfinite(frames))
                 assert np.all(batch_distance_check(frames) < distance_cutoff)
+
+
+atom_idxs = st.integers(0, 100)
+
+
+@st.composite
+def bond_or_angle_idx_arrays(draw):
+    n_idxs = draw(st.one_of(st.just(2), st.just(3)))
+    idxs = st.lists(atom_idxs, min_size=n_idxs, max_size=n_idxs, unique=True).map(tuple)
+    idx_arrays = st.lists(idxs, min_size=0, max_size=100, unique=True).map(
+        lambda ixns: np.array(ixns).reshape(-1, n_idxs)
+    )
+    return draw(idx_arrays)
+
+
+@given(bond_or_angle_idx_arrays())
+@seed(2024)
+def test_canonicalize_bonds(bonds):
+    canonicalized_bonds = canonicalize_bonds(bonds)
+    event("canonical" if bond_idxs_are_canonical(bonds) else "not canonical")
+    assert all(set(canon_idxs) == set(idxs) for canon_idxs, idxs in zip(canonicalized_bonds, bonds))
+    assert bond_idxs_are_canonical(canonicalized_bonds)
+
+
+chiral_atom_idxs = st.lists(atom_idxs, min_size=4, max_size=4, unique=True).map(lambda x: tuple(x))
+chiral_atom_idx_arrays = st.lists(chiral_atom_idxs, min_size=0, max_size=100, unique=True).map(
+    lambda idxs: np.array(idxs).reshape(-1, 4)
+)
+
+
+@given(chiral_atom_idx_arrays)
+@seed(2024)
+def test_canonicalize_chiral_atom_idxs(chiral_atom_idxs):
+    canonicalized_idxs = canonicalize_chiral_atom_idxs(chiral_atom_idxs)
+    event("canonical" if chiral_atom_idxs_are_canonical(chiral_atom_idxs) else "not canonical")
+    assert all(
+        tuple(canon_idxs) in {tuple(idxs[p]) for p in [[0, 1, 2, 3], [0, 2, 3, 1], [0, 3, 1, 2]]}
+        for canon_idxs, idxs in zip(canonicalized_idxs, chiral_atom_idxs)
+    )
+    assert chiral_atom_idxs_are_canonical(canonicalized_idxs)
 
 
 @pytest.mark.nocuda

--- a/timemachine/constants.py
+++ b/timemachine/constants.py
@@ -33,15 +33,15 @@ MAX_FORCE_NORM = 50000.0  # used to check norms in the gradient computations
 DEFAULT_ATOM_MAPPING_KWARGS: Dict[str, Any] = {
     "ring_cutoff": 0.12,
     "chain_cutoff": 0.2,
-    "max_visits": 1e7,
+    "max_visits": 1_000_000,
     "max_connected_components": 1,
     "min_connected_component_size": 1,
-    "max_cores": 1e5,
+    "max_cores": 100_000,
     "enforce_core_core": True,
     "ring_matches_ring_only": True,
     "enforce_chiral": True,
     "disallow_planar_torsion_flips": True,
     "min_threshold": 0,
     "initial_mapping": None,
-    "enforce_chirally_valid_dummy_groups": True,
+    "enforce_chirally_valid_dummy_groups": False,
 }

--- a/timemachine/fe/chiral_utils.py
+++ b/timemachine/fe/chiral_utils.py
@@ -174,7 +174,7 @@ class ChiralRestrIdxSet:
     """Support fast checks of whether a trial 4-tuple is consistent with a set of chiral atom idxs"""
 
     def __init__(self, restr_idxs: List[FourTuple] | NDArray):
-        self.restr_idxs = [(int(c), int(i), int(j), int(k)) for (c, i, j, k) in restr_idxs]
+        self.restr_idxs = restr_idxs
         self.allowed_set, self.disallowed_set = self.expand_symmetries()
 
     @classmethod

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -407,13 +407,13 @@ def make_setup_end_state_harmonic_bond_and_chiral_potentials(
 
         where
 
-        core: list of 2-tuples
+        core: array of shape (core_size, 2)
             Each pair is an atom mapping from mol_a into mol_b
 
-        a_to_c: dict or array, supports []
+        a_to_c: array
             mapping from a into a common core idx
 
-        b_to_c: dict or array, supports []
+        b_to_c: array
             mapping from b into a common core idx
 
         dummy_groups: Dict[int, FrozenSet[int]]
@@ -552,13 +552,13 @@ def setup_end_state(ff, mol_a, mol_b, core, a_to_c, b_to_c, dummy_groups: Dict[i
     mol_b: Chem.Mol
         Molecule providing the dummy atoms.
 
-    core: list of 2-tuples
+    core: array of shape (core_size, 2)
         Each pair is an atom mapping from mol_a into mol_b
 
-    a_to_c: dict or array, supports []
+    a_to_c: array
         mapping from a into a common core idx
 
-    b_to_c: dict or array, supports []
+    b_to_c: array
         mapping from b into a common core idx
 
     dummy_groups: Dict[int, FrozenSet[int]]

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1,4 +1,5 @@
 import warnings
+from collections import defaultdict
 from collections.abc import Iterable
 from enum import IntEnum
 from functools import partial
@@ -1126,21 +1127,19 @@ class AtomMapMixin:
 _Bonded = TypeVar("_Bonded", bound=Union[ChiralAtomRestraint, HarmonicAngleStable, HarmonicBond, PeriodicTorsion])
 
 
-def get_neighbors(atom, bond_idxs) -> List[int]:
-    nbs = []
+def get_neighbors(bond_idxs: Collection[Tuple[int, int]]) -> Dict[int, List[int]]:
+    neighbors = defaultdict(list)
     for i, j in bond_idxs:
-        if i == atom:
-            nbs.append(j)
-        elif j == atom:
-            nbs.append(i)
-    return nbs
+        neighbors[i].append(j)
+        neighbors[j].append(i)
+    return neighbors
 
 
 def check_chiral_validity_src_dst(src_chiral_centers_in_mol_c, dst_chiral_restr_idx_set, src_bond_idxs):
     """Raise error unless, for every chiral center, at least 1 chiral volume is defined in both end-states."""
-
+    neighbors = get_neighbors(src_bond_idxs)
     for c in src_chiral_centers_in_mol_c:
-        nbs = get_neighbors(c, src_bond_idxs)
+        nbs = neighbors[c]
         if len(nbs) == 4:
             i, j, k, l = nbs
             # (ytz): the ordering of i,j,k,l is random if we're reading directly from the mol graph,

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -359,7 +359,9 @@ def get_num_connected_components(num_atoms: int, bonds: Collection[Tuple[int, in
     return len(list(nx.connected_components(g)))
 
 
-def canonicalize_chiral_atom_idxs(idxs):
+def canonicalize_chiral_atom_idxs(idxs: NDArray[np.int32]) -> NDArray[np.int32]:
+    assert idxs.ndim == 2
+    assert idxs.shape[1] == 4
     c = idxs[:, 0:1]
     ijk = idxs[:, 1:]
     ijk_argmin = np.argmin(ijk, axis=1)

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -74,9 +74,9 @@ def bond_isin(bonds: NDArray[np.int32], idxs: NDArray[np.int32]) -> NDArray[np.b
     idxs: NDArray
         1-d array of atom indices
     """
-    b0 = bonds[:, :, None] == idxs[None, None, :]  # (bonds, bond_idxs, idxs)
-    b1 = b0.any(-1)  # (bonds, bond_idxs)
-    b2 = b1.all(-1)  # (bonds,)
+    b0 = bonds[:, :, None] == idxs[None, None, :]  # shape: (n_bonds, n_bond_idxs, n_idxs)
+    b1 = b0.any(-1)  # shape: (n_bonds, n_bond_idxs)
+    b2 = b1.all(-1)  # shape: (n_bonds,)
     return b2
 
 

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1281,7 +1281,7 @@ def make_check_chiral_validity(
         dummy_groups_ab: Dict[int, FrozenSet[int]],
         dummy_groups_ba: Dict[int, FrozenSet[int]],
     ):
-        """Verify that a core and forcefield would allow for valid chiral endstates.
+        """Verify that a core and dummy groups would allow for valid chiral endstates.
 
         Refer to `check_chiral_validity` for definition of validity.
 

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -88,8 +88,11 @@ def setup_dummy_bond_and_chiral_interactions(
     dummy_group: FrozenSet[int],
     root_anchor_atom: int,
     core_atoms: NDArray,
+    verify: bool = True,
 ):
-    assert root_anchor_atom in core_atoms
+    if verify:
+        assert root_anchor_atom in core_atoms
+
     dummy_group_arr = np.array(list(dummy_group))
 
     # dummy group and anchor
@@ -442,6 +445,7 @@ def make_setup_end_state_harmonic_bond_and_chiral_potentials(
                 dg,
                 anchor,
                 core[:, 1],
+                verify,
             )
             # append idxs
             all_dummy_bond_idxs_.extend(all_idxs[0])

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -510,10 +510,6 @@ def make_setup_end_state_harmonic_bond_and_chiral_potentials(
         chiral_atom_potential = ChiralAtomRestraint(chiral_atom_idxs).bind(mol_c_chiral_atom_params)
         chiral_bond_potential = ChiralBondRestraint(chiral_bond_idxs, chiral_bond_signs).bind(mol_a_chiral_bond.params)
 
-        num_atoms = mol_a.GetNumAtoms() + mol_b.GetNumAtoms() - len(core)
-        assert (
-            get_num_connected_components(num_atoms, bond_potential.potential.idxs) == 1
-        ), "hybrid molecule has multiple connected components"
         return bond_potential, chiral_atom_potential, chiral_bond_potential
 
     return setup_end_state_harmonic_bond_and_chiral_potentials
@@ -646,6 +642,11 @@ def setup_end_state(ff, mol_a, mol_b, core, a_to_c, b_to_c, dummy_groups: Dict[i
     bond_potential, chiral_atom_potential, chiral_bond_potential = setup_end_state_harmonic_bond_and_chiral_potentials(
         core, a_to_c, b_to_c, dummy_groups
     )
+
+    num_atoms = mol_a.GetNumAtoms() + mol_b.GetNumAtoms() - len(core)
+    assert (
+        get_num_connected_components(num_atoms, bond_potential.potential.idxs) == 1
+    ), "hybrid molecule has multiple connected components"
 
     return VacuumSystem(
         bond_potential,

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -69,13 +69,13 @@ def bond_isin(bonds: NDArray[np.int32], idxs: NDArray[np.int32]) -> NDArray[np.b
     Parameters
     ----------
     bonds: NDArray
-        (n_bonds, 2) array of bonds
+        (n_bonds, n_bond_idxs) array of bonds (n_bond_idxs=2 for bonds, 3 for angles, 4 for torsions, etc.)
 
     idxs: NDArray
         1-d array of atom indices
     """
-    b0 = bonds[:, :, None] == idxs[None, None, :]  # (bonds, 2 | 3 | 4, idxs)
-    b1 = b0.any(-1)  # (bonds, 2 | 3 | 4)
+    b0 = bonds[:, :, None] == idxs[None, None, :]  # (bonds, bond_idxs, idxs)
+    b1 = b0.any(-1)  # (bonds, bond_idxs)
     b2 = b1.all(-1)  # (bonds,)
     return b2
 

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -468,7 +468,7 @@ def make_setup_end_state_harmonic_bond_and_chiral_potentials(
 
         # assert presence of bonds
         if verify:
-            canon_mol_a_bond_idxs_set = set([canonicalize_bond(x) for x in mol_a_bond_idxs])
+            canon_mol_a_bond_idxs_set = {tuple(x) for x in canonicalize_bonds(mol_a_bond_idxs)}
             for c, i, j, k in mol_a_chiral_atom_idxs:
                 ci = canonicalize_bond((c, i))
                 cj = canonicalize_bond((c, j))

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -455,17 +455,20 @@ def make_setup_end_state_harmonic_bond_and_chiral_potentials(
                 verify,
             )
             # append idxs
-            all_dummy_bond_idxs_.extend(all_idxs[0])
-            all_dummy_chiral_atom_idxs_.extend(all_idxs[1])
+            all_dummy_bond_idxs_.append(all_idxs[0])
+            all_dummy_chiral_atom_idxs_.append(all_idxs[1])
             # append params
-            all_dummy_bond_params_.extend(all_params[0])
-            all_dummy_chiral_atom_params_.extend(all_params[1])
+            all_dummy_bond_params_.append(all_params[0])
+            all_dummy_chiral_atom_params_.append(all_params[1])
 
-        all_dummy_bond_idxs = np.array(all_dummy_bond_idxs_, np.int32).reshape(-1, 2)
-        all_dummy_bond_params = np.array(all_dummy_bond_params_, np.float64).reshape(-1, 2)
+        def concatenate(arrays, empty_shape, empty_dtype):
+            return np.concatenate(arrays) if len(arrays) > 0 else np.empty(empty_shape, empty_dtype)
 
-        all_dummy_chiral_atom_idxs = np.array(all_dummy_chiral_atom_idxs_, np.int32).reshape(-1, 4)
-        all_dummy_chiral_atom_params = np.array(all_dummy_chiral_atom_params_, np.int32)
+        all_dummy_bond_idxs = concatenate(all_dummy_bond_idxs_, (0, 2), np.int32)
+        all_dummy_bond_params = concatenate(all_dummy_bond_params_, (0, 2), np.float64)
+
+        all_dummy_chiral_atom_idxs = concatenate(all_dummy_chiral_atom_idxs_, (0, 4), np.int32)
+        all_dummy_chiral_atom_params = concatenate(all_dummy_chiral_atom_params_, (0,), np.float64)
 
         mol_a_bond_idxs = a_to_c[mol_a_hb.idxs]
         mol_a_chiral_atom_idxs = a_to_c[mol_a_chiral_atom.potential.idxs]

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -105,7 +105,7 @@ def setup_dummy_bond_and_chiral_interactions(
 
     # copy interactions that involve only root_anchor_atom
     for idxs, params in zip(bond_idxs, bond_params):
-        if all([a in dga for a in idxs]):
+        if all(a in dga for a in idxs):
             dummy_bond_idxs.append(tuple([int(x) for x in idxs]))  # tuples are hashable etc.
             dummy_bond_params.append(params)
 
@@ -123,9 +123,9 @@ def setup_dummy_bond_and_chiral_interactions(
     dgc = dummy_group + list(core_atoms)
     for idxs, params in zip(chiral_atom_idxs, chiral_atom_params):
         center, i, j, k = idxs
-        if all([a in dgc for a in idxs]):
+        if all(a in dgc for a in idxs):
             # non center dummy atom count
-            ncda_count = sum([a in dummy_group for a in (i, j, k)])
+            ncda_count = sum(a in dummy_group for a in (i, j, k))
             if ncda_count == 1 or ncda_count == 2 or ncda_count == 3:
                 assert not all(a in core_atoms for a in idxs)
                 dummy_chiral_atom_idxs.append(tuple(int(x) for x in idxs))

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -411,7 +411,8 @@ class BaseTopology:
         conf = get_romol_conf(mol)
 
         # chiral atoms
-        chiral_atom_restr_idxs = np.array(chiral_utils.setup_all_chiral_atom_restr_idxs(mol, conf))
+        chiral_atom_restr_idxs = np.array(chiral_utils.setup_all_chiral_atom_restr_idxs(mol, conf), np.int32)
+        chiral_atom_restr_idxs = chiral_atom_restr_idxs.reshape(-1, 4)
 
         chiral_atom_params = chiral_atom_restraint_k * np.ones(len(chiral_atom_restr_idxs))
         assert len(chiral_atom_params) == len(chiral_atom_restr_idxs)  # TODO: can this be checked in Potential::bind ?
@@ -430,7 +431,7 @@ class BaseTopology:
             chiral_bond_restr_signs.extend(signs)
             chiral_bond_params.extend(chiral_bond_restraint_k for _ in idxs)  # TODO: double-check this
 
-        chiral_bond_restr_idxs = np.array(chiral_bond_restr_idxs)
+        chiral_bond_restr_idxs = np.array(chiral_bond_restr_idxs, dtype=np.int32).reshape(-1, 4)
         chiral_bond_restr_signs = np.array(chiral_bond_restr_signs)
         chiral_bond_params = np.array(chiral_bond_params)
         chiral_bond_potential = potentials.ChiralBondRestraint(chiral_bond_restr_idxs, chiral_bond_restr_signs).bind(


### PR DESCRIPTION
The chiral validity MCS filter added in #1356 is prohibitively slow in some important edge cases where the MCS search visits a large number of chirally-invalid leaf nodes before finding a valid one, because each invocation of the leaf filter is expensive.

One opportunity for improvement is to remove some of the substantial redundant work that is done when setting up chiral restraints for the hybrid mol in the leaf filter. Much of the expensive work is independent of the dummy group assignment, and can be precomputed outside of the MCS search.

This PR refactors bond and chiral restraint setup to reduce the time for a single execution of the chiral validity filter from 200-300 ms down to ~10 ms.

## Summary of changes
- Precompute quantities independent of core and dummy group assignment during MCS initialization
- Move assertion that hybrid mol is connected to `setup_end_state`
- Refactor `setup_dummy_bond_and_chiral_interactions` using vectorized numpy ops
- Remove `recursive_map`, replace with array indexing
- Vectorize bond and chiral atom ixn canonicalization
- Move sanity-check assertions behind `verify` flag (defaulting to True; disabled during MCS)