### PR TITLE
Parallelize HREX Windows with Threads

### DIFF
--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -55,6 +55,8 @@ def test_multiple_steps_store_interval():
     test_xs, test_boxes = ctxt.multiple_steps(10, 10)
     assert len(test_xs) == 1
     assert len(test_xs) == len(test_boxes)
+    print(test_xs.shape, test_boxes.shape)
+    print(test_boxes)
     # We should not get out the input frame
     assert np.any(np.not_equal(x0, test_xs[0]))
 

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -640,6 +640,7 @@ void declare_context(py::module &m) {
                 if (new_x_t.shape()[0] != ctxt.num_atoms()) {
                     throw std::runtime_error("number of new coords disagree with current coords");
                 }
+                py::gil_scoped_release release;
                 ctxt.set_x_t(new_x_t.data());
             },
             py::arg("coords"))
@@ -649,6 +650,7 @@ void declare_context(py::module &m) {
                 if (new_v_t.shape()[0] != ctxt.num_atoms()) {
                     throw std::runtime_error("number of new velocities disagree with current coords");
                 }
+                py::gil_scoped_release release;
                 ctxt.set_v_t(new_v_t.data());
             },
             py::arg("velocities"))
@@ -658,6 +660,7 @@ void declare_context(py::module &m) {
                 if (new_box_t.size() != 9 || new_box_t.shape()[0] != 3) {
                     throw std::runtime_error("box must be 3x3");
                 }
+                py::gil_scoped_release release;
                 ctxt.set_box(new_box_t.data());
             },
             py::arg("box"))
@@ -690,10 +693,10 @@ void declare_context(py::module &m) {
                 ctxt.get_box(buffer.mutable_data());
                 return buffer;
             })
-        .def("get_integrator", &Context::get_integrator)
-        .def("get_potentials", &Context::get_potentials)
-        .def("get_barostat", &Context::get_barostat)
-        .def("get_movers", &Context::get_movers);
+        .def("get_integrator", &Context::get_integrator, py::call_guard<py::gil_scoped_release>())
+        .def("get_potentials", &Context::get_potentials, py::call_guard<py::gil_scoped_release>())
+        .def("get_barostat", &Context::get_barostat, py::call_guard<py::gil_scoped_release>())
+        .def("get_movers", &Context::get_movers, py::call_guard<py::gil_scoped_release>());
 }
 
 void declare_integrator(py::module &m) {


### PR DESCRIPTION
* Create a per state context (which means up to 48x GPU memory usage) to ensure determinism as the thread that runs each state is not deterministic.
* Avoids having to reset params of water sampler and bound potentials parameters
* Performance is dependent on the GPU, more powerful GPUs gain more here