### PR TITLE
Fixes Support for Disabling Optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ pip install -e .
 or
 ```shell
 make build  # Must have installed dev dependencies for this to work
+
+DEBUG_BUILD=true make build  # Disable optimizations and build with debugging information
 ```
 
 ### Running Tests

--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -9,14 +9,15 @@ project(timemachine LANGUAGES CXX CUDA)
 find_package(PythonInterp 3.10 REQUIRED)
 find_package(PythonLibs 3.10 REQUIRED)
 
-string(APPEND CMAKE_CXX_FLAGS "-Werror -Wall -Wextra")
+set(COMMON_COMPILER_FLAGS, "-Werror -Wall -Wextra -O3")
 
-string(APPEND CMAKE_CUDA_FLAGS "-O3 -lineinfo")
+string(APPEND CMAKE_CXX_FLAGS "${COMMON_COMPILER_FLAGS}")
+string(APPEND CMAKE_CUDA_FLAGS "${COMMON_COMPILER_FLAGS}")
+
 string(APPEND CMAKE_CUDA_FLAGS
-  " -Werror all-warnings"
+  " -lineinfo"  # Disabling lineinfo reduces .so file by ~40MB
   " -Wall"
   " -Wno-sign-compare"
-  " -Wextra"
   " -Wno-unused-parameter"
   " -Wreorder"
   " -Wfloat-conversion"

--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -9,18 +9,20 @@ project(timemachine LANGUAGES CXX CUDA)
 find_package(PythonInterp 3.10 REQUIRED)
 find_package(PythonLibs 3.10 REQUIRED)
 
-set(COMMON_COMPILER_FLAGS, "-Werror -Wall -Wextra -O3")
+set(COMMON_COMPILER_FLAGS "-Wall -Wextra")
 
-string(APPEND CMAKE_CXX_FLAGS "${COMMON_COMPILER_FLAGS}")
+string(APPEND CMAKE_CXX_FLAGS "${COMMON_COMPILER_FLAGS} -Werror")
 string(APPEND CMAKE_CUDA_FLAGS "${COMMON_COMPILER_FLAGS}")
 
 string(APPEND CMAKE_CUDA_FLAGS
   " -lineinfo"  # Disabling lineinfo reduces .so file by ~40MB
-  " -Wall"
+  " -Werror all-warnings"
   " -Wno-sign-compare"
   " -Wno-unused-parameter"
   " -Wreorder"
   " -Wfloat-conversion"
+  " -Wno-deprecated-declarations"
+  " -restrict"  # Warn if device pointers are not restricted
 )
 message(${CMAKE_CUDA_FLAGS})
 

--- a/timemachine/cpp/CMakeLists.txt
+++ b/timemachine/cpp/CMakeLists.txt
@@ -9,7 +9,15 @@ project(timemachine LANGUAGES CXX CUDA)
 find_package(PythonInterp 3.10 REQUIRED)
 find_package(PythonLibs 3.10 REQUIRED)
 
+set(DEBUG_BUILD "$ENV{DEBUG_BUILD}")
+
 set(COMMON_COMPILER_FLAGS "-Wall -Wextra")
+if (NOT DEBUG_BUILD)
+  string(APPEND COMMON_COMPILER_FLAGS " -O3")
+else()
+  string(APPEND COMMON_COMPILER_FLAGS " -g")
+endif()
+
 
 string(APPEND CMAKE_CXX_FLAGS "${COMMON_COMPILER_FLAGS} -Werror")
 string(APPEND CMAKE_CUDA_FLAGS "${COMMON_COMPILER_FLAGS}")
@@ -24,7 +32,8 @@ string(APPEND CMAKE_CUDA_FLAGS
   " -Wno-deprecated-declarations"
   " -restrict"  # Warn if device pointers are not restricted
 )
-message(${CMAKE_CUDA_FLAGS})
+message("C++ Compiler Flags" ${CMAKE_CXX_FLAGS})
+message("Cuda Compiler Flags" ${CMAKE_CUDA_FLAGS})
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)

