### PR TITLE
Add ring_forming_breaking_count metric

### DIFF
--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -1597,3 +1597,23 @@ M  END
     )
 
     assert atom_mapping.ring_breaking_count(mol_a, mol_b, core) == (2, 0)
+
+    mol_a = Chem.AddHs(Chem.MolFromSmiles("C1CC2=C(C1)C=CC=C2"))
+    set_mol_name(mol_a, "bicycle_a")
+    mol_b = Chem.AddHs(Chem.MolFromSmiles("C1=CC2=C(C=C1)C=CC=C2"))
+    set_mol_name(mol_b, "bicycle_b")
+
+    AllChem.EmbedMolecule(mol_a, randomSeed=2024)
+    AllChem.EmbedMolecule(mol_b, randomSeed=2024)
+
+    core = np.array(
+        [
+            [5, 1],
+            [6, 0],
+            [7, 5],
+            [8, 4],
+        ]
+    )
+    AllChem.AlignMol(mol_a, mol_b, atomMap=[(6, 0), (7, 5)])
+
+    assert atom_mapping.ring_breaking_count(mol_a, mol_b, core) == (1, 1)

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -1589,6 +1589,11 @@ def test_ring_breaking_count(hif2a_ligands):
     assert atom_mapping.ring_breaking_count(mol_a, mol_b, core) == (0, 0)
     assert atom_mapping.ring_breaking_count(mol_a, mol_b, core) == ref_ring_breaking_count(mol_a, mol_b, core)
 
+    cores = atom_mapping.get_cores(mol_a, mol_b, **{**DEFAULT_ATOM_MAPPING_KWARGS, "max_connected_components": 2})
+    core = cores[0]
+    assert atom_mapping.ring_breaking_count(mol_a, mol_b, core) == (1, 1)
+    assert atom_mapping.ring_breaking_count(mol_a, mol_b, core) == ref_ring_breaking_count(mol_a, mol_b, core)
+
     mol_a = Chem.MolFromMolBlock(
         """bridgehead system
   MJ240300

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -1561,3 +1561,39 @@ def test_ring_forming_breaking_count(hif2a_ligands):
     cores = atom_mapping.get_cores(mol_a, mol_b, **DEFAULT_ATOM_MAPPING_KWARGS)
     core = cores[0]
     assert atom_mapping.ring_forming_breaking_count(mol_a, mol_b, core) == 2
+
+    mol_a = Chem.MolFromMolBlock(
+        """bridgehead system
+  MJ240300
+
+  5  6  0  0  0  0  0  0  0  0999 V2000
+    1.2868    0.3797   -0.0018 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.5802   -0.3964   -0.0438 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.7505   -0.3790    0.0024 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.7069    0.2170   -0.5741 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.7711    0.1787    0.6173 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+  3  4  1  0  0  0  0
+  4  1  1  0  0  0  0
+  3  5  1  0  0  0  0
+  5  1  1  0  0  0  0
+M  END
+"""
+    )
+    mol_a = Chem.AddHs(mol_a)
+    mol_b = Chem.AddHs(Chem.MolFromSmiles("CCC"))
+    set_mol_name(mol_b, "chain")
+    AllChem.EmbedMolecule(mol_a, randomSeed=2024)
+    AllChem.EmbedMolecule(mol_b, randomSeed=2024)
+    AllChem.AlignMol(mol_b, mol_a, atomMap=[(0, 0), (1, 1), (2, 2)])
+
+    core = np.array(
+        [
+            [0, 0],
+            [1, 1],
+            [2, 2],
+        ]
+    )
+
+    assert atom_mapping.ring_forming_breaking_count(mol_a, mol_b, core) == 2

--- a/tests/test_atom_mapping.py
+++ b/tests/test_atom_mapping.py
@@ -1522,7 +1522,7 @@ M  END""",
         verify_chiral_validity_of_core(mol_a, mol_b, core, ff)
 
 
-def test_ring_forming_breaking_count(hif2a_ligands):
+def test_ring_breaking_count(hif2a_ligands):
     mol_a = Chem.AddHs(Chem.MolFromSmiles("C1=CC=CC=C1"))  # benzene
     set_mol_name(mol_a, "benzene")
     mol_b = Chem.AddHs(Chem.MolFromSmiles("CC1=CC=CC=C1"))  # benzene with a methyl
@@ -1539,8 +1539,8 @@ def test_ring_forming_breaking_count(hif2a_ligands):
             [5, 5],
         ]
     )
