### PR TITLE
Remove application code from rbfe module

### DIFF
--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -1,15 +1,211 @@
 import argparse
 import csv
+import pickle
+import traceback
 from dataclasses import replace
-from typing import List
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence
 
+import numpy as np
 from openmm import app
+from rdkit import Chem
 
-from timemachine.constants import KCAL_TO_KJ
-from timemachine.fe import rbfe
-from timemachine.fe.free_energy import WaterSamplingParams
-from timemachine.fe.utils import read_sdf
+from timemachine.constants import DEFAULT_ATOM_MAPPING_KWARGS, KCAL_TO_KJ
+from timemachine.fe import atom_mapping, rbfe
+from timemachine.fe.free_energy import MDParams, WaterSamplingParams
+from timemachine.fe.utils import get_mol_name, read_sdf
 from timemachine.ff import Forcefield
+from timemachine.parallel.client import AbstractClient, AbstractFileClient, CUDAPoolClient, FileClient
+
+
+class Edge(NamedTuple):
+    mol_a_name: str
+    mol_b_name: str
+    metadata: Dict[str, Any]
+
+
+def get_failure_result_path(mol_a_name: str, mol_b_name: str):
+    return f"failure_rbfe_result_{mol_a_name}_{mol_b_name}.pkl"
+
+
+def get_success_result_path(mol_a_name: str, mol_b_name: str):
+    return f"success_rbfe_result_{mol_a_name}_{mol_b_name}.pkl"
+
+
+def run_edge_and_save_results(
+    edge: Edge,
+    mols: Dict[str, Chem.rdchem.Mol],
+    forcefield: Forcefield,
+    protein: app.PDBFile,
+    file_client: AbstractFileClient,
+    n_windows: Optional[int],
+    md_params: MDParams = rbfe.DEFAULT_MD_PARAMS,
+):
+    # Ensure that all mol props (e.g. _Name) are included in pickles
+    # Without this get_mol_name(mol) will fail on roundtripped mol
+    Chem.SetDefaultPickleProperties(Chem.PropertyPickleOptions.AllProps)
+
+    edge_prefix = f"{edge.mol_a_name}_{edge.mol_b_name}"
+
+    try:
+        mol_a = mols[edge.mol_a_name]
+        mol_b = mols[edge.mol_b_name]
+
+        all_cores = atom_mapping.get_cores(
+            mol_a,
+            mol_b,
+            **DEFAULT_ATOM_MAPPING_KWARGS,
+        )
+        core = all_cores[0]
+
+        complex_res, complex_top, _ = rbfe.run_complex(
+            mol_a,
+            mol_b,
+            core,
+            forcefield,
+            protein,
+            md_params,
+            n_windows=n_windows,
+        )
+
+        if isinstance(complex_res, rbfe.HREXSimulationResult):
+            file_client.store(
+                f"{edge_prefix}_complex_hrex_transition_matrix.png", complex_res.hrex_plots.transition_matrix_png
+            )
+            file_client.store(
+                f"{edge_prefix}_complex_hrex_swap_acceptance_rates_convergence.png",
+                complex_res.hrex_plots.swap_acceptance_rates_convergence_png,
+            )
+            file_client.store(
+                f"{edge_prefix}_complex_hrex_replica_state_distribution_heatmap.png",
+                complex_res.hrex_plots.replica_state_distribution_heatmap_png,
+            )
+
+        solvent_res, solvent_top, _ = rbfe.run_solvent(
+            mol_a,
+            mol_b,
+            core,
+            forcefield,
+            protein,
+            md_params,
+            n_windows=n_windows,
+        )
+        if isinstance(solvent_res, rbfe.HREXSimulationResult):
+            file_client.store(
+                f"{edge_prefix}_solvent_hrex_transition_matrix.png", solvent_res.hrex_plots.transition_matrix_png
+            )
+            file_client.store(
+                f"{edge_prefix}_solvent_hrex_swap_acceptance_rates_convergence.png",
+                solvent_res.hrex_plots.swap_acceptance_rates_convergence_png,
+            )
+            file_client.store(
+                f"{edge_prefix}_solvent_hrex_replica_state_distribution_heatmap.png",
+                solvent_res.hrex_plots.replica_state_distribution_heatmap_png,
+            )
+
+    except Exception as err:
+        print(
+            "failed:",
+            " | ".join(
+                [
+                    f"{edge.mol_a_name} -> {edge.mol_b_name} (kJ/mol)",
+                    f"exp_ddg {edge.metadata['exp_ddg']:.2f}" if "exp_ddg" in edge.metadata else "",
+                    (
+                        f"fep_ddg {edge.metadata['fep_ddg']:.2f} +- {edge.metadata['fep_ddg_err']:.2f}"
+                        if "fep_ddg" in edge.metadata and "fep_ddg_err" in edge.metadata
+                        else ""
+                    ),
+                ]
+            ),
+        )
+
+        path = get_failure_result_path(edge.mol_a_name, edge.mol_b_name)
+        tb = traceback.format_exception(None, err, err.__traceback__)
+        file_client.store(path, pickle.dumps((edge, err, tb)))
+
+        print(err)
+        traceback.print_exc()
+
+        return file_client.full_path(path)
+
+    path = get_success_result_path(edge.mol_a_name, edge.mol_b_name)
+    pkl_obj = (mol_a, mol_b, edge.metadata, core, solvent_res, solvent_top, complex_res, complex_top)
+    file_client.store(path, pickle.dumps(pkl_obj))
+
+    solvent_ddg = sum(solvent_res.final_result.dGs)
+    solvent_ddg_err = np.linalg.norm(solvent_res.final_result.dG_errs)
+    complex_ddg = sum(complex_res.final_result.dGs)
+    complex_ddg_err = np.linalg.norm(complex_res.final_result.dG_errs)
+
+    tm_ddg = complex_ddg - solvent_ddg
+    tm_err = np.linalg.norm([complex_ddg_err, solvent_ddg_err])
+
+    print(
+        "finished:",
+        " | ".join(
+            [
+                f"{edge.mol_a_name} -> {edge.mol_b_name} (kJ/mol)",
+                f"complex {complex_ddg:.2f} +- {complex_ddg_err:.2f}",
+                f"solvent {solvent_ddg:.2f} +- {solvent_ddg_err:.2f}",
+                f"tm_pred {tm_ddg:.2f} +- {tm_err:.2f}",
+                f"exp_ddg {edge.metadata['exp_ddg']:.2f}" if "exp_ddg" in edge.metadata else "",
+                (
+                    f"fep_ddg {edge.metadata['fep_ddg']:.2f} +- {edge.metadata['fep_ddg_err']:.2f}"
+                    if "fep_ddg" in edge.metadata and "fep_ddg_err" in edge.metadata
+                    else ""
+                ),
+            ]
+        ),
+    )
+
+    return file_client.full_path(path)
+
+
+def run_edges_parallel(
+    ligands: Sequence[Chem.rdchem.Mol],
+    edges: Sequence[Edge],
+    ff: Forcefield,
+    protein: app.PDBFile,
+    n_gpus: int,
+    pool_client: Optional[AbstractClient] = None,
+    file_client: Optional[AbstractFileClient] = None,
+    md_params: MDParams = rbfe.DEFAULT_MD_PARAMS,
+    n_windows: Optional[int] = None,
+):
+    mols = {get_mol_name(mol): mol for mol in ligands}
+
+    pool_client = pool_client or CUDAPoolClient(n_gpus)
+    pool_client.verify()
+
+    file_client = file_client or FileClient()
+
+    # Ensure that all mol props (e.g. _Name) are included in pickles
+    # Without this get_mol_name(mol) will fail on roundtripped mol
+    Chem.SetDefaultPickleProperties(Chem.PropertyPickleOptions.AllProps)
+
+    jobs = [
+        pool_client.submit(
+            run_edge_and_save_results,
+            edge,
+            mols,
+            ff,
+            protein,
+            file_client,
+            n_windows,
+            md_params,
+        )
+        for edge in edges
+    ]
+
+    # Remove references to completed jobs to allow garbage collection.
+    # TODO: The current approach uses O(edges) memory in the worst case (e.g. if the first job gets stuck). Ideally we
+    #   should process and remove references to jobs in the order they complete, but this would require an interface
+    #   presently not implemented in our custom future classes.
+    paths = []
+    while jobs:
+        job = jobs.pop(0)
+        paths.append(job.result())
+
+    return paths
 
 
 def parse_args():
