### PR TITLE
Accept conformer id in utilities

### DIFF
--- a/tests/test_chiral_restraints.py
+++ b/tests/test_chiral_restraints.py
@@ -665,7 +665,7 @@ $$$$""",
 def make_chiral_flip_pair(well_aligned=True):
     # mol_a, mol_b : substituted chiral cyclobutyl
     # with 2 different alignments of mol_b w.r.t. mol_a
-    mol_dict = {utils.get_mol_name(mol): mol for mol in utils.read_sdf("tests/data/1243_chiral_ring_confs.sdf")}
+    mol_dict = utils.read_sdf_mols_by_name("tests/data/1243_chiral_ring_confs.sdf")
     mol_a = mol_dict["A"]
     mol_b_0 = mol_dict["B_0"]
     mol_b_1 = mol_dict["B_1"]

--- a/tests/test_fe_utils.py
+++ b/tests/test_fe_utils.py
@@ -174,7 +174,7 @@ def test_get_and_set_mol_name():
     assert utils.get_mol_name(mol) == "test_name"
 
 
-def test_set_mol_coords():
+def test_get_and_set_mol_coords():
     np.random.seed(2022)
     mol = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1"))
     AllChem.EmbedMolecule(mol)
@@ -193,6 +193,25 @@ def test_set_mol_coords():
         # Won't be exact, but should be close
         assert not np.all(x1 == x1_copy)
         np.testing.assert_allclose(x1, x1_copy)
+
+
+def test_get_and_set_mol_coords_conf_id():
+    mol = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1"))
+    AllChem.EmbedMultipleConfs(mol, numConfs=2, randomSeed=2024)
+
+    x0 = utils.get_romol_conf(mol, 0)
+    x1 = utils.get_romol_conf(mol, 1)
+    assert np.any(x0 != x1)  # expect different confs
+
+    utils.set_romol_conf(mol, x0, 1)
+    x1_new = utils.get_romol_conf(mol, 1)
+    assert np.all(x0 == x1_new)
+
+    with pytest.raises(ValueError, match="Bad Conformer Id"):
+        _ = utils.get_romol_conf(mol, 2)
+
+    with pytest.raises(ValueError, match="Bad Conformer Id"):
+        _ = utils.set_romol_conf(mol, x0, 2)
 
 
 def test_experimental_conversions_to_kj():

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -8,7 +8,7 @@ from rdkit.Chem import AllChem
 
 from timemachine.fe.free_energy import HostConfig
 from timemachine.fe.model_utils import get_vacuum_val_and_grad_fn
-from timemachine.fe.utils import get_mol_name, get_romol_conf, read_sdf
+from timemachine.fe.utils import get_romol_conf, read_sdf, read_sdf_mols_by_name
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md import builders, minimizer
@@ -55,9 +55,9 @@ from timemachine.potentials.jax_utils import distance_on_pairs
 )
 def test_fire_minimize_host_protein(pdb_path, sdf_path, mol_a_name, mol_b_name):
     ff = Forcefield.load_default()
-    all_mols = read_sdf(sdf_path)
-    mol_a = next(m for m in all_mols if get_mol_name(m) == mol_a_name)
-    mol_b = next(m for m in all_mols if get_mol_name(m) == mol_b_name)
+    mols_by_name = read_sdf_mols_by_name(sdf_path)
+    mol_a = mols_by_name[mol_a_name]
+    mol_b = mols_by_name[mol_b_name]
 
     for mols in [[mol_a], [mol_b], [mol_a, mol_b]]:
         complex_system, complex_coords, complex_box, complex_top, num_water_atoms = builders.build_protein_system(
@@ -90,9 +90,9 @@ def test_pre_equilibrate_host_pfkfb3(host_name, mol_pair):
     ff = Forcefield.load_default()
     mol_a_name, mol_b_name = mol_pair
     with resources.path("timemachine.datasets.fep_benchmark.pfkfb3", "ligands.sdf") as path_to_ligand:
-        all_mols = read_sdf(path_to_ligand)
-    mol_a = next(m for m in all_mols if get_mol_name(m) == mol_a_name)
-    mol_b = next(m for m in all_mols if get_mol_name(m) == mol_b_name)
+        mols_by_name = read_sdf_mols_by_name(path_to_ligand)
+    mol_a = mols_by_name[mol_a_name]
+    mol_b = mols_by_name[mol_b_name]
     mols = [mol_a, mol_b]
     if host_name == "solvent":
         solvent_system, solvent_coords, solvent_box, solvent_top = builders.build_water_system(

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -46,7 +46,7 @@ from timemachine.fe.single_topology import (
     verify_chiral_validity_of_core,
 )
 from timemachine.fe.system import convert_bps_into_system, minimize_scipy, simulate_system
-from timemachine.fe.utils import get_mol_name, get_romol_conf, read_sdf, set_mol_name
+from timemachine.fe.utils import get_mol_name, get_romol_conf, read_sdf, read_sdf_mols_by_name, set_mol_name
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md import minimizer
@@ -632,7 +632,7 @@ def arbitrary_transformation():
     # NOTE: test system can probably be simplified; we just need
     # any SingleTopology and conformation
     with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
-        mols = {get_mol_name(mol): mol for mol in read_sdf(path_to_ligand)}
+        mols = read_sdf_mols_by_name(path_to_ligand)
 
     mol_a = mols["206"]
     mol_b = mols["57"]
@@ -811,7 +811,7 @@ def test_nonbonded_intra_split(precision, rtol, atol, use_tiny_mol):
         Chem.rdMolAlign.AlignMol(mol_a, mol_b, atomMap=[(0, 0)])
     else:
         with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
-            mols = {get_mol_name(mol): mol for mol in read_sdf(path_to_ligand)}
+            mols = read_sdf_mols_by_name(path_to_ligand)
         mol_a = mols["338"]
         mol_b = mols["43"]
     core = _get_core_by_mcs(mol_a, mol_b)
@@ -909,7 +909,7 @@ class SingleTopologyRef(SingleTopology):
 @pytest.mark.parametrize("lamb", [0.0, 0.5, 1.0])
 def test_nonbonded_intra_split_bitwise_identical(precision, lamb):
     with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
-        mols = {get_mol_name(mol): mol for mol in read_sdf(path_to_ligand)}
+        mols = read_sdf_mols_by_name(path_to_ligand)
     mol_a = mols["338"]
     mol_b = mols["43"]
     core = _get_core_by_mcs(mol_a, mol_b)
@@ -960,7 +960,7 @@ def test_combine_with_host_split(precision, rtol, atol):
     # test the split P-L and L-W interactions
 
     with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
-        mols = {get_mol_name(mol): mol for mol in read_sdf(path_to_ligand)}
+        mols = read_sdf_mols_by_name(path_to_ligand)
     mol_a = mols["338"]
     mol_b = mols["43"]
     core = _get_core_by_mcs(mol_a, mol_b)

--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -6,8 +6,8 @@ from rdkit import Chem
 
 from timemachine.constants import DEFAULT_ATOM_MAPPING_KWARGS, DEFAULT_TEMP
 from timemachine.fe import atom_mapping, cif_writer, utils
+from timemachine.fe.free_energy import HostConfig
 from timemachine.fe.rbfe import (
-    HostConfig,
     get_free_idxs,
     optimize_coords_state,
     setup_initial_state,
@@ -15,19 +15,12 @@ from timemachine.fe.rbfe import (
     setup_optimized_host,
 )
 from timemachine.fe.single_topology import AtomMapMixin, SingleTopology
-from timemachine.fe.utils import get_mol_name, read_sdf
+from timemachine.fe.utils import get_mol_name, read_sdf_mols_by_name
 from timemachine.ff import Forcefield
 from timemachine.md import builders
 from timemachine.potentials.jax_utils import distance_on_pairs
 
 SAVE_FRAMES = False
-
-
-def get_mol_by_name(mols, name):
-    for m in mols:
-        if get_mol_name(m) == name:
-            return m
-    assert 0, "Mol not found"
 
 
 def write_trajectory_as_cif(mol_a, mol_b, core, all_frames, host_topology, out_path):
@@ -127,14 +120,14 @@ def test_confgen_hard_edges():
 
     protein_path = "timemachine/testsystems/data/hif2a_nowater_min.pdb"
     with resources.path("timemachine.datasets.fep_benchmark.hif2a", "ligands.sdf") as ligand_path:
-        mols = read_sdf(ligand_path)
+        mols_by_name = read_sdf_mols_by_name(ligand_path)
 
     n_windows = 12
 
     for src, dst in edges:
         print("\nProcessing", src, "->", dst, "\n")
-        mol_a = get_mol_by_name(mols, src)
-        mol_b = get_mol_by_name(mols, dst)
+        mol_a = mols_by_name[src]
+        mol_b = mols_by_name[dst]
         # try both directions
         run_edge(mol_a, mol_b, protein_path, n_windows)
         run_edge(mol_b, mol_a, protein_path, n_windows)
@@ -149,14 +142,14 @@ def test_confgen_spot_edges():
 
     protein_path = "timemachine/testsystems/data/hif2a_nowater_min.pdb"
     with resources.path("timemachine.datasets.fep_benchmark.hif2a", "ligands.sdf") as ligand_path:
-        mols = read_sdf(ligand_path)
+        mols_by_name = read_sdf_mols_by_name(ligand_path)
 
     n_windows = 12
 
     for src, dst in edges:
         print("\nProcessing", src, "->", dst, "\n")
-        mol_a = get_mol_by_name(mols, src)
-        mol_b = get_mol_by_name(mols, dst)
+        mol_a = mols_by_name[src]
+        mol_b = mols_by_name[dst]
         run_edge(mol_a, mol_b, protein_path, n_windows)
 
 
@@ -172,9 +165,10 @@ def test_min_cutoff_failure(pair, seed, n_windows):
     min_cutoff = 1e-8
 
     with resources.path("timemachine.datasets.fep_benchmark.hif2a", "ligands.sdf") as ligand_path:
-        mols = read_sdf(ligand_path)
-    mol_a = get_mol_by_name(mols, src)
-    mol_b = get_mol_by_name(mols, dst)
+        mols_by_name = read_sdf_mols_by_name(ligand_path)
+
+    mol_a = mols_by_name[src]
+    mol_b = mols_by_name[dst]
 
     all_cores = atom_mapping.get_cores(
         mol_a,

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -13,7 +13,7 @@ from timemachine import potentials
 from timemachine.constants import NBParamIdx
 from timemachine.fe import topology
 from timemachine.fe.topology import _SCALE_14_LJ, _SCALE_14_Q, BaseTopology, DualTopology, DualTopologyMinimization
-from timemachine.fe.utils import get_mol_name, get_romol_conf, read_sdf, set_romol_conf
+from timemachine.fe.utils import get_romol_conf, read_sdf, read_sdf_mols_by_name, set_romol_conf
 from timemachine.ff import Forcefield
 from timemachine.potentials.nonbonded import combining_rule_epsilon, combining_rule_sigma
 
@@ -213,7 +213,7 @@ def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
         return u_impl.execute(x0, box)
 
     with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
-        mols_by_name = {get_mol_name(mol): mol for mol in read_sdf(path_to_ligand)}
+        mols_by_name = read_sdf_mols_by_name(path_to_ligand)
 
     # mol with no intramolecular NB terms and no dihedrals
     if use_tiny_mol:

--- a/timemachine/fe/utils.py
+++ b/timemachine/fe/utils.py
@@ -391,20 +391,20 @@ def get_romol_bonds(mol):
     return bond_list
 
 
-def get_romol_conf(mol) -> NDArray:
-    """Coordinates of mol's 0th conformer, in nanometers"""
-    conformer = mol.GetConformer(0)
+def get_romol_conf(mol, conf_id: int = 0) -> NDArray:
+    """Coordinates of the specified conformer, in nanometers"""
+    conformer = mol.GetConformer(conf_id)
     guest_conf = np.array(conformer.GetPositions(), dtype=np.float64)
