### PR TITLE
Updates to EnvironmentBCCHandler

### DIFF
--- a/examples/biphenyl_torsion_sampling_hrex.py
+++ b/examples/biphenyl_torsion_sampling_hrex.py
@@ -171,9 +171,9 @@ def sample_biphenyl_hrex(
         water_box += 0.5 * np.eye(3)  # add a small margin around the box for stability
         num_water_atoms = water_coords.shape[0]
         host_config = HostConfig(water_system, water_coords, water_box, num_water_atoms, water_top)
-        host_bps, host_masses = openmm_deserializer.deserialize_system(water_system, water_top, ff, cutoff=1.2)
+        host_bps, host_masses = openmm_deserializer.deserialize_system(water_system, cutoff=1.2)
 
-        top = HostGuestTopology(host_bps, bt, num_water_atoms)
+        top = HostGuestTopology(host_bps, bt, num_water_atoms, ff, water_top)
 
         # translate ligand indices to system indices
         intramol_atom_pairs_to_decouple += num_water_atoms

--- a/examples/biphenyl_torsion_sampling_hrex.py
+++ b/examples/biphenyl_torsion_sampling_hrex.py
@@ -165,13 +165,13 @@ def sample_biphenyl_hrex(
 
     if solvent:
         # construct water box
-        water_system, water_coords, water_box, _ = builders.build_water_system(
+        water_system, water_coords, water_box, water_top = builders.build_water_system(
             box_width=3.0, water_ff=ff.water_ff, mols=[mol]
         )
         water_box += 0.5 * np.eye(3)  # add a small margin around the box for stability
         num_water_atoms = water_coords.shape[0]
-        host_config = HostConfig(water_system, water_coords, water_box, num_water_atoms)
-        host_bps, host_masses = openmm_deserializer.deserialize_system(water_system, cutoff=1.2)
+        host_config = HostConfig(water_system, water_coords, water_box, num_water_atoms, water_top)
+        host_bps, host_masses = openmm_deserializer.deserialize_system(water_system, water_top, ff, cutoff=1.2)
 
         top = HostGuestTopology(host_bps, bt, num_water_atoms)
 

--- a/examples/water_sampling_common.py
+++ b/examples/water_sampling_common.py
@@ -80,12 +80,12 @@ def get_initial_state(water_pdb, mol, ff, seed, nb_cutoff, use_hmr, lamb):
 
     assert num_water_atoms == len(solvent_conf)
 
-    host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, num_water_atoms)
+    host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, num_water_atoms, solvent_topology)
     if mol is not None:
         # Assumes the mol is a buckyball
         bt = BaseTopology(mol, ff)
         afe = AbsoluteFreeEnergy(mol, bt)
-        potentials, params, combined_masses = afe.prepare_host_edge(ff.get_params(), host_config, lamb)
+        potentials, params, combined_masses = afe.prepare_host_edge(ff, host_config, lamb)
         ligand_idxs = np.arange(num_water_atoms, num_water_atoms + mol.GetNumAtoms(), dtype=np.int32)
         summed_pot_idx = next(i for i, pot in enumerate(potentials) if isinstance(pot, SummedPotential))
         nb_params = np.array(params[summed_pot_idx])
@@ -108,7 +108,9 @@ def get_initial_state(water_pdb, mol, ff, seed, nb_cutoff, use_hmr, lamb):
         ligand_water_params[fully_coupled_ligand_atoms, -1] = 0
         nb_params[ligand_water_flat_idxs] = ligand_water_params.reshape(-1)
     else:
-        host_fns, combined_masses = openmm_deserializer.deserialize_system(host_config.omm_system, cutoff=nb_cutoff)
+        host_fns, combined_masses = openmm_deserializer.deserialize_system(
+            host_config.omm_system, host_config.omm_topology, ff, cutoff=nb_cutoff
+        )
         potentials = [bp.potential for bp in host_fns]
         params = [bp.params for bp in host_fns]
         final_conf = solvent_conf

--- a/examples/water_sampling_common.py
+++ b/examples/water_sampling_common.py
@@ -108,9 +108,7 @@ def get_initial_state(water_pdb, mol, ff, seed, nb_cutoff, use_hmr, lamb):
         ligand_water_params[fully_coupled_ligand_atoms, -1] = 0
         nb_params[ligand_water_flat_idxs] = ligand_water_params.reshape(-1)
     else:
-        host_fns, combined_masses = openmm_deserializer.deserialize_system(
-            host_config.omm_system, host_config.omm_topology, ff, cutoff=nb_cutoff
-        )
+        host_fns, combined_masses = openmm_deserializer.deserialize_system(host_config.omm_system, cutoff=nb_cutoff)
         potentials = [bp.potential for bp in host_fns]
         params = [bp.params for bp in host_fns]
         final_conf = solvent_conf

--- a/tests/common.py
+++ b/tests/common.py
@@ -437,7 +437,7 @@ def check_split_ixns(
     ffs = load_split_forcefields()
 
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as path_to_pdb:
-        complex_system, host_conf, box, _, num_water_atoms = build_protein_system(
+        complex_system, host_conf, box, complex_top, num_water_atoms = build_protein_system(
             str(path_to_pdb), ffs.ref.protein_ff, ffs.ref.water_ff
         )
         box += np.diag([0.1, 0.1, 0.1])
@@ -447,7 +447,7 @@ def check_split_ixns(
     protein_idxs = np.arange(num_protein_atoms, dtype=np.int32)
     water_idxs = np.arange(num_water_atoms, dtype=np.int32) + num_protein_atoms
     num_host_atoms = host_conf.shape[0]
-    host_bps, host_masses = openmm_deserializer.deserialize_system(complex_system, cutoff=1.2)
+    host_bps, host_masses = openmm_deserializer.deserialize_system(complex_system, complex_top, ffs.ref, cutoff=1.2)
     ligand_idxs += num_host_atoms  # shift for the host
 
     n_lambdas = 3

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,7 +3,7 @@ import itertools
 import os
 import unittest
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from importlib import resources
 from tempfile import TemporaryDirectory
 from typing import Optional
@@ -18,12 +18,13 @@ from timemachine.fe import rbfe
 from timemachine.fe.free_energy import HostConfig
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.ff import Forcefield
-from timemachine.ff.handlers import openmm_deserializer
+from timemachine.ff.handlers import nonbonded, openmm_deserializer
 from timemachine.lib import custom_ops
 from timemachine.md.builders import build_protein_system
 from timemachine.potentials import Nonbonded
 from timemachine.potentials.potential import GpuImplWrapper
 from timemachine.potentials.types import PotentialFxn
+from timemachine.testsystems.data.ildn_params import get_amber99ildn_patterns
 
 HILBERT_GRID_DIM = 128
 
@@ -393,6 +394,10 @@ def load_split_forcefields() -> SplitForcefield:
     SIG_SCALE = 0.5  # smaller change to prevent overflow
     EPS_SCALE = 2.0
 
+    patterns = get_amber99ildn_patterns()
+    protein_smirks = [x[0] for x in patterns]
+    protein_params = np.ones((len(protein_smirks),)) * 0.5
+
     ff_ref = Forcefield.load_default()
 
     ff_intra = Forcefield.load_default()
@@ -408,6 +413,9 @@ def load_split_forcefields() -> SplitForcefield:
     ff_env.q_handle.params *= Q_SCALE
     ff_env.lj_handle.params[:, SIG_IDX] *= SIG_SCALE
     ff_env.lj_handle.params[:, EPS_IDX] *= EPS_SCALE
+    env_bcc_handle = nonbonded.EnvironmentBCCPartialHandler(protein_smirks, protein_params, None)
+    ff_env = replace(ff_env, env_bcc_handle=env_bcc_handle)
+    assert ff_env.env_bcc_handle is not None
 
     ff_scaled = Forcefield.load_default()
     assert ff_scaled.q_handle is not None
@@ -420,6 +428,9 @@ def load_split_forcefields() -> SplitForcefield:
     ff_scaled.lj_handle.params[:, EPS_IDX] *= EPS_SCALE
     ff_scaled.lj_handle_intra.params[:, SIG_IDX] *= SIG_SCALE
     ff_scaled.lj_handle_intra.params[:, EPS_IDX] *= EPS_SCALE
+    env_bcc_handle = nonbonded.EnvironmentBCCPartialHandler(protein_smirks, protein_params, None)
+    ff_scaled = replace(ff_scaled, env_bcc_handle=env_bcc_handle)
+    assert ff_scaled.env_bcc_handle is not None
     return SplitForcefield(ff_ref, ff_intra, ff_env, ff_scaled)
 
 
@@ -447,7 +458,7 @@ def check_split_ixns(
     protein_idxs = np.arange(num_protein_atoms, dtype=np.int32)
     water_idxs = np.arange(num_water_atoms, dtype=np.int32) + num_protein_atoms
     num_host_atoms = host_conf.shape[0]
-    host_bps, host_masses = openmm_deserializer.deserialize_system(complex_system, complex_top, ffs.ref, cutoff=1.2)
+    host_bps, host_masses = openmm_deserializer.deserialize_system(complex_system, cutoff=1.2)
     ligand_idxs += num_host_atoms  # shift for the host
 
     n_lambdas = 3
@@ -471,7 +482,9 @@ def check_split_ixns(
         LL_grad_ref, LL_u_ref = compute_intra_grad_u(
             ffs.ref, precision, ligand_conf, box, lamb, num_water_atoms, num_host_atoms
         )
-        sum_grad_ref, sum_u_ref = compute_ref_grad_u(ffs.ref, precision, coords0, box, lamb, num_water_atoms, host_bps)
+        sum_grad_ref, sum_u_ref = compute_ref_grad_u(
+            ffs.ref, precision, coords0, box, lamb, num_water_atoms, host_bps, complex_top
+        )
         PL_grad_ref, PL_u_ref = compute_ixn_grad_u(
             ffs.ref,
             precision,
@@ -483,6 +496,7 @@ def check_split_ixns(
             water_idxs,
             ligand_idxs,
             protein_idxs,
+            complex_top,
             is_solvent=False,
         )
         WL_grad_ref, WL_u_ref = compute_ixn_grad_u(
@@ -496,18 +510,21 @@ def check_split_ixns(
             water_idxs,
             ligand_idxs,
             protein_idxs,
+            complex_top,
             is_solvent=True,
         )
 
         # Should be the same as the new code with the orig ff
-        sum_grad_new, sum_u_new = compute_new_grad_u(ffs.ref, precision, coords0, box, lamb, num_water_atoms, host_bps)
+        sum_grad_new, sum_u_new = compute_new_grad_u(
+            ffs.ref, precision, coords0, box, lamb, num_water_atoms, host_bps, complex_top
+        )
 
         np.testing.assert_allclose(sum_u_ref, sum_u_new, rtol=rtol, atol=atol)
         np.testing.assert_allclose(sum_grad_ref, sum_grad_new, rtol=rtol, atol=atol)
 
         # Compute the grads, potential with the intramolecular terms scaled
         sum_grad_intra, sum_u_intra = compute_new_grad_u(
-            ffs.intra, precision, coords0, box, lamb, num_water_atoms, host_bps
+            ffs.intra, precision, coords0, box, lamb, num_water_atoms, host_bps, complex_top
         )
         LL_grad_intra, LL_u_intra = compute_intra_grad_u(
             ffs.intra, precision, ligand_conf, box, lamb, num_water_atoms, num_host_atoms
@@ -522,7 +539,7 @@ def check_split_ixns(
 
         # Compute the grads, potential with the ligand-env terms scaled
         sum_grad_prot, sum_u_prot = compute_new_grad_u(
-            ffs.env, precision, coords0, box, lamb, num_water_atoms, host_bps
+            ffs.env, precision, coords0, box, lamb, num_water_atoms, host_bps, complex_top
         )
         PL_grad_env, PL_u_env = compute_ixn_grad_u(
             ffs.env,
@@ -535,6 +552,7 @@ def check_split_ixns(
             water_idxs,
             ligand_idxs,
             protein_idxs,
+            complex_top,
             is_solvent=False,
         )
         WL_grad_env, WL_u_env = compute_ixn_grad_u(
@@ -548,6 +566,7 @@ def check_split_ixns(
             water_idxs,
             ligand_idxs,
             protein_idxs,
+            complex_top,
             is_solvent=True,
         )
 

--- a/tests/nonbonded/test_atom_by_atom_energies.py
+++ b/tests/nonbonded/test_atom_by_atom_energies.py
@@ -23,8 +23,8 @@ def test_nonbonded_atom_by_atom_energies_match(num_mols, adjustments, precision,
     """Verify that if looking at not computing the subsets of energies matches the references"""
     rng = np.random.default_rng(2023)
     ff = Forcefield.load_default()
-    system, conf, box, _ = builders.build_water_system(4.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    system, conf, box, top = builders.build_water_system(4.0, ff.water_ff)
+    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 

--- a/tests/nonbonded/test_atom_by_atom_energies.py
+++ b/tests/nonbonded/test_atom_by_atom_energies.py
@@ -24,7 +24,7 @@ def test_nonbonded_atom_by_atom_energies_match(num_mols, adjustments, precision,
     rng = np.random.default_rng(2023)
     ff = Forcefield.load_default()
     system, conf, box, top = builders.build_water_system(4.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 

--- a/tests/nonbonded/test_nonbonded.py
+++ b/tests/nonbonded/test_nonbonded.py
@@ -171,7 +171,7 @@ def test_nblist_box_resize(precision, rtol, atol, du_dp_rtol, du_dp_atol):
 
     host_system, host_conf, box, top = builders.build_water_system(3.0, ff.water_ff)
 
-    host_fns, host_masses = openmm_deserializer.deserialize_system(host_system, top, ff, cutoff=1.2)
+    host_fns, host_masses = openmm_deserializer.deserialize_system(host_system, cutoff=1.2)
 
     test_bp = get_bound_potential_by_type(host_fns, potentials.Nonbonded)
     assert test_bp.params is not None

--- a/tests/nonbonded/test_nonbonded.py
+++ b/tests/nonbonded/test_nonbonded.py
@@ -169,9 +169,9 @@ def test_nblist_box_resize(precision, rtol, atol, du_dp_rtol, du_dp_atol):
     # since we should be rebuilding the nblist when the box sizes change.
     ff = Forcefield.load_default()
 
-    host_system, host_conf, box, _ = builders.build_water_system(3.0, ff.water_ff)
+    host_system, host_conf, box, top = builders.build_water_system(3.0, ff.water_ff)
 
-    host_fns, host_masses = openmm_deserializer.deserialize_system(host_system, cutoff=1.2)
+    host_fns, host_masses = openmm_deserializer.deserialize_system(host_system, top, ff, cutoff=1.2)
 
     test_bp = get_bound_potential_by_type(host_fns, potentials.Nonbonded)
     assert test_bp.params is not None

--- a/tests/nonbonded/test_nonbonded_mol_energy.py
+++ b/tests/nonbonded/test_nonbonded_mol_energy.py
@@ -69,9 +69,9 @@ def test_nonbonded_mol_energy_matches_exchange_mover_batch_U(num_mols, precision
     """Assert that NonbondedMolEnergyPotential Cuda implementation produces the same
     energies as the reference jax version in the BDExchangeMover"""
     ff = Forcefield.load_default()
-    system, conf, box, _ = builders.build_water_system(5.0, ff.water_ff)
+    system, conf, box, top = builders.build_water_system(5.0, ff.water_ff)
     box += np.eye(3) * 0.1
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
@@ -122,8 +122,8 @@ def test_nonbonded_mol_energy_random_moves(box_size, num_mols, moves, precision,
     rng = np.random.default_rng(2023)
     ff = Forcefield.load_default()
 
-    system, conf, _, _ = builders.build_water_system(box_size, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    system, conf, _, top = builders.build_water_system(box_size, ff.water_ff)
+    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
@@ -205,8 +205,8 @@ def test_nonbonded_mol_energy_matches_exchange_mover_batch_U_in_complex(precisio
     """Test that computing the per water energies of a system with a complex is equivalent."""
     ff = Forcefield.load_default()
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as path_to_pdb:
-        complex_system, conf, box, _, _ = builders.build_protein_system(str(path_to_pdb), ff.protein_ff, ff.water_ff)
-    bps, masses = openmm_deserializer.deserialize_system(complex_system, cutoff=1.2)
+        complex_system, conf, box, top, _ = builders.build_protein_system(str(path_to_pdb), ff.protein_ff, ff.water_ff)
+    bps, masses = openmm_deserializer.deserialize_system(complex_system, top, ff, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 

--- a/tests/nonbonded/test_nonbonded_mol_energy.py
+++ b/tests/nonbonded/test_nonbonded_mol_energy.py
@@ -71,7 +71,7 @@ def test_nonbonded_mol_energy_matches_exchange_mover_batch_U(num_mols, precision
     ff = Forcefield.load_default()
     system, conf, box, top = builders.build_water_system(5.0, ff.water_ff)
     box += np.eye(3) * 0.1
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
@@ -123,7 +123,7 @@ def test_nonbonded_mol_energy_random_moves(box_size, num_mols, moves, precision,
     ff = Forcefield.load_default()
 
     system, conf, _, top = builders.build_water_system(box_size, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
@@ -206,7 +206,7 @@ def test_nonbonded_mol_energy_matches_exchange_mover_batch_U_in_complex(precisio
     ff = Forcefield.load_default()
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as path_to_pdb:
         complex_system, conf, box, top, _ = builders.build_protein_system(str(path_to_pdb), ff.protein_ff, ff.water_ff)
-    bps, masses = openmm_deserializer.deserialize_system(complex_system, top, ff, cutoff=1.2)
+    bps, masses = openmm_deserializer.deserialize_system(complex_system, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 

--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -89,8 +89,8 @@ def test_barostat_with_clashes():
     box -= np.eye(3) * 0.1
     bt = BaseTopology(mol_a, ff)
     afe = AbsoluteFreeEnergy(mol_a, bt)
-    host_config = HostConfig(host_system, host_coords, box, host_coords.shape[0])
-    unbound_potentials, sys_params, masses = afe.prepare_host_edge(ff.get_params(), host_config, 0.0)
+    host_config = HostConfig(host_system, host_coords, box, host_coords.shape[0], host_top)
+    unbound_potentials, sys_params, masses = afe.prepare_host_edge(ff, host_config, 0.0)
     coords = afe.prepare_combined_coords(host_coords=host_coords)
 
     # get list of molecules for barostat by looking at bond table
@@ -302,9 +302,9 @@ def test_barostat_varying_pressure():
 
     # Start out with a very large pressure
     pressure = 1013.0
-    host_system, coords, box, _ = build_water_system(3.0, ff.water_ff)
+    host_system, coords, box, host_top = build_water_system(3.0, ff.water_ff)
     box += np.eye(3) * 0.1
-    bps, masses_ = openmm_deserializer.deserialize_system(host_system, cutoff=1.2)
+    bps, masses_ = openmm_deserializer.deserialize_system(host_system, host_top, ff, cutoff=1.2)
 
     masses = np.array(masses_)
 

--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -304,7 +304,7 @@ def test_barostat_varying_pressure():
     pressure = 1013.0
     host_system, coords, box, host_top = build_water_system(3.0, ff.water_ff)
     box += np.eye(3) * 0.1
-    bps, masses_ = openmm_deserializer.deserialize_system(host_system, host_top, ff, cutoff=1.2)
+    bps, masses_ = openmm_deserializer.deserialize_system(host_system, cutoff=1.2)
 
     masses = np.array(masses_)
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -471,9 +471,7 @@ def run_single_topology_benchmarks(
     initial_state = prepare_single_topology_initial_state(st, host_config)
     barostat_interval = 0
     if host_config is not None:
-        host_fns, host_masses = openmm_deserializer.deserialize_system(
-            host_config.omm_system, host_config.omm_topology, st.ff, cutoff=1.2
-        )
+        host_fns, host_masses = openmm_deserializer.deserialize_system(host_config.omm_system, cutoff=1.2)
 
         # RBFE
         x0 = initial_state.x0[: len(host_config.conf)]

--- a/tests/test_benchmark_free_energy.py
+++ b/tests/test_benchmark_free_energy.py
@@ -66,15 +66,17 @@ def setup_hif2a_single_topology_leg(host_name: str, n_windows: int, lambda_endpo
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     if host_name == "complex":
         with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as protein_path:
-            host_sys, host_conf, box, _, num_water_atoms = builders.build_protein_system(
+            host_sys, host_conf, box, host_top, num_water_atoms = builders.build_protein_system(
                 str(protein_path), forcefield.protein_ff, forcefield.water_ff, mols=[mol_a, mol_b]
             )
             box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-        host_config = HostConfig(host_sys, host_conf, box, num_water_atoms)
+        host_config = HostConfig(host_sys, host_conf, box, num_water_atoms, host_top)
     elif host_name == "solvent":
-        host_sys, host_conf, box, _ = builders.build_water_system(4.0, forcefield.water_ff, mols=[mol_a, mol_b])
+        solvent_sys, solvent_conf, box, solvent_top = builders.build_water_system(
+            4.0, forcefield.water_ff, mols=[mol_a, mol_b]
+        )
         box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-        host_config = HostConfig(host_sys, host_conf, box, host_conf.shape[0])
+        host_config = HostConfig(solvent_sys, solvent_conf, box, solvent_conf.shape[0], solvent_top)
 
     single_topology = SingleTopology(mol_a, mol_b, core, forcefield)
     host = setup_optimized_host(single_topology, host_config) if host_config else None

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -7,7 +7,7 @@ from openmm import app, unit
 
 from timemachine.constants import DEFAULT_PROTEIN_FF, DEFAULT_WATER_FF
 from timemachine.fe.utils import get_romol_conf, read_sdf, set_romol_conf
-from timemachine.ff import Forcefield, sanitize_water_ff
+from timemachine.ff import sanitize_water_ff
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md.barostat.utils import compute_box_volume
 from timemachine.md.builders import build_protein_system, build_water_system
@@ -17,7 +17,6 @@ from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topolo
 
 def test_build_water_system():
     mol_a, mol_b, _ = get_hif2a_ligand_pair_single_topology()
-    ff = Forcefield.load_default()
 
     water_system, water_coords, box, water_top = build_water_system(4.0, DEFAULT_WATER_FF)
 
@@ -44,7 +43,7 @@ def test_build_water_system():
     box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     box_with_mols += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
 
-    water_system_bps, _ = openmm_deserializer.deserialize_system(water_system, water_top, ff, cutoff=1.2)
+    water_system_bps, _ = openmm_deserializer.deserialize_system(water_system, cutoff=1.2)
     for bp in water_system_bps:
         (
             du_dx,
@@ -54,7 +53,7 @@ def test_build_water_system():
         ).bound_impl.execute(water_coords, box, compute_u=False)
         check_force_norm(-du_dx)
 
-    water_system_bps, _ = openmm_deserializer.deserialize_system(water_with_mols, water_with_mols_top, ff, cutoff=1.2)
+    water_system_bps, _ = openmm_deserializer.deserialize_system(water_with_mols, cutoff=1.2)
     for bp in water_system_bps:
         (
             du_dx,
@@ -116,7 +115,6 @@ def test_build_protein_system_waters_before_protein():
 def test_build_protein_system():
     rng = np.random.default_rng(2024)
     mol_a, mol_b, _ = get_hif2a_ligand_pair_single_topology()
-    ff = Forcefield.load_default()
 
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as pdb_path:
         host_pdbfile = str(pdb_path)
@@ -142,7 +140,7 @@ def test_build_protein_system():
     box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     box_with_mols += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
 
-    protein_system_bps, _ = openmm_deserializer.deserialize_system(protein_system, protein_top, ff, cutoff=1.2)
+    protein_system_bps, _ = openmm_deserializer.deserialize_system(protein_system, cutoff=1.2)
     for bp in protein_system_bps:
         (
             du_dx,
@@ -152,9 +150,7 @@ def test_build_protein_system():
         ).bound_impl.execute(protein_coords, box, compute_u=False)
         check_force_norm(-du_dx)
 
-    protein_system_bps, _ = openmm_deserializer.deserialize_system(
-        protein_with_mols, protein_with_mols_top, ff, cutoff=1.2
-    )
+    protein_system_bps, _ = openmm_deserializer.deserialize_system(protein_with_mols, cutoff=1.2)
     for bp in protein_system_bps:
         (
             du_dx,

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -7,7 +7,7 @@ from openmm import app, unit
 
 from timemachine.constants import DEFAULT_PROTEIN_FF, DEFAULT_WATER_FF
 from timemachine.fe.utils import get_romol_conf, read_sdf, set_romol_conf
-from timemachine.ff import sanitize_water_ff
+from timemachine.ff import Forcefield, sanitize_water_ff
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md.barostat.utils import compute_box_volume
 from timemachine.md.builders import build_protein_system, build_water_system
@@ -17,10 +17,13 @@ from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topolo
 
 def test_build_water_system():
     mol_a, mol_b, _ = get_hif2a_ligand_pair_single_topology()
+    ff = Forcefield.load_default()
 
-    water_system, water_coords, box, _ = build_water_system(4.0, DEFAULT_WATER_FF)
+    water_system, water_coords, box, water_top = build_water_system(4.0, DEFAULT_WATER_FF)
 
-    water_with_mols, mol_water_coords, box_with_mols, _ = build_water_system(4.0, DEFAULT_WATER_FF, mols=[mol_a, mol_b])
+    water_with_mols, mol_water_coords, box_with_mols, water_with_mols_top = build_water_system(
+        4.0, DEFAULT_WATER_FF, mols=[mol_a, mol_b]
+    )
 
     # No waters should be deleted, but the box will be slightly larger
     assert len(water_coords) == len(mol_water_coords)
@@ -41,7 +44,7 @@ def test_build_water_system():
     box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     box_with_mols += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
 
-    water_system_bps, _ = openmm_deserializer.deserialize_system(water_system, cutoff=1.2)
+    water_system_bps, _ = openmm_deserializer.deserialize_system(water_system, water_top, ff, cutoff=1.2)
     for bp in water_system_bps:
         (
             du_dx,
@@ -51,7 +54,7 @@ def test_build_water_system():
         ).bound_impl.execute(water_coords, box, compute_u=False)
         check_force_norm(-du_dx)
 
-    water_system_bps, _ = openmm_deserializer.deserialize_system(water_with_mols, cutoff=1.2)
+    water_system_bps, _ = openmm_deserializer.deserialize_system(water_with_mols, water_with_mols_top, ff, cutoff=1.2)
     for bp in water_system_bps:
         (
             du_dx,
@@ -113,17 +116,22 @@ def test_build_protein_system_waters_before_protein():
 def test_build_protein_system():
     rng = np.random.default_rng(2024)
     mol_a, mol_b, _ = get_hif2a_ligand_pair_single_topology()
+    ff = Forcefield.load_default()
 
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as pdb_path:
         host_pdbfile = str(pdb_path)
-    protein_system, protein_coords, box, _, num_water_atoms = build_protein_system(
+    protein_system, protein_coords, box, protein_top, num_water_atoms = build_protein_system(
         host_pdbfile, DEFAULT_PROTEIN_FF, DEFAULT_WATER_FF
     )
     num_host_atoms = protein_coords.shape[0] - num_water_atoms
 
-    protein_with_mols, mol_protein_coords, box_with_mols, _, num_water_atoms_with_mols = build_protein_system(
-        host_pdbfile, DEFAULT_PROTEIN_FF, DEFAULT_WATER_FF, mols=[mol_a, mol_b]
-    )
+    (
+        protein_with_mols,
+        mol_protein_coords,
+        box_with_mols,
+        protein_with_mols_top,
+        num_water_atoms_with_mols,
+    ) = build_protein_system(host_pdbfile, DEFAULT_PROTEIN_FF, DEFAULT_WATER_FF, mols=[mol_a, mol_b])
     num_host_atoms_with_mol = mol_protein_coords.shape[0] - num_water_atoms_with_mols
 
     assert num_host_atoms == num_host_atoms_with_mol
@@ -134,7 +142,7 @@ def test_build_protein_system():
     box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     box_with_mols += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
 
-    protein_system_bps, _ = openmm_deserializer.deserialize_system(protein_system, cutoff=1.2)
+    protein_system_bps, _ = openmm_deserializer.deserialize_system(protein_system, protein_top, ff, cutoff=1.2)
     for bp in protein_system_bps:
         (
             du_dx,
@@ -144,7 +152,9 @@ def test_build_protein_system():
         ).bound_impl.execute(protein_coords, box, compute_u=False)
         check_force_norm(-du_dx)
 
-    protein_system_bps, _ = openmm_deserializer.deserialize_system(protein_with_mols, cutoff=1.2)
+    protein_system_bps, _ = openmm_deserializer.deserialize_system(
+        protein_with_mols, protein_with_mols_top, ff, cutoff=1.2
+    )
     for bp in protein_system_bps:
         (
             du_dx,

--- a/tests/test_cuda_bd_exchange_mover.py
+++ b/tests/test_cuda_bd_exchange_mover.py
@@ -201,7 +201,7 @@ def test_pair_of_waters_in_box(proposals_per_move, total_num_proposals, batch_si
     """Given two waters in a large box most moves should be accepted. This is a useful test for verifying memory doesn't leak"""
     ff = Forcefield.load_default()
     system, host_conf, _, top = builders.build_water_system(1.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
@@ -262,7 +262,7 @@ def test_sampling_single_water_in_bulk(
     ff = Forcefield.load_default()
     system, conf, box, top = builders.build_water_system(2.5, ff.water_ff)
     box += np.diag([0.1, 0.1, 0.1])
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
@@ -314,7 +314,7 @@ def test_bias_deletion_bulk_water_with_context(precision, seed, batch_size):
     ff = Forcefield.load_default()
     system, conf, box, top = builders.build_water_system(4.0, ff.water_ff)
     box += np.diag([0.1, 0.1, 0.1])
-    bps, masses = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
@@ -403,7 +403,7 @@ def test_bd_exchange_deterministic_moves(proposals_per_move, batch_size, precisi
     """
     ff = Forcefield.load_default()
     system, conf, _, top = builders.build_water_system(1.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
@@ -462,7 +462,7 @@ def test_bd_exchange_deterministic_batch_moves(proposals_per_move, batch_size, p
     """
     ff = Forcefield.load_default()
     system, conf, _, top = builders.build_water_system(1.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
@@ -545,7 +545,7 @@ def test_moves_in_a_water_box(
     ff = Forcefield.load_default()
     system, conf, box, top = builders.build_water_system(box_size, ff.water_ff)
     box += np.diag([0.1, 0.1, 0.1])
-    bps, masses = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
@@ -713,7 +713,7 @@ def test_compute_incremental_log_weights(batch_size, samples, box_size, precisio
     proposals_per_move = batch_size  # Number doesn't matter here, we aren't calling move
     ff = Forcefield.load_default()
     system, conf, box, top = builders.build_water_system(box_size, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
@@ -783,7 +783,7 @@ def hif2a_complex():
             str(path_to_pdb), ff.protein_ff, ff.water_ff
         )
     box += np.diag([0.1, 0.1, 0.1])
-    bps, masses = openmm_deserializer.deserialize_system(complex_system, complex_top, ff, cutoff=1.2)
+    bps, masses = openmm_deserializer.deserialize_system(complex_system, cutoff=1.2)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
     bond_list = get_bond_list(bond_pot)
@@ -842,9 +842,8 @@ def hif2a_complex():
 def test_moves_with_complex(
     hif2a_complex, num_proposals_per_move, total_num_proposals, batch_size, precision, rtol, atol, seed
 ):
-    ff = Forcefield.load_default()
     complex_system, conf, box, complex_top = hif2a_complex
-    bps, masses = openmm_deserializer.deserialize_system(complex_system, complex_top, ff, cutoff=1.2)
+    bps, masses = openmm_deserializer.deserialize_system(complex_system, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 

--- a/tests/test_cuda_bd_exchange_mover.py
+++ b/tests/test_cuda_bd_exchange_mover.py
@@ -200,8 +200,8 @@ def test_bd_exchange_get_set_params(precision):
 def test_pair_of_waters_in_box(proposals_per_move, total_num_proposals, batch_size, precision, rtol, atol, seed):
     """Given two waters in a large box most moves should be accepted. This is a useful test for verifying memory doesn't leak"""
     ff = Forcefield.load_default()
-    system, host_conf, _, _ = builders.build_water_system(1.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    system, host_conf, _, top = builders.build_water_system(1.0, ff.water_ff)
+    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
@@ -260,9 +260,9 @@ def test_sampling_single_water_in_bulk(
 ):
     """Sample a single water in a box of water. Useful to verify that we are hitting the tail end of buffers"""
     ff = Forcefield.load_default()
-    system, conf, box, _ = builders.build_water_system(2.5, ff.water_ff)
+    system, conf, box, top = builders.build_water_system(2.5, ff.water_ff)
     box += np.diag([0.1, 0.1, 0.1])
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
@@ -312,9 +312,9 @@ def test_sampling_single_water_in_bulk(
 @pytest.mark.parametrize("seed", [2023])
 def test_bias_deletion_bulk_water_with_context(precision, seed, batch_size):
     ff = Forcefield.load_default()
-    system, conf, box, _ = builders.build_water_system(4.0, ff.water_ff)
+    system, conf, box, top = builders.build_water_system(4.0, ff.water_ff)
     box += np.diag([0.1, 0.1, 0.1])
-    bps, masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    bps, masses = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
@@ -402,8 +402,8 @@ def test_bd_exchange_deterministic_moves(proposals_per_move, batch_size, precisi
     * When we attempt K proposals in a batch (each proposal is made up of K proposals) it produces the same as the serial version
     """
     ff = Forcefield.load_default()
-    system, conf, _, _ = builders.build_water_system(1.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    system, conf, _, top = builders.build_water_system(1.0, ff.water_ff)
+    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
@@ -461,8 +461,8 @@ def test_bd_exchange_deterministic_batch_moves(proposals_per_move, batch_size, p
     increase the number of proposals per move in the constructor that the results should be identical
     """
     ff = Forcefield.load_default()
-    system, conf, _, _ = builders.build_water_system(1.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    system, conf, _, top = builders.build_water_system(1.0, ff.water_ff)
+    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
@@ -543,9 +543,9 @@ def test_moves_in_a_water_box(
 ):
     """Verify that the log acceptance probability between the reference and cuda implementation agree"""
     ff = Forcefield.load_default()
-    system, conf, box, _ = builders.build_water_system(box_size, ff.water_ff)
+    system, conf, box, top = builders.build_water_system(box_size, ff.water_ff)
     box += np.diag([0.1, 0.1, 0.1])
-    bps, masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    bps, masses = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
@@ -712,8 +712,8 @@ def test_compute_incremental_log_weights(batch_size, samples, box_size, precisio
     """Verify that the incremental weights computed are valid for different collections of rotations/translations"""
     proposals_per_move = batch_size  # Number doesn't matter here, we aren't calling move
     ff = Forcefield.load_default()
-    system, conf, box, _ = builders.build_water_system(box_size, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    system, conf, box, top = builders.build_water_system(box_size, ff.water_ff)
+    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
@@ -779,9 +779,11 @@ def hif2a_complex():
     seed = 2023
     ff = Forcefield.load_default()
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as path_to_pdb:
-        complex_system, conf, box, _, _ = builders.build_protein_system(str(path_to_pdb), ff.protein_ff, ff.water_ff)
+        complex_system, conf, box, complex_top, _ = builders.build_protein_system(
+            str(path_to_pdb), ff.protein_ff, ff.water_ff
+        )
     box += np.diag([0.1, 0.1, 0.1])
-    bps, masses = openmm_deserializer.deserialize_system(complex_system, cutoff=1.2)
+    bps, masses = openmm_deserializer.deserialize_system(complex_system, complex_top, ff, cutoff=1.2)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
     bond_list = get_bond_list(bond_pot)
@@ -826,7 +828,7 @@ def hif2a_complex():
     for bp in bound_impls:
         du_dx, _ = bp.execute(conf, box, True, False)
         check_force_norm(-du_dx)
-    return complex_system, conf, box
+    return complex_system, conf, box, complex_top
 
 
 @pytest.mark.parametrize(
@@ -840,8 +842,9 @@ def hif2a_complex():
 def test_moves_with_complex(
     hif2a_complex, num_proposals_per_move, total_num_proposals, batch_size, precision, rtol, atol, seed
 ):
-    complex_system, conf, box = hif2a_complex
-    bps, masses = openmm_deserializer.deserialize_system(complex_system, cutoff=1.2)
+    ff = Forcefield.load_default()
+    complex_system, conf, box, complex_top = hif2a_complex
+    bps, masses = openmm_deserializer.deserialize_system(complex_system, complex_top, ff, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
@@ -890,11 +893,11 @@ def hif2a_rbfe_state() -> InitialState:
     seed = 2023
     ff = Forcefield.load_default()
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as path_to_pdb:
-        complex_system, complex_conf, box, _, num_water_atoms = builders.build_protein_system(
+        complex_system, complex_conf, box, complex_top, num_water_atoms = builders.build_protein_system(
             str(path_to_pdb), ff.protein_ff, ff.water_ff
         )
     box += np.diag([0.1, 0.1, 0.1])
-    host_config = HostConfig(complex_system, complex_conf, box, num_water_atoms)
+    host_config = HostConfig(complex_system, complex_conf, box, num_water_atoms, complex_top)
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     st = SingleTopology(mol_a, mol_b, core, ff)
 

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -178,7 +178,7 @@ def test_inner_and_outer_water_groups(seed, radius, precision):
     rng = np.random.default_rng(seed)
     ff = Forcefield.load_default()
     system, coords, box, top = builders.build_water_system(4.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
@@ -218,7 +218,7 @@ def test_translations_inside_and_outside_sphere(seed, n_translations, radius, pr
     rng = np.random.default_rng(seed)
     ff = Forcefield.load_default()
     system, coords, box, top = builders.build_water_system(4.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
@@ -577,7 +577,7 @@ def test_tibd_exchange_deterministic_batch_moves(radius, proposals_per_move, bat
     rng = np.random.default_rng(seed)
     ff = Forcefield.load_default()
     system, conf, _, top = builders.build_water_system(1.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
@@ -765,7 +765,7 @@ def test_tibd_exchange_deterministic_moves(radius, proposals_per_move, batch_siz
     """
     ff = Forcefield.load_default()
     system, conf, _, top = builders.build_water_system(1.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
@@ -855,7 +855,7 @@ def test_targeted_moves_in_bulk_water(
     """Given bulk water molecules with one of them treated as the targeted region"""
     ff = Forcefield.load_default()
     system, conf, ref_box, top = builders.build_water_system(box_size, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
@@ -922,7 +922,7 @@ def test_moves_with_three_waters(
     """Given three water molecules with one of them treated as the targeted region."""
     ff = Forcefield.load_default()
     system, host_conf, _, top = builders.build_water_system(1.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -440,7 +440,7 @@ def test_targeted_insertion_buckyball_edge_cases(radius, moves, precision, rtol,
     bt = BaseTopology(mol, ff)
     afe = AbsoluteFreeEnergy(mol, bt)
     # Fully embed the ligand
-    potentials, params, combined_masses = afe.prepare_host_edge(ff.get_params(), host_config, 0.0)
+    potentials, params, combined_masses = afe.prepare_host_edge(ff, host_config, 0.0)
     ligand_idxs = np.arange(num_water_atoms, num_water_atoms + mol.GetNumAtoms())
 
     conf = afe.prepare_combined_coords(host_config.conf)
@@ -677,7 +677,7 @@ def test_targeted_insertion_buckyball_determinism(radius, proposals_per_move, ba
     bt = BaseTopology(mol, ff)
     afe = AbsoluteFreeEnergy(mol, bt)
     # Fully embed the ligand
-    potentials, params, combined_masses = afe.prepare_host_edge(ff.get_params(), host_config, 0.0)
+    potentials, params, combined_masses = afe.prepare_host_edge(ff, host_config, 0.0)
     ligand_idxs = np.arange(num_water_atoms, num_water_atoms + mol.GetNumAtoms())
 
     conf = afe.prepare_combined_coords(host_config.conf)

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -921,8 +921,8 @@ def test_moves_with_three_waters(
 ):
     """Given three water molecules with one of them treated as the targeted region."""
     ff = Forcefield.load_default()
-    system, host_conf, _, _ = builders.build_water_system(1.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    system, host_conf, _, top = builders.build_water_system(1.0, ff.water_ff)
+    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
 
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -43,7 +43,7 @@ def test_deterministic_energies(precision, rtol, atol):
         complex_system, complex_coords, complex_box, complex_top, num_water_atoms = builders.build_protein_system(
             str(path_to_pdb), ff.protein_ff, ff.water_ff
         )
-    host_fns, host_masses = openmm_deserializer.deserialize_system(complex_system, complex_top, ff, cutoff=1.2)
+    host_fns, host_masses = openmm_deserializer.deserialize_system(complex_system, cutoff=1.2)
 
     # resolve host clashes
     host_config = HostConfig(complex_system, complex_coords, complex_box, num_water_atoms, complex_top)

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -40,13 +40,13 @@ def test_deterministic_energies(precision, rtol, atol):
 
     # build the protein system.
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as path_to_pdb:
-        complex_system, complex_coords, complex_box, _, num_water_atoms = builders.build_protein_system(
+        complex_system, complex_coords, complex_box, complex_top, num_water_atoms = builders.build_protein_system(
             str(path_to_pdb), ff.protein_ff, ff.water_ff
         )
-    host_fns, host_masses = openmm_deserializer.deserialize_system(complex_system, cutoff=1.2)
+    host_fns, host_masses = openmm_deserializer.deserialize_system(complex_system, complex_top, ff, cutoff=1.2)
 
     # resolve host clashes
-    host_config = HostConfig(complex_system, complex_coords, complex_box, num_water_atoms)
+    host_config = HostConfig(complex_system, complex_coords, complex_box, num_water_atoms, complex_top)
     min_coords = minimizer.fire_minimize_host([mol_a, mol_b], host_config, ff)
 
     x0 = min_coords

--- a/tests/test_exchange_mover.py
+++ b/tests/test_exchange_mover.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from timemachine.constants import DEFAULT_KT, DEFAULT_WATER_FF
+from timemachine.ff import Forcefield
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.md.builders import build_water_system
@@ -19,8 +20,9 @@ pytestmark = [pytest.mark.nocuda]
 
 @pytest.mark.parametrize("num_lig_atoms", [1, 2, 3, 4, 10])
 def test_get_water_idxs(num_lig_atoms):
-    system, host_conf, _, _ = build_water_system(3.0, DEFAULT_WATER_FF)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    ff = Forcefield.load_default()
+    system, host_conf, _, top = build_water_system(3.0, DEFAULT_WATER_FF)
+    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
 
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 

--- a/tests/test_exchange_mover.py
+++ b/tests/test_exchange_mover.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 from timemachine.constants import DEFAULT_KT, DEFAULT_WATER_FF
-from timemachine.ff import Forcefield
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.md.builders import build_water_system
@@ -20,9 +19,8 @@ pytestmark = [pytest.mark.nocuda]
 
 @pytest.mark.parametrize("num_lig_atoms", [1, 2, 3, 4, 10])
 def test_get_water_idxs(num_lig_atoms):
-    ff = Forcefield.load_default()
     system, host_conf, _, top = build_water_system(3.0, DEFAULT_WATER_FF)
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
 
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 

--- a/tests/test_forcefields.py
+++ b/tests/test_forcefields.py
@@ -24,13 +24,15 @@ def test_serialization_of_ffs():
         ff = Forcefield.from_handlers(handlers, protein_ff=protein_ff, water_ff=water_ff)
         assert ff.protein_ff == constants.DEFAULT_PROTEIN_FF
         assert ff.water_ff == constants.DEFAULT_WATER_FF
-        handles = ff.get_ordered_handles()
-        for i, handle in enumerate(handles):
-            if i == len(handles) - 1:
-                # ff.env_bcc_handle is None
-                assert handle is None
-            else:
-                assert handle is not None, f"{path} failed to deserialize correctly"
+        assert ff.hb_handle is not None
+        assert ff.ha_handle is not None
+        assert ff.pt_handle is not None
+        assert ff.it_handle is not None
+        assert ff.q_handle is not None
+        assert ff.q_handle_intra is not None
+        assert ff.lj_handle is not None
+        assert ff.lj_handle_intra is not None
+        assert ff.env_bcc_handle is None
 
 
 def test_loading_forcefield_from_file():

--- a/tests/test_forcefields.py
+++ b/tests/test_forcefields.py
@@ -149,12 +149,8 @@ def test_amber14_tip3p_matches_tip3p():
     ref_system, _, _, ref_top = builders.build_water_system(4.0, constants.DEFAULT_WATER_FF)
     tip3p_system, _, _, tip3p_top = builders.build_water_system(4.0, tip3p_water_ff)
 
-    ref_ff = Forcefield.load_default()
-    ref_ff = Forcefield.from_handlers(ref_ff.get_ordered_handles(), water_ff=constants.DEFAULT_WATER_FF)
-    tip3p_ff = Forcefield.from_handlers(ref_ff.get_ordered_handles(), water_ff=tip3p_water_ff)
-
-    ref_pots, ref_masses = openmm_deserializer.deserialize_system(ref_system, ref_top, ref_ff, cutoff)
-    test_pots, test_masses = openmm_deserializer.deserialize_system(tip3p_system, tip3p_top, tip3p_ff, cutoff)
+    ref_pots, ref_masses = openmm_deserializer.deserialize_system(ref_system, cutoff)
+    test_pots, test_masses = openmm_deserializer.deserialize_system(tip3p_system, cutoff)
     np.testing.assert_array_equal(ref_masses, test_masses)
 
     assert len(ref_pots) == len(test_pots)

--- a/tests/test_forcefields.py
+++ b/tests/test_forcefields.py
@@ -24,8 +24,13 @@ def test_serialization_of_ffs():
         ff = Forcefield.from_handlers(handlers, protein_ff=protein_ff, water_ff=water_ff)
         assert ff.protein_ff == constants.DEFAULT_PROTEIN_FF
         assert ff.water_ff == constants.DEFAULT_WATER_FF
-        for handle in ff.get_ordered_handles():
-            assert handle is not None, f"{path} failed to deserialize correctly"
+        handles = ff.get_ordered_handles()
+        for i, handle in enumerate(handles):
+            if i == len(handles) - 1:
+                # ff.env_bcc_handle is None
+                assert handle is None
+            else:
+                assert handle is not None, f"{path} failed to deserialize correctly"
 
 
 def test_loading_forcefield_from_file():
@@ -86,6 +91,9 @@ def test_load_default():
     assert len(ref_handles) == len(test_handles)
 
     for ref_handle, test_handle in zip(ref.get_ordered_handles(), test.get_ordered_handles()):
+        if ref_handle is None:
+            assert test_handle is None
+            continue
         assert ref_handle.smirks == test_handle.smirks
         np.testing.assert_array_equal(ref_handle.params, test_handle.params)
 
@@ -113,6 +121,7 @@ def test_split():
             ff.q_handle_intra,
             ff.lj_handle,
             ff.lj_handle_intra,
+            ff.env_bcc_handle,  # None
         ]
 
         combined = combine_params(ff.get_params(), ff.get_params())
@@ -134,14 +143,18 @@ def test_split():
 def test_amber14_tip3p_matches_tip3p():
     """Verify that given a water box, the same parameters are produced for amber14/tip3p as tip3p, but with additional
     support for Ions"""
-    tip3p_ff = "tip3p"
+    tip3p_water_ff = "tip3p"
     cutoff = 1.2
-    assert constants.DEFAULT_WATER_FF != tip3p_ff
-    ref_system, _, _, _ = builders.build_water_system(4.0, constants.DEFAULT_WATER_FF)
-    tip3p_system, _, _, _ = builders.build_water_system(4.0, tip3p_ff)
+    assert constants.DEFAULT_WATER_FF != tip3p_water_ff
+    ref_system, _, _, ref_top = builders.build_water_system(4.0, constants.DEFAULT_WATER_FF)
+    tip3p_system, _, _, tip3p_top = builders.build_water_system(4.0, tip3p_water_ff)
 
-    ref_pots, ref_masses = openmm_deserializer.deserialize_system(ref_system, cutoff)
-    test_pots, test_masses = openmm_deserializer.deserialize_system(ref_system, cutoff)
+    ref_ff = Forcefield.load_default()
+    ref_ff = Forcefield.from_handlers(ref_ff.get_ordered_handles(), water_ff=constants.DEFAULT_WATER_FF)
+    tip3p_ff = Forcefield.from_handlers(ref_ff.get_ordered_handles(), water_ff=tip3p_water_ff)
+
+    ref_pots, ref_masses = openmm_deserializer.deserialize_system(ref_system, ref_top, ref_ff, cutoff)
+    test_pots, test_masses = openmm_deserializer.deserialize_system(tip3p_system, tip3p_top, tip3p_ff, cutoff)
     np.testing.assert_array_equal(ref_masses, test_masses)
 
     assert len(ref_pots) == len(test_pots)
@@ -153,7 +166,7 @@ def test_amber14_tip3p_matches_tip3p():
         Chem.MolToPDBFile(mol, temp.name)
         # tip3p will fail to handle ions
         with pytest.raises(ValueError, match="No template found for residue 1"):
-            builders.build_protein_system(temp.name, constants.DEFAULT_PROTEIN_FF, tip3p_ff)
+            builders.build_protein_system(temp.name, constants.DEFAULT_PROTEIN_FF, tip3p_water_ff)
 
         # Amber14/tip3p handles ions without issue
         builders.build_protein_system(temp.name, constants.DEFAULT_PROTEIN_FF, constants.DEFAULT_WATER_FF)

--- a/tests/test_forcefields.py
+++ b/tests/test_forcefields.py
@@ -1,3 +1,4 @@
+import dataclasses
 import os
 from glob import glob
 from pathlib import Path
@@ -24,15 +25,11 @@ def test_serialization_of_ffs():
         ff = Forcefield.from_handlers(handlers, protein_ff=protein_ff, water_ff=water_ff)
         assert ff.protein_ff == constants.DEFAULT_PROTEIN_FF
         assert ff.water_ff == constants.DEFAULT_WATER_FF
-        assert ff.hb_handle is not None
-        assert ff.ha_handle is not None
-        assert ff.pt_handle is not None
-        assert ff.it_handle is not None
-        assert ff.q_handle is not None
-        assert ff.q_handle_intra is not None
-        assert ff.lj_handle is not None
-        assert ff.lj_handle_intra is not None
-        assert ff.env_bcc_handle is None
+        for handler_name, handler in dataclasses.asdict(ff).items():
+            if handler_name == "env_bcc_handle":
+                assert handler is None
+            else:
+                assert handler is not None
 
 
 def test_loading_forcefield_from_file():

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -207,8 +207,8 @@ def test_vacuum_and_solvent_edge_types():
     mol = mols[0]
 
     ff = Forcefield.load_default()
-    solvent_system, solvent_coords, solvent_box, _ = builders.build_water_system(3.0, ff.water_ff, mols=[mol])
-    host_system = HostConfig(solvent_system, solvent_coords, solvent_box, solvent_coords.shape[0])
+    solvent_system, solvent_coords, solvent_box, top = builders.build_water_system(3.0, ff.water_ff, mols=[mol])
+    host_system = HostConfig(solvent_system, solvent_coords, solvent_box, solvent_coords.shape[0], top)
     ff_params = ff.get_params()
 
     bt = topology.BaseTopology(mol, ff)
@@ -237,7 +237,7 @@ def solvent_hif2a_ligand_pair_single_topology_lam0_state(hif2a_ligand_pair_singl
     solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(
         3.0, forcefield.water_ff, mols=[st.mol_a, st.mol_b]
     )
-    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
+    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0], solvent_top)
     solvent_host = setup_optimized_host(st, solvent_host_config)
     state = setup_initial_states(st, solvent_host, DEFAULT_TEMP, [0.0], 2023)[0]
     return state
@@ -299,15 +299,15 @@ def test_initial_state_interacting_ligand_atoms(host_name, seed):
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     if host_name == "complex":
         with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as protein_path:
-            host_sys, host_conf, box, _, num_water_atoms = builders.build_protein_system(
+            host_sys, host_conf, box, top, num_water_atoms = builders.build_protein_system(
                 str(protein_path), forcefield.protein_ff, forcefield.water_ff, mols=[mol_a, mol_b]
             )
             box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-        host_config = HostConfig(host_sys, host_conf, box, num_water_atoms)
+        host_config = HostConfig(host_sys, host_conf, box, num_water_atoms, top)
     elif host_name == "solvent":
-        host_sys, host_conf, box, _ = builders.build_water_system(4.0, forcefield.water_ff, mols=[mol_a, mol_b])
+        host_sys, host_conf, box, top = builders.build_water_system(4.0, forcefield.water_ff, mols=[mol_a, mol_b])
         box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-        host_config = HostConfig(host_sys, host_conf, box, host_conf.shape[0])
+        host_config = HostConfig(host_sys, host_conf, box, host_conf.shape[0], top)
 
     single_topology = SingleTopology(mol_a, mol_b, core, forcefield)
 
@@ -401,11 +401,11 @@ def test_get_water_sampler_params_complex():
     st = SingleTopology(mol_a, mol_b, core, forcefield)
 
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as protein_path:
-        host_sys, host_conf, box, _, num_water_atoms = builders.build_protein_system(
+        host_sys, host_conf, box, top, num_water_atoms = builders.build_protein_system(
             str(protein_path), forcefield.protein_ff, forcefield.water_ff, mols=[mol_a, mol_b]
         )
         box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-    host_config = HostConfig(host_sys, host_conf, box, num_water_atoms)
+    host_config = HostConfig(host_sys, host_conf, box, num_water_atoms, top)
     system, masses = convert_omm_system(host_config.omm_system)
     host = Host(system, masses, host_conf, box, host_config.num_water_atoms)
 

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -373,7 +373,7 @@ def test_get_water_sampler_params(num_windows):
 
     num_host_atoms = solvent_conf.shape[0]
     host_system, masses = convert_omm_system(solvent_sys)
-    solvent_host = Host(host_system, masses, solvent_conf, solvent_box, num_host_atoms)
+    solvent_host = Host(host_system, masses, solvent_conf, solvent_box, num_host_atoms, solvent_top)
     mol_a_only_atoms = np.array([i for i in range(st.get_num_atoms()) if st.c_flags[i] == 1])
     mol_b_only_atoms = np.array([i for i in range(st.get_num_atoms()) if st.c_flags[i] == 2])
     for lamb in np.linspace(0.0, 1.0, num_windows, endpoint=True):
@@ -405,7 +405,7 @@ def test_get_water_sampler_params_complex():
         box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     host_config = HostConfig(host_sys, host_conf, box, num_water_atoms, top)
     system, masses = convert_omm_system(host_config.omm_system)
-    host = Host(system, masses, host_conf, box, host_config.num_water_atoms)
+    host = Host(system, masses, host_conf, box, host_config.num_water_atoms, host_config.omm_topology)
 
     lamb = 0.5  # arbitrary
 

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -189,12 +189,11 @@ def test_absolute_vacuum():
     mol = mols[0]
 
     ff = Forcefield.load_default()
-    ff_params = ff.get_params()
 
     bt = topology.BaseTopology(mol, ff)
     afe = free_energy.AbsoluteFreeEnergy(mol, bt)
 
-    unbound_potentials, sys_params, masses = afe.prepare_vacuum_edge(ff_params)
+    unbound_potentials, sys_params, masses = afe.prepare_vacuum_edge(ff)
     assert np.all(masses == utils.get_mol_masses(mol))
     np.testing.assert_array_almost_equal(afe.prepare_combined_coords(), utils.get_romol_conf(mol))
 
@@ -209,14 +208,13 @@ def test_vacuum_and_solvent_edge_types():
     ff = Forcefield.load_default()
     solvent_system, solvent_coords, solvent_box, top = builders.build_water_system(3.0, ff.water_ff, mols=[mol])
     host_system = HostConfig(solvent_system, solvent_coords, solvent_box, solvent_coords.shape[0], top)
-    ff_params = ff.get_params()
 
     bt = topology.BaseTopology(mol, ff)
     afe = free_energy.AbsoluteFreeEnergy(mol, bt)
 
-    vacuum_unbound_potentials, vacuum_sys_params, vacuum_masses = afe.prepare_vacuum_edge(ff_params)
+    vacuum_unbound_potentials, vacuum_sys_params, vacuum_masses = afe.prepare_vacuum_edge(ff)
 
-    solvent_unbound_potentials, solvent_sys_params, solvent_masses = afe.prepare_host_edge(ff_params, host_system, 0.0)
+    solvent_unbound_potentials, solvent_sys_params, solvent_masses = afe.prepare_host_edge(ff, host_system, 0.0)
 
     assert isinstance(vacuum_unbound_potentials, type(solvent_unbound_potentials))
     assert isinstance(vacuum_sys_params, type(solvent_sys_params))
@@ -313,7 +311,7 @@ def test_initial_state_interacting_ligand_atoms(host_name, seed):
 
     host_atoms = 0
     if host_config is not None:
-        # system, masses = convert_omm_system(host_config.omm_system)
+        # system, masses = convert_omm_system(host_config.omm_system, host_config.omm_topology, forcefield)
         host = setup_optimized_host(single_topology, host_config)
         host_atoms += len(host_conf)
 
@@ -406,7 +404,7 @@ def test_get_water_sampler_params_complex():
         )
         box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     host_config = HostConfig(host_sys, host_conf, box, num_water_atoms, top)
-    system, masses = convert_omm_system(host_config.omm_system)
+    system, masses = convert_omm_system(host_config.omm_system, host_config.omm_topology, forcefield)
     host = Host(system, masses, host_conf, box, host_config.num_water_atoms)
 
     lamb = 0.5  # arbitrary

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -311,7 +311,7 @@ def test_initial_state_interacting_ligand_atoms(host_name, seed):
 
     host_atoms = 0
     if host_config is not None:
-        # system, masses = convert_omm_system(host_config.omm_system, host_config.omm_topology, forcefield)
+        # system, masses = convert_omm_system(host_config.omm_system)
         host = setup_optimized_host(single_topology, host_config)
         host_atoms += len(host_conf)
 
@@ -372,7 +372,7 @@ def test_get_water_sampler_params(num_windows):
     )
 
     num_host_atoms = solvent_conf.shape[0]
-    host_system, masses = convert_omm_system(solvent_sys, solvent_top, forcefield)
+    host_system, masses = convert_omm_system(solvent_sys)
     solvent_host = Host(host_system, masses, solvent_conf, solvent_box, num_host_atoms)
     mol_a_only_atoms = np.array([i for i in range(st.get_num_atoms()) if st.c_flags[i] == 1])
     mol_b_only_atoms = np.array([i for i in range(st.get_num_atoms()) if st.c_flags[i] == 2])
@@ -404,7 +404,7 @@ def test_get_water_sampler_params_complex():
         )
         box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     host_config = HostConfig(host_sys, host_conf, box, num_water_atoms, top)
-    system, masses = convert_omm_system(host_config.omm_system, host_config.omm_topology, forcefield)
+    system, masses = convert_omm_system(host_config.omm_system)
     host = Host(system, masses, host_conf, box, host_config.num_water_atoms)
 
     lamb = 0.5  # arbitrary

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -374,7 +374,7 @@ def test_get_water_sampler_params(num_windows):
     )
 
     num_host_atoms = solvent_conf.shape[0]
-    host_system, masses = convert_omm_system(solvent_sys)
+    host_system, masses = convert_omm_system(solvent_sys, solvent_top, forcefield)
     solvent_host = Host(host_system, masses, solvent_conf, solvent_box, num_host_atoms)
     mol_a_only_atoms = np.array([i for i in range(st.get_num_atoms()) if st.c_flags[i] == 1])
     mol_b_only_atoms = np.array([i for i in range(st.get_num_atoms()) if st.c_flags[i] == 2])

--- a/tests/test_hrex_rbfe.py
+++ b/tests/test_hrex_rbfe.py
@@ -40,15 +40,17 @@ def get_hif2a_single_topology_leg(host_name: str | None):
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     if host_name == "complex":
         with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as protein_path:
-            host_sys, host_conf, box, _, num_water_atoms = builders.build_protein_system(
+            host_sys, host_conf, box, host_top, num_water_atoms = builders.build_protein_system(
                 str(protein_path), forcefield.protein_ff, forcefield.water_ff, mols=[mol_a, mol_b]
             )
             box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-        host_config = HostConfig(host_sys, host_conf, box, num_water_atoms)
+        host_config = HostConfig(host_sys, host_conf, box, num_water_atoms, host_top)
     elif host_name == "solvent":
-        host_sys, host_conf, box, _ = builders.build_water_system(4.0, forcefield.water_ff, mols=[mol_a, mol_b])
+        solvent_sys, solvent_conf, box, solvent_top = builders.build_water_system(
+            4.0, forcefield.water_ff, mols=[mol_a, mol_b]
+        )
         box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-        host_config = HostConfig(host_sys, host_conf, box, host_conf.shape[0])
+        host_config = HostConfig(solvent_sys, solvent_conf, box, solvent_conf.shape[0], solvent_top)
 
     return mol_a, mol_b, core, forcefield, host_config
 

--- a/tests/test_jax_nonbonded.py
+++ b/tests/test_jax_nonbonded.py
@@ -118,7 +118,7 @@ difficult_instance_flags = {key: True for key in easy_instance_flags}
 def generate_waterbox_nb_args() -> NonbondedArgs:
     ff = Forcefield.load_default()
     system, conf, box, topology = builders.build_water_system(3.0, ff.water_ff)
-    bps, masses = openmm_deserializer.deserialize_system(system, topology, ff, cutoff=1.2)
+    bps, masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     params = nb.params
 
@@ -331,7 +331,7 @@ def test_jax_nonbonded_block():
     """Assert that nonbonded_block and nonbonded_on_specific_pairs agree"""
     ff = Forcefield.load_default()
     system, conf, box, top = builders.build_water_system(3.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     params = nb.params
 
@@ -365,7 +365,7 @@ def test_jax_nonbonded_block_unsummed():
     """Assert that unsummed nonbonded_block and nonbonded_on_specific_pairs agree"""
     ff = Forcefield.load_default()
     system, conf, box, top = builders.build_water_system(3.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     params = nb.params
 
@@ -438,7 +438,7 @@ def test_precomputation():
     """Assert that nonbonded interaction groups using precomputation agree with reference nonbonded_on_specific_pairs"""
     ff = Forcefield.load_default()
     system, conf, box, top = builders.build_water_system(3.0, ff.water_ff)
-    bps, masses = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    bps, masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     params = nb.params
 

--- a/tests/test_jax_nonbonded.py
+++ b/tests/test_jax_nonbonded.py
@@ -117,8 +117,8 @@ difficult_instance_flags = {key: True for key in easy_instance_flags}
 
 def generate_waterbox_nb_args() -> NonbondedArgs:
     ff = Forcefield.load_default()
-    system, conf, box, _ = builders.build_water_system(3.0, ff.water_ff)
-    bps, masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    system, conf, box, topology = builders.build_water_system(3.0, ff.water_ff)
+    bps, masses = openmm_deserializer.deserialize_system(system, topology, ff, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     params = nb.params
 
@@ -330,8 +330,8 @@ def test_vmap():
 def test_jax_nonbonded_block():
     """Assert that nonbonded_block and nonbonded_on_specific_pairs agree"""
     ff = Forcefield.load_default()
-    system, conf, box, _ = builders.build_water_system(3.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    system, conf, box, top = builders.build_water_system(3.0, ff.water_ff)
+    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     params = nb.params
 
@@ -364,8 +364,8 @@ def test_jax_nonbonded_block():
 def test_jax_nonbonded_block_unsummed():
     """Assert that unsummed nonbonded_block and nonbonded_on_specific_pairs agree"""
     ff = Forcefield.load_default()
-    system, conf, box, _ = builders.build_water_system(3.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    system, conf, box, top = builders.build_water_system(3.0, ff.water_ff)
+    bps, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     params = nb.params
 
@@ -437,8 +437,8 @@ def test_lj_basis():
 def test_precomputation():
     """Assert that nonbonded interaction groups using precomputation agree with reference nonbonded_on_specific_pairs"""
     ff = Forcefield.load_default()
-    system, conf, box, _ = builders.build_water_system(3.0, ff.water_ff)
-    bps, masses = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    system, conf, box, top = builders.build_water_system(3.0, ff.water_ff)
+    bps, masses = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
     nb = get_bound_potential_by_type(bps, Nonbonded)
     params = nb.params
 

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -60,10 +60,10 @@ def test_fire_minimize_host_protein(pdb_path, sdf_path, mol_a_name, mol_b_name):
     mol_b = next(m for m in all_mols if get_mol_name(m) == mol_b_name)
 
     for mols in [[mol_a], [mol_b], [mol_a, mol_b]]:
-        complex_system, complex_coords, complex_box, _, num_water_atoms = builders.build_protein_system(
+        complex_system, complex_coords, complex_box, complex_top, num_water_atoms = builders.build_protein_system(
             str(pdb_path), ff.protein_ff, ff.water_ff, mols=mols
         )
-        host_config = HostConfig(complex_system, complex_coords, complex_box, num_water_atoms)
+        host_config = HostConfig(complex_system, complex_coords, complex_box, num_water_atoms, complex_top)
         x_host = minimizer.fire_minimize_host(mols, host_config, ff)
         assert x_host.shape == complex_coords.shape
 
@@ -76,8 +76,10 @@ def test_fire_minimize_host_solvent():
     mol_b = all_mols[4]
 
     for mols in [[mol_a], [mol_b], [mol_a, mol_b]]:
-        solvent_system, solvent_coords, solvent_box, _ = builders.build_water_system(4.0, ff.water_ff, mols=mols)
-        host_config = HostConfig(solvent_system, solvent_coords, solvent_box, len(solvent_coords))
+        solvent_system, solvent_coords, solvent_box, solvent_top = builders.build_water_system(
+            4.0, ff.water_ff, mols=mols
+        )
+        host_config = HostConfig(solvent_system, solvent_coords, solvent_box, len(solvent_coords), solvent_top)
         x_host = minimizer.fire_minimize_host(mols, host_config, ff)
         assert x_host.shape == solvent_coords.shape
 
@@ -93,14 +95,16 @@ def test_pre_equilibrate_host_pfkfb3(host_name, mol_pair):
     mol_b = next(m for m in all_mols if get_mol_name(m) == mol_b_name)
     mols = [mol_a, mol_b]
     if host_name == "solvent":
-        solvent_system, solvent_coords, solvent_box, _ = builders.build_water_system(4.0, ff.water_ff, mols=mols)
-        host_config = HostConfig(solvent_system, solvent_coords, solvent_box, len(solvent_coords))
+        solvent_system, solvent_coords, solvent_box, solvent_top = builders.build_water_system(
+            4.0, ff.water_ff, mols=mols
+        )
+        host_config = HostConfig(solvent_system, solvent_coords, solvent_box, len(solvent_coords), solvent_top)
     else:
         with resources.path("timemachine.datasets.fep_benchmark.pfkfb3", "6hvi_prepared.pdb") as pdb_path:
-            complex_system, complex_coords, complex_box, _, num_water_atoms = builders.build_protein_system(
+            complex_system, complex_coords, complex_box, complex_top, num_water_atoms = builders.build_protein_system(
                 str(pdb_path), ff.protein_ff, ff.water_ff, mols=mols
             )
-        host_config = HostConfig(complex_system, complex_coords, complex_box, num_water_atoms)
+        host_config = HostConfig(complex_system, complex_coords, complex_box, num_water_atoms, complex_top)
     x_host, x_box = minimizer.pre_equilibrate_host(mols, host_config, ff)
     assert x_host.shape == host_config.conf.shape
     assert compute_box_volume(x_box) < compute_box_volume(host_config.box)
@@ -113,8 +117,8 @@ def test_fire_minimize_host_adamantane():
     mol = Chem.AddHs(Chem.MolFromSmiles("C1C3CC2CC(CC1C2)C3"))
     AllChem.EmbedMolecule(mol, randomSeed=2024)
     # If don't delete the relevant water this minimization fails
-    solvent_system, solvent_coords, solvent_box, _ = builders.build_water_system(4.0, ff.water_ff, mols=[mol])
-    host_config = HostConfig(solvent_system, solvent_coords, solvent_box, len(solvent_coords))
+    solvent_system, solvent_coords, solvent_box, solvent_top = builders.build_water_system(4.0, ff.water_ff, mols=[mol])
+    host_config = HostConfig(solvent_system, solvent_coords, solvent_box, len(solvent_coords), solvent_top)
     x_host = minimizer.fire_minimize_host([mol], host_config, ff)
     assert x_host.shape == solvent_coords.shape
 
@@ -128,10 +132,10 @@ def test_equilibrate_host_barker():
     mol_b = all_mols[4]
 
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as path_to_pdb:
-        complex_system, complex_coords, complex_box, _, num_water_atoms = builders.build_protein_system(
+        complex_system, complex_coords, complex_box, complex_top, num_water_atoms = builders.build_protein_system(
             str(path_to_pdb), ff.protein_ff, ff.water_ff, mols=[mol_a, mol_b]
         )
-        host_config = HostConfig(complex_system, complex_coords, complex_box, num_water_atoms)
+        host_config = HostConfig(complex_system, complex_coords, complex_box, num_water_atoms, complex_top)
 
     # TODO[requirements-gathering]:
     #   do we really want to minimize here ("equilibrate to temperature ~= 0"),
@@ -178,8 +182,8 @@ def test_local_minimize_water_box():
     """
     ff = Forcefield.load_default()
 
-    system, x0, box0, _ = builders.build_water_system(4.0, ff.water_ff)
-    host_fns, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    system, x0, box0, top = builders.build_water_system(4.0, ff.water_ff)
+    host_fns, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
     box0 += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes at the boundary
 
     val_and_grad_fn = minimizer.get_val_and_grad_fn(host_fns, box0)

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -183,7 +183,7 @@ def test_local_minimize_water_box():
     ff = Forcefield.load_default()
 
     system, x0, box0, top = builders.build_water_system(4.0, ff.water_ff)
-    host_fns, _ = openmm_deserializer.deserialize_system(system, top, ff, cutoff=1.2)
+    host_fns, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
     box0 += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes at the boundary
 
     val_and_grad_fn = minimizer.get_val_and_grad_fn(host_fns, box0)

--- a/tests/test_missing_gpu.py
+++ b/tests/test_missing_gpu.py
@@ -13,9 +13,9 @@ pytestmark = [pytest.mark.nogpu, pytest.mark.nightly]
 
 def test_no_gpu_raises_exception():
     ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
-    solvent_system, solvent_coords, solvent_box, _ = builders.build_water_system(3.0, ff.water_ff)
+    solvent_system, solvent_coords, solvent_box, top = builders.build_water_system(3.0, ff.water_ff)
 
-    host_fns, _ = openmm_deserializer.deserialize_system(solvent_system, cutoff=1.2)
+    host_fns, _ = openmm_deserializer.deserialize_system(solvent_system, top, ff, cutoff=1.2)
 
     with pytest.raises(custom_ops.InvalidHardware, match="Invalid Hardware - Code "):
         host_fns[0].to_gpu(np.float32)

--- a/tests/test_missing_gpu.py
+++ b/tests/test_missing_gpu.py
@@ -15,7 +15,7 @@ def test_no_gpu_raises_exception():
     ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
     solvent_system, solvent_coords, solvent_box, top = builders.build_water_system(3.0, ff.water_ff)
 
-    host_fns, _ = openmm_deserializer.deserialize_system(solvent_system, top, ff, cutoff=1.2)
+    host_fns, _ = openmm_deserializer.deserialize_system(solvent_system, cutoff=1.2)
 
     with pytest.raises(custom_ops.InvalidHardware, match="Invalid Hardware - Code "):
         host_fns[0].to_gpu(np.float32)

--- a/tests/test_nblist.py
+++ b/tests/test_nblist.py
@@ -397,15 +397,15 @@ def setup_hif2a_initial_state(host_name: str):
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     if host_name == "complex":
         with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as protein_path:
-            host_sys, host_conf, box, _, num_water_atoms = build_protein_system(
+            host_sys, host_conf, box, host_top, num_water_atoms = build_protein_system(
                 str(protein_path), forcefield.protein_ff, forcefield.water_ff, mols=[mol_a, mol_b]
             )
             box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-        host_config = HostConfig(host_sys, host_conf, box, num_water_atoms)
+        host_config = HostConfig(host_sys, host_conf, box, num_water_atoms, host_top)
     elif host_name == "solvent":
-        host_sys, host_conf, box, _ = build_water_system(4.0, forcefield.water_ff, mols=[mol_a, mol_b])
+        solvent_sys, solvent_conf, box, sovlent_top = build_water_system(4.0, forcefield.water_ff, mols=[mol_a, mol_b])
         box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-        host_config = HostConfig(host_sys, host_conf, box, host_conf.shape[0])
+        host_config = HostConfig(solvent_sys, solvent_conf, box, solvent_conf.shape[0], sovlent_top)
     else:
         assert 0, "Invalid host name"
 

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -34,11 +34,11 @@ def run_bitwise_reproducibility(mol_a, mol_b, core, forcefield, md_params, estim
 
     box_width = 4.0
     n_windows = 3
-    solvent_sys, solvent_conf, solvent_box, _ = builders.build_water_system(
+    solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(
         box_width, forcefield.water_ff, mols=[mol_a, mol_b]
     )
     solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
+    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0], solvent_top)
 
     solvent_res = estimate_relative_free_energy_fn(
         mol_a,
@@ -124,11 +124,11 @@ def run_triple(mol_a, mol_b, core, forcefield, md_params: MDParams, protein_path
     check_sim_result(vacuum_res)
 
     box_width = 4.0
-    solvent_sys, solvent_conf, solvent_box, _ = builders.build_water_system(
+    solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(
         box_width, forcefield.water_ff, mols=[mol_a, mol_b]
     )
     solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
+    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0], solvent_top)
     solvent_res = estimate_relative_free_energy_fn(
         mol_a,
         mol_b,
@@ -144,11 +144,11 @@ def run_triple(mol_a, mol_b, core, forcefield, md_params: MDParams, protein_path
     print("solvent")
     check_sim_result(solvent_res)
 
-    complex_sys, complex_conf, complex_box, _, num_water_atoms = builders.build_protein_system(
+    complex_sys, complex_conf, complex_box, complex_top, num_water_atoms = builders.build_protein_system(
         protein_path, forcefield.protein_ff, forcefield.water_ff
     )
     complex_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-    complex_host_config = HostConfig(complex_sys, complex_conf, complex_box, num_water_atoms)
+    complex_host_config = HostConfig(complex_sys, complex_conf, complex_box, num_water_atoms, complex_top)
     complex_res = estimate_relative_free_energy_fn(
         mol_a,
         mol_b,

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -18,7 +18,7 @@ from timemachine.constants import (
     DEFAULT_ATOM_MAPPING_KWARGS,
     DEFAULT_CHIRAL_ATOM_RESTRAINT_K,
     DEFAULT_CHIRAL_BOND_RESTRAINT_K,
-    Q_IDX,
+    NBParamIdx,
 )
 from timemachine.fe import atom_mapping, single_topology
 from timemachine.fe.dummy import MultipleAnchorWarning
@@ -1035,7 +1035,7 @@ def test_combine_with_host_split(precision, rtol, atol):
         host_ixn_params = host_system.nonbonded.params.copy()
         if not is_solvent and ff.env_bcc_handle is not None:  # protein
             env_bcc_h = ff.env_bcc_handle.get_env_handle(omm_topology, ff)
-            host_ixn_params[:, Q_IDX] = env_bcc_h.parameterize(ff.env_bcc_handle.params)
+            host_ixn_params[:, NBParamIdx.Q_IDX] = env_bcc_h.parameterize(ff.env_bcc_handle.params)
 
         combined_nonbonded_params = np.concatenate([host_ixn_params, guest_params])
         u_impl = u.bind(combined_nonbonded_params).to_gpu(precision=precision).bound_impl

--- a/tests/test_single_topology_combined.py
+++ b/tests/test_single_topology_combined.py
@@ -24,18 +24,17 @@ def hif2a_ligand_pair_single_topology():
 
 @pytest.fixture(scope="module")
 def complex_host_system():
-    ff = Forcefield.load_default()
     host_sys_omm, host_top = get_dhfr_system()
     # Hardcoded to match 5dfr_solv_equil.pdb file
     num_water_atoms = 21069
-    return convert_omm_system(host_sys_omm, host_top, ff), num_water_atoms, host_top
+    return convert_omm_system(host_sys_omm), num_water_atoms, host_top
 
 
 @pytest.fixture(scope="module")
 def solvent_host_system():
     ff = Forcefield.load_default()
     host_sys_omm, conf, _, top = builders.build_water_system(3.0, ff.water_ff)
-    return convert_omm_system(host_sys_omm, top, ff), conf.shape[0], top
+    return convert_omm_system(host_sys_omm), conf.shape[0], top
 
 
 @pytest.mark.parametrize("lamb", [0.0, 1.0])

--- a/tests/test_single_topology_combined.py
+++ b/tests/test_single_topology_combined.py
@@ -33,9 +33,9 @@ def complex_host_system():
 
 @pytest.fixture(scope="module")
 def solvent_host_system():
-    forcefield = Forcefield.load_default()
-    host_sys_omm, conf, _, _ = builders.build_water_system(3.0, forcefield.water_ff)
-    return convert_omm_system(host_sys_omm), conf.shape[0]
+    ff = Forcefield.load_default()
+    host_sys_omm, conf, _, top = builders.build_water_system(3.0, ff.water_ff)
+    return convert_omm_system(host_sys_omm, top, ff), conf.shape[0]
 
 
 @pytest.mark.parametrize("lamb", [0.0, 1.0])

--- a/tests/test_single_topology_combined.py
+++ b/tests/test_single_topology_combined.py
@@ -24,10 +24,11 @@ def hif2a_ligand_pair_single_topology():
 
 @pytest.fixture(scope="module")
 def complex_host_system():
-    host_sys_omm = get_dhfr_system()
+    ff = Forcefield.load_default()
+    host_sys_omm, host_top = get_dhfr_system()
     # Hardcoded to match 5dfr_solv_equil.pdb file
     num_water_atoms = 21069
-    return convert_omm_system(host_sys_omm), num_water_atoms
+    return convert_omm_system(host_sys_omm, host_top, ff), num_water_atoms
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -56,7 +56,7 @@ def run_edge(mol_a, mol_b, protein_path, n_windows):
         box_width, ff.water_ff, mols=[mol_a, mol_b]
     )
     solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
+    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0], solvent_top)
     solvent_host = setup_optimized_host(st, solvent_host_config)
     initial_states = setup_initial_states(st, solvent_host, DEFAULT_TEMP, lambda_schedule, seed)
 
@@ -76,7 +76,7 @@ def run_edge(mol_a, mol_b, protein_path, n_windows):
         protein_path, ff.protein_ff, ff.water_ff, mols=[mol_a, mol_b]
     )
     complex_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-    complex_host_config = HostConfig(complex_sys, complex_conf, complex_box, num_water_atoms)
+    complex_host_config = HostConfig(complex_sys, complex_conf, complex_box, num_water_atoms, complex_top)
     complex_host = setup_optimized_host(st, complex_host_config)
     initial_states = setup_initial_states(st, complex_host, DEFAULT_TEMP, lambda_schedule, seed, min_cutoff=0.7)
 
@@ -184,7 +184,7 @@ def test_min_cutoff_failure(pair, seed, n_windows):
         box_width, ff.water_ff, mols=[mol_a, mol_b]
     )
     solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
+    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0], solvent_top)
     solvent_host = setup_optimized_host(st, solvent_host_config)
     ligand_idxs = np.arange(st.get_num_atoms()) + solvent_host.conf.shape[0]
     expected_moved = ligand_idxs[st.c_flags != 2]

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -10,6 +10,7 @@ from rdkit import Chem
 from rdkit.Chem import AllChem
 
 from timemachine import potentials
+from timemachine.constants import Q_IDX
 from timemachine.fe import topology
 from timemachine.fe.topology import BaseTopology, DualTopology, DualTopologyMinimization
 from timemachine.fe.utils import get_mol_name, get_romol_conf, read_sdf, set_romol_conf
@@ -85,10 +86,10 @@ def parameterize_nonbonded_full(
 @pytest.mark.parametrize("ctor", [BaseTopology, DualTopology, DualTopologyMinimization])
 @pytest.mark.parametrize("use_tiny_mol", [True, False])
 def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
-    def compute_ref_grad_u(ff: Forcefield, precision, x0, box, lamb, num_water_atoms, host_bps):
+    def compute_ref_grad_u(ff: Forcefield, precision, x0, box, lamb, num_water_atoms, host_bps, omm_topology):
         # Use the original code to compute the nb grads and potential
         bt = Topology(ff)
-        hgt = topology.HostGuestTopology(host_bps, bt, num_water_atoms)
+        hgt = topology.HostGuestTopology(host_bps, bt, num_water_atoms, ff, omm_topology)
         params, us = parameterize_nonbonded_full(
             hgt,
             ff.q_handle.params,
@@ -100,10 +101,10 @@ def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
         u_impl = us.bind(params).to_gpu(precision=precision).bound_impl
         return u_impl.execute(x0, box)
 
-    def compute_new_grad_u(ff: Forcefield, precision, x0, box, lamb, num_water_atoms, host_bps):
+    def compute_new_grad_u(ff: Forcefield, precision, x0, box, lamb, num_water_atoms, host_bps, omm_topology):
         # Use the updated topology code to compute the nb grads and potential
         bt = Topology(ff)
-        hgt = topology.HostGuestTopology(host_bps, bt, num_water_atoms)
+        hgt = topology.HostGuestTopology(host_bps, bt, num_water_atoms, ff, omm_topology)
         params, us = hgt.parameterize_nonbonded(
             ff.q_handle.params,
             ff.q_handle_intra.params,
@@ -142,12 +143,13 @@ def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
         water_idxs,
         ligand_idxs,
         protein_idxs,
+        omm_topology,
         is_solvent=False,
     ):
         assert num_water_atoms == len(water_idxs)
         num_total_atoms = len(ligand_idxs) + len(protein_idxs) + num_water_atoms
         bt = Topology(ff)
-        hgt = topology.HostGuestTopology(host_bps, bt, num_water_atoms)
+        hgt = topology.HostGuestTopology(host_bps, bt, num_water_atoms, ff, omm_topology)
         u = potentials.NonbondedInteractionGroup(
             num_total_atoms,
             ligand_idxs,
@@ -163,7 +165,12 @@ def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
             lamb=lamb,
             intramol_params=False,
         )
-        ixn_params = np.concatenate([hgt.host_nonbonded.params, lig_params])
+        host_ixn_params = hgt.host_nonbonded.params.copy()
+        if not is_solvent and ff.env_bcc_handle is not None:  # protein
+            env_bcc_h = ff.env_bcc_handle.get_env_handle(omm_topology, ff)
+            host_ixn_params[:, Q_IDX] = env_bcc_h.parameterize(ff.env_bcc_handle.params)
+
+        ixn_params = np.concatenate([host_ixn_params, lig_params])
         u_impl = u.bind(ixn_params).to_gpu(precision=precision).bound_impl
         return u_impl.execute(x0, box)
 

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -10,7 +10,7 @@ from rdkit import Chem
 from rdkit.Chem import AllChem
 
 from timemachine import potentials
-from timemachine.constants import Q_IDX
+from timemachine.constants import NBParamIdx
 from timemachine.fe import topology
 from timemachine.fe.topology import BaseTopology, DualTopology, DualTopologyMinimization
 from timemachine.fe.utils import get_mol_name, get_romol_conf, read_sdf, set_romol_conf
@@ -168,7 +168,7 @@ def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
         host_ixn_params = hgt.host_nonbonded.params.copy()
         if not is_solvent and ff.env_bcc_handle is not None:  # protein
             env_bcc_h = ff.env_bcc_handle.get_env_handle(omm_topology, ff)
-            host_ixn_params[:, Q_IDX] = env_bcc_h.parameterize(ff.env_bcc_handle.params)
+            host_ixn_params[:, NBParamIdx.Q_IDX] = env_bcc_h.parameterize(ff.env_bcc_handle.params)
 
         ixn_params = np.concatenate([host_ixn_params, lig_params])
         u_impl = u.bind(ixn_params).to_gpu(precision=precision).bound_impl

--- a/timemachine/constants.py
+++ b/timemachine/constants.py
@@ -1,3 +1,4 @@
+from enum import IntEnum
 from typing import Any, Dict
 
 # physical constants
@@ -46,7 +47,10 @@ DEFAULT_ATOM_MAPPING_KWARGS: Dict[str, Any] = {
     "enforce_chirally_valid_dummy_groups": False,
 }
 
-# NB parameter idxs
-Q_IDX = 0
-LJ_SIG_IDX = 1
-LJ_EPS_IDX = 2
+
+class NBParamIdx(IntEnum):
+    # Enum for the index into the NB parameters
+    Q_IDX = 0  # scaled charges
+    LJ_SIG_IDX = 1  # LJ sigma / 2
+    LJ_EPS_IDX = 2  # sqrt(LJ eps)
+    W_IDX = 3  # 4d coord

--- a/timemachine/constants.py
+++ b/timemachine/constants.py
@@ -45,3 +45,8 @@ DEFAULT_ATOM_MAPPING_KWARGS: Dict[str, Any] = {
     "initial_mapping": None,
     "enforce_chirally_valid_dummy_groups": False,
 }
+
+# NB parameter idxs
+Q_IDX = 0
+LJ_SIG_IDX = 1
+LJ_EPS_IDX = 2

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -275,9 +275,7 @@ def setup_initial_states(
         Returns an initial state for each value of lambda.
 
     """
-    host_bps, host_masses = openmm_deserializer.deserialize_system(
-        host_config.omm_system, host_config.omm_topology, ff, cutoff=1.2
-    )
+    host_bps, host_masses = openmm_deserializer.deserialize_system(host_config.omm_system, cutoff=1.2)
     host_conf = minimizer.fire_minimize_host(
         [afe.mol],
         host_config,

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -275,7 +275,9 @@ def setup_initial_states(
         Returns an initial state for each value of lambda.
 
     """
-    host_bps, host_masses = openmm_deserializer.deserialize_system(host_config.omm_system, cutoff=1.2)
+    host_bps, host_masses = openmm_deserializer.deserialize_system(
+        host_config.omm_system, host_config.omm_topology, ff, cutoff=1.2
+    )
     host_conf = minimizer.fire_minimize_host(
         [afe.mol],
         host_config,
@@ -290,7 +292,7 @@ def setup_initial_states(
     for lamb_idx, lamb in enumerate(lambda_schedule):
         ligand_conf = get_romol_conf(afe.mol)
 
-        ubps, params, masses = afe.prepare_host_edge(ff.get_params(), host_config, lamb)
+        ubps, params, masses = afe.prepare_host_edge(ff, host_config, lamb)
         x0 = afe.prepare_combined_coords(host_coords=host_conf)
         bps = []
         for ubp, param in zip(ubps, params):
@@ -326,7 +328,7 @@ def run_solvent(
         box_width, forcefield.water_ff, mols=[mol]
     )
     solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes, deboggle later
-    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
+    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0], solvent_top)
     solvent_res = estimate_absolute_free_energy(
         mol,
         forcefield,

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -441,14 +441,14 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
         combined_masses = self._combine(ligand_masses, host_masses)
         return final_potentials, final_params, combined_masses
 
-    def prepare_vacuum_edge(self, ff_params: ForcefieldParams):
+    def prepare_vacuum_edge(self, ff: Forcefield):
         """
         Prepares the vacuum system
 
         Parameters
         ----------
-        ff_params: ForcefieldParams
-            forcefield parameters
+        ff: Forcefield
+            forcefield to use
 
         Returns
         -------
@@ -456,6 +456,7 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
             unbound_potentials, system_params, combined_masses
 
         """
+        ff_params = ff.get_params()
         ligand_masses = get_mol_masses(self.mol)
         final_params, final_potentials = self._get_system_params_and_potentials(ff_params, self.top, 0.0)
         return final_potentials, final_params, ligand_masses

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -45,11 +45,12 @@ WATER_SAMPLER_MOVERS = (
 
 
 class HostConfig:
-    def __init__(self, omm_system, conf, box, num_water_atoms):
+    def __init__(self, omm_system, conf, box, num_water_atoms, omm_topology):
         self.omm_system = omm_system
         self.conf = conf
         self.box = box
         self.num_water_atoms = num_water_atoms
+        self.omm_topology = omm_topology
 
 
 @dataclass(frozen=True)

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -432,10 +432,8 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
         ligand_masses = get_mol_masses(self.mol)
         ff_params = ff.get_params()
 
-        host_bps, host_masses = openmm_deserializer.deserialize_system(
-            host_config.omm_system, host_config.omm_topology, ff, cutoff=1.2
-        )
-        hgt = topology.HostGuestTopology(host_bps, self.top, host_config.num_water_atoms)
+        host_bps, host_masses = openmm_deserializer.deserialize_system(host_config.omm_system, cutoff=1.2)
+        hgt = topology.HostGuestTopology(host_bps, self.top, host_config.num_water_atoms, ff, host_config.omm_topology)
 
         final_params, final_potentials = self._get_system_params_and_potentials(ff_params, hgt, lamb)
         combined_masses = self._combine(ligand_masses, host_masses)

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -414,8 +414,8 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
 
         Parameters
         ----------
-        ff_params: ForcefieldParams
-            forcefield parameters
+        ff: Forcefield
+            forcefield to use
 
         host_config: HostConfig
             HostConfig containing openmm System object to be deserialized.

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -408,7 +408,7 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
         self.mol = mol
         self.top = top
 
-    def prepare_host_edge(self, ff_params: ForcefieldParams, host_config: HostConfig, lamb: float):
+    def prepare_host_edge(self, ff: Forcefield, host_config: HostConfig, lamb: float):
         """
         Prepares the host-guest system
 
@@ -430,8 +430,11 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
 
         """
         ligand_masses = get_mol_masses(self.mol)
+        ff_params = ff.get_params()
 
-        host_bps, host_masses = openmm_deserializer.deserialize_system(host_config.omm_system, cutoff=1.2)
+        host_bps, host_masses = openmm_deserializer.deserialize_system(
+            host_config.omm_system, host_config.omm_topology, ff, cutoff=1.2
+        )
         hgt = topology.HostGuestTopology(host_bps, self.top, host_config.num_water_atoms)
 
         final_params, final_potentials = self._get_system_params_and_potentials(ff_params, hgt, lamb)

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -26,7 +26,7 @@ from timemachine.fe.plots import (
 from timemachine.fe.protocol_refinement import greedy_bisection_step
 from timemachine.fe.stored_arrays import StoredArrays
 from timemachine.fe.utils import get_mol_masses, get_romol_conf
-from timemachine.ff import ForcefieldParams
+from timemachine.ff import Forcefield, ForcefieldParams
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, custom_ops
 from timemachine.lib.custom_ops import Context

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -202,7 +202,7 @@ def setup_optimized_host(st: SingleTopology, config: HostConfig) -> Host:
     Host
         Minimized host state
     """
-    system, masses = convert_omm_system(config.omm_system)
+    system, masses = convert_omm_system(config.omm_system, config.omm_topology, st.ff)
     conf, box = minimizer.pre_equilibrate_host([st.mol_a, st.mol_b], config, st.ff)
     return Host(system, masses, conf, box, config.num_water_atoms)
 
@@ -894,7 +894,7 @@ def run_solvent(
         box_width, forcefield.water_ff, mols=[mol_a, mol_b]
     )
     solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes, deboggle later
-    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0])
+    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0], solvent_top)
     # min_cutoff defaults to None since the original poses tend to come from posing in a complex and
     # in solvent the molecules may adopt significantly different poses
     solvent_res = estimate_relative_free_energy_bisection_or_hrex(
@@ -927,7 +927,7 @@ def run_complex(
         protein, forcefield.protein_ff, forcefield.water_ff, mols=[mol_a, mol_b]
     )
     complex_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes, deboggle later
-    complex_host_config = HostConfig(complex_sys, complex_conf, complex_box, nwa)
+    complex_host_config = HostConfig(complex_sys, complex_conf, complex_box, nwa, complex_top)
     complex_res = estimate_relative_free_energy_bisection_or_hrex(
         mol_a,
         mol_b,

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -12,7 +12,7 @@ from numpy.typing import NDArray
 from openmm import app
 from rdkit import Chem
 
-from timemachine.constants import DEFAULT_CHIRAL_ATOM_RESTRAINT_K, DEFAULT_CHIRAL_BOND_RESTRAINT_K, Q_IDX
+from timemachine.constants import DEFAULT_CHIRAL_ATOM_RESTRAINT_K, DEFAULT_CHIRAL_BOND_RESTRAINT_K, NBParamIdx
 from timemachine.fe import chiral_utils, interpolate, model_utils, topology, utils
 from timemachine.fe.chiral_utils import ChiralRestrIdxSet
 from timemachine.fe.dummy import (
@@ -1895,7 +1895,7 @@ class SingleTopology(AtomMapMixin):
         hg_nb_ixn_params = host_nonbonded.params.copy()
         if ff.env_bcc_handle is not None:
             env_bcc_h = ff.env_bcc_handle.get_env_handle(omm_topology, ff)
-            hg_nb_ixn_params[:, Q_IDX] = env_bcc_h.parameterize(ff.env_bcc_handle.params)
+            hg_nb_ixn_params[:, NBParamIdx.Q_IDX] = env_bcc_h.parameterize(ff.env_bcc_handle.params)
 
         ixn_pot, ixn_params = get_ligand_ixn_pots_params(
             get_lig_idxs(),

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -7,7 +7,6 @@ import numpy as np
 import scipy
 
 from timemachine import potentials
-from timemachine.ff import Forcefield
 from timemachine.integrator import simulate
 from timemachine.potentials import (
     BoundPotential,
@@ -113,11 +112,11 @@ def convert_bps_into_system(bps: Sequence[potentials.BoundPotential]):
     return VacuumSystem(bond, angle, torsion, nonbonded, chiral_atom, chiral_bond)
 
 
-def convert_omm_system(omm_system, omm_topology, ff: Forcefield) -> Tuple["VacuumSystem", List[float]]:
+def convert_omm_system(omm_system) -> Tuple["VacuumSystem", List[float]]:
     """Convert an openmm.System to a VacuumSystem object, also returning the masses"""
     from timemachine.ff.handlers import openmm_deserializer
 
-    bps, masses = openmm_deserializer.deserialize_system(omm_system, omm_topology, ff, cutoff=1.2)
+    bps, masses = openmm_deserializer.deserialize_system(omm_system, cutoff=1.2)
     system = convert_bps_into_system(bps)
     return system, masses
 

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -7,7 +7,7 @@ import numpy as np
 import scipy
 
 from timemachine import potentials
-from timemachine.ff.nonbonded.handlers import EnvironmentBCCHandler
+from timemachine.ff import Forcefield
 from timemachine.integrator import simulate
 from timemachine.potentials import (
     BoundPotential,

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -7,6 +7,7 @@ import numpy as np
 import scipy
 
 from timemachine import potentials
+from timemachine.ff.nonbonded.handlers import EnvironmentBCCHandler
 from timemachine.integrator import simulate
 from timemachine.potentials import (
     BoundPotential,
@@ -22,7 +23,6 @@ from timemachine.potentials import (
     Potential,
     SummedPotential,
 )
-from timemachine.ff.nonbonded.handlers import EnvironmentBCCHandler
 
 # Chiral bond restraints are disabled until checks are added (see GH #815)
 # from timemachine.potentials import bonded, chiral_restraints, nonbonded
@@ -117,10 +117,7 @@ def convert_omm_system(omm_system, omm_topology, ff: Forcefield) -> Tuple["Vacuu
     """Convert an openmm.System to a VacuumSystem object, also returning the masses"""
     from timemachine.ff.handlers import openmm_deserializer
 
-    bps, masses = openmm_deserializer.deserialize_system(omm_system, cutoff=1.2)
-    env_bcc_h = get_env_bcc_h(ff)
-    if env_bcc_h is not None:
-        env_bcc_h.
+    bps, masses = openmm_deserializer.deserialize_system(omm_system, omm_topology, ff, cutoff=1.2)
     system = convert_bps_into_system(bps)
     return system, masses
 

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -22,6 +22,7 @@ from timemachine.potentials import (
     Potential,
     SummedPotential,
 )
+from timemachine.ff.nonbonded.handlers import EnvironmentBCCHandler
 
 # Chiral bond restraints are disabled until checks are added (see GH #815)
 # from timemachine.potentials import bonded, chiral_restraints, nonbonded
@@ -112,11 +113,14 @@ def convert_bps_into_system(bps: Sequence[potentials.BoundPotential]):
     return VacuumSystem(bond, angle, torsion, nonbonded, chiral_atom, chiral_bond)
 
 
-def convert_omm_system(omm_system) -> Tuple["VacuumSystem", List[float]]:
+def convert_omm_system(omm_system, omm_topology, ff: Forcefield) -> Tuple["VacuumSystem", List[float]]:
     """Convert an openmm.System to a VacuumSystem object, also returning the masses"""
     from timemachine.ff.handlers import openmm_deserializer
 
     bps, masses = openmm_deserializer.deserialize_system(omm_system, cutoff=1.2)
+    env_bcc_h = get_env_bcc_h(ff)
+    if env_bcc_h is not None:
+        env_bcc_h.
     system = convert_bps_into_system(bps)
     return system, masses
 

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -6,7 +6,7 @@ from numpy.typing import NDArray
 from openmm import app
 
 from timemachine import potentials
-from timemachine.constants import DEFAULT_CHIRAL_ATOM_RESTRAINT_K, DEFAULT_CHIRAL_BOND_RESTRAINT_K, Q_IDX
+from timemachine.constants import DEFAULT_CHIRAL_ATOM_RESTRAINT_K, DEFAULT_CHIRAL_BOND_RESTRAINT_K, NBParamIdx
 from timemachine.fe import chiral_utils
 from timemachine.fe.system import VacuumSystem
 from timemachine.fe.utils import get_romol_conf
@@ -88,7 +88,7 @@ class HostGuestTopology:
         self.hg_nb_ixn_params = self.host_nonbonded.params.copy()
         if self.ff.env_bcc_handle is not None:
             env_bcc_h = self.ff.env_bcc_handle.get_env_handle(self.omm_topology, self.ff)
-            self.hg_nb_ixn_params[:, Q_IDX] = env_bcc_h.parameterize(self.ff.env_bcc_handle.params)
+            self.hg_nb_ixn_params[:, NBParamIdx.Q_IDX] = env_bcc_h.parameterize(self.ff.env_bcc_handle.params)
 
     def get_water_idxs(self) -> NDArray:
         return np.arange(self.num_water_atoms, dtype=np.int32) + self.num_other_atoms

--- a/timemachine/ff/__init__.py
+++ b/timemachine/ff/__init__.py
@@ -133,6 +133,7 @@ class Forcefield:
             q_handle_intra=q_handle_intra,
             lj_handle=ff.lj_handle,
             lj_handle_intra=ff.lj_handle_intra,
+            env_bcc_handle=None,
             protein_ff=ff.protein_ff,
             water_ff=ff.water_ff,
         )

--- a/timemachine/ff/__init__.py
+++ b/timemachine/ff/__init__.py
@@ -69,6 +69,7 @@ class Forcefield:
 
     lj_handle: Optional[nonbonded.LennardJonesHandler]
     lj_handle_intra: Optional[nonbonded.LennardJonesIntraHandler]
+    env_bcc_handle: Optional[nonbonded.EnvironmentBCCPartialHandler]
 
     protein_ff: str
     water_ff: str
@@ -153,9 +154,13 @@ class Forcefield:
         q_handle = None
         q_handle_intra = None
         q_handle_solv = None
+        env_bcc_handle = None
 
         for handle in ff_handlers:
-            if isinstance(handle, bonded.HarmonicBondHandler):
+            if isinstance(handle, nonbonded.EnvironmentBCCPartialHandler):
+                assert env_bcc_handle is None
+                env_bcc_handle = handle
+            elif isinstance(handle, bonded.HarmonicBondHandler):
                 assert hb_handle is None
                 hb_handle = handle
             elif isinstance(handle, bonded.HarmonicAngleHandler):
@@ -238,6 +243,7 @@ class Forcefield:
             q_handle_intra,
             lj_handle,
             lj_handle_intra,
+            env_bcc_handle,
             protein_ff,
             water_ff,
         )
@@ -253,6 +259,7 @@ class Forcefield:
             self.q_handle_intra,
             self.lj_handle,
             self.lj_handle_intra,
+            self.env_bcc_handle,
         ]
 
     def get_params(self) -> ForcefieldParams:
@@ -268,6 +275,7 @@ class Forcefield:
             params(self.q_handle_intra),
             params(self.lj_handle),
             params(self.lj_handle_intra),
+            params(self.env_bcc_handle),
         )
 
     def serialize(self) -> str:

--- a/timemachine/ff/__init__.py
+++ b/timemachine/ff/__init__.py
@@ -276,7 +276,6 @@ class Forcefield:
             params(self.q_handle_intra),
             params(self.lj_handle),
             params(self.lj_handle_intra),
-            params(self.env_bcc_handle),
         )
 
     def serialize(self) -> str:

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -9,6 +9,7 @@ import numpy as np
 from rdkit import Chem
 
 from timemachine import constants
+from timemachine.ff import Forcefield
 from timemachine.ff.handlers.bcc_aromaticity import AromaticityModel
 from timemachine.ff.handlers.bcc_aromaticity import match_smirks as oe_match_smirks
 from timemachine.ff.handlers.serialize import SerializableMixIn
@@ -507,17 +508,6 @@ class AM1BCCSolventHandler(AM1BCCHandler):
     pass
 
 
-class EnvironmentBCCPartialHandler(SerializableMixIn):
-    # stored in the ff.py file
-    def __init__(self, smirks, params, props):
-        self.smirks = smirks
-        self.params = params
-        self.props = props
-
-    def get_env_handle(self, omm_topology, ff: Forcefield) -> EnvironmentBCCHandler:
-        return EnvironmentBCCHandler(self.smirks, self.params, ff.protein_ff_name, ff.water_ff_name, omm_topology)
-
-
 class EnvironmentBCCHandler(SerializableMixIn):
     """
     Applies BCCs to residues in a forcefield. Needs a concrete openmm topology to use.
@@ -625,6 +615,17 @@ class EnvironmentBCCHandler(SerializableMixIn):
         )
 
         return final_charges
+
+
+class EnvironmentBCCPartialHandler(SerializableMixIn):
+    # stored in the ff.py file
+    def __init__(self, smirks, params, props):
+        self.smirks = smirks
+        self.params = params
+        self.props = props
+
+    def get_env_handle(self, omm_topology, ff: Forcefield) -> EnvironmentBCCHandler:
+        return EnvironmentBCCHandler(self.smirks, self.params, ff.protein_ff, ff.water_ff, omm_topology)
 
 
 class AM1CCCHandler(SerializableMixIn):

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -590,7 +590,7 @@ class EnvironmentBCCHandler(SerializableMixIn):
                 dst_res_template_name = template_for_residue[dst_atom.residue.index].name
                 assert src_res_template_name == dst_res_template_name
                 if src_res_template_name == "HOH":
-                    # Don't fit waters
+                    # Skip waters
                     continue
                 bond_idxs.append((src_atom.index, dst_atom.index))
                 residue_bond_kv = self.res_to_bonds_to_param_idxs[src_res_template_name]
@@ -608,7 +608,6 @@ class EnvironmentBCCHandler(SerializableMixIn):
 
         self.bond_idxs = np.array(bond_idxs)
         self.param_idxs = np.array(param_idxs)
-        # print('ZZZ param_idxs', self.param_idxs.shape, self.param_idxs)
         self.signs = np.array(signs)
 
     def parameterize(self, params):
@@ -621,11 +620,6 @@ class EnvironmentBCCHandler(SerializableMixIn):
         final_charges = apply_bond_charge_corrections(
             self.initial_charges, self.bond_idxs, bond_deltas, runtime_validate=False
         )
-        # import jax
-        # print('FFNB initial_charges', self.initial_charges)
-        # jax.debug.print('FFNB params={p}', p=params)
-        # print('FFNB bond_deltas', bond_deltas)
-        # print('FFNB final_charges', final_charges)
         return final_charges
 
 

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -614,7 +614,6 @@ class EnvironmentBCCHandler(SerializableMixIn):
     def parameterize(self, params):
         # If there aren't any matched parameters (i.e. it's all water),
         # then there is nothing to do
-        return self.initial_charges
         if len(self.param_idxs) == 0:
             return self.initial_charges
 

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -507,9 +507,20 @@ class AM1BCCSolventHandler(AM1BCCHandler):
     pass
 
 
+class EnvironmentBCCPartialHandler(SerializableMixIn):
+    # stored in the ff.py file
+    def __init__(self, smirks, params, props):
+        self.smirks = smirks
+        self.params = params
+        self.props = props
+
+    def get_env_handle(self, omm_topology, ff: Forcefield) -> EnvironmentBCCHandler:
+        return EnvironmentBCCHandler(self.smirks, self.params, ff.protein_ff_name, ff.water_ff_name, omm_topology)
+
+
 class EnvironmentBCCHandler(SerializableMixIn):
     """
-    Applies BCCs to residues in a forcefield.
+    Applies BCCs to residues in a forcefield. Needs a concrete openmm topology to use.
     """
 
     def __init__(self, patterns, params, protein_ff_name, water_ff_name, topology):

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -614,6 +614,7 @@ class EnvironmentBCCHandler(SerializableMixIn):
     def parameterize(self, params):
         # If there aren't any matched parameters (i.e. it's all water),
         # then there is nothing to do
+        return self.initial_charges
         if len(self.param_idxs) == 0:
             return self.initial_charges
 

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -510,6 +510,7 @@ class AM1BCCSolventHandler(AM1BCCHandler):
 class EnvironmentBCCHandler(SerializableMixIn):
     """
     Applies BCCs to residues in a protein. Needs a concrete openmm topology to use.
+    NOTE: Currently, this only supports the amber99sbildn protein forcefield.
     """
 
     def __init__(self, patterns, params, protein_ff_name, water_ff_name, topology):
@@ -520,6 +521,7 @@ class EnvironmentBCCHandler(SerializableMixIn):
 
         from timemachine.ff.handlers import openmm_deserializer
 
+        assert protein_ff_name == "amber99sbildn", f"{protein_ff_name} is not currently supported"
         self.patterns = patterns
         self.params = np.array(params)
         self.env_ff = ForceField(f"{protein_ff_name}.xml", f"{water_ff_name}.xml")
@@ -634,6 +636,8 @@ class EnvironmentBCCPartialHandler(SerializableMixIn):
 
     This class is a serializable version of `EnvironmentBCCHandler`,
     so it can be stored in the forcefield python file in the normal way.
+
+    NOTE: Currently, this only supports the amber99sbildn protein forcefield.
     """
 
     def __init__(self, smirks, params, props):

--- a/timemachine/ff/handlers/nonbonded.py
+++ b/timemachine/ff/handlers/nonbonded.py
@@ -509,7 +509,7 @@ class AM1BCCSolventHandler(AM1BCCHandler):
 
 class EnvironmentBCCHandler(SerializableMixIn):
     """
-    Applies BCCs to residues in a forcefield. Needs a concrete openmm topology to use.
+    Applies BCCs to residues in a protein. Needs a concrete openmm topology to use.
     """
 
     def __init__(self, patterns, params, protein_ff_name, water_ff_name, topology):
@@ -624,13 +624,35 @@ class EnvironmentBCCHandler(SerializableMixIn):
 
 
 class EnvironmentBCCPartialHandler(SerializableMixIn):
-    # stored in the ff.py file
+    """
+    This class is used to represent the environment BCC terms
+    that modify the charges used for the environment-ligand
+    interaction potential.
+
+    The current implementation skips water molecules, so only the
+    protein charges are modified.
+
+    This class is a serializable version of `EnvironmentBCCHandler`,
+    so it can be stored in the forcefield python file in the normal way.
+    """
+
     def __init__(self, smirks, params, props):
         self.smirks = smirks
         self.params = np.array(params)
         self.props = props
 
     def get_env_handle(self, omm_topology, ff) -> EnvironmentBCCHandler:
+        """
+        Return an initialized `EnvironmentBCCHandler` which can be used to
+        get the (possibly updated) environment charges.
+
+        Parameters
+        ----------
+        omm_topology:
+            Openmm topology object for the environment.
+
+        ff: Forcefield
+        """
         return EnvironmentBCCHandler(self.smirks, self.params, ff.protein_ff, ff.water_ff, omm_topology)
 
 

--- a/timemachine/ff/handlers/openmm_deserializer.py
+++ b/timemachine/ff/handlers/openmm_deserializer.py
@@ -3,7 +3,7 @@ from typing import DefaultDict, List, Tuple
 
 import numpy as np
 import openmm as mm
-from openmm import unit
+from openmm import app, unit
 
 from timemachine import constants, potentials
 from timemachine.ff import Forcefield
@@ -122,7 +122,7 @@ def deserialize_nonbonded_force(force, N):
 
 
 def deserialize_system(
-    system: mm.System, omm_topology, ff: Forcefield, cutoff: float
+    system: mm.System, omm_topology: app.topology.Topology, ff: Forcefield, cutoff: float
 ) -> Tuple[List[potentials.BoundPotential], List[float]]:
     """
     Deserialize an OpenMM XML file
@@ -131,6 +131,10 @@ def deserialize_system(
     ----------
     system: openmm.System
         A system object to be deserialized
+    omm_topology: app.topology.Topology
+        A corresponding topology object
+    ff: Forcefield
+        Forcefield used to potentially modify the environment parameters.
     cutoff: float
         Nonbonded cutoff, in nm
 

--- a/timemachine/ff/handlers/openmm_deserializer.py
+++ b/timemachine/ff/handlers/openmm_deserializer.py
@@ -211,7 +211,7 @@ def deserialize_system(
 
             if ff.env_bcc_handle is not None:
                 env_bcc_h = ff.env_bcc_handle.get_env_handle(omm_topology, ff)
-                nb_params[:, Q_IDX] = env_bcc_h.parameterize(nb_params[:, Q_IDX])
+                nb_params[:, Q_IDX] = env_bcc_h.parameterize(ff.env_bcc_handle.params)
 
             bps_dict["Nonbonded"].append(
                 potentials.Nonbonded(N, exclusion_idxs, scale_factors, beta, cutoff).bind(nb_params)

--- a/timemachine/ff/handlers/openmm_deserializer.py
+++ b/timemachine/ff/handlers/openmm_deserializer.py
@@ -105,8 +105,8 @@ def deserialize_nonbonded_force(force, N):
     )
 
     # optimizations
-    nb_params[:, constants.LJ_SIG_IDX] = nb_params[:, 1] / 2
-    nb_params[:, constants.LJ_EPS_IDX] = np.sqrt(nb_params[:, 2])
+    nb_params[:, constants.NBParamIdx.LJ_SIG_IDX] = nb_params[:, 1] / 2
+    nb_params[:, constants.NBParamIdx.LJ_EPS_IDX] = np.sqrt(nb_params[:, 2])
 
     beta = 2.0  # erfc correction
 

--- a/timemachine/ff/handlers/openmm_deserializer.py
+++ b/timemachine/ff/handlers/openmm_deserializer.py
@@ -3,16 +3,11 @@ from typing import DefaultDict, List, Tuple
 
 import numpy as np
 import openmm as mm
-from openmm import app, unit
+from openmm import unit
 
 from timemachine import constants, potentials
-from timemachine.ff import Forcefield
 
 ORDERED_FORCES = ["HarmonicBond", "HarmonicAngle", "PeriodicTorsion", "Nonbonded"]
-
-Q_IDX = 0
-LJ_SIG_IDX = 1
-LJ_EPS_IDX = 2
 
 
 def value(quantity):
@@ -110,8 +105,8 @@ def deserialize_nonbonded_force(force, N):
     )
 
     # optimizations
-    nb_params[:, LJ_SIG_IDX] = nb_params[:, 1] / 2
-    nb_params[:, LJ_EPS_IDX] = np.sqrt(nb_params[:, 2])
+    nb_params[:, constants.LJ_SIG_IDX] = nb_params[:, 1] / 2
+    nb_params[:, constants.LJ_EPS_IDX] = np.sqrt(nb_params[:, 2])
 
     beta = 2.0  # erfc correction
 
@@ -121,9 +116,7 @@ def deserialize_nonbonded_force(force, N):
     return nb_params, exclusion_idxs, beta, scale_factors
 
 
-def deserialize_system(
-    system: mm.System, omm_topology: app.topology.Topology, ff: Forcefield, cutoff: float
-) -> Tuple[List[potentials.BoundPotential], List[float]]:
+def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potentials.BoundPotential], List[float]]:
     """
     Deserialize an OpenMM XML file
 
@@ -131,10 +124,6 @@ def deserialize_system(
     ----------
     system: openmm.System
         A system object to be deserialized
-    omm_topology: app.topology.Topology
-        A corresponding topology object
-    ff: Forcefield
-        Forcefield used to potentially modify the environment parameters.
     cutoff: float
         Nonbonded cutoff, in nm
 
@@ -212,10 +201,6 @@ def deserialize_system(
 
         if isinstance(force, mm.NonbondedForce):
             nb_params, exclusion_idxs, beta, scale_factors = deserialize_nonbonded_force(force, N)
-
-            if ff.env_bcc_handle is not None:
-                env_bcc_h = ff.env_bcc_handle.get_env_handle(omm_topology, ff)
-                nb_params[:, Q_IDX] = env_bcc_h.parameterize(ff.env_bcc_handle.params)
 
             bps_dict["Nonbonded"].append(
                 potentials.Nonbonded(N, exclusion_idxs, scale_factors, beta, cutoff).bind(nb_params)

--- a/timemachine/ff/handlers/serialize.py
+++ b/timemachine/ff/handlers/serialize.py
@@ -13,6 +13,8 @@ def serialize_handlers(all_handlers, protein_ff, water_ff):
     final_ff[serialization_format.WATER_FF_TAG] = water_ff
 
     for handler in all_handlers:
+        if handler is None:  # optional handler not specified
+            continue
         ff_obj = handler.serialize()
 
         for k in ff_obj.keys():

--- a/timemachine/ff/make_placeholder_ff.py
+++ b/timemachine/ff/make_placeholder_ff.py
@@ -52,6 +52,7 @@ placeholder_ff = Forcefield(
     lj_handle_intra=placeholder_lj_handle_intra,
     protein_ff="amber99sbildn",
     water_ff="amber14/tip3p",
+    env_bcc_handle=None,
 )
 
 # serialize

--- a/timemachine/md/enhanced.py
+++ b/timemachine/md/enhanced.py
@@ -433,7 +433,7 @@ def get_solvent_phase_system(mol, ff, lamb: float, box_width=3.0, margin=0.5, mi
         box_width, ff.water_ff, mols=[mol]
     )
     water_box = water_box + np.eye(3) * margin  # add a small margin around the box for stability
-    host_config = HostConfig(water_system, water_coords, water_box, water_coords.shape[0])
+    host_config = HostConfig(water_system, water_coords, water_box, water_coords.shape[0], water_topology)
 
     # construct alchemical system
     bt = topology.BaseTopology(mol, ff)

--- a/timemachine/md/enhanced.py
+++ b/timemachine/md/enhanced.py
@@ -438,8 +438,7 @@ def get_solvent_phase_system(mol, ff, lamb: float, box_width=3.0, margin=0.5, mi
     # construct alchemical system
     bt = topology.BaseTopology(mol, ff)
     afe = free_energy.AbsoluteFreeEnergy(mol, bt)
-    ff_params = ff.get_params()
-    potentials, params, masses = afe.prepare_host_edge(ff_params, host_config, lamb)
+    potentials, params, masses = afe.prepare_host_edge(ff, host_config, lamb)
 
     # concatenate (optionally minimized) water_coords and ligand_coords
     ligand_coords = get_romol_conf(mol)

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -189,7 +189,9 @@ def pre_equilibrate_host(
         max_lambda=minimizer_max_lambda,
     )
 
-    host_bps, host_masses = openmm_deserializer.deserialize_system(host_config.omm_system, cutoff=1.2)
+    host_bps, host_masses = openmm_deserializer.deserialize_system(
+        host_config.omm_system, host_config.omm_topology, ff, cutoff=1.2
+    )
 
     num_host_atoms = host_config.conf.shape[0]
 
@@ -334,7 +336,9 @@ def make_host_du_dx_fxn(
     assert host_config.box.shape == (3, 3)
 
     # openmm host_system -> timemachine host_bps
-    host_bps, _ = openmm_deserializer.deserialize_system(host_config.omm_system, cutoff=1.2)
+    host_bps, _ = openmm_deserializer.deserialize_system(
+        host_config.omm_system, host_config.omm_topology, ff, cutoff=1.2
+    )
 
     # construct appropriate topology from (mols, ff)
     if len(mols) == 1:

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -189,9 +189,7 @@ def pre_equilibrate_host(
         max_lambda=minimizer_max_lambda,
     )
 
-    host_bps, host_masses = openmm_deserializer.deserialize_system(
-        host_config.omm_system, host_config.omm_topology, ff, cutoff=1.2
-    )
+    host_bps, host_masses = openmm_deserializer.deserialize_system(host_config.omm_system, cutoff=1.2)
 
     num_host_atoms = host_config.conf.shape[0]
 
@@ -216,7 +214,7 @@ def pre_equilibrate_host(
     combined_masses = np.concatenate(mass_list)
     combined_coords = np.concatenate(conf_list)
 
-    hgt = topology.HostGuestTopology(host_bps, top, host_config.num_water_atoms)
+    hgt = topology.HostGuestTopology(host_bps, top, host_config.num_water_atoms, ff, host_config.omm_topology)
 
     dt = 1.5e-3
     friction = 1.0
@@ -336,9 +334,7 @@ def make_host_du_dx_fxn(
     assert host_config.box.shape == (3, 3)
 
     # openmm host_system -> timemachine host_bps
-    host_bps, _ = openmm_deserializer.deserialize_system(
-        host_config.omm_system, host_config.omm_topology, ff, cutoff=1.2
-    )
+    host_bps, _ = openmm_deserializer.deserialize_system(host_config.omm_system, cutoff=1.2)
 
     # construct appropriate topology from (mols, ff)
     if len(mols) == 1:
@@ -348,7 +344,7 @@ def make_host_du_dx_fxn(
     else:
         raise ValueError("mols must be length 1 or 2")
 
-    hgt = topology.HostGuestTopology(host_bps, top, host_config.num_water_atoms)
+    hgt = topology.HostGuestTopology(host_bps, top, host_config.num_water_atoms, ff, host_config.omm_topology)
 
     # read conformers from mol_coords if given, or each mol's conf0 otherwise
     conf_list = [np.asarray(host_config.conf)]

--- a/timemachine/testsystems/dhfr.py
+++ b/timemachine/testsystems/dhfr.py
@@ -3,7 +3,6 @@ from importlib import resources
 import numpy as np
 from openmm import app
 
-from timemachine.ff import Forcefield
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md.builders import strip_units
 
@@ -11,9 +10,6 @@ from timemachine.md.builders import strip_units
 def setup_dhfr():
     with resources.path("timemachine.testsystems.data", "5dfr_solv_equil.pdb") as pdb_path:
         host_pdb = app.PDBFile(str(pdb_path))
-
-    tm_ff = Forcefield.load_default()
-    modeller = app.Modeller(host_pdb.topology, host_pdb.positions)
 
     protein_ff = app.ForceField("amber99sbildn.xml", "tip3p.xml")
     host_system = protein_ff.createSystem(
@@ -23,7 +19,7 @@ def setup_dhfr():
     box = host_pdb.topology.getPeriodicBoxVectors()
     box = strip_units(box)
 
-    host_fns, host_masses = openmm_deserializer.deserialize_system(host_system, modeller.topology, tm_ff, cutoff=1.0)
+    host_fns, host_masses = openmm_deserializer.deserialize_system(host_system, cutoff=1.0)
 
     return host_fns, host_masses, np.array(host_coords), np.array(box)
 

--- a/timemachine/testsystems/dhfr.py
+++ b/timemachine/testsystems/dhfr.py
@@ -28,9 +28,8 @@ def get_dhfr_system():
     with resources.path("timemachine.testsystems.data", "5dfr_solv_equil.pdb") as pdb_path:
         host_pdb = app.PDBFile(str(pdb_path))
 
-    modeller = app.Modeller(host_pdb.topology, host_pdb.positions)
     protein_ff = app.ForceField("amber99sbildn.xml", "tip3p.xml")
     host_system = protein_ff.createSystem(
         host_pdb.topology, nonbondedMethod=app.NoCutoff, constraints=None, rigidWater=False
     )
-    return host_system, modeller.topology
+    return host_system, host_pdb.topology

--- a/timemachine/testsystems/dhfr.py
+++ b/timemachine/testsystems/dhfr.py
@@ -32,8 +32,9 @@ def get_dhfr_system():
     with resources.path("timemachine.testsystems.data", "5dfr_solv_equil.pdb") as pdb_path:
         host_pdb = app.PDBFile(str(pdb_path))
 
+    modeller = app.Modeller(host_pdb.topology, host_pdb.positions)
     protein_ff = app.ForceField("amber99sbildn.xml", "tip3p.xml")
     host_system = protein_ff.createSystem(
         host_pdb.topology, nonbondedMethod=app.NoCutoff, constraints=None, rigidWater=False
     )
-    return host_system
+    return host_system, modeller.topology


### PR DESCRIPTION
- Store openmm topology in HostConfig (needed to use EnvironmentBCCHandler)
- Add optional ff.env_bcc_handle handle (default is None) which will apply the modified charges if present
- Add EnvironmentBCCPartialHandler which is what gets serialized in ff.py (since EnvironmentBCCHandler requires the openmm topology, it can't be serialized directly)
- Update topology.HostGuestTopology.parameterize_nonbonded and single_topology.SingleTopology.combine_with_host to apply updated charges for the environment-ligand interactions only if Forcefield.env_bcc_handle is not None
- Update corresponding topology tests to check the new handler applies the expected P-L ixn parameters