### PR TITLE
Bugfix for improper parameterization and canonicalization.

### DIFF
--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -530,8 +530,6 @@ def test_canonicalize_improper_idxs():
         assert idxs == canonicalize_improper_idxs(idxs)
 
     # these are in the ccw rotation set
-    #                          1          2          0
-    # bad_improper_idxs = [(5,1,0,3), (5,3,1,0), (5,0,3,1)]
     assert canonicalize_improper_idxs((1, 5, 0, 3)) == (1, 5, 3, 0)
     assert canonicalize_improper_idxs((3, 5, 1, 0)) == (3, 5, 0, 1)
     assert canonicalize_improper_idxs((0, 5, 3, 1)) == (0, 5, 1, 3)

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -2005,3 +2005,40 @@ M  END
 
     # should not raise an assertion
     verify_chiral_validity_of_core(mol_a, mol_b, core, ff)
+
+
+def get_vacuum_system_and_conf(mol_a, mol_b, core, lamb):
+    ff = Forcefield.load_default()
+    st = SingleTopology(mol_a, mol_b, core, ff)
+    conf_a = get_romol_conf(mol_a)
+    conf_b = get_romol_conf(mol_b)
+    conf = st.combine_confs(conf_a, conf_b, lamb)
+    return st.setup_intermediate_state(lamb), conf
+
+
+def test_hif2a_end_state_symmetry():
+    """
+    Test that end-states are symmetric
+    """
+    with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
+        mols = read_sdf(path_to_ligand)
+
+    for idx, mol_a in enumerate(mols):
+        for mol_b in mols[idx + 1 :]:
+            print("testing", mol_a.GetProp("_Name"), "->", mol_b.GetProp("_Name"))
+            core = atom_mapping.get_cores(mol_a, mol_b, **DEFAULT_ATOM_MAPPING_KWARGS)[0]
+            sys_fwd, conf_fwd = get_vacuum_system_and_conf(mol_a, mol_b, core, 0.0)
+            sys_rev, conf_rev = get_vacuum_system_and_conf(mol_b, mol_a, core[:, ::-1], 1.0)
+
+            box = 100.0 * np.eye(3)
+
+            assert sys_fwd.chiral_atom
+            assert sys_rev.chiral_atom
+            assert sys_fwd.torsion
+            assert sys_rev.torsion
+
+            np.testing.assert_allclose(sys_fwd.bond(conf_fwd, box), sys_rev.bond(conf_rev, box))
+            np.testing.assert_allclose(sys_fwd.angle(conf_fwd, box), sys_rev.angle(conf_rev, box))
+            np.testing.assert_allclose(sys_fwd.nonbonded(conf_fwd, box), sys_rev.nonbonded(conf_rev, box))
+            np.testing.assert_allclose(sys_fwd.chiral_atom(conf_fwd, box), sys_rev.chiral_atom(conf_rev, box))
+            np.testing.assert_allclose(sys_fwd.torsion(conf_fwd, box), sys_rev.torsion(conf_rev, box), rtol=1e-4)

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -523,7 +523,7 @@ def test_canonicalize_chiral_atom_idxs(chiral_atom_idxs):
 @pytest.mark.nocuda
 def test_canonicalize_improper_idxs():
     # these are in the cw rotation set
-    improper_idxs = [(5, 0, 1, 3), (5, 1, 3, 0), (5, 3, 0, 1)]
+    improper_idxs = [(0, 5, 1, 3), (1, 5, 3, 0), (3, 5, 0, 1)]
 
     for idxs in improper_idxs:
         # we should do nothing here.
@@ -532,9 +532,9 @@ def test_canonicalize_improper_idxs():
     # these are in the ccw rotation set
     #                          1          2          0
     # bad_improper_idxs = [(5,1,0,3), (5,3,1,0), (5,0,3,1)]
-    assert canonicalize_improper_idxs((5, 1, 0, 3)) == (5, 1, 3, 0)
-    assert canonicalize_improper_idxs((5, 3, 1, 0)) == (5, 3, 0, 1)
-    assert canonicalize_improper_idxs((5, 0, 3, 1)) == (5, 0, 1, 3)
+    assert canonicalize_improper_idxs((1, 5, 0, 3)) == (1, 5, 3, 0)
+    assert canonicalize_improper_idxs((3, 5, 1, 0)) == (3, 5, 0, 1)
+    assert canonicalize_improper_idxs((0, 5, 3, 1)) == (0, 5, 1, 3)
 
 
 @pytest.mark.nocuda

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -2016,6 +2016,8 @@ def get_vacuum_system_and_conf(mol_a, mol_b, core, lamb):
     return st.setup_intermediate_state(lamb), conf
 
 
