### PR TITLE
Removes Neighborlist sync from Nonbonded potentials

### DIFF
--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -13,7 +13,7 @@ from timemachine.md.barostat.utils import compute_box_center, compute_box_volume
 from timemachine.md.builders import build_water_system
 from timemachine.md.enhanced import get_solvent_phase_system
 from timemachine.md.thermostat.utils import sample_velocities
-from timemachine.potentials import HarmonicBond
+from timemachine.potentials import HarmonicBond, SummedPotential
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
 
 
@@ -93,7 +93,7 @@ def test_barostat_with_clashes():
     coords = afe.prepare_combined_coords(host_coords=host_coords)
 
     # get list of molecules for barostat by looking at bond table
-    harmonic_bond_potential = unbound_potentials[0]
+    harmonic_bond_potential = next(pot for pot in unbound_potentials if isinstance(pot, HarmonicBond))
     bond_list = get_bond_list(harmonic_bond_potential)
     group_indices = get_group_indices(bond_list, len(masses))
 
@@ -144,7 +144,7 @@ def test_barostat_zero_interval():
     )
 
     # get list of molecules for barostat by looking at bond table
-    harmonic_bond_potential = unbound_potentials[0]
+    harmonic_bond_potential = next(pot for pot in unbound_potentials if isinstance(pot, HarmonicBond))
     bond_list = get_bond_list(harmonic_bond_potential)
     group_indices = get_group_indices(bond_list, len(masses))
 
@@ -192,7 +192,7 @@ def test_barostat_partial_group_idxs():
     )
 
     # get list of molecules for barostat by looking at bond table
-    harmonic_bond_potential = unbound_potentials[0]
+    harmonic_bond_potential = next(pot for pot in unbound_potentials if isinstance(pot, HarmonicBond))
     bond_list = get_bond_list(harmonic_bond_potential)
     group_indices = get_group_indices(bond_list, len(masses))
 
@@ -251,7 +251,7 @@ def test_barostat_is_deterministic():
     )
 
     # get list of molecules for barostat by looking at bond table
-    harmonic_bond_potential = unbound_potentials[0]
+    harmonic_bond_potential = next(pot for pot in unbound_potentials if isinstance(pot, HarmonicBond))
     bond_list = get_bond_list(harmonic_bond_potential)
     group_indices = get_group_indices(bond_list, len(masses))
 
@@ -365,7 +365,7 @@ def test_barostat_recentering_upon_acceptance():
     unbound_potentials, sys_params, masses, coords, complex_box = get_solvent_phase_system(mol_a, ff, lam, margin=0.0)
 
     # get list of molecules for barostat by looking at bond table
-    harmonic_bond_potential = unbound_potentials[0]
+    harmonic_bond_potential = next(pot for pot in unbound_potentials if isinstance(pot, HarmonicBond))
     bond_list = get_bond_list(harmonic_bond_potential)
     group_indices = get_group_indices(bond_list, len(masses))
 
@@ -445,12 +445,16 @@ def test_molecular_ideal_gas():
         mol_a, ff, lamb=1.0, margin=0.0
     )
 
+    unbound_potentials = list(_unbound_potentials)
+    sys_params = list(_sys_params)
+
     # drop the nonbonded potential
-    unbound_potentials = _unbound_potentials[:-1]
-    sys_params = _sys_params[:-1]
+    nb_pot_idx = next(i for i, pot in enumerate(unbound_potentials) if isinstance(pot, SummedPotential))
+    unbound_potentials.pop(nb_pot_idx)
+    sys_params.pop(nb_pot_idx)
 
     # get list of molecules for barostat by looking at bond table
-    harmonic_bond_potential = unbound_potentials[0]
+    harmonic_bond_potential = next(pot for pot in unbound_potentials if isinstance(pot, HarmonicBond))
     bond_list = get_bond_list(harmonic_bond_potential)
     group_indices = get_group_indices(bond_list, len(masses))
 
@@ -583,7 +587,7 @@ def test_barostat_scaling_behavior():
     )
 
     # get list of molecules for barostat by looking at bond table
