### PR TITLE
Assert that states differ only in their parameters

### DIFF
--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -1,5 +1,5 @@
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, fields, replace
 from functools import cache
 from typing import Callable, Iterator, List, Optional, Sequence, Tuple
 from warnings import warn
@@ -803,6 +803,29 @@ def make_pair_bar_plots(res: PairBarResult, temperature: float, prefix: str) -> 
     return PairBarPlots(dG_errs_png, overlap_summary_png, overlap_detail_png)
 
 
+def assert_potentials_compatible(bps1: Sequence[BoundPotential], bps2: Sequence[BoundPotential]):
+    """Asserts that two sequences of bound potentials are equivalent except for their parameters"""
+
+    def field_equal(x1, x2):
+        assert type(x1) is type(x2)
+        if isinstance(x1, np.ndarray):
+            return np.all(x1 == x2)
+        else:
+            return x1 == x2
+
+    def assert_equal(p1, p2):
+        assert type(p1) is type(p2)
+        for field in fields(p1):
+            assert field_equal(
+                getattr(p1, field.name), getattr(p2, field.name)
+            ), f"objects differ in field '{field.name}'"
+
+    assert len(bps1) == len(bps2)
+
+    for bp1, bp2 in zip(bps1, bps2):
+        assert_equal(bp1.potential, bp2.potential)
+
+
 def run_sims_sequential(
     initial_states: Sequence[InitialState],
     md_params: MDParams,
@@ -837,7 +860,11 @@ def run_sims_sequential(
     # u_kln matrix (2, 2, n_frames) for each pair of adjacent lambda windows and energy term
     u_kln_by_component_by_lambda = []
 
-    # NOTE: this assumes that states differ only in their parameters, but we do not check this!
+    # Ensure that states differ only in their parameters so that we can safely instantiate potentials from the first
+    # state and use set_params for efficiency
+    for s in initial_states[1:]:
+        assert_potentials_compatible(initial_states[0].potentials, s.potentials)
+
     unbound_impls = [p.potential.to_gpu(np.float32).unbound_impl for p in initial_states[0].potentials]
     for initial_state in initial_states:
         # run simulation
@@ -929,14 +956,18 @@ def run_sims_bisection(
         return traj
 
     # Set up a single set of unbound potentials for computing the batch U fns
-    # NOTE: this assumes that states differ only in their parameters, but we do not check this!
-    unbound_impls = [p.potential.to_gpu(np.float32).unbound_impl for p in get_initial_state(lambdas[0]).potentials]
+    potentials_0 = get_initial_state(lambdas[0]).potentials
+    unbound_impls = [p.potential.to_gpu(np.float32).unbound_impl for p in potentials_0]
 
     # NOTE: we don't cache get_state to avoid holding BoundPotentials in memory since they
     # 1. can use significant GPU memory
     # 2. can be reconstructed relatively quickly
     def get_state(lamb: float) -> EnergyDecomposedState[StoredArrays]:
         initial_state = get_initial_state(lamb)
+
+        # Ensure that state differs only in parameters
+        assert_potentials_compatible(initial_state.potentials, potentials_0)
+
         traj = get_samples(lamb)
         batch_u_fns = get_batch_u_fns(unbound_impls, [p.params for p in initial_state.potentials], temperature)
         return EnergyDecomposedState(traj.frames, traj.boxes, batch_u_fns)
@@ -1139,8 +1170,12 @@ def run_sims_hrex(
     if n_swap_attempts_per_iter is None:
         n_swap_attempts_per_iter = get_swap_attempts_per_iter_heuristic(len(initial_states))
 
+    # Ensure that states differ only in their parameters so that we can safely instantiate potentials from the first
+    # state and use set_params for efficiency
+    for s in initial_states[1:]:
+        assert_potentials_compatible(initial_states[0].potentials, s.potentials)
+
     # Set up overall potential and context using the first state.
-    # NOTE: this assumes that states differ only in their parameters, but we do not check this!
     context = get_context(initial_states[0], md_params=md_params)
     bound_potentials = context.get_potentials()
     assert len(bound_potentials) == 1


### PR DESCRIPTION
Improves the safety of an optimization we currently use in free energy computations where we only instantiate potentials for one end state and assume the other states differ only in their parameters.