### PR TITLE
Remove L-W ixn group and merge w/P-L group

### DIFF
--- a/examples/biphenyl_torsion_sampling_hrex.py
+++ b/examples/biphenyl_torsion_sampling_hrex.py
@@ -97,10 +97,8 @@ def get_potentials_solvent(
     nb_params, nb_pot = top.parameterize_nonbonded(
         ff_params.q_params,
         ff_params.q_params_intra,
-        ff_params.q_params_solv,
         ff_params.lj_params,
         ff_params.lj_params_intra,
-        ff_params.lj_params_solv,
         lamb,
     )
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -378,7 +378,6 @@ def gen_nonbonded_params_with_4d_offsets(
 class SplitForcefield:
     ref: Forcefield  # ref ff
     intra: Forcefield  # intermolecular charge terms/LJ terms scaled
-    solv: Forcefield  # water-ligand charge terms/LJ terms scaled
     prot: Forcefield  # protein-ligand charge terms/LJ terms scaled
     scaled: Forcefield  # all NB terms scaled
 
@@ -403,13 +402,6 @@ def load_split_forcefields() -> SplitForcefield:
     ff_intra.lj_handle_intra.params[:, SIG_IDX] *= SIG_SCALE
     ff_intra.lj_handle_intra.params[:, EPS_IDX] *= EPS_SCALE
 
-    ff_solv = Forcefield.load_default()
-    assert ff_solv.q_handle_solv is not None
-    assert ff_solv.lj_handle_solv is not None
-    ff_solv.q_handle_solv.params *= Q_SCALE
-    ff_solv.lj_handle_solv.params[:, SIG_IDX] *= SIG_SCALE
-    ff_solv.lj_handle_solv.params[:, EPS_IDX] *= EPS_SCALE
-
     ff_prot = Forcefield.load_default()
     assert ff_prot.q_handle is not None
     assert ff_prot.lj_handle is not None
@@ -420,20 +412,15 @@ def load_split_forcefields() -> SplitForcefield:
     ff_scaled = Forcefield.load_default()
     assert ff_scaled.q_handle is not None
     assert ff_scaled.q_handle_intra is not None
-    assert ff_scaled.q_handle_solv is not None
     assert ff_scaled.lj_handle is not None
     assert ff_scaled.lj_handle_intra is not None
-    assert ff_scaled.lj_handle_solv is not None
     ff_scaled.q_handle.params *= Q_SCALE
     ff_scaled.q_handle_intra.params *= Q_SCALE
-    ff_scaled.q_handle_solv.params *= Q_SCALE
     ff_scaled.lj_handle.params[:, SIG_IDX] *= SIG_SCALE
     ff_scaled.lj_handle.params[:, EPS_IDX] *= EPS_SCALE
     ff_scaled.lj_handle_intra.params[:, SIG_IDX] *= SIG_SCALE
     ff_scaled.lj_handle_intra.params[:, EPS_IDX] *= EPS_SCALE
-    ff_scaled.lj_handle_solv.params[:, SIG_IDX] *= SIG_SCALE
-    ff_scaled.lj_handle_solv.params[:, EPS_IDX] *= EPS_SCALE
-    return SplitForcefield(ff_ref, ff_intra, ff_solv, ff_prot, ff_scaled)
+    return SplitForcefield(ff_ref, ff_intra, ff_prot, ff_scaled)
 
 
 def check_split_ixns(
@@ -477,7 +464,6 @@ def check_split_ixns(
             ref - ref ff
             intra - ligand-ligand intramolecular parameters are scaled
             prot - protein-ligand interaction parameters are scaled
-            solv - water-ligand interaction parameters are scaled
         """
 
         # Compute the grads, potential with the ref ff
@@ -532,31 +518,6 @@ def check_split_ixns(
 
         np.testing.assert_allclose(expected_u, sum_u_intra, rtol=rtol, atol=atol)
         np.testing.assert_allclose(expected_grad, sum_grad_intra, rtol=rtol, atol=atol)
-
-        # Compute the grads, potential with the ligand-water terms scaled
-        sum_grad_solv, sum_u_solv = compute_new_grad_u(
-            ffs.solv, precision, coords0, box, lamb, num_water_atoms, host_bps
-        )
-        WL_grad_solv, WL_u_solv = compute_ixn_grad_u(
-            ffs.solv,
-            precision,
-            coords0,
-            box,
-            lamb,
-            num_water_atoms,
-            host_bps,
-            water_idxs,
-            ligand_idxs,
-            protein_idxs,
-            is_solvent=True,
-        )
-
-        # U_solv = U_sum_ref - WL_ref + WL_solv
-        expected_u = sum_u_ref - WL_u_ref + WL_u_solv
-        expected_grad = sum_grad_ref - WL_grad_ref + WL_grad_solv
-
-        np.testing.assert_allclose(expected_u, sum_u_solv, rtol=rtol, atol=atol)
-        np.testing.assert_allclose(expected_grad, sum_grad_solv, rtol=rtol, atol=atol)
 
         # Compute the grads, potential with the protein-ligand terms scaled
         sum_grad_prot, sum_u_prot = compute_new_grad_u(

--- a/tests/test_chiral_restraints.py
+++ b/tests/test_chiral_restraints.py
@@ -120,20 +120,16 @@ class BaseTopologyRescaledCharges(topology.BaseTopology):
         self,
         ff_q_params,
         ff_q_params_intra,
-        ff_q_params_solv,
         ff_lj_params,
         ff_lj_params_intra,
-        ff_lj_params_solv,
         intramol_params=True,
     ):
         params, nb = topology.BaseTopology.parameterize_nonbonded(
             self,
             ff_q_params,
             ff_q_params_intra,
-            ff_q_params_solv,
             ff_lj_params,
             ff_lj_params_intra,
-            ff_lj_params_solv,
             intramol_params=intramol_params,
         )
         charge_indices = jnp.index_exp[:, 0]

--- a/tests/test_forcefields.py
+++ b/tests/test_forcefields.py
@@ -127,8 +127,8 @@ def test_split():
 
     check(ffs.ref)
     check(ffs.intra)
-    check(ffs.prot)
-    check(ffs.prot)
+    check(ffs.env)
+    check(ffs.scaled)
 
 
 def test_amber14_tip3p_matches_tip3p():

--- a/tests/test_forcefields.py
+++ b/tests/test_forcefields.py
@@ -101,10 +101,8 @@ def test_split():
         np.testing.assert_array_equal(ff.it_handle.params, params.it_params)
         np.testing.assert_array_equal(ff.q_handle.params, params.q_params)
         np.testing.assert_array_equal(ff.q_handle_intra.params, params.q_params_intra)
-        np.testing.assert_array_equal(ff.q_handle_solv.params, params.q_params_solv)
         np.testing.assert_array_equal(ff.lj_handle.params, params.lj_params)
         np.testing.assert_array_equal(ff.lj_handle_intra.params, params.lj_params_intra)
-        np.testing.assert_array_equal(ff.lj_handle_solv.params, params.lj_params_solv)
 
         assert ff.get_ordered_handles() == [
             ff.hb_handle,
@@ -113,10 +111,8 @@ def test_split():
             ff.it_handle,
             ff.q_handle,
             ff.q_handle_intra,
-            ff.q_handle_solv,
             ff.lj_handle,
             ff.lj_handle_intra,
-            ff.lj_handle_solv,
         ]
 
         combined = combine_params(ff.get_params(), ff.get_params())
@@ -126,10 +122,8 @@ def test_split():
         np.testing.assert_array_equal((ff.it_handle.params, ff.it_handle.params), combined.it_params)
         np.testing.assert_array_equal((ff.q_handle.params, ff.q_handle.params), combined.q_params)
         np.testing.assert_array_equal((ff.q_handle_intra.params, ff.q_handle_intra.params), combined.q_params_intra)
-        np.testing.assert_array_equal((ff.q_handle_solv.params, ff.q_handle_solv.params), combined.q_params_solv)
         np.testing.assert_array_equal((ff.lj_handle.params, ff.lj_handle.params), combined.lj_params)
         np.testing.assert_array_equal((ff.lj_handle_intra.params, ff.lj_handle_intra.params), combined.lj_params_intra)
-        np.testing.assert_array_equal((ff.lj_handle_solv.params, ff.lj_handle_solv.params), combined.lj_params_solv)
 
     check(ffs.ref)
     check(ffs.intra)

--- a/tests/test_forcefields.py
+++ b/tests/test_forcefields.py
@@ -127,7 +127,6 @@ def test_split():
 
     check(ffs.ref)
     check(ffs.intra)
-    check(ffs.solv)
     check(ffs.prot)
     check(ffs.prot)
 

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -370,9 +370,7 @@ def test_get_water_sampler_params(num_windows):
         state = setup_initial_state(st, lamb, solvent_host, DEFAULT_TEMP, 2024)
         water_sampler_nb_params = get_water_sampler_params(state)
         nb_pot = next(p.potential for p in state.potentials if isinstance(p.potential, Nonbonded))
-        ligand_water_params = st._get_guest_params(
-            forcefield.q_handle_solv, forcefield.lj_handle_solv, lamb, nb_pot.cutoff
-        )
+        ligand_water_params = st._get_guest_params(forcefield.q_handle, forcefield.lj_handle, lamb, nb_pot.cutoff)
         if lamb == 0.0:
             assert np.all(ligand_water_params[mol_a_only_atoms][:, 3] == 0.0)
             assert np.all(ligand_water_params[mol_b_only_atoms][:, 3] == nb_pot.cutoff)

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -1023,7 +1023,7 @@ def test_combine_with_host_split(precision, rtol, atol):
             ligand_idxs,
             host_system.nonbonded.potential.beta,
             cutoff,
-            col_atom_idxs=protein_idxs + water_idxs,
+            col_atom_idxs=np.array(list(protein_idxs) + list(water_idxs), dtype=np.int32),
         )
 
         q_handle = ff.q_handle

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -854,7 +854,7 @@ def test_nonbonded_intra_split(precision, rtol, atol, use_tiny_mol):
             vacuum_u_inter_scaled,
             solvent_grad_inter_scaled,
             solvent_u_inter_scaled,
-        ) = get_vacuum_solvent_u_grads(ffs.solv, lamb)
+        ) = get_vacuum_solvent_u_grads(ffs.prot, lamb)
 
         # Compute the expected intermol scaled potential
         expected_inter_scaled_u = solvent_u_scaled - vacuum_u_scaled + vacuum_u_ref
@@ -1023,11 +1023,11 @@ def test_combine_with_host_split(precision, rtol, atol):
             ligand_idxs,
             host_system.nonbonded.potential.beta,
             cutoff,
-            col_atom_idxs=water_idxs if is_solvent else protein_idxs,
+            col_atom_idxs=protein_idxs + water_idxs,
         )
 
-        q_handle = ff.q_handle_solv if is_solvent else ff.q_handle
-        lj_handle = ff.lj_handle_solv if is_solvent else ff.lj_handle
+        q_handle = ff.q_handle
+        lj_handle = ff.lj_handle
         guest_params = st._get_guest_params(q_handle, lj_handle, lamb, cutoff)
 
         host_params = host_system.nonbonded.params

--- a/tests/test_single_topology_combined.py
+++ b/tests/test_single_topology_combined.py
@@ -102,10 +102,7 @@ def test_combined_parameters_nonbonded(host_system_fixture, lamb, hif2a_ligand_p
 
     # 2) decoupling parameters for host-guest interactions
     # 2a) w offsets
-    if host_system_fixture == "solvent_host_system":
-        assert len(hgs.nonbonded_host_guest_ixn.potential.potentials) == 1  # ligand-water
-    elif host_system_fixture == "complex_host_system":
-        assert len(hgs.nonbonded_host_guest_ixn.potential.potentials) == 2  # ligand-water, ligand-protein
+    assert len(hgs.nonbonded_host_guest_ixn.potential.potentials) == 1  # ligand-env
 
     for potential, params in zip(
         hgs.nonbonded_host_guest_ixn.potential.potentials, hgs.nonbonded_host_guest_ixn.potential.params_init
@@ -188,10 +185,7 @@ def test_combined_parameters_nonbonded_intermediate(
 
     hgs = st.combine_with_host(host_sys, lamb, num_water_atoms)
 
-    if host_system_fixture == "solvent_host_system":
-        assert len(hgs.nonbonded_host_guest_ixn.potential.potentials) == 1  # ligand-water
-    elif host_system_fixture == "complex_host_system":
-        assert len(hgs.nonbonded_host_guest_ixn.potential.potentials) == 2  # ligand-water, ligand-protein
+    assert len(hgs.nonbonded_host_guest_ixn.potential.potentials) == 1  # ligand-env
 
     for potential, params in zip(
         hgs.nonbonded_host_guest_ixn.potential.potentials, hgs.nonbonded_host_guest_ixn.potential.params_init

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -153,7 +153,7 @@ def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
             ligand_idxs,
             hgt.host_nonbonded.potential.beta,
             hgt.host_nonbonded.potential.cutoff,
-            col_atom_idxs=np.array(list(protein_idxs) + list(water_idxs), dtype=np.int32),
+            col_atom_idxs=water_idxs if is_solvent else protein_idxs,
         )
         lig_params, _ = bt.parameterize_nonbonded(
             ff.q_handle.params,

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -153,7 +153,7 @@ def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
             ligand_idxs,
             hgt.host_nonbonded.potential.beta,
             hgt.host_nonbonded.potential.cutoff,
-            col_atom_idxs=water_idxs if is_solvent else protein_idxs,
+            col_atom_idxs=np.array(list(protein_idxs) + list(water_idxs), dtype=np.int32),
         )
         lig_params, _ = bt.parameterize_nonbonded(
             ff.q_handle.params,

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -28,10 +28,8 @@ def test_dual_topology_nonbonded_pairlist():
     nb_params, nb = dt.parameterize_nonbonded(
         ff.q_handle.params,
         ff.q_handle_intra.params,
-        ff.q_handle_solv.params,
         ff.lj_handle.params,
         ff.lj_handle_intra.params,
-        ff.lj_handle_solv.params,
         0.0,
     )
 
@@ -62,16 +60,14 @@ def parameterize_nonbonded_full(
     hgt: topology.HostGuestTopology,
     ff_q_params,
     ff_q_params_intra,
-    ff_q_params_solv,
     ff_lj_params,
     ff_lj_params_intra,
-    ff_lj_params_solv,
     lamb: float,
 ):
     # Implements the full NB potential for the host guest system
     num_guest_atoms = hgt.guest_topology.get_num_atoms()
     guest_params, guest_pot = hgt.guest_topology.parameterize_nonbonded(
-        ff_q_params, ff_q_params_intra, ff_q_params_solv, ff_lj_params, ff_lj_params_intra, ff_lj_params_solv, lamb
+        ff_q_params, ff_q_params_intra, ff_lj_params, ff_lj_params_intra, lamb
     )
     assert hgt.host_nonbonded is not None
     hg_exclusion_idxs = np.concatenate(
@@ -97,10 +93,8 @@ def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
             hgt,
             ff.q_handle.params,
             ff.q_handle_intra.params,
-            ff.q_handle_solv.params,
             ff.lj_handle.params,
             ff.lj_handle_intra.params,
-            ff.lj_handle_solv.params,
             lamb=lamb,
         )
         u_impl = us.bind(params).to_gpu(precision=precision).bound_impl
@@ -113,10 +107,8 @@ def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
         params, us = hgt.parameterize_nonbonded(
             ff.q_handle.params,
             ff.q_handle_intra.params,
-            ff.q_handle_solv.params,
             ff.lj_handle.params,
             ff.lj_handle_intra.params,
-            ff.lj_handle_solv.params,
             lamb=lamb,
         )
         u_impl = us.bind(params).to_gpu(precision=precision).bound_impl
@@ -128,10 +120,8 @@ def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
         params, us = bt.parameterize_nonbonded(
             ff.q_handle.params,
             ff.q_handle_intra.params,
-            ff.q_handle_solv.params,
             ff.lj_handle.params,
             ff.lj_handle_intra.params,
-            ff.lj_handle_solv.params,
             lamb=lamb,
         )
         u_impl = us.bind(params).to_gpu(precision=precision).bound_impl
@@ -166,12 +156,10 @@ def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
             col_atom_idxs=water_idxs if is_solvent else protein_idxs,
         )
         lig_params, _ = bt.parameterize_nonbonded(
-            ff.q_handle_solv.params if is_solvent else ff.q_handle.params,
+            ff.q_handle.params,
             ff.q_handle_intra.params,
-            ff.q_handle_solv.params,
-            ff.lj_handle_solv.params if is_solvent else ff.lj_handle.params,
+            ff.lj_handle.params,
             ff.lj_handle_intra.params,
-            ff.lj_handle_solv.params,
             lamb=lamb,
             intramol_params=False,
         )

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -378,10 +378,8 @@ class BaseFreeEnergy:
             topology.parameterize_nonbonded(
                 ff_params.q_params,
                 ff_params.q_params_intra,
-                ff_params.q_params_solv,
                 ff_params.lj_params,
                 ff_params.lj_params_intra,
-                ff_params.lj_params_solv,
                 lamb,
             ),
         ]

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1869,8 +1869,7 @@ class SingleTopology(AtomMapMixin):
         num_guest_atoms = self.get_num_atoms()
         cutoff = host_nonbonded.potential.cutoff
 
-        guest_ixn_water_params = self._get_guest_params(self.ff.q_handle_solv, self.ff.lj_handle_solv, lamb, cutoff)
-        guest_ixn_other_params = self._get_guest_params(self.ff.q_handle, self.ff.lj_handle, lamb, cutoff)
+        guest_ixn_env_params = self._get_guest_params(self.ff.q_handle, self.ff.lj_handle, lamb, cutoff)
 
         # L-W terms
         num_other_atoms = num_host_atoms - num_water_atoms
@@ -1886,11 +1885,9 @@ class SingleTopology(AtomMapMixin):
 
         ixn_pots, ixn_params = get_ligand_ixn_pots_params(
             get_lig_idxs(),
-            get_water_idxs(),
-            get_other_idxs(),
+            get_other_idxs() + get_water_idxs(),
             host_nonbonded.params,
-            guest_ixn_water_params,
-            guest_ixn_other_params,
+            guest_ixn_env_params,
             beta=host_nonbonded.potential.beta,
             cutoff=cutoff,
         )

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1883,9 +1883,12 @@ class SingleTopology(AtomMapMixin):
         def get_other_idxs():
             return np.arange(num_other_atoms, dtype=np.int32)
 
+        def get_env_idxs():
+            return np.array(list(get_other_idxs()) + list(get_water_idxs()), dtype=np.int32)
+
         ixn_pots, ixn_params = get_ligand_ixn_pots_params(
             get_lig_idxs(),
-            get_other_idxs() + get_water_idxs(),
+            get_env_idxs(),
             host_nonbonded.params,
             guest_ixn_env_params,
             beta=host_nonbonded.potential.beta,

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -150,26 +150,17 @@ class HostGuestTopology:
         self,
         ff_q_params,
         ff_q_params_intra,
-        ff_q_params_solv,
         ff_lj_params,
         ff_lj_params_intra,
-        ff_lj_params_solv,
         lamb: float,
     ):
         num_guest_atoms = self.guest_topology.get_num_atoms()
-        # ligand other interactions
+        # ligand-environment interactions
         # NOTE: None is passed for the other params to indicate they are not used.
-        guest_ixn_other_params, _ = self.guest_topology.parameterize_nonbonded(
+        guest_ixn_env_params, _ = self.guest_topology.parameterize_nonbonded(
             ff_q_params, None, None, ff_lj_params, None, None, lamb, intramol_params=False
         )
 
-        # ligand water interactions
-        # NOTE: We assume the handlers of the solvent terms are the same as the
-        # non-solvent terms (so we can pass ff_q_params_solv in place of ff_q_params).
-        # If this changes, this code will need to be updated.
-        guest_ixn_water_params, _ = self.guest_topology.parameterize_nonbonded(
-            ff_q_params_solv, None, None, ff_lj_params_solv, None, None, lamb, intramol_params=False
-        )
         # ligand intramolecular interactions
         guest_intra_params, guest_intra_pot = self.guest_topology.parameterize_nonbonded_pairlist(
             None, ff_q_params_intra, None, ff_lj_params_intra, intramol_params=True
@@ -179,18 +170,12 @@ class HostGuestTopology:
         beta = guest_intra_pot.beta
         cutoff = guest_intra_pot.cutoff
         guest_intra_pot.idxs = guest_intra_pot.idxs + self.num_host_atoms
-        assert guest_ixn_water_params.shape == (num_guest_atoms, 4)
         assert self.host_nonbonded is not None
         assert beta == self.host_nonbonded.potential.beta
         assert cutoff == self.host_nonbonded.potential.cutoff
 
         exclusion_idxs = self.host_nonbonded.potential.exclusion_idxs
         scale_factors = self.host_nonbonded.potential.scale_factors
-
-        # Note: The choice of zeros here is arbitrary. It doesn't affect the
-        # potentials or grads, but anything that looks at the parameters
-        # (such as hashing for the seed) could depend on these values
-        hg_nb_params = jnp.concatenate([self.host_nonbonded.params, np.zeros(guest_ixn_water_params.shape)])
 
         host_guest_pot = potentials.Nonbonded(
             self.num_host_atoms + num_guest_atoms,
@@ -203,17 +188,15 @@ class HostGuestTopology:
 
         ixn_pots, ixn_params = get_ligand_ixn_pots_params(
             self.get_lig_idxs(),
-            self.get_water_idxs(),
-            self.get_other_idxs(),
+            self.get_other_idxs() + self.get_water_idxs(),
             self.host_nonbonded.params,
-            guest_ixn_water_params,
-            guest_ixn_other_params,
+            guest_ixn_env_params,
             beta=beta,
             cutoff=cutoff,
         )
 
         hg_total_pot = [host_guest_pot] + ixn_pots
-        hg_total_params = [hg_nb_params] + ixn_params
+        hg_total_params = [self.host_nonbonded.params] + ixn_params
 
         # If the molecule has < 4 atoms there may not be any intramolecular terms
         # so they should be ignored here
@@ -260,10 +243,8 @@ class BaseTopology:
         self,
         ff_q_params,
         ff_q_params_intra,
-        ff_q_params_solv,
         ff_lj_params,
         ff_lj_params_intra,
-        ff_lj_params_solv,
         lamb: float,
         intramol_params=True,
     ):
@@ -516,10 +497,8 @@ class DualTopology(BaseTopology):
         self,
         ff_q_params,
         ff_q_params_intra,
-        ff_q_params_solv,
         ff_lj_params,
         ff_lj_params_intra,
-        ff_lj_params_solv,
         lamb: float,
         intramol_params=True,
     ):
@@ -660,10 +639,8 @@ class DualTopologyMinimization(DualTopology):
         self,
         ff_q_params,
         ff_q_params_intra,
-        ff_q_params_solv,
         ff_lj_params,
         ff_lj_params_intra,
-        ff_lj_params_solv,
         lamb: float,
         intramol_params=True,
     ):
@@ -673,10 +650,8 @@ class DualTopologyMinimization(DualTopology):
         params, nb_potential = super().parameterize_nonbonded(
             ff_q_params,
             ff_q_params_intra,
-            ff_q_params_solv,
             ff_lj_params,
             ff_lj_params_intra,
-            ff_lj_params_solv,
             lamb,
             intramol_params=intramol_params,
         )
@@ -707,11 +682,9 @@ def exclude_all_ligand_ligand_ixns(num_host_atoms: int, num_guest_atoms: int) ->
 
 def get_ligand_ixn_pots_params(
     lig_idxs: NDArray,
-    water_idxs: NDArray,
-    other_idxs: Optional[NDArray],
+    env_idxs: Optional[NDArray],
     host_nb_params: Params,
-    guest_params_ixn_water: Params,
-    guest_params_ixn_other: Params,
+    guest_params_ixn_env: Params,
     beta=2.0,
     cutoff=1.2,
 ):
@@ -724,59 +697,33 @@ def get_ligand_ixn_pots_params(
     lig_idxs_list:
         List of ligand indexes (dtype, np.int32), one for each ligand.
 
-    water_idxs:
-        Indexes for the water atoms.
-
-    other_idxs:
-        Indexes for the other environment atoms that are not waters.
+    env_idxs:
+        Indexes for the environment atoms including waters.
         May be None if there are no other atoms.
 
     host_nb_params:
         Nonbonded parameters for the host (environment) atoms.
 
-    guest_params_ixn_water:
-        Parameters for the guest (ligand) NB interactions with water.
-
-    guest_params_ixn_other:
+    guest_params_ixn_env:
         Parameters for the guest (ligand) NB interactions with the
         non-water environment atoms.
     """
 
     # Init
-    other_idxs = other_idxs if other_idxs is not None else np.array([])
+    env_idxs = env_idxs if env_idxs is not None else np.array([])
 
     # Ligand-Water terms
     num_lig_atoms = len(lig_idxs)
-    num_total_atoms = num_lig_atoms + len(water_idxs) + len(other_idxs)
+    num_total_atoms = num_lig_atoms + len(env_idxs)
 
-    hg_water_pot = potentials.NonbondedInteractionGroup(
-        num_total_atoms,
-        lig_idxs,
-        beta,
-        cutoff,
-        col_atom_idxs=water_idxs,
-    )
-    hg_water_params = jnp.concatenate([host_nb_params, guest_params_ixn_water])
-
-    # Ligand-Other (protein) terms
-    hg_other_pots = []
-    hg_other_params = []
-    if len(other_idxs):
-        hg_other_pots.append(
-            potentials.NonbondedInteractionGroup(
-                num_total_atoms,
-                lig_idxs,
-                beta,
-                cutoff,
-                col_atom_idxs=other_idxs,
-            )
+    hg_ixn_pots = [
+        potentials.NonbondedInteractionGroup(
+            num_total_atoms,
+            lig_idxs,
+            beta,
+            cutoff,
+            col_atom_idxs=env_idxs,
         )
-        hg_other_params.append(jnp.concatenate([host_nb_params, guest_params_ixn_other]))
-
-    # If the ordering of these parameters change, will need to change
-    # timemachine.fe.free_energy::get_water_sampler_params
-    # total potential = host_guest_pot + guest_intra_pot + lw_ixn_pots + lp_ixn_pots
-    hg_ixn_pots = [hg_water_pot] + hg_other_pots
-    hg_ixn_params = [hg_water_params] + hg_other_params
-
+    ]
+    hg_ixn_params = [jnp.concatenate([host_nb_params, guest_params_ixn_env])]
     return hg_ixn_pots, hg_ixn_params

--- a/timemachine/ff/__init__.py
+++ b/timemachine/ff/__init__.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any, Generic, Iterable, Optional, Tuple, TypeVar, Union
 from warnings import warn
 
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_equal
 
 from timemachine.constants import DEFAULT_FF, DEFAULT_PROTEIN_FF, DEFAULT_WATER_FF
 from timemachine.ff.handlers import bonded, nonbonded
@@ -202,7 +202,7 @@ class Forcefield:
         if lj_handle_solv is not None:
             assert lj_handle is not None
             assert lj_handle_solv is not None
-            assert_almost_equal(
+            assert_equal(
                 lj_handle.params,
                 lj_handle_solv.params,
                 err_msg="Split ligand-solvent LJ interactions are no longer supported",
@@ -223,7 +223,7 @@ class Forcefield:
         if q_handle_solv is not None:
             assert q_handle is not None
             assert q_handle_solv is not None
-            assert_almost_equal(
+            assert_equal(
                 q_handle.params,
                 q_handle_solv.params,
                 err_msg="Split ligand-solvent charge interactions are no longer supported",

--- a/timemachine/ff/__init__.py
+++ b/timemachine/ff/__init__.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import Any, Generic, Iterable, Optional, Tuple, TypeVar, Union
 from warnings import warn
 
+from numpy.testing import assert_almost_equal
+
 from timemachine.constants import DEFAULT_FF, DEFAULT_PROTEIN_FF, DEFAULT_WATER_FF
 from timemachine.ff.handlers import bonded, nonbonded
 from timemachine.ff.handlers.deserialize import deserialize_handlers
@@ -21,10 +23,8 @@ class ForcefieldParams(Generic[_T]):
     it_params: _T
     q_params: _T
     q_params_intra: _T
-    q_params_solv: _T
     lj_params: _T
     lj_params_intra: _T
-    lj_params_solv: _T
 
 
 def combine_params(a: ForcefieldParams[_T], b: ForcefieldParams[_T]) -> ForcefieldParams[Tuple[_T, _T]]:
@@ -35,10 +35,8 @@ def combine_params(a: ForcefieldParams[_T], b: ForcefieldParams[_T]) -> Forcefie
         (a.it_params, b.it_params),
         (a.q_params, b.q_params),
         (a.q_params_intra, b.q_params_intra),
-        (a.q_params_solv, b.q_params_solv),
         (a.lj_params, b.lj_params),
         (a.lj_params_intra, b.lj_params_intra),
-        (a.lj_params_solv, b.lj_params_solv),
     )
 
 
@@ -68,17 +66,9 @@ class Forcefield:
             nonbonded.PrecomputedChargeHandler,
         ]
     ]
-    q_handle_solv: Optional[
-        Union[
-            nonbonded.SimpleChargeSolventHandler,
-            nonbonded.AM1BCCSolventHandler,
-            nonbonded.AM1CCCSolventHandler,
-            nonbonded.PrecomputedChargeHandler,
-        ]
-    ]
+
     lj_handle: Optional[nonbonded.LennardJonesHandler]
     lj_handle_intra: Optional[nonbonded.LennardJonesIntraHandler]
-    lj_handle_solv: Optional[nonbonded.LennardJonesSolventHandler]
 
     protein_ff: str
     water_ff: str
@@ -133,17 +123,14 @@ class Forcefield:
         ff = cls.load_default()
         q_handle = PrecomputedChargeHandler()
         q_handle_intra = PrecomputedChargeHandler()
-        q_handle_solv = PrecomputedChargeHandler()
         return Forcefield(
             ff.hb_handle,
             ff.ha_handle,
             ff.pt_handle,
             ff.it_handle,
             q_handle=q_handle,
-            q_handle_solv=q_handle_solv,
             q_handle_intra=q_handle_intra,
             lj_handle=ff.lj_handle,
-            lj_handle_solv=ff.lj_handle_solv,
             lj_handle_intra=ff.lj_handle_intra,
             protein_ff=ff.protein_ff,
             water_ff=ff.water_ff,
@@ -212,11 +199,14 @@ class Forcefield:
                     lj_handle.smirks, lj_handle.params, lj_handle.props
                 )
 
-        if lj_handle_solv is None:
-            if isinstance(lj_handle, nonbonded.LennardJonesHandler):
-                lj_handle_solv = nonbonded.LennardJonesSolventHandler(
-                    lj_handle.smirks, lj_handle.params, lj_handle.props
-                )
+        if lj_handle_solv is not None:
+            assert lj_handle is not None
+            assert lj_handle_solv is not None
+            assert_almost_equal(
+                lj_handle.params,
+                lj_handle_solv.params,
+                err_msg="Split ligand-solvent LJ interactions are no longer supported",
+            )
 
         if q_handle_intra is None:
             # Copy the forcefield parameters to the intramolecular term if not
@@ -230,17 +220,14 @@ class Forcefield:
             else:
                 raise ValueError(f"Unsupported charge handler {q_handle}")
 
-        if q_handle_solv is None:
-            # Copy the forcefield parameters to the solvent term if not
-            # already handled.
-            if isinstance(q_handle, nonbonded.AM1CCCHandler):
-                q_handle_solv = nonbonded.AM1CCCSolventHandler(q_handle.smirks, q_handle.params, q_handle.props)
-            elif isinstance(q_handle, nonbonded.AM1BCCHandler):
-                q_handle_solv = nonbonded.AM1BCCSolventHandler(q_handle.smirks, q_handle.params, q_handle.props)
-            elif isinstance(q_handle, nonbonded.SimpleChargeHandler):
-                q_handle_solv = nonbonded.SimpleChargeSolventHandler(q_handle.smirks, q_handle.params, q_handle.props)
-            else:
-                raise ValueError(f"Unsupported charge handler {q_handle}")
+        if q_handle_solv is not None:
+            assert q_handle is not None
+            assert q_handle_solv is not None
+            assert_almost_equal(
+                q_handle.params,
+                q_handle_solv.params,
+                err_msg="Split ligand-solvent charge interactions are no longer supported",
+            )
 
         return cls(
             hb_handle,
@@ -249,10 +236,8 @@ class Forcefield:
             it_handle,
             q_handle,
             q_handle_intra,
-            q_handle_solv,
             lj_handle,
             lj_handle_intra,
-            lj_handle_solv,
             protein_ff,
             water_ff,
         )
@@ -266,10 +251,8 @@ class Forcefield:
             self.it_handle,
             self.q_handle,
             self.q_handle_intra,
-            self.q_handle_solv,
             self.lj_handle,
             self.lj_handle_intra,
-            self.lj_handle_solv,
         ]
 
     def get_params(self) -> ForcefieldParams:
@@ -283,10 +266,8 @@ class Forcefield:
             params(self.it_handle),
             params(self.q_handle),
             params(self.q_handle_intra),
-            params(self.q_handle_solv),
             params(self.lj_handle),
             params(self.lj_handle_intra),
-            params(self.lj_handle_solv),
         )
 
     def serialize(self) -> str:

--- a/timemachine/ff/make_placeholder_ff.py
+++ b/timemachine/ff/make_placeholder_ff.py
@@ -10,10 +10,8 @@ from timemachine.ff.handlers.bonded import (
 from timemachine.ff.handlers.nonbonded import (
     LennardJonesHandler,
     LennardJonesIntraHandler,
-    LennardJonesSolventHandler,
     SimpleChargeHandler,
     SimpleChargeIntraHandler,
-    SimpleChargeSolventHandler,
 )
 
 # bonded
@@ -34,7 +32,6 @@ _q_params = np.zeros(1)
 
 placeholder_q_handle = SimpleChargeHandler(smirks=_q_smirks, params=_q_params, props=None)
 placeholder_q_handle_intra = SimpleChargeIntraHandler(smirks=_q_smirks, params=_q_params, props=None)
-placeholder_q_handle_solv = SimpleChargeSolventHandler(smirks=_q_smirks, params=_q_params, props=None)
 
 # lj / ljintra / ljsolvent
 _lj_smirks = ["[*:1]"]
@@ -42,7 +39,6 @@ _lj_params = np.array([[0.1, 1.0]])
 
 placeholder_lj_handle = LennardJonesHandler(smirks=_lj_smirks, params=_lj_params, props=None)
 placeholder_lj_handle_intra = LennardJonesIntraHandler(smirks=_lj_smirks, params=_lj_params, props=None)
-placeholder_lj_handle_solv = LennardJonesSolventHandler(smirks=_lj_smirks, params=_lj_params, props=None)
 
 # construct
 placeholder_ff = Forcefield(
@@ -52,10 +48,8 @@ placeholder_ff = Forcefield(
     it_handle=placeholder_it_handle,
     q_handle=placeholder_q_handle,
     q_handle_intra=placeholder_q_handle_intra,
-    q_handle_solv=placeholder_q_handle_solv,
     lj_handle=placeholder_lj_handle,
     lj_handle_intra=placeholder_lj_handle_intra,
-    lj_handle_solv=placeholder_lj_handle_solv,
     protein_ff="amber99sbildn",
     water_ff="amber14/tip3p",
 )

--- a/timemachine/md/enhanced.py
+++ b/timemachine/md/enhanced.py
@@ -94,10 +94,8 @@ class VacuumState:
         self.nb_params, self.nb_potential = bt.parameterize_nonbonded(
             ff.q_handle.params,
             ff.q_handle_intra.params,
-            ff.q_handle_solv.params,
             ff.lj_handle.params,
             ff.lj_handle_intra.params,
-            ff.lj_handle_solv.params,
             self.lamb,
         )
 

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -53,10 +53,8 @@ def parameterize_system(topo, ff: Forcefield, lamb: float) -> Tuple[List[Potenti
         topo.parameterize_nonbonded(
             ff_params.q_params,
             ff_params.q_params_intra,
-            ff_params.q_params_solv,
             ff_params.lj_params,
             ff_params.lj_params_intra,
-            ff_params.lj_params_solv,
             lamb,
         ),
     ]


### PR DESCRIPTION
- Remove the L-W specific ixn group and merge it back in with the P-L (now env-L) ixn gorup.
- This should improve performance
- Maintain backward compatibility with FFs that have a separate 'solvent' section if the parameters match those of the original ixn group