-    harmonic_bond_potential = unbound_potentials[0]
+    harmonic_bond_potential = next(pot for pot in unbound_potentials if isinstance(pot, HarmonicBond))
     bond_list = get_bond_list(harmonic_bond_potential)
     group_indices = get_group_indices(bond_list, len(masses))
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -69,7 +69,6 @@ def generate_hif2a_frames(n_frames: int, frame_interval: int, seed=None, barosta
     harmonic_bond_potential = next(
         bp.potential for bp in initial_state.potentials if isinstance(bp.potential, HarmonicBond)
     )
-
     bond_list = get_bond_list(harmonic_bond_potential)
     masses = initial_state.integrator.masses
     if hmr:

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -66,8 +66,10 @@ def generate_hif2a_frames(n_frames: int, frame_interval: int, seed=None, barosta
     temperature = constants.DEFAULT_TEMP
     pressure = constants.DEFAULT_PRESSURE
 
-    harmonic_bond_potential = initial_state.potentials[0].potential
-    assert isinstance(harmonic_bond_potential, HarmonicBond)
+    harmonic_bond_potential = next(
+        bp.potential for bp in initial_state.potentials if isinstance(bp.potential, HarmonicBond)
+    )
+
     bond_list = get_bond_list(harmonic_bond_potential)
     masses = initial_state.integrator.masses
     if hmr:

--- a/tests/test_jax_nonbonded.py
+++ b/tests/test_jax_nonbonded.py
@@ -17,6 +17,7 @@ from timemachine.fe.reweighting import one_sided_exp
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md import builders
+from timemachine.potentials import Nonbonded
 from timemachine.potentials.jax_utils import get_all_pairs_indices, pairs_from_interaction_groups, pairwise_distances
 from timemachine.potentials.nonbonded import (
     basis_expand_lj_atom,
@@ -117,7 +118,7 @@ def generate_waterbox_nb_args() -> NonbondedArgs:
     ff = Forcefield.load_default()
     system, conf, box, _ = builders.build_water_system(3.0, ff.water_ff)
     bps, masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
-    nb = bps[-1]
+    nb = next(bp for bp in bps if isinstance(bp.potential, Nonbonded))
     params = nb.params
 
     beta = nb.potential.beta
@@ -330,7 +331,7 @@ def test_jax_nonbonded_block():
     ff = Forcefield.load_default()
     system, conf, box, _ = builders.build_water_system(3.0, ff.water_ff)
     bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
-    nb = bps[-1]
+    nb = next(bp for bp in bps if isinstance(bp.potential, Nonbonded))
     params = nb.params
 
     N = conf.shape[0]
@@ -364,7 +365,7 @@ def test_jax_nonbonded_block_unsummed():
     ff = Forcefield.load_default()
     system, conf, box, _ = builders.build_water_system(3.0, ff.water_ff)
     bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
-    nb = bps[-1]
+    nb = next(bp for bp in bps if isinstance(bp.potential, Nonbonded))
     params = nb.params
 
     N = conf.shape[0]
@@ -437,7 +438,7 @@ def test_precomputation():
     ff = Forcefield.load_default()
     system, conf, box, _ = builders.build_water_system(3.0, ff.water_ff)
     bps, masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
-    nb = bps[-1]
+    nb = next(bp for bp in bps if isinstance(bp.potential, Nonbonded))
     params = nb.params
 
     n_atoms = conf.shape[0]

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -14,7 +14,7 @@ from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, VelocityVerl
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.md.enhanced import get_solvent_phase_system
 from timemachine.md.minimizer import check_force_norm
-from timemachine.potentials import SummedPotential
+from timemachine.potentials import HarmonicBond, SummedPotential
 from timemachine.testsystems.ligands import get_biphenyl
 
 pytestmark = [pytest.mark.memcheck]
@@ -450,7 +450,8 @@ def test_multiple_steps_local_consistency(freeze_reference):
         check_force_norm(-ref_du_dx)
 
     # Verify that running with a barostat doesn't change the results
-    group_idxs = get_group_indices(get_bond_list(unbound_potentials[0]), len(masses))
+    bonded_pot = next(pot for pot in unbound_potentials if isinstance(pot, HarmonicBond))
+    group_idxs = get_group_indices(get_bond_list(bonded_pot), len(masses))
 
     pressure = 1.0
 
@@ -514,7 +515,8 @@ def test_get_movers():
 
     intg_impl = intg.impl()
 
-    group_idxs = get_group_indices(get_bond_list(unbound_potentials[0]), len(masses))
+    bonded_pot = next(pot for pot in unbound_potentials if isinstance(pot, HarmonicBond))
+    group_idxs = get_group_indices(get_bond_list(bonded_pot), len(masses))
 
     barostat = MonteCarloBarostat(coords.shape[0], pressure, temperature, group_idxs, 1, seed)
     barostat_impl = barostat.impl(bps)
@@ -779,7 +781,8 @@ def test_setup_context_with_references():
 
         movers = []
         if barostat_interval > 0:
-            group_idxs = get_group_indices(get_bond_list(unbound_potentials[0]), len(masses))
+            bonded_pot = next(pot for pot in unbound_potentials if isinstance(pot, HarmonicBond))
+            group_idxs = get_group_indices(get_bond_list(bonded_pot), len(masses))
 
             barostat = MonteCarloBarostat(coords.shape[0], pressure, temperature, group_idxs, 1, seed)
             barostat_impl = barostat.impl(bps)

--- a/tests/test_mtm.py
+++ b/tests/test_mtm.py
@@ -16,7 +16,7 @@ from timemachine.md import enhanced
 from timemachine.md.barostat.moves import NPTMove
 from timemachine.md.moves import OptimizedMTMMove, ReferenceMTMMove
 from timemachine.md.states import CoordsVelBox
-from timemachine.potentials import NonbondedInteractionGroup, nonbonded
+from timemachine.potentials import NonbondedInteractionGroup, SummedPotential, nonbonded
 
 
 def get_ff_am1ccc():
@@ -55,12 +55,14 @@ def test_optimized_MTM():
     vacuum_samples = _vacuum_xv_samples[:, 0, :]
     ubps, params, masses, coords, box = enhanced.get_solvent_phase_system(mol, ff, 0.0)
 
+    summed_pot = next(pot for pot in ubps if isinstance(pot, SummedPotential))
+
     # Unwrap SummedPotential to get intermolecular water-ligand potential
     nb_idx, nb_wl_potential = next(
-        (i, pot) for i, pot in enumerate(ubps[-1].potentials) if isinstance(pot, NonbondedInteractionGroup)
+        (i, pot) for i, pot in enumerate(summed_pot.potentials) if isinstance(pot, NonbondedInteractionGroup)
     )
 
-    nb_params = ubps[-1].params_init[nb_idx]
+    nb_params = summed_pot.params_init[nb_idx]
 
     beta = nb_wl_potential.beta
     cutoff = nb_wl_potential.cutoff

--- a/tests/test_mtm_condensed.py
+++ b/tests/test_mtm_condensed.py
@@ -17,7 +17,7 @@ from timemachine.md import enhanced
 from timemachine.md.barostat.moves import NPTMove
 from timemachine.md.moves import NVTMove, OptimizedMTMMove
 from timemachine.md.states import CoordsVelBox
-from timemachine.potentials import NonbondedInteractionGroup, bonded, nonbonded
+from timemachine.potentials import NonbondedInteractionGroup, SummedPotential, bonded, nonbonded
 
 
 @pytest.mark.skip("Has shown to be flaky, needs further investigation. Condensed MTM not currently used")
@@ -63,11 +63,14 @@ def test_condensed_phase_mtm(seed):
     ubps, params, masses, coords, box = enhanced.get_solvent_phase_system(mol, ff, 0.0)
 
     # Unwrap SummedPotential to get water-ligand nonbonded potential
+    summed_pot = next(pot for pot in ubps if isinstance(pot, SummedPotential))
+
+    # Unwrap SummedPotential to get intermolecular water-ligand potential
     nb_idx, nb_wl_potential = next(
-        (i, pot) for i, pot in enumerate(ubps[-1].potentials) if isinstance(pot, NonbondedInteractionGroup)
+        (i, pot) for i, pot in enumerate(summed_pot.potentials) if isinstance(pot, NonbondedInteractionGroup)
     )
 
-    nb_params = ubps[-1].params_init[nb_idx]
+    nb_params = summed_pot.params_init[nb_idx]
 
     beta = nb_wl_potential.beta
     cutoff = nb_wl_potential.cutoff

--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -104,6 +104,7 @@ pybind11_add_module(${LIBRARY_NAME} SHARED NO_EXTRAS
   src/tibd_exchange_move.cu
   src/nonbonded_mol_energy.cu
   src/kernels/k_hilbert.cu
+  src/kernels/k_nonbonded_common.cu
   src/kernels/k_indices.cu
   src/kernels/k_logsumexp.cu
   src/kernels/k_rotations.cu

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -12,6 +12,7 @@ template <typename RealType>
 void __global__ k_find_block_bounds(
     const int num_tiles,                       // Number of tiles
     const int num_indices,                     // Number of indices
+    const int *__restrict__ rebuild_flag,      // [1] Flag indicating to rebuild
     const unsigned int *__restrict__ row_idxs, // [num_indices]
     const double *__restrict__ coords,         // [N*3]
     const double *__restrict__ box,            // [3*3]
@@ -27,6 +28,10 @@ void __global__ k_find_block_bounds(
     int tile_idx = (blockIdx.x * blockDim.x + threadIdx.x) / WARP_SIZE;
 
     if (tile_idx >= num_tiles) {
+        return;
+    }
+
+    if (*rebuild_flag == 0) {
         return;
     }
 
@@ -118,10 +123,15 @@ void __global__ k_find_block_bounds(
 void __global__ k_compact_trim_atoms(
     const int N,
     const int Y,
+    const int *rebuild_flag, // [1] Flag indicating whether to rebuild
     unsigned int *__restrict__ trim_atoms,
     unsigned int *__restrict__ interactionCount,
     int *__restrict__ interactingTiles,
     unsigned int *__restrict__ interactingAtoms) {
+
+    if (*rebuild_flag == 0) {
+        return;
+    }
 
     // we can probably get away with using only 32 if we do some fancier remainder tricks, but this isn't a huge save
     __shared__ int ixn_j_buffer[2 * WARP_SIZE];
@@ -201,6 +211,7 @@ void __global__ k_find_blocks_with_ixns(
     const int N,                                  // Total number of atoms
     const int NC,                                 // Number of columns idxs
     const int NR,                                 // Number of rows idxs
+    const int *rebuild_flag,                      // [1] Flag indicating whether to rebuild
     const unsigned int *__restrict__ column_idxs, // [NC]
     const unsigned int *__restrict__ row_idxs,    // [NR]
     const RealType *__restrict__ column_bb_ctr,   // [N * 3] block centers
@@ -216,6 +227,10 @@ void __global__ k_find_blocks_with_ixns(
     const double cutoff) {
 
     static_assert(TILE_SIZE == WARP_SIZE, "TILE_SIZE != WARP_SIZE is not currently supported");
+
+    if (*rebuild_flag == 0) {
+        return;
+    }
 
     const int indexInWarp = threadIdx.x % WARP_SIZE;
     const int warpMask = (1 << indexInWarp) - 1;

--- a/timemachine/cpp/src/kernels/k_neighborlist.cuh
+++ b/timemachine/cpp/src/kernels/k_neighborlist.cuh
@@ -24,14 +24,14 @@ void __global__ k_find_block_bounds(
     // Algorithm taken from https://github.com/openmm/openmm/blob/master/platforms/cuda/src/kernels/findInteractingBlocks.cu#L7
     // Computes smaller bounding boxes than simpler form by accounting for periodic box conditions
 
+    if (*rebuild_flag == 0) {
+        return;
+    }
+
     // each warp processes one tile
     int tile_idx = (blockIdx.x * blockDim.x + threadIdx.x) / WARP_SIZE;
 
     if (tile_idx >= num_tiles) {
-        return;
-    }
-
-    if (*rebuild_flag == 0) {
         return;
     }
 

--- a/timemachine/cpp/src/kernels/k_nonbonded_common.cu
+++ b/timemachine/cpp/src/kernels/k_nonbonded_common.cu
@@ -19,7 +19,7 @@ void __global__ k_update_neighborlist_state(
     }
 
     while (block_idx < N * D) {
-        if (block_idx < constexpr(D * D)) {
+        if (block_idx < D * D) {
             nblist_box[block_idx] = box[block_idx];
         }
         nblist_coords[block_idx] = coords[block_idx];

--- a/timemachine/cpp/src/kernels/k_nonbonded_common.cu
+++ b/timemachine/cpp/src/kernels/k_nonbonded_common.cu
@@ -1,0 +1,31 @@
+
+#include "k_nonbonded_common.cuh"
+
+namespace timemachine {
+
+void __global__ k_update_neighborlist_state(
+    const int N,
+    const int *__restrict__ rebuild_flag, // [1]
+    const double *__restrict__ coords,    // [N, 3]
+    const double *__restrict__ box,       // [3, 3]
+    double *__restrict__ nblist_coords,   // [N, 3]
+    double *__restrict__ nblist_box       // [3, 3]
+) {
+    const int D = 3;
+    int block_idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (*rebuild_flag == 0) {
+        return;
+    }
+
+    while (block_idx < N * D) {
+        if (block_idx < constexpr(D * D)) {
+            nblist_box[block_idx] = box[block_idx];
+        }
+        nblist_coords[block_idx] = coords[block_idx];
+
+        block_idx += gridDim.x * blockDim.x;
+    }
+}
+
+} // namespace timemachine

--- a/timemachine/cpp/src/kernels/k_nonbonded_common.cuh
+++ b/timemachine/cpp/src/kernels/k_nonbonded_common.cuh
@@ -245,4 +245,13 @@ void __device__ __forceinline__ compute_lj(
     eps_grad = lj_scale * 4 * (sig6_inv_d6ij - 1) * sig6_inv_d6ij;
 }
 
+void __global__ k_update_neighborlist_state(
+    const int N,
+    const int *__restrict__ rebuild_flag, // [1]
+    const double *__restrict__ coords,    // [N, 3]
+    const double *__restrict__ box,       // [3, 3]
+    double *__restrict__ nblist_coords,   // [N, 3]
+    double *__restrict__ nblist_box       // [3, 3]
+);
+
 } // namespace timemachine

--- a/timemachine/cpp/src/neighborlist.hpp
+++ b/timemachine/cpp/src/neighborlist.hpp
@@ -52,7 +52,12 @@ public:
     get_nblist_host(const int N, const double *h_coords, const double *h_box, const double cutoff);
 
     void build_nblist_device(
-        const int N, const double *d_coords, const double *d_box, const double cutoff, const cudaStream_t stream);
+        const int N,
+        const int *rebuild_flag,
+        const double *d_coords,
+        const double *d_box,
+        const double cutoff,
+        const cudaStream_t stream);
 
     void compute_block_bounds_host(
         const int N, const double *h_coords, const double *h_box, double *h_bb_ctrs, double *h_bb_exts);
@@ -84,7 +89,12 @@ private:
     int Y() const;
 
     void compute_block_bounds_device(
-        const int N, const int D, const double *d_coords, const double *d_box, cudaStream_t stream);
+        const int N,
+        const int D,
+        const int *rebuild_flag,
+        const double *d_coords,
+        const double *d_box,
+        cudaStream_t stream);
 };
 
 } // namespace timemachine

--- a/timemachine/cpp/src/nonbonded_all_pairs.cu
+++ b/timemachine/cpp/src/nonbonded_all_pairs.cu
@@ -69,7 +69,6 @@ NonbondedAllPairs<RealType>::NonbondedAllPairs(
     cudaSafeMalloc(&d_nblist_box_, 3 * 3 * sizeof(*d_nblist_box_));
     gpuErrchk(cudaMemset(d_nblist_box_, 0, 3 * 3 * sizeof(*d_nblist_box_)));
     cudaSafeMalloc(&d_rebuild_nblist_, 1 * sizeof(*d_rebuild_nblist_));
-    gpuErrchk(cudaMallocHost(&p_rebuild_nblist_, 1 * sizeof(*p_rebuild_nblist_)));
 
     if (!disable_hilbert_) {
         this->hilbert_sort_.reset(new HilbertSort(N_));
@@ -97,7 +96,6 @@ template <typename RealType> NonbondedAllPairs<RealType>::~NonbondedAllPairs() {
     gpuErrchk(cudaFree(d_nblist_x_));
     gpuErrchk(cudaFree(d_nblist_box_));
     gpuErrchk(cudaFree(d_rebuild_nblist_));
-    gpuErrchk(cudaFreeHost(p_rebuild_nblist_));
 
     gpuErrchk(cudaEventDestroy(nblist_flag_sync_event_));
 };
@@ -153,8 +151,6 @@ void NonbondedAllPairs<RealType>::sort(const double *d_coords, const double *d_b
             d_sorted_atom_idxs_, d_atom_idxs_, K_ * sizeof(*d_atom_idxs_), cudaMemcpyDeviceToDevice, stream));
     }
     gpuErrchk(cudaMemsetAsync(d_rebuild_nblist_, 1, sizeof(*d_rebuild_nblist_), stream));
-    // Set the pinned memory to indicate that we need to rebuild
-    p_rebuild_nblist_[0] = 1;
 }
 
 template <typename RealType>
@@ -206,11 +202,6 @@ void NonbondedAllPairs<RealType>::execute_device(
         k_check_rebuild_coords_and_box_gather<RealType><<<ceil_divide(K_, tpb), tpb, 0, stream>>>(
             K_, d_atom_idxs_, d_x, d_nblist_x_, d_box, d_nblist_box_, nblist_padding_, d_rebuild_nblist_);
         gpuErrchk(cudaPeekAtLastError());
-
-        // we can optimize this away by doing the check on the GPU directly.
-        gpuErrchk(cudaMemcpyAsync(
-            p_rebuild_nblist_, d_rebuild_nblist_, 1 * sizeof(*p_rebuild_nblist_), cudaMemcpyDeviceToHost, stream));
-        gpuErrchk(cudaEventRecord(nblist_flag_sync_event_, stream));
     }
     // compute new coordinates/params
     k_gather_coords_and_params<double, 3, PARAMS_PER_ATOM>
@@ -224,17 +215,13 @@ void NonbondedAllPairs<RealType>::execute_device(
     if (d_du_dp) {
         gpuErrchk(cudaMemsetAsync(d_gathered_du_dp_, 0, K_ * PARAMS_PER_ATOM * sizeof(*d_gathered_du_dp_), stream));
     }
-    // Syncing to an event allows having additional kernels run while we synchronize
-    // Note that if no event is recorded, this is effectively a no-op, such as in the case of sorting.
-    gpuErrchk(cudaEventSynchronize(nblist_flag_sync_event_));
-    if (p_rebuild_nblist_[0] > 0) {
-
-        nblist_.build_nblist_device(K_, d_gathered_x_, d_box, cutoff_ + nblist_padding_, stream);
-
-        gpuErrchk(cudaMemsetAsync(d_rebuild_nblist_, 0, sizeof(*d_rebuild_nblist_), stream));
-        gpuErrchk(cudaMemcpyAsync(d_nblist_x_, d_x, N * 3 * sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
-        gpuErrchk(cudaMemcpyAsync(d_nblist_box_, d_box, 3 * 3 * sizeof(*d_box), cudaMemcpyDeviceToDevice, stream));
-    }
+    nblist_.build_nblist_device(K_, d_rebuild_nblist_, d_gathered_x_, d_box, cutoff_ + nblist_padding_, stream);
+    // Update the neighborlist state if necessary
+    k_update_neighborlist_state<<<ceil_divide(N, tpb), tpb, 0, stream>>>(
+        N, d_rebuild_nblist_, d_x, d_box, d_nblist_x_, d_nblist_box_);
+    gpuErrchk(cudaPeekAtLastError());
+    // Set the flag to 0
+    gpuErrchk(cudaMemsetAsync(d_rebuild_nblist_, 0, sizeof(*d_rebuild_nblist_), stream));
 
     // look up which kernel we need for this computation
     int kernel_idx = 0;

--- a/timemachine/cpp/src/nonbonded_all_pairs.hpp
+++ b/timemachine/cpp/src/nonbonded_all_pairs.hpp
@@ -33,7 +33,6 @@ private:
     double *d_nblist_box_; // box which was used to rebuild the nblist
     __int128 *d_u_buffer_;
     int *d_rebuild_nblist_; // whether or not we have to rebuild the nblist
-    int *p_rebuild_nblist_; // pinned
 
     // "gathered" arrays represent the subset of atoms specified by
     // atom_idxs (if the latter is specified, otherwise all atoms).

--- a/timemachine/cpp/src/nonbonded_interaction_group.cu
+++ b/timemachine/cpp/src/nonbonded_interaction_group.cu
@@ -66,7 +66,6 @@ NonbondedInteractionGroup<RealType>::NonbondedInteractionGroup(
     cudaSafeMalloc(&d_nblist_box_, 3 * 3 * sizeof(*d_nblist_box_));
     gpuErrchk(cudaMemset(d_nblist_box_, 0, 3 * 3 * sizeof(*d_nblist_box_)));
     cudaSafeMalloc(&d_rebuild_nblist_, 1 * sizeof(*d_rebuild_nblist_));
-    gpuErrchk(cudaMallocHost(&p_rebuild_nblist_, 1 * sizeof(*p_rebuild_nblist_)));
 
     if (!disable_hilbert_) {
         this->hilbert_sort_.reset(new HilbertSort(N_));
@@ -94,7 +93,6 @@ template <typename RealType> NonbondedInteractionGroup<RealType>::~NonbondedInte
     gpuErrchk(cudaFree(d_nblist_x_));
     gpuErrchk(cudaFree(d_nblist_box_));
     gpuErrchk(cudaFree(d_rebuild_nblist_));
-    gpuErrchk(cudaFreeHost(p_rebuild_nblist_));
 
     gpuErrchk(cudaEventDestroy(nblist_flag_sync_event_));
 };
@@ -116,8 +114,6 @@ void NonbondedInteractionGroup<RealType>::sort(const double *d_coords, const dou
             d_perm_ + NR_, d_col_atom_idxs_, NC_ * sizeof(*d_col_atom_idxs_), cudaMemcpyDeviceToDevice, stream));
     }
     gpuErrchk(cudaMemsetAsync(d_rebuild_nblist_, 1, sizeof(*d_rebuild_nblist_), stream));
-    // Set the pinned memory to indicate that we need to rebuild
-    p_rebuild_nblist_[0] = 1;
 }
 
 template <typename RealType>
@@ -179,10 +175,6 @@ void NonbondedInteractionGroup<RealType>::execute_device(
         k_check_rebuild_coords_and_box_gather<RealType><<<B_K, tpb, 0, stream>>>(
             NR_ + NC_, d_perm_, d_x, d_nblist_x_, d_box, d_nblist_box_, nblist_padding_, d_rebuild_nblist_);
         gpuErrchk(cudaPeekAtLastError());
-        // we can optimize this away by doing the check on the GPU directly.
-        gpuErrchk(cudaMemcpyAsync(
-            p_rebuild_nblist_, d_rebuild_nblist_, 1 * sizeof(*p_rebuild_nblist_), cudaMemcpyDeviceToHost, stream));
-        gpuErrchk(cudaEventRecord(nblist_flag_sync_event_, stream));
     }
 
     // compute new coordinates/params
@@ -197,17 +189,12 @@ void NonbondedInteractionGroup<RealType>::execute_device(
         gpuErrchk(cudaMemsetAsync(d_sorted_du_dp_, 0, K * PARAMS_PER_ATOM * sizeof(*d_sorted_du_dp_), stream))
     }
 
-    // Syncing to an event allows having additional kernels run while we synchronize
-    // Note that if no event is recorded, this is effectively a no-op, such as in the case of sorting.
-    gpuErrchk(cudaEventSynchronize(nblist_flag_sync_event_));
-    if (p_rebuild_nblist_[0] > 0) {
-
-        nblist_.build_nblist_device(K, d_sorted_x_, d_box, cutoff_ + nblist_padding_, stream);
-
-        gpuErrchk(cudaMemsetAsync(d_rebuild_nblist_, 0, sizeof(*d_rebuild_nblist_), stream));
-        gpuErrchk(cudaMemcpyAsync(d_nblist_x_, d_x, N * 3 * sizeof(*d_x), cudaMemcpyDeviceToDevice, stream));
-        gpuErrchk(cudaMemcpyAsync(d_nblist_box_, d_box, 3 * 3 * sizeof(*d_box), cudaMemcpyDeviceToDevice, stream));
-    }
+    nblist_.build_nblist_device(K, d_rebuild_nblist_, d_sorted_x_, d_box, cutoff_ + nblist_padding_, stream);
+    // Update the neighborlist state if necessary
+    k_update_neighborlist_state<<<ceil_divide(N, tpb), tpb, 0, stream>>>(
+        N, d_rebuild_nblist_, d_x, d_box, d_nblist_x_, d_nblist_box_);
+    gpuErrchk(cudaPeekAtLastError());
+    gpuErrchk(cudaMemsetAsync(d_rebuild_nblist_, 0, sizeof(*d_rebuild_nblist_), stream));
 
     // look up which kernel we need for this computation
     int kernel_idx = 0;

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -296,8 +296,8 @@ def setup_initial_states(
             bp = ubp.bind(param)
             bps.append(bp)
 
-        bond_potential = ubps[0]
-        assert isinstance(bond_potential, potentials.HarmonicBond)
+        bond_potential = next(pot for pot in ubps if isinstance(pot, potentials.HarmonicBond))
+
         hmr_masses = model_utils.apply_hmr(masses, bond_potential.idxs)
         group_idxs = get_group_indices(get_bond_list(bond_potential), len(masses))
         baro = MonteCarloBarostat(len(hmr_masses), 1.0, temperature, group_idxs, 15, seed)

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -371,10 +371,8 @@ def image_frames(initial_state: InitialState, frames: np.ndarray, boxes: np.ndar
 class BaseFreeEnergy:
     @staticmethod
     def _get_system_params_and_potentials(ff_params: ForcefieldParams, topology, lamb: float):
+        # Ordering of the pairs impacts performance. Prefer slower potentials first
         params_potential_pairs = [
-            topology.parameterize_harmonic_bond(ff_params.hb_params),
-            topology.parameterize_harmonic_angle(ff_params.ha_params),
-            topology.parameterize_periodic_torsion(ff_params.pt_params, ff_params.it_params),
             topology.parameterize_nonbonded(
                 ff_params.q_params,
                 ff_params.q_params_intra,
@@ -382,6 +380,9 @@ class BaseFreeEnergy:
                 ff_params.lj_params_intra,
                 lamb,
             ),
+            topology.parameterize_periodic_torsion(ff_params.pt_params, ff_params.it_params),
+            topology.parameterize_harmonic_angle(ff_params.ha_params),
+            topology.parameterize_harmonic_bond(ff_params.hb_params),
         ]
 
         params, potentials = zip(*params_potential_pairs)

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -170,15 +170,16 @@ class HostGuestSystem:
     nonbonded_host_guest_ixn: BoundPotential[SummedPotential]
 
     def get_U_fns(self):
+        # Ordering here is from the slowest to the fastest kernel
         return [
-            self.bond,
-            self.angle,
-            self.torsion,
-            # Chiral bond restraints are disabled until checks are added
-            # for consistency.
-            self.chiral_atom,
-            # self.chiral_bond,
-            self.nonbonded_guest_pairs,
             self.nonbonded_host,
             self.nonbonded_host_guest_ixn,
+            self.nonbonded_guest_pairs,
+            self.torsion,
+            self.chiral_atom,
+            self.angle,
+            self.bond,
+            # Chiral bond restraints are disabled until checks are added
+            # for consistency.
+            # self.chiral_bond,
         ]

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -172,8 +172,8 @@ class HostGuestSystem:
     def get_U_fns(self):
         # Ordering here is from the slowest to the fastest kernel
         return [
-            self.nonbonded_host,
             self.nonbonded_host_guest_ixn,
+            self.nonbonded_host,  # Prefer after host-guest as it is AllPairs + exclusions
             self.nonbonded_guest_pairs,
             self.torsion,
             self.chiral_atom,

--- a/timemachine/ff/handlers/openmm_deserializer.py
+++ b/timemachine/ff/handlers/openmm_deserializer.py
@@ -7,7 +7,8 @@ from openmm import unit
 
 from timemachine import constants, potentials
 
-ORDERED_FORCES = ["HarmonicBond", "HarmonicAngle", "PeriodicTorsion", "Nonbonded"]
+# These forces are ordered for performance
+ORDERED_FORCES = ["Nonbonded", "PeriodicTorsion", "HarmonicBond", "HarmonicAngle"]
 
 
 def value(quantity):

--- a/timemachine/ff/handlers/openmm_deserializer.py
+++ b/timemachine/ff/handlers/openmm_deserializer.py
@@ -8,7 +8,7 @@ from openmm import unit
 from timemachine import constants, potentials
 
 # These forces are ordered for performance
-ORDERED_FORCES = ["Nonbonded", "PeriodicTorsion", "HarmonicBond", "HarmonicAngle"]
+ORDERED_FORCES = ["Nonbonded", "PeriodicTorsion", "HarmonicAngle", "HarmonicBond"]
 
 
 def value(quantity):
@@ -208,8 +208,7 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
 
             # nrg_fns.append(('Exclusions', (exclusion_idxs, scale_factors, es_scale_factors)))
 
-    # ugh, ... various parts of our code assume the bps are in a certain order
-    # so put them back in that order here
+    # Re-order potentials for performance reasons.
     bps = []
     for k in ORDERED_FORCES:
         if bps_dict.get(k):

--- a/timemachine/md/barostat/moves.py
+++ b/timemachine/md/barostat/moves.py
@@ -103,9 +103,9 @@ class NPTMove(NVTMove):
     ):
         super().__init__(bps, masses, temperature, n_steps, seed, dt=dt, friction=friction)
 
-        assert isinstance(bps[0].potential, HarmonicBond), "First potential must be of type HarmonicBond"
+        bonded_pot = next(bp.potential for bp in bps if isinstance(bp.potential, HarmonicBond))
 
-        bond_list = get_bond_list(bps[0].potential)
+        bond_list = get_bond_list(bonded_pot)
         group_idxs = get_group_indices(bond_list, len(masses))
 
         barostat = lib.MonteCarloBarostat(len(masses), pressure, temperature, group_idxs, barostat_interval, seed + 1)

--- a/timemachine/md/enhanced.py
+++ b/timemachine/md/enhanced.py
@@ -26,7 +26,7 @@ from timemachine.md import builders, minimizer
 from timemachine.md.barostat.moves import NPTMove
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.md.states import CoordsVelBox
-from timemachine.potentials import bonded, rmsd
+from timemachine.potentials import HarmonicBond, bonded, rmsd
 
 logger = logging.getLogger(__name__)
 
@@ -475,10 +475,12 @@ def equilibrate_solvent_phase(
 
     all_impls = [bp.to_gpu(np.float32).bound_impl for bp in bps]
 
+    bonded_pot = next(pot for pot in potentials if isinstance(pot, HarmonicBond))
+
     intg_equil = lib.LangevinIntegrator(temperature, dt, friction, masses, seed)
     intg_equil_impl = intg_equil.impl()
 
-    bond_list = get_bond_list(potentials[0])
+    bond_list = get_bond_list(bonded_pot)
     group_idxs = get_group_indices(bond_list, len(masses))
     barostat_interval = 5
 

--- a/timemachine/potentials/potentials.py
+++ b/timemachine/potentials/potentials.py
@@ -126,7 +126,7 @@ class Nonbonded(Potential):
         atom_idxs = self.atom_idxs if self.atom_idxs is not None else np.arange(self.num_atoms, dtype=np.int32)
         exclusion_idxs, scale_factors = nonbonded.filter_exclusions(atom_idxs, self.exclusion_idxs, self.scale_factors)
         exclusions = NonbondedExclusions(exclusion_idxs, scale_factors, self.beta, self.cutoff)
-        return FanoutSummedPotential([all_pairs, exclusions]).to_gpu(precision)
+        return FanoutSummedPotential([exclusions, all_pairs]).to_gpu(precision)
 
 
 @dataclass

--- a/timemachine/potentials/potentials.py
+++ b/timemachine/potentials/potentials.py
@@ -126,7 +126,7 @@ class Nonbonded(Potential):
         atom_idxs = self.atom_idxs if self.atom_idxs is not None else np.arange(self.num_atoms, dtype=np.int32)
         exclusion_idxs, scale_factors = nonbonded.filter_exclusions(atom_idxs, self.exclusion_idxs, self.scale_factors)
         exclusions = NonbondedExclusions(exclusion_idxs, scale_factors, self.beta, self.cutoff)
-        return FanoutSummedPotential([exclusions, all_pairs]).to_gpu(precision)
+        return FanoutSummedPotential([all_pairs, exclusions]).to_gpu(precision)
 
 
 @dataclass


### PR DESCRIPTION
* Need to remove the Ligand-Complex IxnGroup before merging this as it will determine the performance impact. Will open after #1372 to ensure that this makes a difference 
* Re-orders potentials, so that the Nonbonded potentials are upfront and we can hide the faster kernels in the 'shadow' of the neighborlist/nonbonded kernels.

# Benchmarks

A10
Cuda Arch 8.6

Lose some performance on the non-RBFE simulations (no ixn-group, pairlist) due to the overhead of running no-op kernels but make up for it in the RBFE simulations and local MD. About 5% for RBFE and 8% for local MD

## Master
```
dhfr-apo: N=23558 speed: 698.28ns/day dt: 2.5fs (ran 100000 steps in 30.94s)
dhfr-apo-barostat-interval-25: N=23558 speed: 630.02ns/day dt: 2.5fs (ran 100000 steps in 34.29s)

hif2a-apo: N=8805 speed: 1213.16ns/day dt: 2.5fs (ran 100000 steps in 17.81s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1036.86ns/day dt: 2.5fs (ran 100000 steps in 20.84s)
hif2a-rbfe-barostat-interval-25: N=8840 speed: 868.29ns/day dt: 2.5fs (ran 100000 steps in 24.88s)
hif2a-rbfe-local: N=8840 speed: 1280.69ns/day dt: 2.5fs (ran 100000 steps in 16.87s)
hif2a-rbfe-barostat-interval-25-water-sampling-interval-400: N=8840 speed: 802.98ns/day dt: 2.5fs (ran 100000 steps in 26.90s)

solvent-apo: N=6282 speed: 1690.23ns/day dt: 2.5fs (ran 100000 steps in 12.78s)
solvent-apo-barostat-interval-25: N=6282 speed: 1347.52ns/day dt: 2.5fs (ran 100000 steps in 16.03s)
solvent-rbfe-barostat-interval-25: N=6317 speed: 1086.41ns/day dt: 2.5fs (ran 100000 steps in 19.89s)
solvent-rbfe-local: N=6317 speed: 1377.21ns/day dt: 2.5fs (ran 100000 steps in 15.69s)
```

## PR
```
dhfr-apo: N=23558 speed: 640.36ns/day dt: 2.5fs (ran 100000 steps in 33.73s)
dhfr-apo-barostat-interval-25: N=23558 speed: 583.22ns/day dt: 2.5fs (ran 100000 steps in 37.04s)

hif2a-apo: N=8805 speed: 1167.89ns/day dt: 2.5fs (ran 100000 steps in 18.50s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1005.05ns/day dt: 2.5fs (ran 100000 steps in 21.49s)
hif2a-rbfe-barostat-interval-25: N=8840 speed: 916.01ns/day dt: 2.5fs (ran 100000 steps in 23.58s)
hif2a-rbfe-local: N=8840 speed: 1378.70ns/day dt: 2.5fs (ran 100000 steps in 15.67s)
hif2a-rbfe-barostat-interval-25-water-sampling-interval-400: N=8840 speed: 687.72ns/day dt: 2.5fs (ran 100000 steps in 31.41s)

solvent-apo: N=6282 speed: 1627.12ns/day dt: 2.5fs (ran 100000 steps in 13.28s)
solvent-apo-barostat-interval-25: N=6282 speed: 1312.01ns/day dt: 2.5fs (ran 100000 steps in 16.47s)
solvent-rbfe-barostat-interval-25: N=6317 speed: 1188.85ns/day dt: 2.5fs (ran 100000 steps in 18.17s)
solvent-rbfe-local: N=6317 speed: 1552.69ns/day dt: 2.5fs (ran 100000 steps in 13.92s)
```