### PR TITLE
Clean up atom mapping code a bit

### DIFF
--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -11,7 +11,14 @@ from timemachine.constants import DEFAULT_ATOM_MAPPING_KWARGS
 from timemachine.fe import atom_mapping
 from timemachine.fe.mcgregor import MaxVisitsWarning, NoMappingError
 from timemachine.fe.single_topology import DummyGroupAssignmentError, verify_chiral_validity_of_core
-from timemachine.fe.utils import get_mol_name, get_romol_conf, plot_atom_mapping_grid, read_sdf, set_romol_conf
+from timemachine.fe.utils import (
+    get_mol_name,
+    get_romol_conf,
+    plot_atom_mapping_grid,
+    read_sdf,
+    set_mol_name,
+    set_romol_conf,
+)
 from timemachine.ff import Forcefield
 
 pytestmark = [pytest.mark.nocuda]
@@ -1025,7 +1032,7 @@ def polyphenylene_smiles(n):
 def make_polyphenylene(n, dihedral_deg):
     """Make a chain of n benzene rings with each ring rotated `dihedral_deg` degrees with respect to the previous ring"""
     mol = Chem.MolFromSmiles(polyphenylene_smiles(n))
-    mol.SetProp("_Name", f"{n}_{dihedral_deg}")
+    set_mol_name(mol, f"{n}_{dihedral_deg}")
     mol = AllChem.AddHs(mol)
     AllChem.EmbedMolecule(mol, randomSeed=2024)
     for k in range(n - 1):  # n - 1 inter-ring bonds to rotate

--- a/tests/test_fe_utils.py
+++ b/tests/test_fe_utils.py
@@ -165,12 +165,12 @@ def test_image_molecules():
         np.testing.assert_array_almost_equal(imaged_mol, mol_coords)
 
 
-def test_get_mol_name():
+def test_get_and_set_mol_name():
     mol = Chem.MolFromSmiles("c1ccccc1")
     with pytest.raises(KeyError):
         utils.get_mol_name(mol)
 
-    mol.SetProp("_Name", "test_name")
+    utils.set_mol_name(mol, "test_name")
     assert utils.get_mol_name(mol) == "test_name"
 
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -574,7 +574,7 @@ def test_am1_differences():
     smi = "Clc1c(Cl)c(Cl)c(-c2c(Cl)c(Cl)c(Cl)c(Cl)c2Cl)c(Cl)c1Cl"
     mol = Chem.MolFromSmiles(smi)
     mol = Chem.AddHs(mol)
-    mol.SetProp("_Name", "Debug")
+    utils.set_mol_name(mol, "Debug")
     assert AllChem.EmbedMolecule(mol) == 0
 
     suppl = [mol]

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -45,7 +45,7 @@ from timemachine.fe.single_topology import (
     verify_chiral_validity_of_core,
 )
 from timemachine.fe.system import convert_bps_into_system, minimize_scipy, simulate_system
-from timemachine.fe.utils import get_mol_name, get_romol_conf, read_sdf
+from timemachine.fe.utils import get_mol_name, get_romol_conf, read_sdf, set_mol_name
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md import minimizer
@@ -1056,7 +1056,7 @@ def test_combine_with_host_split(precision, rtol, atol):
 def ligand_from_smiles(smiles):
     mol = Chem.AddHs(Chem.MolFromSmiles(smiles))
     AllChem.Compute2DCoords(mol)
-    mol.SetProp("_Name", smiles)
+    set_mol_name(mol, smiles)
     return mol
 
 

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -373,7 +373,7 @@ def _get_cores_impl(
     all_cores = remove_cores_smaller_than_largest(all_cores)
     all_cores = _deduplicate_all_cores(all_cores)
 
-    dists = []
+    mean_sq_distances = []
     valence_mismatches = []
     cb_counts = []
 
@@ -385,7 +385,7 @@ def _get_cores_impl(
         r2_ij = np.sum(np.power(r_i - r_j, 2))
         # No need to perform square root here, only care about ordering
         mean_sq_dist = r2_ij / len(core)
-        dists.append(mean_sq_dist)
+        mean_sq_distances.append(mean_sq_dist)
 
         v_count = 0
         for idx, jdx in core:
@@ -399,7 +399,7 @@ def _get_cores_impl(
         )
 
     sort_vals = np.array(
-        list(zip(cb_counts, valence_mismatches, dists)), dtype=[("cb", "i"), ("valence", "i"), ("msd", "f")]
+        list(zip(cb_counts, valence_mismatches, mean_sq_distances)), dtype=[("cb", "i"), ("valence", "i"), ("msd", "f")]
     )
     sorted_cores = []
 

--- a/timemachine/fe/utils.py
+++ b/timemachine/fe/utils.py
@@ -249,9 +249,8 @@ def plot_atom_mapping_grid(
         hbcs.append(bond_colors_a)
         hbcs.append(bond_colors_b)
 
-    num_mols = len(extra_mols) + 2
-
     all_mols = [mol_a_3d, mol_b_3d, *extra_mols]
+    num_mols = len(all_mols)
 
     legends: List[str] = []
     while len(legends) < num_mols:

--- a/timemachine/fe/utils.py
+++ b/timemachine/fe/utils.py
@@ -419,6 +419,11 @@ def get_mol_name(mol) -> str:
     return mol.GetProp("_Name")
 
 
+def set_mol_name(mol, name: str):
+    """Set an RDKit mol's name"""
+    mol.SetProp("_Name", name)
+
+
 def sanitize_energies(full_us, lamb_idx, cutoff=10000):
     """
     Given a matrix with F rows and K columns,


### PR DESCRIPTION
* Test is no longer expected to take 30 minutes
* Don't do RMSD, since the square root is unnecessary
* No longer compute the bonds after atom mapping
* Uniquify without returning incorrect bonds
* Seems to improve wall clock time of tests by about 5%