### PR TITLE
Close Matplotlib figures after writing

### DIFF
--- a/tests/test_hrex_rbfe.py
+++ b/tests/test_hrex_rbfe.py
@@ -124,24 +124,19 @@ def test_hrex_rbfe_hif2a(hif2a_single_topology_leg, seed):
         rss_traj.append(Process().memory_info().rss)
         return traj
 
-    with catch_warnings(record=True) as captured_warnings:
-        with patch("timemachine.fe.free_energy.sample_with_context", sample_and_record_rss):
-            result = estimate_relative_free_energy_bisection_hrex(
-                mol_a,
-                mol_b,
-                core,
-                forcefield,
-                host_config,
-                md_params,
-                lambda_interval=(0.0, 0.15),
-                n_windows=n_windows,
-                min_cutoff=0.7 if host_name == "complex" else None,
-            )
+    with patch("timemachine.fe.free_energy.sample_with_context", sample_and_record_rss):
+        result = estimate_relative_free_energy_bisection_hrex(
+            mol_a,
+            mol_b,
+            core,
+            forcefield,
+            host_config,
+            md_params,
+            lambda_interval=(0.0, 0.15),
+            n_windows=n_windows,
+            min_cutoff=0.7 if host_name == "complex" else None,
+        )
 
-    assert all(
-        "are retained until explicitly closed and may consume too much memory" not in str(warn.message)
-        for warn in captured_warnings
-    )
     # Check that memory usage is not increasing
     rss_traj = rss_traj[10:]  # discard initial transients
     rss_diff_count = np.sum(np.diff(rss_traj) != 0)

--- a/tests/test_hrex_rbfe.py
+++ b/tests/test_hrex_rbfe.py
@@ -103,9 +103,6 @@ def test_hrex_rbfe_hif2a_water_sampling_warning(hif2a_single_topology_leg, seed)
 
 @pytest.mark.parametrize("seed", [2024])
 def test_hrex_rbfe_hif2a(hif2a_single_topology_leg, seed):
