### PR TITLE
Prefer a more terse way of converting vectors to numpy arrays

### DIFF
--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -187,8 +187,7 @@ void declare_hilbert_sort(py::module &m) {
                 verify_coords_and_box(coords, box);
 
                 std::vector<unsigned int> sort_perm = sorter.sort_host(N, coords.data(), box.data());
-                py::array_t<uint32_t, py::array::c_style> output_perm(sort_perm.size());
-                std::memcpy(output_perm.mutable_data(), sort_perm.data(), sort_perm.size() * sizeof(unsigned int));
+                py::array_t<uint32_t, py::array::c_style> output_perm(sort_perm.size(), sort_perm.data());
                 return output_perm;
             },
             py::arg("coords"),
@@ -356,12 +355,9 @@ void declare_context(py::module &m) {
                 int N = ctxt.num_atoms();
                 int D = 3;
                 int F = result[0].size() / (N * D);
-                py::array_t<double, py::array::c_style> out_x_buffer({F, N, D});
-                std::memcpy(out_x_buffer.mutable_data(), result[0].data(), result[0].size() * sizeof(double));
+                py::array_t<double, py::array::c_style> out_x_buffer({F, N, D}, result[0].data());
 
-                py::array_t<double, py::array::c_style> box_buffer({F, D, D});
-                std::memcpy(box_buffer.mutable_data(), result[1].data(), result[1].size() * sizeof(double));
-
+                py::array_t<double, py::array::c_style> box_buffer({F, D, D}, result[1].data());
                 return py::make_tuple(out_x_buffer, box_buffer);
             },
             py::arg("n_steps"),
@@ -419,11 +415,9 @@ void declare_context(py::module &m) {
                     ctxt.multiple_steps_local(n_steps, vec_local_idxs, x_interval, radius, k, seed);
                 const int D = 3;
                 const int F = result[0].size() / (N * D);
-                py::array_t<double, py::array::c_style> out_x_buffer({F, N, D});
-                std::memcpy(out_x_buffer.mutable_data(), result[0].data(), result[0].size() * sizeof(double));
+                py::array_t<double, py::array::c_style> out_x_buffer({F, N, D}, result[0].data());
 
-                py::array_t<double, py::array::c_style> box_buffer({F, D, D});
-                std::memcpy(box_buffer.mutable_data(), result[1].data(), result[1].size() * sizeof(double));
+                py::array_t<double, py::array::c_style> box_buffer({F, D, D}, result[1].data());
                 return py::make_tuple(out_x_buffer, box_buffer);
             },
             py::arg("n_steps"),
@@ -517,11 +511,9 @@ void declare_context(py::module &m) {
                     n_steps, reference_idx, vec_selection_idxs, x_interval, radius, k);
                 const int D = 3;
                 const int F = result[0].size() / (N * D);
-                py::array_t<double, py::array::c_style> out_x_buffer({F, N, D});
-                std::memcpy(out_x_buffer.mutable_data(), result[0].data(), result[0].size() * sizeof(double));
+                py::array_t<double, py::array::c_style> out_x_buffer({F, N, D}, result[0].data());
 
-                py::array_t<double, py::array::c_style> box_buffer({F, D, D});
-                std::memcpy(box_buffer.mutable_data(), result[1].data(), result[1].size() * sizeof(double));
+                py::array_t<double, py::array::c_style> box_buffer({F, D, D}, result[1].data());
                 return py::make_tuple(out_x_buffer, box_buffer);
             },
             py::arg("n_steps"),
@@ -1593,13 +1585,9 @@ void declare_mover(py::module &m) {
 
                 std::array<std::vector<double>, 2> result = mover.move_host(N, coords.data(), box.data());
 
-                py::array_t<double, py::array::c_style> out_x_buffer({N, D});
-                std::memcpy(
-                    out_x_buffer.mutable_data(), result[0].data(), result[0].size() * sizeof(*result[0].data()));
+                py::array_t<double, py::array::c_style> out_x_buffer({N, D}, result[0].data());
 
-                py::array_t<double, py::array::c_style> box_buffer({D, D});
-                std::memcpy(box_buffer.mutable_data(), result[1].data(), result[1].size() * sizeof(*result[1].data()));
-
+                py::array_t<double, py::array::c_style> box_buffer({D, D}, result[1].data());
                 return py::make_tuple(out_x_buffer, box_buffer);
             },
             py::arg("coords"),
@@ -1791,12 +1779,9 @@ template <typename RealType> void declare_biased_deletion_exchange_move(py::modu
 
                 std::array<std::vector<double>, 2> result = mover.move_host(N, coords.data(), box.data());
 
-                py::array_t<double, py::array::c_style> out_x_buffer({N, D});
-                std::memcpy(
-                    out_x_buffer.mutable_data(), result[0].data(), result[0].size() * sizeof(*result[0].data()));
+                py::array_t<double, py::array::c_style> out_x_buffer({N, D}, result[0].data());
 
-                py::array_t<double, py::array::c_style> box_buffer({D, D});
-                std::memcpy(box_buffer.mutable_data(), result[1].data(), result[1].size() * sizeof(*result[1].data()));
+                py::array_t<double, py::array::c_style> box_buffer({D, D}, result[1].data());
 
                 return py::make_tuple(out_x_buffer, box_buffer);
             },
@@ -1862,9 +1847,7 @@ template <typename RealType> void declare_biased_deletion_exchange_move(py::modu
                 std::vector<double> flat_params = mover.get_params();
                 const int D = PARAMS_PER_ATOM;
                 const int N = flat_params.size() / D;
-                py::array_t<double, py::array::c_style> out_params({N, D});
-                std::memcpy(
-                    out_params.mutable_data(), flat_params.data(), flat_params.size() * sizeof(*flat_params.data()));
+                py::array_t<double, py::array::c_style> out_params({N, D}, flat_params.data());
                 return out_params;
             })
         .def(


### PR DESCRIPTION
* Originally went down the route of attempting to use `py::capsule` to avoid having to perform a memory copy (as described in https://github.com/pybind/pybind11/issues/1042#issuecomment-325941022), but think because we wrap them in `std::array` the vectors are cleaned up before the capsule triggers.
* Probably should look at `py::capsule` in the future as it could reduce the memory copying taking place in our wrapped code as well as reduce the amount of time we require the GIL (relating to #1370 )