### PR TITLE
Quick fix for chiral volume conversions.

### DIFF
--- a/tests/test_chiral_restraints.py
+++ b/tests/test_chiral_restraints.py
@@ -854,3 +854,125 @@ def test_chiral_inversion_in_single_topology_solvent():
     # with open("solvent_chiral_energies_b.png", "wb") as ofs:
     #     data_b = plot_as_png_fxn(plot_chiral_restraint_energies, heatmap_b)
     #     ofs.write(data_b)
+
+
+import matplotlib.pyplot as plt
+
+from timemachine.fe.utils import plot_atom_mapping_grid
+
+
+def plot_and_save(f, fname, *args, **kwargs):
+    """
+    Given a function which generates a plot, return the plot as png bytes.
+    """
+    plt.clf()
+    f(*args, **kwargs)
+    with open(fname, "wb") as fh:
+        plt.savefig(fh, format="png", bbox_inches="tight")
+
+
+from timemachine.fe.plots import (
+    plot_hrex_replica_state_distribution,
+    plot_hrex_replica_state_distribution_heatmap,
+    plot_hrex_swap_acceptance_rates_convergence,
+    plot_hrex_transition_matrix,
+)
+
+
+def test_ring_breaking_chiral_restraints_failure():
+    mol_a = Chem.MolFromMolBlock(
+        """
+  Mrv2311 10092413403D
+
+  6  6  0  0  0  0            999 V2000
+    0.1292    1.5540   -0.4103 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.8029    0.8102    0.1698 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0572    0.0397    0.8217 O   0  0  0  0  0  0  0  0  0  0  0  0
+    1.1063    0.7870    0.2530 C   0  0  2  0  0  0  0  0  0  0  0  0
+    2.1161    1.7939    1.5497 F   0  0  0  0  0  0  0  0  0  0  0  0
+    1.8910    0.0536   -0.6026 Cl  0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+  3  4  1  0  0  0  0
+  1  4  1  0  0  0  0
+  4  5  1  0  0  0  0
+  4  6  1  0  0  0  0
+M  END
+$$$$""",
+        removeHs=False,
+    )
+
+    # keeps 2 chiral restraints
+    perm = [0, 1, 2, 3, 4, 5]
+
+    # keeps all chiral restraints
+    # perm = [3, 4, 5, 0, 2, 1]
+
+    perm_kv = {}
+    for new_idx, old_idx in enumerate(perm):
+        perm_kv[old_idx] = new_idx
+
+    mol_a = Chem.RenumberAtoms(mol_a, perm)
+    mol_a.SetProp("_Name", "mol")
+    mol_b = Chem.Mol(mol_a)
+
+    core = np.array([[1, 1], [2, 2], [3, 3], [4, 5]], dtype=np.int32)
+    core_perm = []
+    for i, j in core:
+        core_perm.append([perm_kv[i], perm_kv[j]])
+    core = np.array(core_perm, dtype=np.int32)
+
+    res = plot_atom_mapping_grid(mol_a, mol_b, core)
+    fpath = "atom_mapping.svg"
+    print("core mapping written to", fpath)
+    with open(fpath, "w") as fh:
+        fh.write(res)
+
+    short_hrex_params = replace(DEFAULT_HREX_PARAMS, n_frames=1000, n_eq_steps=10000, steps_per_frame=400)
+    ff = Forcefield.load_default()
+
+    vacuum_res = run_vacuum(mol_a, mol_b, core, ff, None, short_hrex_params, n_windows=48, min_overlap=0.666)
+
+    with open("vacuum_res.pkl", "wb") as fh:
+        import pickle
+
+        pickle.dump((vacuum_res, mol_a, mol_b, core), fh)
+
+    with open("vacuum_overlap.png", "wb") as fh:
+        fh.write(vacuum_res.plots.overlap_detail_png)
+
+    plot_and_save(
+        plot_hrex_swap_acceptance_rates_convergence,
+        "vac_plot_hrex_swap_acceptance_rates_convergence.png",
+        vacuum_res.hrex_diagnostics.cumulative_swap_acceptance_rates,
+    )
+    plot_and_save(
+        plot_hrex_transition_matrix,
+        "vac_plot_hrex_transition_matrix.png",
+        vacuum_res.hrex_diagnostics.transition_matrix,
+    )
+
+    plot_and_save(
+        plot_hrex_replica_state_distribution,
+        "vac_plot_hrex_replica_state_distribution.png",
+        vacuum_res.hrex_diagnostics.cumulative_replica_state_counts,
+    )
+    plot_and_save(
+        plot_hrex_replica_state_distribution_heatmap,
+        "vac_plot_hrex_replica_state_distribution_heatmap.png",
+        vacuum_res.hrex_diagnostics.cumulative_replica_state_counts,
+    )
+
+    from timemachine.fe.plots import plot_as_png_fxn, plot_chiral_restraint_energies
+
+    atom_map_mixin = AtomMapMixin(mol_a, mol_b, core)
+
+    heatmap_a, heatmap_b = make_chiral_flip_heatmaps(vacuum_res, atom_map_mixin)
+
+    with open("solvent_chiral_energies_a.png", "wb") as ofs:
+        data_a = plot_as_png_fxn(plot_chiral_restraint_energies, heatmap_a)
+        ofs.write(data_a)
+
+    with open("solvent_chiral_energies_b.png", "wb") as ofs:
+        data_b = plot_as_png_fxn(plot_chiral_restraint_energies, heatmap_b)
+        ofs.write(data_b)

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -38,6 +38,7 @@ from timemachine.fe.single_topology import (
     canonicalize_chiral_atom_idxs,
     canonicalize_improper_idxs,
     cyclic_difference,
+    find_induced_bonds_angles_from_chiral_idxs,
     handle_ring_opening_closing,
     interpolate_harmonic_bond_params,
     interpolate_harmonic_force_constant,
@@ -2005,3 +2006,66 @@ M  END
 
     # should not raise an assertion
     verify_chiral_validity_of_core(mol_a, mol_b, core, ff)
+
+
+def test_find_converting_chiral_volumes():
+    mol_a = Chem.MolFromMolBlock(
+        """
+  Mrv2311 10092413403D
+
+  6  6  0  0  0  0            999 V2000
+    0.1292    1.5540   -0.4103 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.8029    0.8102    0.1698 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0572    0.0397    0.8217 O   0  0  0  0  0  0  0  0  0  0  0  0
+    1.1063    0.7870    0.2530 C   0  0  2  0  0  0  0  0  0  0  0  0
+    2.1161    1.7939    1.5497 F   0  0  0  0  0  0  0  0  0  0  0  0
+    1.8910    0.0536   -0.6026 Cl  0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+  3  4  1  0  0  0  0
+  1  4  1  0  0  0  0
+  4  5  1  0  0  0  0
+  4  6  1  0  0  0  0
+M  END
+$$$$""",
+        removeHs=False,
+    )
+
+    for atom in mol_a.GetAtoms():
+        atom.SetProp("atomLabel", str(atom.GetIdx()))
+    # keeps 2 chiral restraints, 6 are converting
+    perm = [0, 1, 2, 3, 4, 5]
+    # keeps all chiral restraints
+    # perm = [3, 4, 5, 0, 2, 1]
+    perm_kv = {}
+    for new_idx, old_idx in enumerate(perm):
+        perm_kv[old_idx] = new_idx
+    mol_a = Chem.RenumberAtoms(mol_a, perm)
+    mol_a.SetProp("_Name", "mol")
+    mol_b = Chem.Mol(mol_a)
+    core = np.array([[1, 1], [2, 2], [3, 3], [4, 5]], dtype=np.int32)
+    core_perm = []
+    for i, j in core:
+        core_perm.append([perm_kv[i], perm_kv[j]])
+    core = np.array(core_perm, dtype=np.int32)
+
+    # res = plot_atom_mapping_grid(mol_a, mol_b, core)
+    # fpath = "atom_mapping.svg"
+    # print("core mapping written to", fpath)
+    # with open(fpath, "w") as fh:
+    #     fh.write(res)
+
+    ff = Forcefield.load_default()
+
+    st = SingleTopology(mol_a, mol_b, core, ff)
+
+    affected_chiral_atom_idxs = st.find_converting_chiral_volumes()
+    assert len(affected_chiral_atom_idxs) == 6
+
+    bond_idxs, angle_idxs = find_induced_bonds_angles_from_chiral_idxs(affected_chiral_atom_idxs)
+
+    # keep bonds the same, only stagger the angles/chiral terms differently
+
+    # print(bond_idxs, angle_idxs)
+
+    st.setup_intermediate_state(0.5)

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1066,6 +1066,23 @@ class AtomMapFlags(IntEnum):
     MOL_B = 2
 
 
+def find_induced_bonds_angles_from_chiral_idxs(chiral_idxs):
+    bonds = set()
+    angles = set()
+
+    for c, j, k, l in chiral_idxs:
+        bonds.add(canonicalize_bond([c, j]))
+        bonds.add(canonicalize_bond([c, k]))
+        bonds.add(canonicalize_bond([c, l]))
+
+    for c, j, k, l in chiral_idxs:
+        angles.add(canonicalize_bond([j, c, k]))
+        angles.add(canonicalize_bond([j, c, l]))
+        angles.add(canonicalize_bond([k, c, l]))
+
+    return bonds, angles
+
+
 class AtomMapMixin:
     """
     A Mixin class containing the atom_mapping information. This Mixin sets up the following
@@ -1241,9 +1258,9 @@ def assert_chiral_consistency_and_validity(
     dst_chiral_restr_idx_set = ChiralRestrIdxSet(dst_chiral_idxs)
 
     assert_chiral_consistency(src_chiral_restr_idx_set, dst_chiral_restr_idx_set, src_bond_idxs, dst_bond_idxs)
-    check_chiral_validity_impl(
-        atom_map, src_chiral_restr_idx_set, dst_chiral_restr_idx_set, src_bond_idxs, dst_bond_idxs
-    )
+    # check_chiral_validity_impl(
+    #     atom_map, src_chiral_restr_idx_set, dst_chiral_restr_idx_set, src_bond_idxs, dst_bond_idxs
+    # )
 
 
 def verify_chiral_validity_of_core(mol_a: Chem.Mol, mol_b: Chem.Mol, core: NDArray, forcefield):
@@ -1614,6 +1631,54 @@ class SingleTopology(AtomMapMixin):
 
         return ChiralBondRestraint(chiral_bond_idxs, np.array(chiral_bond_signs)).bind(jnp.array(chiral_bond_params))
 
+    def find_converting_chiral_volumes(self):
+        # this can't call into setup_intermedaite_state since it'd end up recursive
+        src_chiral_idxs = set(tuple(x) for x in self.src_system.chiral_atom.potential.idxs)
+        dst_chiral_idxs = set(tuple(x) for x in self.dst_system.chiral_atom.potential.idxs)
+        return dst_chiral_idxs.symmetric_difference(src_chiral_idxs)
+
+    def split_chiral_bonds_and_angles(self, bond_potential, angle_potential):
+        """
+        Given an angle potential, split the angle idxs into those involved in a convert chiral set and those not involved
+        """
+        bad_bond_idxs, bad_angle_idxs = find_induced_bonds_angles_from_chiral_idxs(
+            self.find_converting_chiral_volumes()
+        )
+
+        chiral_bond_idxs = []
+        chiral_bond_params = []
+        achiral_bond_idxs = []
+        achiral_bond_params = []
+
+        for idxs, params in zip(bond_potential.potential.idxs, bond_potential.params):
+            if tuple(idxs) in bad_bond_idxs:
+                chiral_bond_idxs.append(tuple(idxs))
+                chiral_bond_params.append(params)
+            else:
+                achiral_bond_idxs.append(tuple(idxs))
+                achiral_bond_params.append(params)
+
+        chiral_bond = HarmonicBond(np.array(chiral_bond_idxs, dtype=np.int32)).bind(chiral_bond_params)
+        achiral_bond = HarmonicBond(np.array(achiral_bond_idxs, dtype=np.int32)).bind(achiral_bond_params)
+
+        chiral_angle_idxs = []
+        chiral_angle_params = []
+        achiral_angle_idxs = []
+        achiral_angle_params = []
+
+        for idxs, params in zip(angle_potential.potential.idxs, angle_potential.params):
+            if tuple(idxs) in bad_angle_idxs:
+                chiral_angle_idxs.append(tuple(idxs))
+                chiral_angle_params.append(params)
+            else:
+                achiral_angle_idxs.append(tuple(idxs))
+                achiral_angle_params.append(params)
+
+        chiral_angle = HarmonicAngleStable(np.array(chiral_angle_idxs, dtype=np.int32)).bind(chiral_angle_params)
+        achiral_angle = HarmonicAngleStable(np.array(achiral_angle_idxs, dtype=np.int32)).bind(achiral_angle_params)
+
+        return chiral_bond, achiral_bond, chiral_angle, achiral_angle
+
     def setup_intermediate_state(self, lamb) -> VacuumSystem:
         r"""
         Set up intermediate states at some value of the alchemical parameter :math:`\lambda`.
@@ -1640,15 +1705,45 @@ class SingleTopology(AtomMapMixin):
         src_system = self.src_system
         dst_system = self.dst_system
 
-        # stagger the lambda schedule
+        # split schedule depending on if we're breaking/forming chiral volumes
         bonds_min, bonds_max = [0.0, 0.7]
         angles_min, angles_max = [0.0, 0.7]
         torsions_min, torsions_max = [0.7, 1.0]
-        chiral_atoms_min, chiral_atoms_max = [0.7, 1.0]
 
-        bond = self._setup_intermediate_bonded_term(
-            src_system.bond,
-            dst_system.bond,
+        # bonds involved in chiral volumes need to be turned on before volumes
+        # angles involved in chiral volumes need to be turned on after volumes
+        chiral_bonds_min, chiral_bonds_max = [0.0, 0.5]
+        chiral_atoms_min, chiral_atoms_max = [0.5, 0.6]
+        chiral_angles_min, chiral_angles_max = [0.6, 0.7]
+
+        (
+            src_affected_bond,
+            src_unaffected_bond,
+            src_affected_angle,
+            src_unaffected_angle,
+        ) = self.split_chiral_bonds_and_angles(src_system.bond, src_system.angle)
+        (
+            dst_affected_bond,
+            dst_unaffected_bond,
+            dst_affected_angle,
+            dst_unaffected_angle,
+        ) = self.split_chiral_bonds_and_angles(dst_system.bond, dst_system.angle)
+
+        bond_affected = self._setup_intermediate_bonded_term(
+            src_affected_bond,
+            dst_affected_bond,
+            lamb,
+            interpolate.align_harmonic_bond_idxs_and_params,
+            partial(
+                interpolate_harmonic_bond_params,
+                k_min=0.1,  # ~ BOLTZ * (300 K) / (5 nm)^2
+                lambda_min=chiral_bonds_min,
+                lambda_max=chiral_bonds_max,
+            ),
+        )
+        bond_unaffected = self._setup_intermediate_bonded_term(
+            src_unaffected_bond,
+            dst_unaffected_bond,
             lamb,
             interpolate.align_harmonic_bond_idxs_and_params,
             partial(
@@ -1658,10 +1753,25 @@ class SingleTopology(AtomMapMixin):
                 lambda_max=bonds_max,
             ),
         )
+        bond = HarmonicBond(np.concatenate([bond_affected.potential.idxs, bond_unaffected.potential.idxs])).bind(
+            np.concatenate([bond_affected.params, bond_unaffected.params])
+        )
 
-        angle = self._setup_intermediate_bonded_term(
-            src_system.angle,
-            dst_system.angle,
+        angle_affected = self._setup_intermediate_bonded_term(
+            src_affected_angle,
+            dst_affected_angle,
+            lamb,
+            interpolate.align_harmonic_angle_idxs_and_params,
+            partial(
+                interpolate_harmonic_angle_params,
+                k_min=0.05,  # ~ BOLTZ * (300 K) / (2 * pi)^2
+                lambda_min=chiral_angles_min,
+                lambda_max=chiral_angles_max,
+            ),
+        )
+        angle_unaffected = self._setup_intermediate_bonded_term(
+            src_unaffected_angle,
+            dst_unaffected_angle,
             lamb,
             interpolate.align_harmonic_angle_idxs_and_params,
             partial(
@@ -1671,6 +1781,9 @@ class SingleTopology(AtomMapMixin):
                 lambda_max=angles_max,
             ),
         )
+        angle = HarmonicAngleStable(
+            np.concatenate([angle_affected.potential.idxs, angle_unaffected.potential.idxs])
+        ).bind(np.concatenate([angle_affected.params, angle_unaffected.params]))
 
         assert src_system.torsion
         assert dst_system.torsion


### PR DESCRIPTION
This PR is an attempt at a quick fix for:

1) Disabling the chiral validity check
2) Explicitly identifying bonds/angles involved in chiral volumes that are being toggled (either from off->on, or on->off) and using a different alchemical schedule for them. 

Pending a lot more systematic validation. 