### PR TITLE
[wip] Offline overlap-based protocol rebalancing

### DIFF
--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -677,17 +677,19 @@ def test_assert_potentials_compatible(hif2a_ligand_pair_single_topology):
 def test_initial_state_to_bound_impl():
     # get initial state : near-duplicate of pytest fixture
     # initial_state = solvent_hif2a_ligand_pair_single_topology_lam0_state()
-    st, forcefield = hif2a_ligand_pair_single_topology
+    mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
+    forcefield = Forcefield.load_default()
+    st = SingleTopology(mol_a, mol_b, core, forcefield)
     solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(
         3.0, forcefield.water_ff, mols=[st.mol_a, st.mol_b]
     )
     solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
     solvent_host = setup_optimized_host(st, solvent_host_config)
-    initial_state = setup_initial_states(st, solvent_host, DEFAULT_TEMP, [0.5], 2023)[0]
+    initial_state = setup_initial_states(st, solvent_host, DEFAULT_TEMP, [0.5], 2024)[0]
 
     # minimal test
     bound_impl = initial_state.to_bound_impl()
     x, box = initial_state.x0, initial_state.box0
-    du_dx, u = bound_impl.execute(x, box)
+    du_dx, u = bound_impl.execute(x, box, compute_du_dx=True, compute_u=True)
     assert np.isfinite(u)
     assert np.isfinite(du_dx).all()

--- a/tests/test_protocol_optimization.py
+++ b/tests/test_protocol_optimization.py
@@ -178,4 +178,4 @@ def test_overlap_rebalancing_on_gaussian():
     optimized_nbr_dist = summarize_protocol(optimized_protocol, overlap_dist)
 
     assert len(optimized_protocol) <= target_num_states
-    assert np.min(optimized_nbr_dist) >= np.min(greedy_nbr_dist)
+    assert np.max(optimized_nbr_dist) <= np.max(greedy_nbr_dist)

--- a/tests/test_protocol_optimization.py
+++ b/tests/test_protocol_optimization.py
@@ -128,15 +128,17 @@ def summarize_protocol(lambdas, dist_fxn):
     neighbor_distances = []
     for k in range(K - 1):
         neighbor_distances.append(dist_fxn(lambdas[k], lambdas[k + 1]))
-    print(
-        f"\t# states = {K}, min(d(i,i+1)) = {min(neighbor_distances):.3f}, max(d(i,i+1)) = {max(neighbor_distances):.3f}"
-    )
-    return np.array(neighbor_distances)
+    neighbor_distances = np.array(neighbor_distances)
+    min_dist, max_dist = np.min(neighbor_distances), np.max(neighbor_distances)
+    msg = f"\t# states = {K}, min(d(i,i+1)) = {min_dist:.3f}, max(d(i,i+1)) = {max_dist:.3f}"
+    msg += f"\t{str(neighbor_distances)}"
+    print(msg)
+    return neighbor_distances
 
 
 def test_overlap_rebalancing_on_gaussian():
     # initial_lams = linspace(0,1), along a path where nonuniform lams are probably better
-    initial_num_states = 10
+    initial_num_states = 20
 
     def initial_path(lam):
         offset = lam * 4
@@ -163,8 +165,9 @@ def test_overlap_rebalancing_on_gaussian():
     _ = summarize_protocol(initial_lams, overlap_dist)
 
     # optimize for a target neighbor distance
-    target_dist = 0.5
-    print(f"optimized with target dist = {target_dist}:")
+    target_overlap = 0.1
+    target_dist = 1 - target_overlap
+    print(f"optimized with target dist = {target_dist} (target overlap = {target_overlap}):")
     greedy_prot = greedily_optimize_protocol(overlap_dist, target_dist)
     greedy_nbr_dist = summarize_protocol(greedy_prot, overlap_dist)
     assert np.max(greedy_nbr_dist) <= target_dist + 1e-5  # a little wiggle room

--- a/tests/test_protocol_optimization.py
+++ b/tests/test_protocol_optimization.py
@@ -8,7 +8,7 @@ from timemachine.optimize.protocol import (
     construct_work_stddev_estimator,
     linear_u_kn_interpolant,
     log_weights_from_mixture,
-    rebalance_initial_protocol,
+    rebalance_initial_protocol_by_work_stddev,
 )
 
 np.random.seed(2021)
@@ -20,7 +20,7 @@ def test_rebalance_initial_protocol():
     """Integration test: assert that protocol optimization improves run-to-run variance in free energy estimates"""
     initial_protocol = np.linspace(0, 1, 64)
     mbar = simulate_protocol(initial_protocol, seed=2021)