-    assert atom_mapping.ring_forming_breaking_count(mol_a, mol_b, core) == 2
-    assert atom_mapping.ring_forming_breaking_count(mol_b, mol_a, core[:, [1, 0]]) == 2
+    assert atom_mapping.ring_breaking_count(mol_a, mol_b, core) == (1, 1)
+    assert atom_mapping.ring_breaking_count(mol_b, mol_a, core[:, [1, 0]]) == (1, 1)
 
     mols_by_name = {get_mol_name(m): m for m in hif2a_ligands}
     # This transformation will always form a ring
@@ -1549,8 +1549,8 @@ def test_ring_forming_breaking_count(hif2a_ligands):
     cores = atom_mapping.get_cores(mol_a, mol_b, **DEFAULT_ATOM_MAPPING_KWARGS)
     core = cores[0]
 
-    assert atom_mapping.ring_forming_breaking_count(mol_a, mol_b, core) == 1
-    assert atom_mapping.ring_forming_breaking_count(mol_b, mol_a, core[:, [1, 0]]) == 1
+    assert atom_mapping.ring_breaking_count(mol_a, mol_b, core) == (1, 0)
+    assert atom_mapping.ring_breaking_count(mol_b, mol_a, core[:, [1, 0]]) == (0, 1)
 
     # Will construct two pair of 3 ring systems of which only a single ring can be mapped
     # with one atom in the second ring mapped. This means that the second ring is formed/broken (in both endstates)
@@ -1560,7 +1560,7 @@ def test_ring_forming_breaking_count(hif2a_ligands):
 
     cores = atom_mapping.get_cores(mol_a, mol_b, **DEFAULT_ATOM_MAPPING_KWARGS)
     core = cores[0]
-    assert atom_mapping.ring_forming_breaking_count(mol_a, mol_b, core) == 2
+    assert atom_mapping.ring_breaking_count(mol_a, mol_b, core) == (1, 1)
 
     mol_a = Chem.MolFromMolBlock(
         """bridgehead system
@@ -1596,4 +1596,4 @@ M  END
         ]
     )
 
-    assert atom_mapping.ring_forming_breaking_count(mol_a, mol_b, core) == 2
+    assert atom_mapping.ring_breaking_count(mol_a, mol_b, core) == (2, 0)

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -292,7 +292,7 @@ def ring_breaking_count(mol_a, mol_b, core: NDArray) -> Tuple[int, int]:
     if len(g.edges) < 3:
         return (0, 0)
 
-    def core_dummy_bond(graph: nx.Graph, e: Tuple[int, int]):
+    def core_dummy_bond(graph: nx.Graph, e: Tuple[int, int]) -> bool:
         """Determine if a bond is between two nodes of the same type. If not it is a core-dummy bond. Expects that one
         of the atom types is AtomMapFlags.CORE and the other is AtomMapFlags.MOL_A or AtomMapFlags.MOL_B
         """

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -334,7 +334,7 @@ def ring_breaking_count(mol_a, mol_b, core: NDArray) -> Tuple[int, int]:
                     ring_atoms.remove_edge(*edges[0])
             except nx.exception.NetworkXNoCycle:
                 pass
-    return tuple(breaking_count)
+    return breaking_count[0], breaking_count[1]
 
 
 def core_bonds_broken_count(mol_a, mol_b, core):

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -301,12 +301,12 @@ def ring_forming_breaking_count(mol_a, mol_b, core: NDArray) -> int:
             ring_atoms = subgraph.subgraph(
                 [n for n, data in subgraph.nodes(data=True) if data["atom_type"] != atom_type]
             )
-            core_atoms = [data["atom_type"] == AtomMapFlags.CORE for _, data in ring_atoms.nodes(data=True)]
+            ring_atom_is_core = [data["atom_type"] == AtomMapFlags.CORE for _, data in ring_atoms.nodes(data=True)]
             # If no atoms are core atoms, it is not a ring forming/breaking transformation and just an insertion
-            if not any(core_atoms):
+            if not any(ring_atom_is_core):
                 continue
             # If the ring atoms are all core atoms, no ring break has occurred
-            if all(core_atoms):
+            if all(ring_atom_is_core):
                 continue
             try:
                 nx.find_cycle(ring_atoms)

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -243,7 +243,14 @@ def _deduplicate_all_cores(all_cores):
     return list(unique_cores.values())
 
 
-def ring_forming_breaking_count(mol_a, mol_b, core):
+def ring_forming_breaking_count(mol_a, mol_b, core: NDArray) -> int:
+    """Counts the number of rings broken and formed given a core. Does not count ring insertion/deletions. Considers
+    the number number of rings broken/formed in both endstates, reversing the mol order and the core order produces
+    the same value.
+
+    The algorithm is to add all ring atoms/bonds to a graph, and count the cycles that contain both core and mol a or
+    mol b atoms.
+    """
     g = nx.Graph()
     core_a_to_b = {a: b for a, b in core}
     core_b_to_a = {b: a for a, b in core}

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -252,19 +252,19 @@ def ring_forming_breaking_count(mol_a, mol_b, core: NDArray) -> int:
     mol b atoms.
     """
     g = nx.Graph()
-    core_a_to_b = {a: b for a, b in core}
-    core_b_to_a = {b: a for a, b in core}
+    core_atoms_a = set(core[:, 0])
+    core_atoms_b = set(core[:, 1])
     for atom in mol_a.GetAtoms():
         idx = atom.GetIdx()
         if atom.IsInRing():
-            if idx in core_a_to_b:
+            if idx in core_atoms_a:
                 g.add_node(idx, atom_type=AtomMapFlags.CORE)
             else:
                 g.add_node(idx, atom_type=AtomMapFlags.MOL_A)
     for atom in mol_b.GetAtoms():
         idx = atom.GetIdx()
         if atom.IsInRing():
-            if idx in core_b_to_a:
+            if idx in core_atoms_b:
                 g.add_node(idx + mol_a.GetNumAtoms(), atom_type=AtomMapFlags.CORE)
             else:
                 g.add_node(idx + mol_a.GetNumAtoms(), atom_type=AtomMapFlags.MOL_B)

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -269,6 +269,7 @@ def ring_forming_breaking_count(mol_a, mol_b, core: NDArray) -> int:
             else:
                 g.add_node(idx + mol_a.GetNumAtoms(), atom_type=AtomMapFlags.MOL_B)
 
+    # if there are no ring atoms, return 0
     if len(g.nodes) == 0:
         return 0
 

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -120,7 +120,7 @@ def get_cores(
     Additional notes
     ----------------
     1) The returned cores are jointly sorted in increasing order based on the number of core-dummy bonds broken,
-       the sum of valence values changed, and the rmsd of the alignment.
+       the sum of valence values changed, and the mean square distance of the alignment.
     2) The number of cores atoms may vary slightly, but the number of mapped edges are the same.
     3) If a time-out has occurred due to max_visits, then an exception is thrown.
 