@@ -34,12 +230,12 @@ def parse_args():
     return parser.parse_args()
 
 
-def read_edges_csv(path: str) -> List[rbfe.Edge]:
+def read_edges_csv(path: str) -> List[Edge]:
     with open(path) as fp:
         reader = csv.reader(fp, delimiter=",")
         next(reader, None)  # skip header
         return [
-            rbfe.Edge(
+            Edge(
                 mol_a_name,
                 mol_b_name,
                 {
@@ -74,7 +270,7 @@ if __name__ == "__main__":
     if args.water_sampling_interval is not None and args.water_sampling_interval > 0:
         md_params = replace(md_params, water_sampling_params=WaterSamplingParams(interval=args.water_sampling_interval))
 
-    _ = rbfe.run_edges_parallel(
+    _ = run_edges_parallel(
         ligands,
         edges,
         forcefield,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,7 +16,6 @@ from scipy.special import logsumexp
 
 from timemachine.constants import DEFAULT_FF, DEFAULT_KT, KCAL_TO_KJ
 from timemachine.datasets import fetch_freesolv
-from timemachine.fe import rbfe
 from timemachine.fe.free_energy import PairBarResult, SimulationResult
 from timemachine.fe.utils import get_mol_name
 
@@ -146,6 +145,10 @@ def test_smc_freesolv(smc_free_solv_path):
     assert mean_abs_err_kcalmol <= 2
 
 
+def get_success_result_path(mol_a_name: str, mol_b_name: str):
+    return f"success_rbfe_result_{mol_a_name}_{mol_b_name}.pkl"
+
+
 @contextmanager
 def get_rbfe_edge_list_hif2a_path(seed):
     with resources.as_file(resources.files("timemachine.datasets.fep_benchmark.hif2a")) as hif2a_data:
@@ -161,7 +164,7 @@ def get_rbfe_edge_list_hif2a_path(seed):
         )
 
         def run(results_csv, temp_dir):
-            output_path = str(Path(temp_dir) / rbfe.get_success_result_path("*", "*"))
+            output_path = str(Path(temp_dir) / get_success_result_path("*", "*"))
             assert len(glob(output_path)) == 0
             config = dict(results_csv=results_csv, **base_config)
             _ = run_example("rbfe_edge_list.py", get_cli_args(config), cwd=temp_dir)
@@ -241,7 +244,7 @@ def test_rbfe_edge_list_hif2a(rbfe_edge_list_hif2a_path):
                     assert frame.shape == (N, 3)
 
     for mol_a_name, mol_b_name in edges:
-        check_results(path / rbfe.get_success_result_path(mol_a_name, mol_b_name))
+        check_results(path / get_success_result_path(mol_a_name, mol_b_name))
 
 
 def assert_simulation_results_equal(r1: SimulationResult, r2: SimulationResult):
@@ -267,7 +270,7 @@ def test_rbfe_edge_list_reproducible(rbfe_edge_list_hif2a_path):
             for mol_a_name, mol_b_name in edges:
 
                 def load_results(dir):
-                    path = dir / rbfe.get_success_result_path(mol_a_name, mol_b_name)
+                    path = dir / get_success_result_path(mol_a_name, mol_b_name)
                     assert path.exists()
                     return load_simulation_results(path)
 
@@ -308,8 +311,8 @@ def test_water_sampling_mc_bulk_water(insertion_type):
         # expect running this script to write summary_result_result_{mol_name}_*.pkl files
         proc = run_example("water_sampling_mc.py", get_cli_args(config), cwd=temp_dir)
         assert proc.returncode == 0
-        assert (Path(temp_dir) / config["out_cif"]).is_file()
-        last_frame = Path(temp_dir) / config["save_last_frame"]
+        assert (Path(temp_dir) / str(config["out_cif"])).is_file()
+        last_frame = Path(temp_dir) / str(config["save_last_frame"])
         assert last_frame.is_file()
 
         test_data = np.load(last_frame)
@@ -342,8 +345,8 @@ def test_water_sampling_mc_buckyball(batch_size, insertion_type):
         # expect running this script to write summary_result_result_{mol_name}_*.pkl files
         proc = run_example("water_sampling_mc.py", get_cli_args(config), cwd=temp_dir)
         assert proc.returncode == 0
-        assert (Path(temp_dir) / config["out_cif"]).is_file()
-        last_frame = Path(temp_dir) / config["save_last_frame"]
+        assert (Path(temp_dir) / str(config["out_cif"])).is_file()
+        last_frame = Path(temp_dir) / str(config["save_last_frame"])
         assert last_frame.is_file()
 
         test_data = np.load(last_frame)

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -1,17 +1,16 @@
 import pickle
-import traceback
 import warnings
 from dataclasses import dataclass, replace
 from functools import partial
-from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Sequence, Tuple, Union, cast
+from typing import Callable, Iterable, List, Optional, Sequence, Tuple, Union, cast
 
 import numpy as np
 from numpy.typing import NDArray
 from openmm import app
 from rdkit import Chem
 
-from timemachine.constants import DEFAULT_ATOM_MAPPING_KWARGS, DEFAULT_PRESSURE, DEFAULT_TEMP
-from timemachine.fe import atom_mapping, model_utils
+from timemachine.constants import DEFAULT_PRESSURE, DEFAULT_TEMP
+from timemachine.fe import model_utils
 from timemachine.fe.free_energy import (
     HostConfig,
     HREXParams,
@@ -41,7 +40,6 @@ from timemachine.lib import LangevinIntegrator, MonteCarloBarostat
 from timemachine.md import builders, minimizer
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.md.thermostat.utils import sample_velocities
-from timemachine.parallel.client import AbstractClient, AbstractFileClient, CUDAPoolClient, FileClient
 from timemachine.potentials import BoundPotential, jax_utils
 
 DEFAULT_NUM_WINDOWS = 48
@@ -942,194 +940,3 @@ def run_complex(
         min_cutoff=min_cutoff,
     )
     return complex_res, complex_top, complex_host_config
-
-
-class Edge(NamedTuple):
-    mol_a_name: str
-    mol_b_name: str
-    metadata: Dict[str, Any]
-
-
-def get_failure_result_path(mol_a_name: str, mol_b_name: str):
-    return f"failure_rbfe_result_{mol_a_name}_{mol_b_name}.pkl"
-
-
-def get_success_result_path(mol_a_name: str, mol_b_name: str):
-    return f"success_rbfe_result_{mol_a_name}_{mol_b_name}.pkl"
-
-
-def run_edge_and_save_results(
-    edge: Edge,
-    mols: Dict[str, Chem.rdchem.Mol],
-    forcefield: Forcefield,
-    protein: app.PDBFile,
-    file_client: AbstractFileClient,
-    n_windows: Optional[int],
-    md_params: MDParams = DEFAULT_MD_PARAMS,
-):
-    # Ensure that all mol props (e.g. _Name) are included in pickles
-    # Without this get_mol_name(mol) will fail on roundtripped mol
-    Chem.SetDefaultPickleProperties(Chem.PropertyPickleOptions.AllProps)
-
-    edge_prefix = f"{edge.mol_a_name}_{edge.mol_b_name}"
-
-    try:
-        mol_a = mols[edge.mol_a_name]
-        mol_b = mols[edge.mol_b_name]
-
-        all_cores = atom_mapping.get_cores(
-            mol_a,
-            mol_b,
-            **DEFAULT_ATOM_MAPPING_KWARGS,
-        )
-        core = all_cores[0]
-
-        complex_res, complex_top, _ = run_complex(
-            mol_a,
-            mol_b,
-            core,
-            forcefield,
-            protein,
-            md_params,
-            n_windows=n_windows,
-        )
-
-        if isinstance(complex_res, HREXSimulationResult):
-            file_client.store(
-                f"{edge_prefix}_complex_hrex_transition_matrix.png", complex_res.hrex_plots.transition_matrix_png
-            )
-            file_client.store(
-                f"{edge_prefix}_complex_hrex_swap_acceptance_rates_convergence.png",
-                complex_res.hrex_plots.swap_acceptance_rates_convergence_png,
-            )
-            file_client.store(
-                f"{edge_prefix}_complex_hrex_replica_state_distribution_heatmap.png",
-                complex_res.hrex_plots.replica_state_distribution_heatmap_png,
-            )
-
-        solvent_res, solvent_top, _ = run_solvent(
-            mol_a,
-            mol_b,
-            core,
-            forcefield,
-            protein,
-            md_params,
-            n_windows=n_windows,
-        )
-        if isinstance(solvent_res, HREXSimulationResult):
-            file_client.store(
-                f"{edge_prefix}_solvent_hrex_transition_matrix.png", solvent_res.hrex_plots.transition_matrix_png
-            )
-            file_client.store(
-                f"{edge_prefix}_solvent_hrex_swap_acceptance_rates_convergence.png",
-                solvent_res.hrex_plots.swap_acceptance_rates_convergence_png,
-            )
-            file_client.store(
-                f"{edge_prefix}_solvent_hrex_replica_state_distribution_heatmap.png",
-                solvent_res.hrex_plots.replica_state_distribution_heatmap_png,
-            )
-
-    except Exception as err:
-        print(
-            "failed:",
-            " | ".join(
-                [
-                    f"{edge.mol_a_name} -> {edge.mol_b_name} (kJ/mol)",
-                    f"exp_ddg {edge.metadata['exp_ddg']:.2f}" if "exp_ddg" in edge.metadata else "",
-                    (
-                        f"fep_ddg {edge.metadata['fep_ddg']:.2f} +- {edge.metadata['fep_ddg_err']:.2f}"
-                        if "fep_ddg" in edge.metadata and "fep_ddg_err" in edge.metadata
-                        else ""
-                    ),
-                ]
-            ),
-        )
-
-        path = get_failure_result_path(edge.mol_a_name, edge.mol_b_name)
-        tb = traceback.format_exception(None, err, err.__traceback__)
-        file_client.store(path, pickle.dumps((edge, err, tb)))
-
-        print(err)
-        traceback.print_exc()
-
-        return file_client.full_path(path)
-
-    path = get_success_result_path(edge.mol_a_name, edge.mol_b_name)
-    pkl_obj = (mol_a, mol_b, edge.metadata, core, solvent_res, solvent_top, complex_res, complex_top)
-    file_client.store(path, pickle.dumps(pkl_obj))
-
-    solvent_ddg = sum(solvent_res.final_result.dGs)
-    solvent_ddg_err = np.linalg.norm(solvent_res.final_result.dG_errs)
-    complex_ddg = sum(complex_res.final_result.dGs)
-    complex_ddg_err = np.linalg.norm(complex_res.final_result.dG_errs)
-
-    tm_ddg = complex_ddg - solvent_ddg
-    tm_err = np.linalg.norm([complex_ddg_err, solvent_ddg_err])
-
-    print(
-        "finished:",
-        " | ".join(
-            [
-                f"{edge.mol_a_name} -> {edge.mol_b_name} (kJ/mol)",
-                f"complex {complex_ddg:.2f} +- {complex_ddg_err:.2f}",
-                f"solvent {solvent_ddg:.2f} +- {solvent_ddg_err:.2f}",
-                f"tm_pred {tm_ddg:.2f} +- {tm_err:.2f}",
-                f"exp_ddg {edge.metadata['exp_ddg']:.2f}" if "exp_ddg" in edge.metadata else "",
-                (
-                    f"fep_ddg {edge.metadata['fep_ddg']:.2f} +- {edge.metadata['fep_ddg_err']:.2f}"
-                    if "fep_ddg" in edge.metadata and "fep_ddg_err" in edge.metadata
-                    else ""
-                ),
-            ]
-        ),
-    )
-
-    return file_client.full_path(path)
-
-
-def run_edges_parallel(
-    ligands: Sequence[Chem.rdchem.Mol],
-    edges: Sequence[Edge],
-    ff: Forcefield,
-    protein: app.PDBFile,
-    n_gpus: int,
-    pool_client: Optional[AbstractClient] = None,
-    file_client: Optional[AbstractFileClient] = None,
-    md_params: MDParams = DEFAULT_MD_PARAMS,
-    n_windows: Optional[int] = None,
-):
-    mols = {get_mol_name(mol): mol for mol in ligands}
-
-    pool_client = pool_client or CUDAPoolClient(n_gpus)
-    pool_client.verify()
-
-    file_client = file_client or FileClient()
-
-    # Ensure that all mol props (e.g. _Name) are included in pickles
-    # Without this get_mol_name(mol) will fail on roundtripped mol
-    Chem.SetDefaultPickleProperties(Chem.PropertyPickleOptions.AllProps)
-
-    jobs = [
-        pool_client.submit(
-            run_edge_and_save_results,
-            edge,
-            mols,
-            ff,
-            protein,
-            file_client,
-            n_windows,
-            md_params,
-        )
-        for edge in edges
-    ]
-
-    # Remove references to completed jobs to allow garbage collection.
-    # TODO: The current approach uses O(edges) memory in the worst case (e.g. if the first job gets stuck). Ideally we
-    #   should process and remove references to jobs in the order they complete, but this would require an interface
-    #   presently not implemented in our custom future classes.
-    paths = []
-    while jobs:
-        job = jobs.pop(0)
-        paths.append(job.result())
-
-    return paths


### PR DESCRIPTION
Moves application code that is fairly specific to a use case (running a list of edges asynchronously) out of the `fe.rbfe` module to the example where it is used.