-    return guest_conf / 10  # from angstroms to nm
+    return guest_conf / 10.0  # from angstroms to nm
 
 
-def set_romol_conf(mol, new_coords: NDArray):
+def set_romol_conf(mol, new_coords: NDArray, conf_id: int = 0):
     """Sets coordinates of mol's 0th conformer. Expects coords in nanometers and converts to angstrom"""
     assert new_coords.shape[0] == mol.GetNumAtoms()
     # convert from nm to angstroms
-    angstrom_coords = new_coords * 10
+    angstrom_coords = new_coords * 10.0
     angstrom_coords = angstrom_coords.astype(np.float64)  # Must be float64
-    conf = mol.GetConformer(0)
+    conf = mol.GetConformer(conf_id)
     for i, pos in enumerate(angstrom_coords):
         conf.SetAtomPosition(i, pos)
 

--- a/timemachine/fe/utils.py
+++ b/timemachine/fe/utils.py
@@ -1,6 +1,6 @@
 import hashlib
 from pathlib import Path
-from typing import List, Optional, Sequence, Union
+from typing import Dict, List, Optional, Sequence
 
 import numpy as np
 from numpy.typing import NDArray
@@ -464,7 +464,7 @@ def sanitize_energies(full_us, lamb_idx, cutoff=10000):
     return np.where(abs_us < cutoff, full_us, np.inf)
 
 