@@ -168,6 +168,12 @@ def get_cores(
 
     min_threshold: int
         Number of edges to require for a valid mapping
+
+    initial_mapping: np.ndarray
+        Initial core mapping to start the search with
+
+    enforce_chirally_valid_dummy_groups: bool
+        Filter out cores that are chirally invalid (i.e. unable to setup chiral restraints at both endstates)
 
     Returns
     -------

--- a/timemachine/fe/atom_mapping.py
+++ b/timemachine/fe/atom_mapping.py
@@ -311,11 +311,12 @@ def ring_breaking_count(mol_a, mol_b, core: NDArray) -> Tuple[int, int]:
                 [n for n, data in subgraph.nodes(data=True) if data["atom_type"] in (AtomMapFlags.CORE, atom_type)]
             )
             ring_atom_is_core = [data["atom_type"] == AtomMapFlags.CORE for _, data in ring_atoms.nodes(data=True)]
-            # If no atoms are core atoms, it is not a ring forming/breaking transformation and just an insertion
-            if not any(ring_atom_is_core):
+            ring_atom_count = np.sum(ring_atom_is_core, dtype=np.int32)
+            # If is only one or fewer core atoms, it is not a ring forming/breaking transformation and just an insertion
+            if ring_atom_count <= 1:
                 continue
-            # If the ring atoms are all core atoms, no ring break has occurred
-            if all(ring_atom_is_core):
+            elif ring_atom_count == len(ring_atoms):
+                # If the ring atoms are all core atoms, no ring break has occurred
                 continue
             try:
                 while len(ring_atoms.edges) >= 3:


### PR DESCRIPTION
Ring breaking/forming is often an expensive transformation, and this metrics could help us identify expensive edges upfront. Either to modify how maps are constructed (i.e. down weight edges that have ring forming/breaking) or simply as an additional indicator of the difficulty of a transformation.

Note that `core_bonds_broken_count` only considers core-core bonds broken, which is zero when `enforce_core_core` is true. 
https://github.com/proteneer/timemachine/blob/030faa23ec5e1c3e43b4f628990b002c225d2e69/timemachine/fe/atom_mapping.py#L239-L251

This function only identifies where a ring is formed or broken, (i.e. the ring is disconnected in the intermediate states) and does not consider ring insertions as forming/breaking since an insertion maintains the ring bonds through the windows.