### PR TITLE
Allocate memory only once in multiple_step methods

### DIFF
--- a/timemachine/cpp/src/context.hpp
+++ b/timemachine/cpp/src/context.hpp
@@ -26,23 +26,27 @@ public:
     void initialize();
     void finalize();
 
-    std::array<std::vector<double>, 2> multiple_steps(const int n_steps, int store_x_interval);
+    void multiple_steps(const int n_steps, const int n_samples, double *h_x, double *h_box);
 
-    std::array<std::vector<double>, 2> multiple_steps_local(
+    void multiple_steps_local(
         const int n_steps,
         const std::vector<int> &local_idxs,
-        const int store_x_interval,
+        const int n_samples,
         const double radius,
         const double k,
-        const int seed);
+        const int seed,
+        double *h_x,
+        double *h_box);
 
-    std::array<std::vector<double>, 2> multiple_steps_local_selection(
+    void multiple_steps_local_selection(
         const int n_steps,
         const int reference_idx,
         const std::vector<int> &selection_idxs,
-        const int store_x_interval,
+        const int n_samples,
         const double radius,
-        const double k);
+        const double k,
+        double *h_x,
+        double *h_box);
 
     int num_atoms() const;
 
@@ -79,13 +83,15 @@ private:
 
     void _ensure_local_md_intialized();
 
-    void _verify_box(cudaStream_t stream);
+    void _verify_box(const double *box_buffer, cudaStream_t stream);
 
     int step_;
 
     double *d_x_t_;   // coordinates
     double *d_v_t_;   // velocities
     double *d_box_t_; // box vectors
+
+    cudaStream_t stream_; // Stream work will be scheduled into
 
     std::shared_ptr<Integrator> intg_;
     std::vector<std::shared_ptr<BoundPotential>> bps_;

--- a/timemachine/cpp/src/context.hpp
+++ b/timemachine/cpp/src/context.hpp
@@ -91,8 +91,6 @@ private:
     double *d_v_t_;   // velocities
     double *d_box_t_; // box vectors
 
-    cudaStream_t stream_; // Stream work will be scheduled into
-
     std::shared_ptr<Integrator> intg_;
     std::vector<std::shared_ptr<BoundPotential>> bps_;
     std::vector<std::shared_ptr<BoundPotential>> nonbonded_pots_; // Potentials used to verify

--- a/timemachine/cpp/src/wrap_kernels.cpp
+++ b/timemachine/cpp/src/wrap_kernels.cpp
@@ -188,8 +188,7 @@ void declare_hilbert_sort(py::module &m) {
                 verify_coords_and_box(coords, box);
 
                 std::vector<unsigned int> sort_perm = sorter.sort_host(N, coords.data(), box.data());
-                py::array_t<uint32_t, py::array::c_style> output_perm(sort_perm.size());
-                std::memcpy(output_perm.mutable_data(), sort_perm.data(), sort_perm.size() * sizeof(unsigned int));
+                py::array_t<uint32_t, py::array::c_style> output_perm(sort_perm.size(), sort_perm.data());
                 return output_perm;
             },
             py::arg("coords"),
