### PR TITLE
Clean up HREX, BDExchangeMover and TIBDExchangeMover

### DIFF
--- a/timemachine/cpp/src/bd_exchange_move.cu
+++ b/timemachine/cpp/src/bd_exchange_move.cu
@@ -200,7 +200,7 @@ void BDExchangeMove<RealType>::move(
             // Run only after the first pass, to maintain meaningful `log_probability_host` values
             // Run a separate kernel to replace the before logsumexp values with the after if accepted a move
             // Could also recompute the logsumexp each round, but more expensive than probably necessary.
-            k_store_accepted_log_probability<RealType><<<1, 1, 0>>>(
+            k_store_accepted_log_probability<RealType><<<1, 1, 0, stream>>>(
                 num_target_mols_,
                 batch_size_,
                 d_selected_sample_.data,

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -538,8 +538,8 @@ def get_context(initial_state: InitialState, md_params: Optional[MDParams] = Non
 
         water_params = get_water_sampler_params(initial_state)
 
-        # Generate a new random seed based on the md params seed
-        rng = np.random.default_rng(md_params.seed)
+        # Generate a new random seed based on the integrator seed, MDParams seed is constant across states
+        rng = np.random.default_rng(initial_state.integrator.seed)
         water_sampler_seed = rng.integers(np.iinfo(np.int32).max)
 
         water_sampler = custom_ops.TIBDExchangeMove_f32(


### PR DESCRIPTION
* Fixes a potential bug in the BDExchangeMover that doesn't pass the stream to a kernel. Not seen in practice because we use the default stream as well as the fact that we synchronize the stream immediately before calling the kernel in question. Good to fix regardless
* Fixes an HREX test that was no longer patching the correct function as of #1334, added assertions to avoid missing again
* Removes duplicate equilibration logic in `run_sims_hrex` to avoid code becoming stale. 
* Avoids setting the same seed for TIBDExchangeMover in `get_context` across initial states. Use the integrator seed, which is distinct to each InitialState.