### PR TITLE
Enables minimizing system with only parts of system restrained

### DIFF
--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -247,7 +247,7 @@ def test_local_minimize_restrained_subset(seed, minimizer_config):
 
     u_init, g_init = val_and_grad_fn(x0)
 
-    with pytest.raises(AssertionError, match="Restraint k must be provided if restrained idxs provided"):
+    with pytest.raises(AssertionError, match="Restraint k be greater than 0.0 if restrained indices provided"):
         minimizer.local_minimize(x0, box0, val_and_grad_fn, free_idxs, minimizer_config, restrained_idxs=frozen_idxs)
 
     # Set a large k, to ensure movement of restrained idxs is minimal

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -228,7 +228,7 @@ def test_local_minimize_water_box(minimizer_config):
 )
 def test_local_minimize_restrained_subset(seed, minimizer_config):
     """
-    Test that we can locally relax a box of water by selecting some random indices.
+    Test that we can minimize systems and only restrain subsets of the atoms.
     """
     rng = np.random.default_rng(seed)
     ff = Forcefield.load_default()
@@ -267,9 +267,9 @@ def test_local_minimize_restrained_subset(seed, minimizer_config):
     # All free atoms should have moved
     assert np.linalg.norm(x0[free_idxs] - x_opt[free_idxs]) > 0.0
     # Restrained atoms should have moved very slightly
-    assert np.linalg.norm(x0[restrained_idxs] - x_opt[restrained_idxs]) < 0.01
+    assert np.linalg.norm(x0[restrained_idxs] - x_opt[restrained_idxs]) < 0.011
     # Unrestrained atoms should have moved more
-    assert np.linalg.norm(x0[unrestrained_idxs] - x_opt[unrestrained_idxs]) > 0.01
+    assert np.linalg.norm(x0[unrestrained_idxs] - x_opt[unrestrained_idxs]) > 0.011
 
 
 def test_local_minimize_water_box_with_bounds():

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -283,14 +283,13 @@ def test_local_minimize_restrained_subset(seed, minimizer_config):
         minimizer.ScipyMinimizationConfig("L-BFGS-B"),
     ],
 )
-def test_local_minimize_restrained_water_trigger_failure(seed, minimizer_config):
+def test_local_minimize_restrained_waters_trigger_failure(seed, minimizer_config):
     """Construct a water box and attempt to minimize a benzene mol into it without removing clashy waters. Verify
-    that if restraining the water atoms, minimization fails.
+    that if the water atoms are restrained that minimization fails and without restraints the minimization succeeds.
     """
     benzene = Chem.AddHs(Chem.MolFromSmiles("c1ccccc1"))
     AllChem.EmbedMolecule(benzene, randomSeed=seed)
 
-    rng = np.random.default_rng(seed)
     ff = Forcefield.load_default()
 
     # Use non-zero lambda to ensure forces are large to start

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -251,7 +251,7 @@ def test_local_minimize_restrained_subset(seed, minimizer_config):
         minimizer.local_minimize(x0, box0, val_and_grad_fn, free_idxs, minimizer_config, restrained_idxs=frozen_idxs)
 
     # Set a large k, to ensure movement of restrained idxs is minimal
-    k = 500_000
+    k = 500_000.0
 
     with pytest.raises(AssertionError, match="Restrained indices must be a subset of local indices"):
         minimizer.local_minimize(
@@ -316,7 +316,7 @@ def test_local_minimize_restrained_waters_trigger_failure(seed, minimizer_config
     free_idxs = idxs_within_cutoff(coords, coords[ligand_idxs], box, cutoff=0.5).tolist()
 
     # Set a large k, making it difficult to move waters out of the way if restrained
-    k = 500_000
+    k = 500_000.0
 
     # Restraining all atoms should trigger a failure
     with pytest.raises(minimizer.MinimizationError):

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -384,7 +384,7 @@ def test_local_minimize_water_box_with_bounds():
         minimizer.ScipyMinimizationConfig("L-BFGS-B"),
     ],
 )