+@pytest.mark.nocuda
+@pytest.mark.nightly(reason="slow")
 def test_hif2a_end_state_symmetry():
     """
     Test that end-states are symmetric
@@ -2041,4 +2043,4 @@ def test_hif2a_end_state_symmetry():
             np.testing.assert_allclose(sys_fwd.angle(conf_fwd, box), sys_rev.angle(conf_rev, box))
             np.testing.assert_allclose(sys_fwd.nonbonded(conf_fwd, box), sys_rev.nonbonded(conf_rev, box))
             np.testing.assert_allclose(sys_fwd.chiral_atom(conf_fwd, box), sys_rev.chiral_atom(conf_rev, box))
-            np.testing.assert_allclose(sys_fwd.torsion(conf_fwd, box), sys_rev.torsion(conf_rev, box), rtol=1e-4)
+            np.testing.assert_allclose(sys_fwd.torsion(conf_fwd, box), sys_rev.torsion(conf_rev, box))

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -320,9 +320,9 @@ def canonicalize_improper_idxs(idxs) -> Tuple[int, int, int, int]:
 
     This does not do idxs[0] < idxs[-1] canonicalization.
     """
-    i, j, k, l = idxs
+    j, c, k, l = idxs
 
-    # i is the center
+    # c is the center
     # generate lexical order
     key = (j, k, l)
 
@@ -337,7 +337,7 @@ def canonicalize_improper_idxs(idxs) -> Tuple[int, int, int, int]:
     cw_items = sorted([cw_jkl, cw_klj, cw_ljk])
 
     if key in cw_items:
-        return (i, j, k, l)
+        return (j, c, k, l)
 
     # generate counter clockwise permutations
     ccw_kjl = (kk, jj, ll)  # swap 1st and 2nd element
@@ -351,7 +351,9 @@ def canonicalize_improper_idxs(idxs) -> Tuple[int, int, int, int]:
         if cw_item == key:
             break
 
-    return (i, *cw_items[idx])
+    j, k, l = cw_items[idx]
+
+    return (j, c, k, l)
 
 
 def get_num_connected_components(num_atoms: int, bonds: Collection[Tuple[int, int]]) -> int:
@@ -639,7 +641,7 @@ def setup_end_state(ff, mol_a, mol_b, core, a_to_c, b_to_c, dummy_groups: Dict[i
 
     # check that the improper idxs are canonical
     def assert_improper_idxs_are_canonical(all_idxs):
-        for _, j, k, l in all_idxs:
+        for j, _, k, l in all_idxs:
             jj, kk, ll = sorted((j, k, l))
             assert (jj, kk, ll) == (j, k, l) or (kk, ll, jj) == (j, k, l) or (ll, jj, kk) == (j, k, l)
 

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -308,7 +308,7 @@ def canonicalize_improper_idxs(idxs) -> Tuple[int, int, int, int]:
     """
     Canonicalize an improper_idx while being symmetry aware.
 
-    Given idxs (i,j,k,l), where i is the center, and (j,k,l) are neighbors:
+    Given idxs (j,c,k,l), where c is the center, and (j,k,l) are neighbors:
 
     0) Canonicalize the (j,k,l) into (jj,kk,ll) by sorting
     1) Generate clockwise rotations of (jj,kk,ll)

--- a/timemachine/ff/handlers/bonded.py
+++ b/timemachine/ff/handlers/bonded.py
@@ -243,7 +243,7 @@ class ImproperTorsionHandler(SerializableMixIn):
             center = atom_idxs[1]
             others = [atom_idxs[0], atom_idxs[2], atom_idxs[3]]
             for p in [(others[i], others[j], others[k]) for (i, j, k) in [(0, 1, 2), (1, 2, 0), (2, 0, 1)]]:
-                improper_idxs.append(canonicalize_bond((center, p[0], p[1], p[2])))
+                improper_idxs.append((p[0], center, p[1], p[2]))
                 param_idxs.append(p_idx)
 
         param_idxs = np.array(param_idxs)

--- a/timemachine/potentials/bonded.py
+++ b/timemachine/potentials/bonded.py
@@ -192,7 +192,6 @@ def periodic_torsion(conf, params, box, torsion_idxs):
     * box argument unused
     * if conf has more than 3 dimensions, this function only depends on the first 3
     """
-    print("CALLING PERIODIC TORSION")
     if torsion_idxs.shape[0] == 0:
         return 0.0
 

--- a/timemachine/potentials/bonded.py
+++ b/timemachine/potentials/bonded.py
@@ -192,6 +192,7 @@ def periodic_torsion(conf, params, box, torsion_idxs):
     * box argument unused
     * if conf has more than 3 dimensions, this function only depends on the first 3
     """
+    print("CALLING PERIODIC TORSION")
     if torsion_idxs.shape[0] == 0:
         return 0.0
 


### PR DESCRIPTION
This PR fixes two issues:

1) A fundamental mis-parameterization on the handler level of an improper torsion where `[i,c,k,l]` was parameterized into `[c,i,k,l]`. 
2) As a result, we need to re-adjust the canonicalization algorithm we use for impropers during `setup_intermediate_state()`

Many thanks to @mcwitt  for producing a simple repro.  