### PR TITLE
Perform shallow clones of Pybind/Eigen

### DIFF
--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -32,12 +32,12 @@ set(LIBRARY_NAME custom_ops)
 set(PYBIND_SRC_DIR pybind11)
 
 if(NOT EXISTS ${PYBIND_SRC_DIR})
-  execute_process(COMMAND git clone --branch v2.9.2 https://github.com/pybind/pybind11.git ${PYBIND_SRC_DIR})
+  execute_process(COMMAND git clone --depth 1 --branch v2.9.2 https://github.com/pybind/pybind11.git ${PYBIND_SRC_DIR})
 endif()
 
 set(EIGEN_SRC_DIR eigen)
 if(NOT EXISTS ${EIGEN_SRC_DIR})
-  execute_process(COMMAND git clone --branch 3.3.9 https://gitlab.com/libeigen/eigen.git ${EIGEN_SRC_DIR})
+  execute_process(COMMAND git clone --depth 1 --branch 3.3.9 https://gitlab.com/libeigen/eigen.git ${EIGEN_SRC_DIR})
 endif()
 
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/${PYBIND_SRC_DIR} ${CMAKE_CURRENT_BINARY_DIR}/${PYBIND_SRC_DIR})


### PR DESCRIPTION
* Reduces the data cloned by 120MB, should make pip installing faster on linux
* Appears to save ~10 seconds compared to `pip install timemachine@git+https://github.com/proteneer/timemachine/@0430d506d74f58bdc154c78d5ed0ae6076436e85` 