-@pytest.mark.parametrize("restraint_k", [None, 3_000.0])
+@pytest.mark.parametrize("restraint_k", [0.0, 3_000.0])
 def test_local_minimize_strained_ligand(minimizer_config, restraint_k):
     """
     Test that we can minimize a ligand in vacuum using local_minimize when the ligand is strained.

--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -269,7 +269,7 @@ $$$$
         state = setup_initial_state(st, lamb, None, DEFAULT_TEMP, 2024)
 
         free_idxs = get_free_idxs(state)
-        x_opt_unrestrained = optimize_coords_state(state.potentials, state.x0, state.box0, free_idxs, False, k=None)
+        x_opt_unrestrained = optimize_coords_state(state.potentials, state.x0, state.box0, free_idxs, False, k=0.0)
         x_opt_restrained = optimize_coords_state(state.potentials, state.x0, state.box0, free_idxs, False, k=2000.0)
         interacting_atoms = state.interacting_atoms
         displacement_distances_unrestrained = distance_on_pairs(

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -166,6 +166,8 @@ class InitialState:
     protein_idxs: NDArray
     # The atoms that are in the 4d plane defined by w_coord == 0.0
     interacting_atoms: Optional[NDArray] = None
+    # The atomic number of atom element, used for restraining heavy-atoms when minimizing.
+    ligand_atom_elements: Optional[NDArray] = None
 
     def __post_init__(self):
         assert self.ligand_idxs.dtype == np.int32 or self.ligand_idxs.dtype == np.int64

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -166,7 +166,7 @@ class InitialState:
     protein_idxs: NDArray
     # The atoms that are in the 4d plane defined by w_coord == 0.0
     interacting_atoms: Optional[NDArray] = None
-    # The atomic number of atom element, used for restraining heavy-atoms when minimizing.
+    # The atomic number of each ligand atom, used for restraining heavy-atoms when minimizing.
     ligand_atom_elements: Optional[NDArray] = None
 
     def __post_init__(self):

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -166,8 +166,6 @@ class InitialState:
     protein_idxs: NDArray
     # The atoms that are in the 4d plane defined by w_coord == 0.0
     interacting_atoms: Optional[NDArray] = None
-    # The atomic number of each ligand atom, used for restraining heavy-atoms when minimizing.
-    ligand_atom_elements: Optional[NDArray] = None
 
     def __post_init__(self):
         assert self.ligand_idxs.dtype == np.int32 or self.ligand_idxs.dtype == np.int64

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -186,8 +186,20 @@ def setup_initial_state(
     else:
         interacting_atoms = ligand_idxs[st.c_flags == AtomMapFlags.CORE]
 
+    ligand_elements = st.get_alchemical_elements(lamb)
+
     return InitialState(
-        potentials, intg, baro, x0, v0, box0, lamb, ligand_idxs, protein_idxs, interacting_atoms=interacting_atoms
+        potentials,
+        intg,
+        baro,
+        x0,
+        v0,
+        box0,
+        lamb,
+        ligand_idxs,
+        protein_idxs,
+        interacting_atoms=interacting_atoms,
+        ligand_atom_elements=ligand_elements,
     )
 
 
@@ -380,6 +392,8 @@ def _optimize_coords_along_states(
                 free_idxs,
                 minimization_config=minimization_config,
                 assert_energy_decreased=idx == 0,
+                # Only restraint heavy atom
+                restrained_idxs=initial_state.ligand_idxs[initial_state.ligand_atom_elements != 1],
                 k=k,
             )
         except (AssertionError, minimizer.MinimizationError) as e:

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -328,6 +328,7 @@ def optimize_coords_state(
     free_idxs: List[int],
     assert_energy_decreased: bool,
     k: Optional[float],
+    restrained_idxs: Optional[NDArray] = None,
     minimization_config: Optional[minimizer.MinimizationConfig] = None,
 ) -> NDArray:
     val_and_grad_fn = minimizer.get_val_and_grad_fn(potentials, box)
@@ -343,6 +344,7 @@ def optimize_coords_state(
         free_idxs,
         minimization_config,
         assert_energy_decreased=assert_energy_decreased,
+        restrained_idxs=restrained_idxs,
         restraint_k=k,
     )
     assert np.all(np.isfinite(x_opt)), "Minimization resulted in a nan"

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -281,7 +281,7 @@ def setup_optimized_initial_state(
     optimized_initial_states: Sequence[InitialState],
     temperature: float,
     seed: int,
-    k: Optional[float] = DEFAULT_POSITIONAL_RESTRAINT_K,
+    k: float = DEFAULT_POSITIONAL_RESTRAINT_K,
 ) -> InitialState:
     """Setup an InitialState for the specified lambda and optimize the coordinates given a list of pre-optimized IntialStates.
     If the specified lambda exists within the list of optimized_initial_states list, return the existing InitialState.