-    plt.close()  # Close the open figures in case it was opened before the test
-    # Reduce the threshold for the maximum plots open, should only open one at any given time
-    plt.rcParams.update({"figure.max_open_warning": 2})
     host_name, (mol_a, mol_b, core, forcefield, host_config) = hif2a_single_topology_leg
     md_params = MDParams(
         n_frames=200,

--- a/tests/test_hrex_rbfe.py
+++ b/tests/test_hrex_rbfe.py
@@ -105,6 +105,7 @@ def test_hrex_rbfe_hif2a_water_sampling_warning(hif2a_single_topology_leg, seed)
 
 @pytest.mark.parametrize("seed", [2024])
 def test_hrex_rbfe_hif2a(hif2a_single_topology_leg, seed):
+    plt.close()  # Close the open figures in case it was opened before the test
     # Reduce the threshold for the maximum plots open, should only open one at any given time
     plt.rcParams.update({"figure.max_open_warning": 2})
     host_name, (mol_a, mol_b, core, forcefield, host_config) = hif2a_single_topology_leg

--- a/tests/test_hrex_rbfe.py
+++ b/tests/test_hrex_rbfe.py
@@ -50,8 +50,6 @@ def get_hif2a_single_topology_leg(host_name: str | None):
         box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
         host_config = HostConfig(host_sys, host_conf, box, host_conf.shape[0])
 
-    forcefield = Forcefield.load_default()
-
     return mol_a, mol_b, core, forcefield, host_config
 
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -14,7 +14,7 @@ def test_forward_and_reverse_ddg_plot():
     dummy_solv_ukln = rng.random(size=ukln_shape)
     dummy_complex_ukln = rng.random(size=ukln_shape)
 
-    plot_forward_and_reverse_ddg(dummy_solv_ukln, dummy_complex_ukln)
+    assert len(plot_forward_and_reverse_ddg(dummy_solv_ukln, dummy_complex_ukln)) > 0
 
 
 def test_forward_and_reverse_ddg_plot_validation():
@@ -36,7 +36,7 @@ def test_forward_and_reverse_dg_plot(ukln_shape):
     dummy_ukln = rng.random(size=ukln_shape) * 1000
 
     frames_per_step = min(ukln_shape[-1], 100)
-    plot_forward_and_reverse_dg(dummy_ukln, frames_per_step=frames_per_step)
+    assert len(plot_forward_and_reverse_dg(dummy_ukln, frames_per_step=frames_per_step)) > 0
 
 
 def test_forward_and_reverse_dg_plot_validation():

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -460,6 +460,7 @@ def plot_as_png_fxn(f, *args, **kwargs) -> bytes:
     f(*args, **kwargs)
     buffer = io.BytesIO()
     plt.savefig(buffer, format="png", bbox_inches="tight")
+    plt.close()
     buffer.seek(0)
     plot_png = buffer.read()
     return plot_png

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -217,7 +217,7 @@ def plot_forward_and_reverse_ddg(
     fwd_err = np.linalg.norm([complex_fwd_err, solvent_fwd_err], axis=0) * kBT / KCAL_TO_KJ
     rev_err = np.linalg.norm([complex_rev_err, solvent_rev_err], axis=0) * kBT / KCAL_TO_KJ
 
-    return plot_fwd_reverse_predictions(fwd, fwd_err, rev, rev_err)
+    return plot_as_png_fxn(plot_fwd_reverse_predictions, fwd, fwd_err, rev, rev_err)
 
 
 def plot_forward_and_reverse_dg(
@@ -249,7 +249,8 @@ def plot_forward_and_reverse_dg(
 
     kBT = BOLTZ * temperature
 
-    return plot_fwd_reverse_predictions(
+    return plot_as_png_fxn(
+        plot_fwd_reverse_predictions,
         fwd * kBT / KCAL_TO_KJ,
         fwd_err * kBT / KCAL_TO_KJ,
         rev * kBT / KCAL_TO_KJ,
@@ -279,10 +280,6 @@ def plot_fwd_reverse_predictions(
         Energies std errors computed in reverse direction, in units of kcal/mol
     energy_type: string
         The type of free energy that is being plotted, typically '∆∆G' or '∆G'
-
-    Returns
-    -------
-    energy_convergence_plot_bytes: bytes
     """
     assert len(fwd) == len(rev)
     assert len(fwd) == len(fwd_err)
@@ -319,13 +316,6 @@ def plot_fwd_reverse_predictions(
     plt.xlabel("Fraction of simulation time")
     plt.ylabel(f"{energy_type} (kcal/mol)")
     plt.legend()
-
-    buffer = io.BytesIO()
-    plt.savefig(buffer, format="png", bbox_inches="tight")
-    buffer.seek(0)
-    plot_png = buffer.read()
-
-    return plot_png
 
 
 def plot_chiral_restraint_energies(chiral_energies: NDArray, figsize: Tuple[float, float] = (13, 10)):

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -450,7 +450,7 @@ def plot_as_png_fxn(f, *args, **kwargs) -> bytes:
     f(*args, **kwargs)
     buffer = io.BytesIO()
     plt.savefig(buffer, format="png", bbox_inches="tight")
-    # plt.close()
+    plt.close()
     buffer.seek(0)
     plot_png = buffer.read()
     return plot_png

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -450,7 +450,7 @@ def plot_as_png_fxn(f, *args, **kwargs) -> bytes:
     f(*args, **kwargs)
     buffer = io.BytesIO()
     plt.savefig(buffer, format="png", bbox_inches="tight")
-    plt.close()
+    # plt.close()
     buffer.seek(0)
     plot_png = buffer.read()
     return plot_png


### PR DESCRIPTION
* Been noticing this warning in tests a lot recently and have seen OOMs from running many RBFE calculations in the same process. Not sure it is the plotting, but a super simple change so figured I would resolve this.
* Dependent on the Matplotlib backend. Doesn't fail in CI because there is no GUI, locally this does fail. Makes this a pretty insignificant change, would still advocate for it. 