-def read_sdf(fname: Union[str, Path], removeHs: bool = False) -> List[Chem.Mol]:
+def read_sdf(fname: str | Path, removeHs: bool = False) -> List[Chem.Mol]:
     """Read list of mols from an SDF
 
     Parameters
@@ -483,6 +483,12 @@ def read_sdf(fname: Union[str, Path], removeHs: bool = False) -> List[Chem.Mol]:
     supplier = Chem.SDMolSupplier(str(fname), removeHs=removeHs)
     mols = [mol for mol in supplier]
     return mols
+
+
+def read_sdf_mols_by_name(fname: str | Path, removeHs: bool = False) -> Dict[str, Chem.Mol]:
+    mols = read_sdf(fname, removeHs)
+    mols_by_name = {get_mol_name(mol): mol for mol in mols}
+    return mols_by_name
 
 
 def extract_delta_Us_from_U_knk(U_knk):

--- a/timemachine/fe/utils.py
+++ b/timemachine/fe/utils.py
@@ -399,7 +399,7 @@ def get_romol_conf(mol, conf_id: int = 0) -> NDArray:
 
 
 def set_romol_conf(mol, new_coords: NDArray, conf_id: int = 0):
-    """Sets coordinates of mol's 0th conformer. Expects coords in nanometers and converts to angstrom"""
+    """Sets coordinates of the specified conformer. Expects coords in nanometers and converts to angstroms"""
     assert new_coords.shape[0] == mol.GetNumAtoms()
     # convert from nm to angstroms
     angstrom_coords = new_coords * 10.0

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -682,11 +682,11 @@ def replace_conformer_with_minimized(
     ff : Forcefield
         Forcefield to use in energy minimization
 
-    conf_id : int
-        ID of the conformer to replace
-
     minimizer_config: FireMinimizationConfig or ScipyMinimizationConfig, optional
         Defaults to BFGS minimization if not provided
+
+    conf_id : int
+        ID of the conformer to replace
     """
     top = topology.BaseTopology(mol, ff)
     system = top.setup_end_state()

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -596,7 +596,7 @@ def local_minimize(
     return x_final
 
 
-def replace_conformer_with_minimized(mol: Chem.rdchem.Mol, ff: Forcefield):
+def replace_conformer_with_minimized(mol: Chem.rdchem.Mol, ff: Forcefield, conf_id: int = 0):
     """Replace the first conformer of the given mol with a conformer minimized with respect to the given forcefield.
 
     Parameters
@@ -606,12 +606,15 @@ def replace_conformer_with_minimized(mol: Chem.rdchem.Mol, ff: Forcefield):
 
     ff : Forcefield
         Forcefield to use in energy minimization
+
+    conf_id : int
+        ID of the conformer to replace
     """
     top = topology.BaseTopology(mol, ff)
     system = top.setup_end_state()
     val_and_grad_fn = jax.value_and_grad(system.get_U_fn())
-    xs = get_romol_conf(mol)
+    xs = get_romol_conf(mol, conf_id)
     box = np.eye(3) * 100.0
     all_idxs = np.arange(mol.GetNumAtoms())
     xs_opt = local_minimize(xs, box, val_and_grad_fn, all_idxs, verbose=False)
-    set_romol_conf(mol, xs_opt)
+    set_romol_conf(mol, xs_opt, conf_id)


### PR DESCRIPTION
Small quality of life improvement to accept the target conformer ID as an optional argument in several utility functions.

Also adds `read_sdf_mols_by_name`, similar to `read_sdf` except returning a dict mapping name to mol.