### PR TITLE
Add resolve_intramol_clashes

### DIFF
--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -399,7 +399,7 @@ def test_minimizer_failure_toy_system():
 
 
 def test_resolve_intramol_clashes():
-    """start from a conformer where |force| is +inf"""
+    """start from a conformer where |force(x.astype(f32))| is +inf"""
 
     mol_dict = {mol.GetProp("_Name"): mol for mol in fetch_freesolv()}
     mol = mol_dict["mobley_2850833"]
@@ -416,7 +416,7 @@ def test_resolve_intramol_clashes():
     def force_norm(x, lam):
         return np.max(np.linalg.norm(grad(U_fxn)(x, lam), axis=1))
 
-    assert np.isposinf(force_norm(x0, 0.0)), "oops, test isn't strong enough"
+    assert np.isposinf(force_norm(x0.astype(np.float32), 0.0)), "oops, test isn't strong enough"
     assert force_norm(x0, 1.0) < force_norm(x0, 0.0), "oops, lam isn't doing enough"
 
     x1 = resolve_intramol_clashes(mol, ff, in_place=False)
@@ -428,4 +428,4 @@ def test_resolve_intramol_clashes():
     x2 = resolve_intramol_clashes(mol, ff, in_place=True)
 
     np.testing.assert_equal(x2, x1, "oops, minimization wasn't deterministic")
-    np.testing.assert_equal(get_romol_conf(mol), x1, "oops, in_place=True didn't update mol in-place")
+    np.testing.assert_allclose(get_romol_conf(mol), x1, err_msg="oops, in_place=True didn't update mol in-place")

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -569,10 +569,6 @@ def wrap_for_scipy(f, x0):
     return fun
 
 
-#
-# def
-
-
 def local_minimize(
     x0: NDArray,
     box0: NDArray,


### PR DESCRIPTION
Add a utility function that energy-minimizes a `mol`'s 0'th conformer, while otherwise remaining as close as possible to the input conformer.

For example, if `mol` has a pair of atoms placed on top of each other:

<img width="292" alt="image" src="https://github.com/user-attachments/assets/256dd833-ef3e-44bd-8d1c-527a54d3d2f0">

(resulting in |force(x)| of +inf)

`resolve_intramol_clashes(mol, ff)` will produce:

<img width="292" alt="image" src="https://github.com/user-attachments/assets/56ca5bd4-fd1e-43ea-868c-127302c95c2c">


This is implemented by introducing a softened potential function `U(x, lam)`, with `lam` increasing the distances used in `NonbondedPairListPrecomputed`. At `lam=1` all intramolecular pairs `ij` have their effective distance `d_ij` increased to `>= 0.75 * sig_ij`, and at `lam=0` we recover the original `U(x)`.

A restrained minimization is performed at `lam=1`, then another restrained minimization is performed at `lam=0`.