-    new_protocol = rebalance_initial_protocol(
+    new_protocol = rebalance_initial_protocol_by_work_stddev(
         initial_protocol,
         mbar.f_k,
         mbar.u_kn,

--- a/tests/test_protocol_optimization.py
+++ b/tests/test_protocol_optimization.py
@@ -187,7 +187,7 @@ def test_overlap_rebalancing_on_gaussian():
     rng = np.random.default_rng(2024)
     random_lams = rng.uniform(0, 1, 20)
     self_distances = [overlap_dist(lam, lam) for lam in random_lams]
-    np.testing.assert_allclose(self_distances, 0.0)
+    np.testing.assert_allclose(self_distances, 0.0, atol=1e-10)
     for lam_i in random_lams:
         # compare to some random lam_j between lam_i and 1
         lams_above = sorted(set(rng.uniform(lam_i, 1, 5)))

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -162,6 +162,13 @@ class InitialState:
         assert self.ligand_idxs.dtype == np.int32 or self.ligand_idxs.dtype == np.int64
         assert self.protein_idxs.dtype == np.int32 or self.protein_idxs.dtype == np.int64
 
+    def to_bound_impl(self, precision=np.float32):
+        bps = self.potentials
+        summed_pot = SummedPotential([bp.potential for bp in bps], [bp.params for bp in bps])
+        params = np.concatenate([bp.params.reshape(-1) for bp in bps])
+        impl = summed_pot.to_gpu(precision).bind(params).bound_impl
+        return impl
+
 
 @dataclass
 class BarResult:

--- a/timemachine/optimize/protocol.py
+++ b/timemachine/optimize/protocol.py
@@ -142,7 +142,7 @@ def linear_u_kn_interpolant(lambdas: Array, u_kn: Array) -> Callable:
     return vec_u_interp
 
 
-# distance fxns: (1) max(work_stddev(a->b), work_stddev(b->a)), (2) overlap(a,b)
+# distance fxns: (1) max(work_stddev(a->b), work_stddev(b->a)), (2) 1 - overlap(a,b)
 
 
 # (1) work stddev
@@ -334,7 +334,7 @@ def produce_target_number_of_equidistant_states(distance_fxn, target_num_states=
     except RuntimeError as e:
         print(f"bisection failed: {e}")
 
-    # scan the trial vals tested by bisection, to find a target_distance that produces <= target_num_states
+    # find the smallest target_distance such that len(greedily_optimize_protocol(target_distance)) == target_num_states
     lowest_so_far = initial_target_distance
     for dist in protocols_by_target_dist.keys():
         if (len(protocols_by_target_dist[dist]) == target_num_states) and (dist < lowest_so_far):

--- a/timemachine/optimize/protocol.py
+++ b/timemachine/optimize/protocol.py
@@ -337,7 +337,7 @@ def produce_target_number_of_equidistant_states(distance_fxn, target_num_states=
     # scan the trial vals tested by bisection, to find a target_distance that produces <= target_num_states
     lowest_so_far = initial_target_distance
     for dist in protocols_by_target_dist.keys():
-        if len(protocols_by_target_dist[dist] == target_num_states) and dist < lowest_so_far:
+        if (len(protocols_by_target_dist[dist]) == target_num_states) and (dist < lowest_so_far):
             lowest_so_far = dist
     best_target_dist = lowest_so_far
 

--- a/timemachine/optimize/protocol.py
+++ b/timemachine/optimize/protocol.py
@@ -334,12 +334,12 @@ def produce_target_number_of_equidistant_states(distance_fxn, target_num_states=
     except RuntimeError as e:
         print(f"bisection failed: {e}")
 
-    # scan the trial vals tested by bisection, to find the largest target_distance that produces <= target_num_states
-    largest_valid_dist_so_far = min_target_distance
+    # scan the trial vals tested by bisection, to find a target_distance that produces <= target_num_states
+    lowest_so_far = initial_target_distance
     for dist in protocols_by_target_dist.keys():
-        if (dist >= largest_valid_dist_so_far) and (len(protocols_by_target_dist[dist]) <= target_num_states):
-            largest_valid_dist_so_far = dist
-    best_target_dist = largest_valid_dist_so_far
+        if len(protocols_by_target_dist[dist] == target_num_states) and dist < lowest_so_far:
+            lowest_so_far = dist
+    best_target_dist = lowest_so_far
 
     prot = protocols_by_target_dist[best_target_dist]
     return prot


### PR DESCRIPTION
Currently TM has a few methods for adapting the number and spacing of lambda windows along a fixed path, depending on the setting:
* greedy bisection : starts with no samples between 0<lam<1, finds a sequence of lams such that overlap(lams[i], lams[i+1]) > threshold. ( https://github.com/proteneer/timemachine/pull/959 )
* adaptive smc : starts with no samples at lam>0, finds a sequence of lams such that ~ chi2_div(lams[i], lams[i+1]) ~= threshold ( https://github.com/proteneer/timemachine/pull/1177 )
* offline "rebalancing" : starts with samples that allow reweighting to any lam between 0 and 1, finds a sequence of lams such that heuristic_dist(lams[i], lams[i+1]) ~= threshold ( https://github.com/proteneer/timemachine/pull/538 )


This PR will extend the offline "rebalancing" functionality, with the intent of compressing the output of greedy bisection. (Motivation: bisection guarantees that the estimated overlap(lams[i], lams[i+1]) > threshold, but does not minimize len(lams).)