@@ -328,7 +328,7 @@ def optimize_coords_state(
     box: NDArray,
     free_idxs: List[int],
     assert_energy_decreased: bool,
-    k: Optional[float],
+    k: float,
     restrained_idxs: Optional[NDArray] = None,
     minimization_config: Optional[minimizer.MinimizationConfig] = None,
 ) -> NDArray:
@@ -362,7 +362,7 @@ def get_free_idxs(initial_state: InitialState, cutoff: float = 0.5) -> List[int]
 
 
 def _optimize_coords_along_states(
-    initial_states: List[InitialState], k: Optional[float], minimization_config: minimizer.MinimizationConfig
+    initial_states: List[InitialState], k: float, minimization_config: minimizer.MinimizationConfig
 ) -> List[NDArray]:
     # use the end-state to define the optimization settings
     end_state = initial_states[0]
@@ -394,7 +394,7 @@ def _optimize_coords_along_states(
 def optimize_coordinates(
     initial_states: List[InitialState],
     min_cutoff: Optional[float] = 0.7,
-    k: Optional[float] = DEFAULT_POSITIONAL_RESTRAINT_K,
+    k: float = DEFAULT_POSITIONAL_RESTRAINT_K,
     minimization_config: Optional[minimizer.MinimizationConfig] = None,
 ) -> List[NDArray]:
     """
@@ -407,10 +407,9 @@ def optimize_coordinates(
     min_cutoff: float, optional
         Throw error if any atom moves more than this distance (nm) after minimization
 
-    k: float, optional
+    k: float
         force constant for a positional harmonic restraint potential to apply to the initial positions.
-        If None, minimize with no positional restraint. Refer to `timemachine.potentials.bonded.harmonic_positional_restraint`
-        for implementation.
+        Refer to `timemachine.potentials.bonded.harmonic_positional_restraint` for implementation.
 
     minimization_config: minimizer.MinimizationConfig, optional
         Options to define the type of minimization for the states

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -384,6 +384,10 @@ def _optimize_coords_along_states(
     for idx, initial_state in enumerate(initial_states):
         print(f"Optimizing initial state at λ={initial_state.lamb}")
         free_idxs = get_free_idxs(initial_state)
+        restrained_idxs = None
+        if initial_state.ligand_atom_elements is not None:
+            # Only restraint heavy atoms
+            restrained_idxs = initial_state.ligand_idxs[initial_state.ligand_atom_elements != 1]
         try:
             x_opt = optimize_coords_state(
                 initial_state.potentials,
@@ -392,8 +396,7 @@ def _optimize_coords_along_states(
                 free_idxs,
                 minimization_config=minimization_config,
                 assert_energy_decreased=idx == 0,
-                # Only restraint heavy atom
-                restrained_idxs=initial_state.ligand_idxs[initial_state.ligand_atom_elements != 1],
+                restrained_idxs=restrained_idxs,
                 k=k,
             )
         except (AssertionError, minimizer.MinimizationError) as e:

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1120,6 +1120,22 @@ class AtomMapMixin:
         """
         return self.mol_a.GetNumAtoms() + self.mol_b.GetNumAtoms() - len(self.core) - len(self.core)
 
+    def get_alchemical_elements(self, lamb: float) -> NDArray:
+        ligand_elements = []
+        for idx, flag in enumerate(self.c_flags):
+            if flag == AtomMapFlags.CORE:
+                if lamb <= 0.5:
+                    ligand_elements.append(self.mol_a.GetAtomWithIdx(self.c_to_a[idx]).GetAtomicNum())
+                else:
+                    ligand_elements.append(self.mol_b.GetAtomWithIdx(self.c_to_b[idx]).GetAtomicNum())
+            elif flag == AtomMapFlags.MOL_A:
+                ligand_elements.append(self.mol_a.GetAtomWithIdx(self.c_to_a[idx]).GetAtomicNum())
+            elif flag == AtomMapFlags.MOL_B:
+                ligand_elements.append(self.mol_b.GetAtomWithIdx(self.c_to_b[idx]).GetAtomicNum())
+            else:
+                assert False
+        return np.array(ligand_elements, dtype=np.int32)
+
 
 class MissingBondsInChiralVolumeException(Exception):
     pass

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1048,7 +1048,7 @@ class AtomMapMixin:
     self.c_flags
     """
 
-    def __init__(self, mol_a, mol_b, core):
+    def __init__(self, mol_a, mol_b, core: NDArray):
         assert core.shape[1] == 2
         assert mol_a is not None
         assert mol_b is not None
@@ -1089,16 +1089,16 @@ class AtomMapMixin:
         self.c_to_a = {v: k for k, v in enumerate(self.a_to_c)}
         self.c_to_b = {v: k for k, v in enumerate(self.b_to_c)}
 
-    def get_dummy_atoms_a(self):
+    def get_dummy_atoms_a(self) -> set[int]:
         return {idx for idx, flag in enumerate(self.c_flags) if flag == AtomMapFlags.MOL_A}
 
-    def get_dummy_atoms_b(self):
+    def get_dummy_atoms_b(self) -> set[int]:
         return {idx for idx, flag in enumerate(self.c_flags) if flag == AtomMapFlags.MOL_B}
 
-    def get_core_atoms(self):
+    def get_core_atoms(self) -> set[int]:
         return {idx for idx, flag in enumerate(self.c_flags) if flag == AtomMapFlags.CORE}
 
-    def get_num_atoms(self):
+    def get_num_atoms(self) -> int:
         """
         Get the total number of atoms in the alchemical hybrid.
 
@@ -1109,7 +1109,7 @@ class AtomMapMixin:
         """
         return self.mol_a.GetNumAtoms() + self.mol_b.GetNumAtoms() - len(self.core)
 
-    def get_num_dummy_atoms(self):
+    def get_num_dummy_atoms(self) -> int:
         """
         Get the total number of dummy atoms in the alchemical hybrid.
 
@@ -1120,7 +1120,15 @@ class AtomMapMixin:
         """
         return self.mol_a.GetNumAtoms() + self.mol_b.GetNumAtoms() - len(self.core) - len(self.core)
 
-    def get_alchemical_elements(self, lamb: float) -> NDArray:
+    def get_alchemical_elements(self, lamb: float) -> NDArray[np.int32]:
+        """
+        Get the elements of the atoms in the alchemical hybrid.
+
+        Returns
+        -------
+        np.ndarray[np.int32]
+            The atomic number of each atom
+        """
         ligand_elements = []
         for idx, flag in enumerate(self.c_flags):
             if flag == AtomMapFlags.CORE:

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1120,30 +1120,6 @@ class AtomMapMixin:
         """
         return self.mol_a.GetNumAtoms() + self.mol_b.GetNumAtoms() - len(self.core) - len(self.core)
 
-    def get_alchemical_elements(self, lamb: float) -> NDArray[np.int32]:
-        """
-        Get the elements of the atoms in the alchemical hybrid.
-
-        Returns
-        -------
-        np.ndarray[np.int32]
-            The atomic number of each atom
-        """
-        ligand_elements = []
-        for idx, flag in enumerate(self.c_flags):
-            if flag == AtomMapFlags.CORE:
-                if lamb <= 0.5:
-                    ligand_elements.append(self.mol_a.GetAtomWithIdx(self.c_to_a[idx]).GetAtomicNum())
-                else:
-                    ligand_elements.append(self.mol_b.GetAtomWithIdx(self.c_to_b[idx]).GetAtomicNum())
-            elif flag == AtomMapFlags.MOL_A:
-                ligand_elements.append(self.mol_a.GetAtomWithIdx(self.c_to_a[idx]).GetAtomicNum())
-            elif flag == AtomMapFlags.MOL_B:
-                ligand_elements.append(self.mol_b.GetAtomWithIdx(self.c_to_b[idx]).GetAtomicNum())
-            else:
-                assert False
-        return np.array(ligand_elements, dtype=np.int32)
-
 
 class MissingBondsInChiralVolumeException(Exception):
     pass

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -602,9 +602,10 @@ def local_minimize(
 
     if not isinstance(minimizer_config, (FireMinimizationConfig, ScipyMinimizationConfig)):
         raise ValueError(f"Invalid minimizer config: {type(minimizer_config)}")
-    if restrained_idxs is not None:
-        assert set(restrained_idxs).issubset(set(local_idxs)), "Restrained indices must be a subset of local indices"
     assert restraint_k >= 0.0, "Restraint k must be greater than or equal to 0.0"
+    if restrained_idxs is not None:
+        assert restraint_k > 0.0, "Restraint k be greater than 0.0 if restrained indices provided"
+        assert set(restrained_idxs).issubset(set(local_idxs)), "Restrained indices must be a subset of local indices"
 
     method = "FIRE"
     if isinstance(minimizer_config, ScipyMinimizationConfig):

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -480,6 +480,8 @@ def get_val_and_grad_fn(bps: Sequence[BoundPotential], box: NDArray, precision=n
 
     box: np.array (3,3)
 
+    precision: np.float64 or np.float32
+
     Returns
     -------
     Energy function with gradient

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -552,7 +552,7 @@ def local_minimize(
     minimizer_config: MinimizationConfig,
     verbose: bool = True,
     assert_energy_decreased: bool = True,
-    restraint_k: Optional[float] = None,
+    restraint_k: float = 0.0,
     restrained_idxs: Optional[NDArray] = None,
 ):
     """
@@ -581,14 +581,12 @@ def local_minimize(
     assert_energy_decreased: bool
         Throw an assertion if the energy does not decrease
 
-    restraint_k: float, optional
+    restraint_k: float
         Restraint k to wrap val_and_grad_fn in a positional harmonic restraint to the input positions of the local_idxs.
-        If None, minimize with no positional restraint. Refer to `timemachine.potentials.bonded.harmonic_positional_restraint`
-        for implementation.
+        Refer to `timemachine.potentials.bonded.harmonic_positional_restraint` for implementation.
 
     restrained_idxs: np.ndarray, optional
-        A subset of idxs to restrain, must be a subset of local_idxs. If not provided and
-        restraint_k is not None, all local_idxs are restrained.
+        A subset of idxs to restrain, must be a subset of local_idxs. If restrained_idxs is None, all local_idxs are restrained.
 
 
     Returns
@@ -605,8 +603,8 @@ def local_minimize(
     if not isinstance(minimizer_config, (FireMinimizationConfig, ScipyMinimizationConfig)):
         raise ValueError(f"Invalid minimizer config: {type(minimizer_config)}")
     if restrained_idxs is not None:
-        assert restraint_k is not None, "Restraint k must be provided if restrained idxs provided"
         assert set(restrained_idxs).issubset(set(local_idxs)), "Restrained indices must be a subset of local indices"
+    assert restraint_k >= 0.0, "Restraint k must be greater than or equal to 0.0"
 
     method = "FIRE"
     if isinstance(minimizer_config, ScipyMinimizationConfig):
@@ -621,9 +619,7 @@ def local_minimize(
 
     # Only use the restrained function when minimizing, don't otherwise use to compute energy/forces
     minimizer_val_and_grad = val_and_grad_fn
-    if restraint_k is not None:
-        assert restraint_k > 0.0
-
+    if restraint_k > 0.0:
         if restrained_idxs is None:
             restrained_idxs = free_idxs
         minimizer_val_and_grad = wrap_val_and_grad_with_positional_restraint(

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -602,7 +602,7 @@ def local_minimize(
 
     if not isinstance(minimizer_config, (FireMinimizationConfig, ScipyMinimizationConfig)):
         raise ValueError(f"Invalid minimizer config: {type(minimizer_config)}")
-    assert restraint_k >= 0.0, "Restraint k must be greater than or equal to 0.0"
+    assert isinstance(restraint_k, float) and restraint_k >= 0.0, "Restraint k must be greater than or equal to 0.0"
     if restrained_idxs is not None:
         assert restraint_k > 0.0, "Restraint k be greater than 0.0 if restrained indices provided"
         assert set(restrained_idxs).issubset(set(local_idxs)), "Restrained indices must be a subset of local indices"

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -602,7 +602,7 @@ def local_minimize(
 
     if not isinstance(minimizer_config, (FireMinimizationConfig, ScipyMinimizationConfig)):
         raise ValueError(f"Invalid minimizer config: {type(minimizer_config)}")
-    assert isinstance(restraint_k, float) and restraint_k >= 0.0, "Restraint k must be greater than or equal to 0.0"
+    assert restraint_k >= 0.0, "Restraint k must be greater than or equal to 0.0"
     if restrained_idxs is not None:
         assert restraint_k > 0.0, "Restraint k be greater than 0.0 if restrained indices provided"
         assert set(restrained_idxs).issubset(set(local_idxs)), "Restrained indices must be a subset of local indices"


### PR DESCRIPTION
* Adds support for specifying a subset of the local idxs as being restrained in `minimizer.local_minimize`.
* Passes the ligand interacting atoms as the restrained atoms rather than restraining all of the free indices. Originally had tried restraining heavy atoms in https://github.com/proteneer/timemachine/pull/1421/commits/02786256cf88be678e8142b68319352da1ca012f but code is a bit janky and didn't resolve any additional failures. Where hydrogen atoms clash and trigger failures, line search causes the ligand to blow up even if the hydrogens are unrestrained. @maxentile is working on a minimization approach that will resolve this in the future. 