### PR TITLE
remove extraneous summed potential now that the L-E ixn groups are merged

### DIFF
--- a/tests/test_cuda_bd_exchange_mover.py
+++ b/tests/test_cuda_bd_exchange_mover.py
@@ -10,7 +10,7 @@ from scipy.spatial.transform import Rotation
 from scipy.special import logsumexp
 
 from timemachine.constants import DEFAULT_PRESSURE, DEFAULT_TEMP
-from timemachine.fe.free_energy import HostConfig, InitialState, MDParams, sample
+from timemachine.fe.free_energy import HostConfig, InitialState, MDParams, get_water_sampler_params, sample
 from timemachine.fe.model_utils import apply_hmr, image_frame
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.ff import Forcefield
@@ -21,7 +21,7 @@ from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.md.exchange.exchange_mover import BDExchangeMove as RefBDExchangeMove
 from timemachine.md.exchange.exchange_mover import get_water_idxs, translate_coordinates
 from timemachine.md.minimizer import check_force_norm
-from timemachine.potentials import HarmonicBond, Nonbonded, NonbondedInteractionGroup
+from timemachine.potentials import HarmonicBond, Nonbonded
 from timemachine.potentials.potential import get_bound_potential_by_type
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
 
@@ -932,11 +932,9 @@ def test_bd_moves_with_complex_and_ligand(
     box = initial_state.box0
 
     bps = initial_state.potentials
-    ligand_env_pot = get_bound_potential_by_type(bps, NonbondedInteractionGroup)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
-
-    water_params = ligand_env_pot.params
+    water_params = get_water_sampler_params(initial_state)
 
     bond_list = get_bond_list(bond_pot)
     all_group_idxs = get_group_indices(bond_list, conf.shape[0])

--- a/tests/test_cuda_bd_exchange_mover.py
+++ b/tests/test_cuda_bd_exchange_mover.py
@@ -21,7 +21,7 @@ from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.md.exchange.exchange_mover import BDExchangeMove as RefBDExchangeMove
 from timemachine.md.exchange.exchange_mover import get_water_idxs, translate_coordinates
 from timemachine.md.minimizer import check_force_norm
-from timemachine.potentials import HarmonicBond, Nonbonded, NonbondedInteractionGroup, SummedPotential
+from timemachine.potentials import HarmonicBond, Nonbonded, NonbondedInteractionGroup
 from timemachine.potentials.potential import get_bound_potential_by_type
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
 
@@ -932,15 +932,11 @@ def test_bd_moves_with_complex_and_ligand(
     box = initial_state.box0
 
     bps = initial_state.potentials
-    ligand_env_pot = get_bound_potential_by_type(bps, SummedPotential).potential
+    ligand_env_pot = get_bound_potential_by_type(bps, NonbondedInteractionGroup)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
-    ixn_group_idx = next(
-        i for i, pot in enumerate(ligand_env_pot.potentials) if isinstance(pot, NonbondedInteractionGroup)
-    )
-
-    water_params = ligand_env_pot.params_init[ixn_group_idx]
+    water_params = ligand_env_pot.params
 
     bond_list = get_bond_list(bond_pot)
     all_group_idxs = get_group_indices(bond_list, conf.shape[0])

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -501,8 +501,8 @@ def test_targeted_insertion_brd4_rbfe_with_context(
     box = initial_state.box0
 
     bps = initial_state.potentials
-    summed_pot = get_bound_potential_by_type(initial_state.potentials, SummedPotential)
-    water_params = summed_pot.potential.params_init[0]
+    nb_ixn_pot = get_bound_potential_by_type(initial_state.potentials, NonbondedInteractionGroup)
+    water_params = nb_ixn_pot.params
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
@@ -993,15 +993,11 @@ def test_targeted_moves_with_complex_and_ligand_in_brd4(
 
     bps = initial_state.potentials
 
-    ligand_env_pot = get_bound_potential_by_type(bps, SummedPotential).potential
+    ligand_env_pot = get_bound_potential_by_type(bps, NonbondedInteractionGroup)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
-    ixn_group_idx = next(
-        i for i, pot in enumerate(ligand_env_pot.potentials) if isinstance(pot, NonbondedInteractionGroup)
-    )
-
-    water_params = ligand_env_pot.params_init[ixn_group_idx]
+    water_params = ligand_env_pot.params
 
     bond_list = get_bond_list(bond_pot)
     all_group_idxs = get_group_indices(bond_list, conf.shape[0])

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -37,7 +37,7 @@ from timemachine.md.exchange.exchange_mover import (
     get_water_idxs,
 )
 from timemachine.md.minimizer import check_force_norm
-from timemachine.potentials import HarmonicBond, Nonbonded, NonbondedInteractionGroup, SummedPotential
+from timemachine.potentials import HarmonicBond, Nonbonded, SummedPotential
 from timemachine.potentials.potential import get_bound_potential_by_type
 
 
@@ -1075,31 +1075,6 @@ def test_targeted_moves_with_complex_and_ligand_in_brd4(
             # If an unexpect error was raised, re-raise the error
             raise
     assert False, f"No moves were made after {iterations}"
-
-
-def update_initial_state(initial_state):
-    # Here for review, will remove before merging
-    updated_potentials = []
-    for pot in initial_state.potentials:
-        if isinstance(pot.potential, SummedPotential):
-            lw_pot, lp_pot = pot.potential.potentials
-            lw_params, lp_params = pot.potential.params_init
-            lw_col_idxs, lp_col_idxs = lw_pot.col_atom_idxs, lp_pot.col_atom_idxs
-            col_idxs = np.array(list(sorted(list(lw_col_idxs) + list(lp_col_idxs))), dtype=np.int32)
-
-            ubp = NonbondedInteractionGroup(
-                lw_pot.num_atoms,
-                lw_pot.row_atom_idxs,
-                lw_pot.beta,
-                lw_pot.cutoff,
-                col_idxs,
-                lw_pot.disable_hilbert_sort,
-                lw_pot.nblist_padding,
-            )
-            pot = ubp.bind(lw_params)  # same params for both
-        updated_potentials.append(pot)
-    initial_state = replace(initial_state, potentials=updated_potentials)
-    return initial_state
 
 
 @pytest.mark.memcheck

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -427,6 +427,12 @@ def test_get_water_sampler_params_complex():
     np.testing.assert_array_equal(orig_prot_nb_params, water_sampler_nb_params_update[state.protein_idxs])
     np.testing.assert_array_equal(water_sampler_nb_params, water_sampler_nb_params_update)
 
+    # should also work for numpy arrays
+    nb_bp.params = np.array(nb_bp.params)
+    water_sampler_nb_params_update = get_water_sampler_params(state)
+    np.testing.assert_array_equal(orig_prot_nb_params, water_sampler_nb_params_update[state.protein_idxs])
+    np.testing.assert_array_equal(water_sampler_nb_params, water_sampler_nb_params_update)
+
 
 def test_run_sims_bisection_early_stopping(hif2a_ligand_pair_single_topology_lam0_state):
     initial_state = hif2a_ligand_pair_single_topology_lam0_state

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -46,6 +46,7 @@ from timemachine.md.states import CoordsVelBox
 from timemachine.potentials import (
     HarmonicBond,
     Nonbonded,
+    NonbondedInteractionGroup,
     NonbondedPairListPrecomputed,
     SummedPotential,
     make_summed_potential,
@@ -371,6 +372,7 @@ def test_get_water_sampler_params(num_windows):
     solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(
         3.0, forcefield.water_ff, mols=[mol_a, mol_b]
     )
+
     num_host_atoms = solvent_conf.shape[0]
     host_system, masses = convert_omm_system(solvent_sys)
     solvent_host = Host(host_system, masses, solvent_conf, solvent_box, num_host_atoms)
@@ -389,6 +391,41 @@ def test_get_water_sampler_params(num_windows):
             assert np.all(ligand_water_params[mol_b_only_atoms][:, 3] == 0.0)
 
         np.testing.assert_array_equal(water_sampler_nb_params[num_host_atoms:], ligand_water_params)
+
+
+@pytest.mark.nocuda
+def test_get_water_sampler_params_complex():
+    mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
+    # Use the simple charges simply because it is faster
+    forcefield = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
+    st = SingleTopology(mol_a, mol_b, core, forcefield)
+
+    with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as protein_path:
+        host_sys, host_conf, box, _, num_water_atoms = builders.build_protein_system(
+            str(protein_path), forcefield.protein_ff, forcefield.water_ff, mols=[mol_a, mol_b]
+        )
+        box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
+    host_config = HostConfig(host_sys, host_conf, box, num_water_atoms)
+    system, masses = convert_omm_system(host_config.omm_system)
+    host = Host(system, masses, host_conf, box, host_config.num_water_atoms)
+
+    lamb = 0.5  # arbitrary
+
+    # original params
+    state = setup_initial_state(st, lamb, host, DEFAULT_TEMP, 2024)
+
+    water_sampler_nb_params = get_water_sampler_params(state)
+
+    nb_bp = get_bound_potential_by_type(state.potentials, NonbondedInteractionGroup)
+    orig_prot_nb_params = nb_bp.params[state.protein_idxs][:]
+
+    np.testing.assert_array_equal(orig_prot_nb_params, water_sampler_nb_params[state.protein_idxs])
+
+    # updated ixn params, should still give the same params for the water sampler
+    nb_bp.params = nb_bp.params.at[state.protein_idxs, 0].set(1.0)
+    water_sampler_nb_params_update = get_water_sampler_params(state)
+    np.testing.assert_array_equal(orig_prot_nb_params, water_sampler_nb_params_update[state.protein_idxs])
+    np.testing.assert_array_equal(water_sampler_nb_params, water_sampler_nb_params_update)
 
 
 def test_run_sims_bisection_early_stopping(hif2a_ligand_pair_single_topology_lam0_state):

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -791,7 +791,7 @@ def test_combine_with_host():
         potentials.PeriodicTorsion,
         potentials.NonbondedPairListPrecomputed,
         potentials.Nonbonded,
-        potentials.SummedPotential,  # P-L + L-W interactions
+        potentials.NonbondedInteractionGroup,  # P-L + L-W interactions
         potentials.ChiralAtomRestraint,
         # potentials.ChiralBondRestraint,
         # NOTE: chiral bond restraints excluded

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -791,7 +791,7 @@ def test_combine_with_host():
         potentials.PeriodicTorsion,
         potentials.NonbondedPairListPrecomputed,
         potentials.Nonbonded,
-        potentials.NonbondedInteractionGroup,  # P-L + L-W interactions
+        potentials.NonbondedInteractionGroup,  # L-P + L-W interactions
         potentials.ChiralAtomRestraint,
         # potentials.ChiralBondRestraint,
         # NOTE: chiral bond restraints excluded

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -507,7 +507,7 @@ def get_water_sampler_params(initial_state: InitialState) -> NDArray:
         ]
         if isinstance(water_params, jax.Array):
             water_params = water_params.at[initial_state.protein_idxs].set(prot_params)
-        else:
+        else:  # NDArray
             water_params[initial_state.protein_idxs] = prot_params
 
     assert water_params.shape[1] == 4

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -35,7 +35,7 @@ from timemachine.md.exchange.exchange_mover import get_water_idxs
 from timemachine.md.hrex import HREX, HREXDiagnostics, ReplicaIdx, StateIdx, get_swap_attempts_per_iter_heuristic
 from timemachine.md.states import CoordsVelBox
 from timemachine.potentials import BoundPotential, HarmonicBond, NonbondedInteractionGroup, SummedPotential
-from timemachine.potentials.potential import get_bound_potential_by_type, get_potential_by_type
+from timemachine.potentials.potential import get_bound_potential_by_type
 from timemachine.utils import batches, pairwise_transform_and_combine
 
 WATER_SAMPLER_MOVERS = (
@@ -496,16 +496,9 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
 def get_water_sampler_params(initial_state: InitialState) -> NDArray:
     """Given an initial state, return the parameters that define the nonbonded parameters of water with respect to the
     entire system.
-
-    Since we split the different components of the NB into ligand-water, ligand-protein, we want to use the ligand-water parameter
-    to ensure that the ligand component is correctly configured for the specific lambda window.
     """
-    summed_pot = get_bound_potential_by_type(initial_state.potentials, SummedPotential).potential
-    # TBD Figure out a better way of handling the jankyness of having to select the IxnGroup that defines the Ligand-Water
-    # Currently this just hardcodes to the first ixn group potential which is the ligand-water ixn group as returned by HostTopology.parameterize_nonbonded
-    ixn_group_idx = next(i for i, pot in enumerate(summed_pot.potentials) if isinstance(pot, NonbondedInteractionGroup))
-    assert isinstance(summed_pot.potentials[ixn_group_idx], NonbondedInteractionGroup)
-    water_params = summed_pot.params_init[ixn_group_idx]
+    nb_ixn_pot = get_bound_potential_by_type(initial_state.potentials, NonbondedInteractionGroup)
+    water_params = nb_ixn_pot.params
     assert water_params.shape[1] == 4
     water_params = np.asarray(water_params)
     return water_params
@@ -533,9 +526,8 @@ def get_context(initial_state: InitialState, md_params: Optional[MDParams] = Non
 
         water_idxs = get_water_idxs(group_indices, ligand_idxs=initial_state.ligand_idxs)
 
-        summed_pot = get_bound_potential_by_type(initial_state.potentials, SummedPotential).potential
         # Select a Nonbonded Potential to get the the cutoff/beta, assumes all have same cutoff/beta.
-        nb = get_potential_by_type(summed_pot.potentials, NonbondedInteractionGroup)
+        nb = get_bound_potential_by_type(initial_state.potentials, NonbondedInteractionGroup).potential
 
         water_params = get_water_sampler_params(initial_state)
 

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -494,24 +494,20 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
 
 
 def get_water_sampler_params(initial_state: InitialState) -> NDArray:
-    """Given an initial state, return the parameters that define the nonbonded parameters of water with respect to the
+    """Given an initial state, return a copy of the parameters that define the nonbonded parameters of water with respect to the
     entire system.
     """
     nb_ixn_pot = get_bound_potential_by_type(initial_state.potentials, NonbondedInteractionGroup)
-    water_params = nb_ixn_pot.params
+    water_params = np.array(nb_ixn_pot.params)
 
     # If the protein is present, use the original protein parameters for the water sampler
     if len(initial_state.protein_idxs):
         prot_params = get_bound_potential_by_type(initial_state.potentials, Nonbonded).params[
             initial_state.protein_idxs
         ]
-        if isinstance(water_params, jax.Array):
-            water_params = water_params.at[initial_state.protein_idxs].set(prot_params)
-        else:  # NDArray
-            water_params[initial_state.protein_idxs] = prot_params
+        water_params[initial_state.protein_idxs] = prot_params
 
     assert water_params.shape[1] == 4
-    water_params = np.asarray(water_params)
     return water_params
 
 

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -16,6 +16,7 @@ from timemachine.potentials import (
     HarmonicAngleStable,
     HarmonicBond,
     Nonbonded,
+    NonbondedInteractionGroup,
     NonbondedPairListPrecomputed,
     PeriodicTorsion,
     Potential,
@@ -167,7 +168,7 @@ class HostGuestSystem:
     chiral_bond: BoundPotential[ChiralBondRestraint]
     nonbonded_guest_pairs: BoundPotential[NonbondedPairListPrecomputed]
     nonbonded_host: BoundPotential[Nonbonded]
-    nonbonded_host_guest_ixn: BoundPotential[SummedPotential]
+    nonbonded_host_guest_ixn: BoundPotential[NonbondedInteractionGroup]
 
     def get_U_fns(self):
         return [

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -725,7 +725,7 @@ def get_ligand_ixn_pots_params(
     num_lig_atoms = len(lig_idxs)
     num_total_atoms = num_lig_atoms + len(env_idxs)
 
-    hg_ixn_pots = potentials.NonbondedInteractionGroup(
+    hg_ixn_pot = potentials.NonbondedInteractionGroup(
         num_total_atoms,
         lig_idxs,
         beta,
@@ -734,4 +734,4 @@ def get_ligand_ixn_pots_params(
     )
 
     hg_ixn_params = jnp.concatenate([host_nb_params, guest_params_ixn_env])
-    return hg_ixn_pots, hg_ixn_params
+    return hg_ixn_pot, hg_ixn_params


### PR DESCRIPTION
- Remove SummedPotential for SingleTopology class
- Look up NonbondedInteractionGroup directly
- This was missed in https://github.com/proteneer/timemachine/pull/1372
