### PR TITLE
Improve ordering of Local MD potentials

### DIFF
--- a/timemachine/cpp/src/local_md_potentials.cu
+++ b/timemachine/cpp/src/local_md_potentials.cu
@@ -68,14 +68,17 @@ LocalMDPotentials::LocalMDPotentials(
         construct_ixn_group_potential(N_, nonbonded_bp_->potential, nonbonded_bp_->size, nonbonded_bp_->d_p.data);
 
     // Add the restraint potential and ixn group potential
-    all_potentials_.push_back(bound_free_restraint_);
+    // Since the restraint has no sync, push to front
+    all_potentials_.insert(all_potentials_.begin(), bound_free_restraint_);
+    // Push ixn group to back since it has a sync
     all_potentials_.push_back(ixn_group_);
     if (!freeze_reference) {
         frozen_restraint_ = std::shared_ptr<LogFlatBottomBond<float>>(
             new LogFlatBottomBond<float>(default_bonds, 1 / (temperature * BOLTZ)));
         bound_frozen_restraint_ =
             std::shared_ptr<BoundPotential>(new BoundPotential(frozen_restraint_, default_params));
-        all_potentials_.push_back(bound_frozen_restraint_);
+        // Since the restraint has no sync, push to front
+        all_potentials_.insert(all_potentials_.begin(), bound_frozen_restraint_);
     }
 
     gpuErrchk(cub::DevicePartition::If(


### PR DESCRIPTION
Previously was pushing all of the Local MD constructed potentials to the end of the list of potentials. However this creates concurrency issues due to the syncing that takes place. Instead moving the potentials without syncs to the starts allows us to hide more latency.

* Improves performance by ~4% in solvent, ~2% in complex.

# Benchmarks

A4000 GPU
Cuda Arch 8.6

## Master
```
hif2a-rbfe-local: N=8840 speed: 1252.14ns/day dt: 2.5fs (ran 100000 steps in 17.26s)
solvent-rbfe-local: N=6317 speed: 1518.21ns/day dt: 2.5fs (ran 100000 steps in 14.23s)
```

## PR
```
hif2a-rbfe-local: N=8840 speed: 1272.77ns/day dt: 2.5fs (ran 100000 steps in 16.98s)  # 2% speed up
solvent-rbfe-local: N=6317 speed: 1568.31ns/day dt: 2.5fs (ran 100000 steps in 13.78s) # 4% speed up
```