--- a/timemachine/cpp/src/context.cu
+++ b/timemachine/cpp/src/context.cu
@@ -17,17 +17,13 @@
 
 namespace timemachine {
 
-namespace {
-
-bool is_barostat(std::shared_ptr<Mover> &mover) {
+static bool is_barostat(std::shared_ptr<Mover> &mover) {
     if (std::shared_ptr<MonteCarloBarostat<float>> baro = std::dynamic_pointer_cast<MonteCarloBarostat<float>>(mover);
         baro) {
         return true;
     }
     return false;
 }
-
-} // namespace
 
 Context::Context(
     int N,

--- a/timemachine/cpp/src/context.cu
+++ b/timemachine/cpp/src/context.cu
@@ -17,6 +17,18 @@
 
 namespace timemachine {
 
+namespace {
+
+bool is_barostat(std::shared_ptr<Mover> &mover) {
+    if (std::shared_ptr<MonteCarloBarostat<float>> baro = std::dynamic_pointer_cast<MonteCarloBarostat<float>>(mover);
+        baro) {
+        return true;
+    }
+    return false;
+}
+
+} // namespace
+
 Context::Context(
     int N,
     const double *x_0,
@@ -40,14 +52,6 @@ Context::~Context() {
     gpuErrchk(cudaFree(d_v_t_));
     gpuErrchk(cudaFree(d_box_t_));
 };
-
-bool is_barostat(std::shared_ptr<Mover> &mover) {
-    if (std::shared_ptr<MonteCarloBarostat<float>> baro = std::dynamic_pointer_cast<MonteCarloBarostat<float>>(mover);
-        baro) {
-        return true;
-    }
-    return false;
-}
 
 void Context::_verify_box(const double *box_buffer, cudaStream_t stream) {
     // If there are no nonbonded potentials, nothing to check.

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -6,7 +6,7 @@
 
 namespace timemachine {
 
-template <typename T> T *allocate(const std::size_t length) {
+template <typename T> T *allocate_gpu_memory(const std::size_t length) {
     T *buffer;
     cudaSafeMalloc(&buffer, length * sizeof(T));
     return buffer;
@@ -19,7 +19,7 @@ template <typename T> DeviceBuffer<T>::DeviceBuffer(const std::vector<T> &vec) :
 template <typename T> DeviceBuffer<T>::DeviceBuffer() : DeviceBuffer(0) {}
 
 template <typename T>
-DeviceBuffer<T>::DeviceBuffer(const std::size_t length) : length(length), data(allocate<T>(length)) {}
+DeviceBuffer<T>::DeviceBuffer(const std::size_t length) : length(length), data(allocate_gpu_memory<T>(length)) {}
 
 template <typename T> void DeviceBuffer<T>::realloc(const size_t new_length) {
     // Print a warning if buffers were non-zero when resized, this can have real performance impacts
@@ -29,7 +29,7 @@ template <typename T> void DeviceBuffer<T>::realloc(const size_t new_length) {
     // Free the existing data
     gpuErrchk(cudaFree(data));
     this->length = new_length;
-    this->data = allocate<T>(new_length);
+    this->data = allocate_gpu_memory<T>(new_length);
 }
 
 template <typename T> DeviceBuffer<T>::~DeviceBuffer() {

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -6,15 +6,11 @@
 
 namespace timemachine {
 
-namespace {
-
-template <typename T> T *allocate_gpu_memory(const std::size_t length) {
+template <typename T> static T *allocate_gpu_memory(const std::size_t length) {
     T *buffer;
     cudaSafeMalloc(&buffer, length * sizeof(T));
     return buffer;
 }
-
-} // namespace
 
 template <typename T> DeviceBuffer<T>::DeviceBuffer(const std::vector<T> &vec) : DeviceBuffer(vec.size()) {
     this->copy_from(&vec[0]);

--- a/timemachine/cpp/src/device_buffer.cu
+++ b/timemachine/cpp/src/device_buffer.cu
@@ -6,11 +6,15 @@
 
 namespace timemachine {
 
+namespace {
+
 template <typename T> T *allocate_gpu_memory(const std::size_t length) {
     T *buffer;
     cudaSafeMalloc(&buffer, length * sizeof(T));
     return buffer;
 }
+
+} // namespace
 
 template <typename T> DeviceBuffer<T>::DeviceBuffer(const std::vector<T> &vec) : DeviceBuffer(vec.size()) {
     this->copy_from(&vec[0]);

--- a/timemachine/cpp/src/local_md_potentials.cu
+++ b/timemachine/cpp/src/local_md_potentials.cu
@@ -13,12 +13,16 @@
 
 namespace timemachine {
 
+namespace {
+
 // Struct representing the CUB < operation
 struct LessThan {
     int compare;
     CUB_RUNTIME_FUNCTION __device__ __forceinline__ explicit LessThan(int compare) : compare(compare) {}
     CUB_RUNTIME_FUNCTION __device__ __forceinline__ bool operator()(const int &a) const { return (a < compare); }
 };
+
+} // namespace
 
 LocalMDPotentials::LocalMDPotentials(
     const int N, const std::vector<std::shared_ptr<BoundPotential>> &bps, bool freeze_reference, double temperature)

--- a/timemachine/cpp/src/nonbonded_common.cpp
+++ b/timemachine/cpp/src/nonbonded_common.cpp
@@ -15,25 +15,7 @@
 
 namespace timemachine {
 
-void verify_atom_idxs(const int N, const std::vector<int> &atom_idxs, const bool allow_empty) {
-    if (atom_idxs.size() == 0) {
-        if (allow_empty) {
-            // No further checks if we allow the indices to be empty
-            return;
-        }
-        throw std::runtime_error("indices can't be empty");
-    }
-    std::set<int> unique_idxs(atom_idxs.begin(), atom_idxs.end());
-    if (unique_idxs.size() != atom_idxs.size()) {
-        throw std::runtime_error("atom indices must be unique");
-    }
-    if (*std::max_element(atom_idxs.begin(), atom_idxs.end()) >= N) {
-        throw std::runtime_error("index values must be less than N(" + std::to_string(N) + ")");
-    }
-    if (*std::min_element(atom_idxs.begin(), atom_idxs.end()) < 0) {
-        throw std::runtime_error("index values must be greater or equal to zero");
-    }
-}
+namespace {
 
 bool is_summed_potential(std::shared_ptr<Potential> pot) {
     if (std::shared_ptr<FanoutSummedPotential> fanned_potential = std::dynamic_pointer_cast<FanoutSummedPotential>(pot);
@@ -56,6 +38,28 @@ bool is_nonbonded_all_pairs_potential(std::shared_ptr<Potential> pot) {
         return true;
     }
     return false;
+}
+
+} // namespace
+
+void verify_atom_idxs(const int N, const std::vector<int> &atom_idxs, const bool allow_empty) {
+    if (atom_idxs.size() == 0) {
+        if (allow_empty) {
+            // No further checks if we allow the indices to be empty
+            return;
+        }
+        throw std::runtime_error("indices can't be empty");
+    }
+    std::set<int> unique_idxs(atom_idxs.begin(), atom_idxs.end());
+    if (unique_idxs.size() != atom_idxs.size()) {
+        throw std::runtime_error("atom indices must be unique");
+    }
+    if (*std::max_element(atom_idxs.begin(), atom_idxs.end()) >= N) {
+        throw std::runtime_error("index values must be less than N(" + std::to_string(N) + ")");
+    }
+    if (*std::min_element(atom_idxs.begin(), atom_idxs.end()) < 0) {
+        throw std::runtime_error("index values must be greater or equal to zero");
+    }
 }
 
 // get_nonbonded_all_pair_cutoff_with_padding returns the cutoff plus padding. Using these value can be used

--- a/timemachine/cpp/src/nonbonded_common.cpp
+++ b/timemachine/cpp/src/nonbonded_common.cpp
@@ -15,9 +15,7 @@
 
 namespace timemachine {
 
-namespace {
-
-bool is_summed_potential(std::shared_ptr<Potential> pot) {
+static bool is_summed_potential(std::shared_ptr<Potential> pot) {
     if (std::shared_ptr<FanoutSummedPotential> fanned_potential = std::dynamic_pointer_cast<FanoutSummedPotential>(pot);
         fanned_potential != nullptr) {
         return true;
@@ -28,7 +26,7 @@ bool is_summed_potential(std::shared_ptr<Potential> pot) {
     return false;
 }
 
-bool is_nonbonded_all_pairs_potential(std::shared_ptr<Potential> pot) {
+static bool is_nonbonded_all_pairs_potential(std::shared_ptr<Potential> pot) {
     if (std::shared_ptr<NonbondedAllPairs<float>> nb_pot = std::dynamic_pointer_cast<NonbondedAllPairs<float>>(pot);
         nb_pot) {
         return true;
@@ -39,8 +37,6 @@ bool is_nonbonded_all_pairs_potential(std::shared_ptr<Potential> pot) {
     }
     return false;
 }
-
-} // namespace
 
 void verify_atom_idxs(const int N, const std::vector<int> &atom_idxs, const bool allow_empty) {
     if (atom_idxs.size() == 0) {

--- a/timemachine/cpp/src/pinned_host_buffer.cu
+++ b/timemachine/cpp/src/pinned_host_buffer.cu
@@ -3,9 +3,7 @@
 
 namespace timemachine {
 
-namespace {
-
-template <typename T> T *allocate_pinned_host_memory(const std::size_t length) {
+template <typename T> static T *allocate_pinned_host_memory(const std::size_t length) {
     if (length < 1) {
         throw std::runtime_error("device buffer length must at least be 1");
     }
@@ -13,8 +11,6 @@ template <typename T> T *allocate_pinned_host_memory(const std::size_t length) {
     gpuErrchk(cudaMallocHost(&buffer, length * sizeof(T)));
     return buffer;
 }
-
-} // namespace
 
 template <typename T>
 PinnedHostBuffer<T>::PinnedHostBuffer(const std::size_t length)

--- a/timemachine/cpp/src/pinned_host_buffer.cu
+++ b/timemachine/cpp/src/pinned_host_buffer.cu
@@ -3,6 +3,8 @@
 
 namespace timemachine {
 
+namespace {
+
 template <typename T> T *allocate_pinned_host_memory(const std::size_t length) {
     if (length < 1) {
         throw std::runtime_error("device buffer length must at least be 1");
@@ -11,6 +13,8 @@ template <typename T> T *allocate_pinned_host_memory(const std::size_t length) {
     gpuErrchk(cudaMallocHost(&buffer, length * sizeof(T)));
     return buffer;
 }
+
+} // namespace
 
 template <typename T>
 PinnedHostBuffer<T>::PinnedHostBuffer(const std::size_t length)

--- a/timemachine/cpp/src/pinned_host_buffer.cu
+++ b/timemachine/cpp/src/pinned_host_buffer.cu
@@ -3,7 +3,7 @@
 
 namespace timemachine {
 
-template <typename T> T *allocate(const std::size_t length) {
+template <typename T> T *allocate_pinned_host_memory(const std::size_t length) {
     if (length < 1) {
         throw std::runtime_error("device buffer length must at least be 1");
     }
@@ -13,7 +13,8 @@ template <typename T> T *allocate(const std::size_t length) {
 }
 
 template <typename T>
-PinnedHostBuffer<T>::PinnedHostBuffer(const std::size_t length) : size(length * sizeof(T)), data(allocate<T>(length)) {}
+PinnedHostBuffer<T>::PinnedHostBuffer(const std::size_t length)
+    : size(length * sizeof(T)), data(allocate_pinned_host_memory<T>(length)) {}
 
 template <typename T> PinnedHostBuffer<T>::~PinnedHostBuffer() {
     // TODO: the file/line context reported by gpuErrchk on failure is


### PR DESCRIPTION
This PR resolves the inability to build and test the repo without `-O3`. Due to having multiple definitions of `allocate` in the `timemachine` namespace, the `allocate` defined in `DeviceBuffer` was being used to allocate pinned memory when `-O3` was not included, but worked as expected with `-O3`.

The other changes in the PR:
* Use `static` and unnamed namespaces to isolate functions and structs inside of impl files. Should be part of our best practice going forward.
* If env var `DEBUG_BUILD` is set, disable `-O3` and add debugging information. Useful to catch issues like this in the future. 
* Adds `-O3` to gcc. Looks like this makes some tests 15% faster :exploding_head: 
* Prints both the GCC/NVCC compiler flags, just to be consistent and to make sure things are work as expected.