@@ -350,20 +349,23 @@ void declare_context(py::module &m) {
         .def(
             "multiple_steps",
             [](Context &ctxt, const int n_steps, int store_x_interval) -> py::tuple {
+                if (store_x_interval < 0) {
+                    throw std::runtime_error("store_x_interval must be greater than or equal to zero");
+                }
                 // (ytz): I hate C++
-                int x_interval = (store_x_interval <= 0) ? n_steps : store_x_interval;
-                std::array<std::vector<double>, 2> result = ctxt.multiple_steps(n_steps, x_interval);
-
                 int N = ctxt.num_atoms();
                 int D = 3;
-                int F = result[0].size() / (N * D);
-                py::array_t<double, py::array::c_style> out_x_buffer({F, N, D});
-                std::memcpy(out_x_buffer.mutable_data(), result[0].data(), result[0].size() * sizeof(double));
 
-                py::array_t<double, py::array::c_style> box_buffer({F, D, D});
-                std::memcpy(box_buffer.mutable_data(), result[1].data(), result[1].size() * sizeof(double));
-
-                return py::make_tuple(out_x_buffer, box_buffer);
+                // If the store_x_interval is 0, collect the last frame by setting x_interval to n_steps
+                const int x_interval = (store_x_interval == 0) ? n_steps : store_x_interval;
+                // n_samples determines the number of frames that will be collected, computed to be able to allocate
+                // the buffers up front to avoid allocating memory twice
+                const int n_samples = n_steps / x_interval;
+                py::array_t<double, py::array::c_style> out_x_buffer({n_samples, N, D});
+                py::array_t<double, py::array::c_style> box_buffer({n_samples, D, D});
+                auto res = py::make_tuple(out_x_buffer, box_buffer);
+                ctxt.multiple_steps(n_steps, n_samples, out_x_buffer.mutable_data(), box_buffer.mutable_data());
+                return res;
             },
             py::arg("n_steps"),
             py::arg("store_x_interval") = 0,
@@ -408,24 +410,36 @@ void declare_context(py::module &m) {
                 if (n_steps <= 0) {
                     throw std::runtime_error("local steps must be at least one");
                 }
+                if (store_x_interval < 0) {
+                    throw std::runtime_error("store_x_interval must be greater than or equal to zero");
+                }
                 verify_local_md_parameters(radius, k);
 
                 const int N = ctxt.num_atoms();
-                const int x_interval = (store_x_interval <= 0) ? n_steps : store_x_interval;
+                const int D = 3;
 
                 std::vector<int> vec_local_idxs = py_array_to_vector(local_idxs);
                 verify_atom_idxs(N, vec_local_idxs);
 
-                std::array<std::vector<double>, 2> result =
-                    ctxt.multiple_steps_local(n_steps, vec_local_idxs, x_interval, radius, k, seed);
-                const int D = 3;
-                const int F = result[0].size() / (N * D);
-                py::array_t<double, py::array::c_style> out_x_buffer({F, N, D});
-                std::memcpy(out_x_buffer.mutable_data(), result[0].data(), result[0].size() * sizeof(double));
+                // If the store_x_interval is 0, collect the last frame by setting x_interval to n_steps
+                const int x_interval = (store_x_interval == 0) ? n_steps : store_x_interval;
+                // n_samples determines the number of frames that will be collected, computed to be able to allocate
+                // the buffers up front to avoid allocating memory twice
+                const int n_samples = n_steps / x_interval;
+                py::array_t<double, py::array::c_style> out_x_buffer({n_samples, N, D});
+                py::array_t<double, py::array::c_style> box_buffer({n_samples, D, D});
+                auto res = py::make_tuple(out_x_buffer, box_buffer);
 
-                py::array_t<double, py::array::c_style> box_buffer({F, D, D});
-                std::memcpy(box_buffer.mutable_data(), result[1].data(), result[1].size() * sizeof(double));
-                return py::make_tuple(out_x_buffer, box_buffer);
+                ctxt.multiple_steps_local(
+                    n_steps,
+                    vec_local_idxs,
+                    n_samples,
+                    radius,
+                    k,
+                    seed,
+                    out_x_buffer.mutable_data(),
+                    box_buffer.mutable_data());
+                return res;
             },
             py::arg("n_steps"),
             py::arg("local_idxs"),
@@ -499,10 +513,13 @@ void declare_context(py::module &m) {
                 if (n_steps <= 0) {
                     throw std::runtime_error("local steps must be at least one");
                 }
+                if (store_x_interval < 0) {
+                    throw std::runtime_error("store_x_interval must be greater than or equal to zero");
+                }
                 verify_local_md_parameters(radius, k);
 
                 const int N = ctxt.num_atoms();
-                const int x_interval = (store_x_interval <= 0) ? n_steps : store_x_interval;
+                const int D = 3;
 
                 if (reference_idx < 0 || reference_idx >= N) {
                     throw std::runtime_error("reference idx must be at least 0 and less than " + std::to_string(N));
@@ -513,17 +530,25 @@ void declare_context(py::module &m) {
                 if (selection_set.find(reference_idx) != selection_set.end()) {
                     throw std::runtime_error("reference idx must not be in selection idxs");
                 }
+                // If the store_x_interval is 0, collect the last frame by setting x_interval to n_steps
+                const int x_interval = (store_x_interval == 0) ? n_steps : store_x_interval;
+                // n_samples determines the number of frames that will be collected, computed to be able to allocate
+                // the buffers up front to avoid allocating memory twice
+                const int n_samples = n_steps / x_interval;
+                py::array_t<double, py::array::c_style> out_x_buffer({n_samples, N, D});
+                py::array_t<double, py::array::c_style> box_buffer({n_samples, D, D});
+                auto res = py::make_tuple(out_x_buffer, box_buffer);
 
-                std::array<std::vector<double>, 2> result = ctxt.multiple_steps_local_selection(
-                    n_steps, reference_idx, vec_selection_idxs, x_interval, radius, k);
-                const int D = 3;
-                const int F = result[0].size() / (N * D);
-                py::array_t<double, py::array::c_style> out_x_buffer({F, N, D});
-                std::memcpy(out_x_buffer.mutable_data(), result[0].data(), result[0].size() * sizeof(double));
-
-                py::array_t<double, py::array::c_style> box_buffer({F, D, D});
-                std::memcpy(box_buffer.mutable_data(), result[1].data(), result[1].size() * sizeof(double));
-                return py::make_tuple(out_x_buffer, box_buffer);
+                ctxt.multiple_steps_local_selection(
+                    n_steps,
+                    reference_idx,
+                    vec_selection_idxs,
+                    n_samples,
+                    radius,
+                    k,
+                    out_x_buffer.mutable_data(),
+                    box_buffer.mutable_data());
+                return res;
             },
             py::arg("n_steps"),
             py::arg("reference_idx"),
@@ -728,6 +753,7 @@ void declare_potential(py::module &m) {
                 if (params.ndim() < 2) {
                     throw std::runtime_error("parameters must have at least 2 dimensions");
                 }
+
                 const long unsigned int coord_batches = coords.shape()[0];
                 const long unsigned int N = coords.shape()[1];
                 const long unsigned int D = coords.shape()[2];
@@ -1025,6 +1051,7 @@ void declare_potential(py::module &m) {
                 const long unsigned int D = coords.shape()[1];
                 const long unsigned int P = params.size();
                 verify_coords_and_box(coords, box);
+
                 // initialize with fixed garbage values for debugging convenience (these should be overwritten by `execute_host`)
                 std::vector<unsigned long long> du_dx;
                 if (compute_du_dx) {
@@ -1134,6 +1161,7 @@ void declare_bound_potential(py::module &m) {
                 const long unsigned int N = coords.shape()[0];
                 const long unsigned int D = coords.shape()[1];
                 verify_coords_and_box(coords, box);
+
                 // initialize with fixed garbage values for debugging convenience (these should be overwritten by `execute_host`)
                 std::vector<unsigned long long> du_dx;
                 if (compute_du_dx) {
@@ -1182,6 +1210,7 @@ void declare_bound_potential(py::module &m) {
                 if (coords.shape()[0] != boxes.shape()[0]) {
                     throw std::runtime_error("number of batches of coords and boxes don't match");
                 }
+
                 const long unsigned int coord_batches = coords.shape()[0];
                 const long unsigned int N = coords.shape()[1];
                 const long unsigned int D = coords.shape()[2];
@@ -1594,13 +1623,9 @@ void declare_mover(py::module &m) {
 
                 std::array<std::vector<double>, 2> result = mover.move_host(N, coords.data(), box.data());
 
-                py::array_t<double, py::array::c_style> out_x_buffer({N, D});
-                std::memcpy(
-                    out_x_buffer.mutable_data(), result[0].data(), result[0].size() * sizeof(*result[0].data()));
+                py::array_t<double, py::array::c_style> out_x_buffer({N, D}, result[0].data());
 
-                py::array_t<double, py::array::c_style> box_buffer({D, D});
-                std::memcpy(box_buffer.mutable_data(), result[1].data(), result[1].size() * sizeof(*result[1].data()));
-
+                py::array_t<double, py::array::c_style> box_buffer({D, D}, result[1].data());
                 return py::make_tuple(out_x_buffer, box_buffer);
             },
             py::arg("coords"),
@@ -1792,12 +1817,9 @@ template <typename RealType> void declare_biased_deletion_exchange_move(py::modu
 
                 std::array<std::vector<double>, 2> result = mover.move_host(N, coords.data(), box.data());
 
-                py::array_t<double, py::array::c_style> out_x_buffer({N, D});
-                std::memcpy(
-                    out_x_buffer.mutable_data(), result[0].data(), result[0].size() * sizeof(*result[0].data()));
+                py::array_t<double, py::array::c_style> out_x_buffer({N, D}, result[0].data());
 
-                py::array_t<double, py::array::c_style> box_buffer({D, D});
-                std::memcpy(box_buffer.mutable_data(), result[1].data(), result[1].size() * sizeof(*result[1].data()));
+                py::array_t<double, py::array::c_style> box_buffer({D, D}, result[1].data());
 
                 return py::make_tuple(out_x_buffer, box_buffer);
             },
@@ -1863,9 +1885,7 @@ template <typename RealType> void declare_biased_deletion_exchange_move(py::modu
                 std::vector<double> flat_params = mover.get_params();
                 const int D = PARAMS_PER_ATOM;
                 const int N = flat_params.size() / D;
-                py::array_t<double, py::array::c_style> out_params({N, D});
-                std::memcpy(
-                    out_params.mutable_data(), flat_params.data(), flat_params.size() * sizeof(*flat_params.data()));
+                py::array_t<double, py::array::c_style> out_params({N, D}, flat_params.data());
                 return out_params;
             })
         .def(


### PR DESCRIPTION
* Part of https://github.com/proteneer/timemachine/pull/1370 originally, and reverted in https://github.com/proteneer/timemachine/pull/1386 due to GIL/stream issues.
* 2% performance improvement for vacuum sampling, the previous 5% reported improvement in #1370 appears to have been an outlier (less converged than previously thought)

# Benchmark
A10 Gpu, Cuda arch 8.6

## Master
```
dhfr-apo: N=23558 speed: 688.41ns/day dt: 2.5fs (ran 100000 steps in 31.57s)
dhfr-apo-barostat-interval-25: N=23558 speed: 620.84ns/day dt: 2.5fs (ran 100000 steps in 34.99s)

hif2a-apo: N=8805 speed: 1181.44ns/day dt: 2.5fs (ran 100000 steps in 18.51s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1015.06ns/day dt: 2.5fs (ran 100000 steps in 21.52s)
hif2a-rbfe-barostat-interval-25: N=8840 speed: 871.83ns/day dt: 2.5fs (ran 100000 steps in 25.02s)
hif2a-rbfe-local: N=8840 speed: 1426.18ns/day dt: 2.5fs (ran 100000 steps in 15.37s)
hif2a-rbfe-barostat-interval-25-water-sampling-interval-400: N=8840 speed: 813.72ns/day dt: 2.5fs (ran 100000 steps in 26.80s)

solvent-apo: N=6282 speed: 1627.95ns/day dt: 2.5fs (ran 100000 steps in 13.48s)
solvent-apo-barostat-interval-25: N=6282 speed: 1299.46ns/day dt: 2.5fs (ran 100000 steps in 16.82s)
solvent-rbfe-barostat-interval-25: N=6317 speed: 1093.19ns/day dt: 2.5fs (ran 100000 steps in 19.96s)
solvent-rbfe-local: N=6317 speed: 1543.73ns/day dt: 2.5fs (ran 100000 steps in 14.19s)
ahfe-barostat-interval-15: N=6316 speed: 1035.72ns/day dt: 2.5fs (ran 100000 steps in 21.06s)
ahfe-local: N=6316 speed: 1459.63ns/day dt: 2.5fs (ran 100000 steps in 14.98s)

vacuum-rbfe: N=35 speed: 9386.68ns/day dt: 2.5fs (ran 100000 steps in 2.48s)
```

## Changes
```
dhfr-apo: N=23558 speed: 689.27ns/day dt: 2.5fs (ran 100000 steps in 31.57s)
dhfr-apo-barostat-interval-25: N=23558 speed: 621.66ns/day dt: 2.5fs (ran 100000 steps in 34.98s)

hif2a-apo: N=8805 speed: 1191.14ns/day dt: 2.5fs (ran 100000 steps in 18.32s)
hif2a-apo-barostat-interval-25: N=8805 speed: 1018.23ns/day dt: 2.5fs (ran 100000 steps in 21.40s)
hif2a-rbfe-barostat-interval-25: N=8840 speed: 869.11ns/day dt: 2.5fs (ran 100000 steps in 25.05s)
hif2a-rbfe-local: N=8840 speed: 1433.37ns/day dt: 2.5fs (ran 100000 steps in 15.26s)
hif2a-rbfe-barostat-interval-25-water-sampling-interval-400: N=8840 speed: 814.40ns/day dt: 2.5fs (ran 100000 steps in 26.74s)

solvent-apo: N=6282 speed: 1625.39ns/day dt: 2.5fs (ran 100000 steps in 13.47s)
solvent-apo-barostat-interval-25: N=6282 speed: 1301.21ns/day dt: 2.5fs (ran 100000 steps in 16.83s)
solvent-rbfe-barostat-interval-25: N=6317 speed: 1092.67ns/day dt: 2.5fs (ran 100000 steps in 19.96s)
solvent-rbfe-local: N=6317 speed: 1543.45ns/day dt: 2.5fs (ran 100000 steps in 14.19s)
ahfe-barostat-interval-15: N=6316 speed: 1039.31ns/day dt: 2.5fs (ran 100000 steps in 20.98s)
ahfe-local: N=6316 speed: 1459.90ns/day dt: 2.5fs (ran 100000 steps in 14.98s)

vacuum-rbfe: N=35 speed: 9481.68ns/day dt: 2.5fs (ran 100000 steps in 2.46s)
```