### PR TITLE
Split of propers and impropers from torsions, add ST symmetry test.

### DIFF
--- a/examples/biphenyl_torsion_sampling_hrex.py
+++ b/examples/biphenyl_torsion_sampling_hrex.py
@@ -94,7 +94,8 @@ def get_potentials_solvent(
     hb_params, hb_pot = top.parameterize_harmonic_bond(ff_params.hb_params)
     ha_params, ha_pot = top.parameterize_harmonic_angle(ff_params.ha_params)
 
-    pt_params, pt_pot = top.parameterize_periodic_torsion(ff_params.pt_params, ff_params.it_params)
+    pt_params, pt_pot = top.parameterize_proper_torsion(ff_params.pt_params)
+    it_params, it_pot = top.parameterize_improper_torsion(ff_params.it_params)
     nb_params, nb_pot = top.parameterize_nonbonded(
         ff_params.q_params,
         ff_params.q_params_intra,
@@ -131,6 +132,7 @@ def get_potentials_solvent(
         hb_pot.bind(hb_params),
         ha_pot.bind(ha_params),
         pt_pot.bind(pt_params),
+        it_pot.bind(it_params),
         nb_pot.bind(nb_params),
     ]
 

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -384,8 +384,6 @@ $$$$""",
             if key not in counts_kv_src:
                 counts_kv_src[key] = 0
             counts_kv_src[key] += 1  # store period
-        else:
-            assert 0
 
     assert counts_kv_src[duplicate_proper_idxs] == 2
 
@@ -396,8 +394,6 @@ $$$$""",
             if key not in counts_kv_dst:
                 counts_kv_dst[key] = 0
             counts_kv_dst[key] += 1  # store period
-        else:
-            assert 0
 
     assert duplicate_proper_idxs not in counts_kv_dst
 

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -123,7 +123,40 @@ def test_align_proper():
     assert test_set == ref_set
 
 
-# TBD: implement a test_align_improper
+def test_align_improper():
+    """
+    Test that we can align idxs and parameters correctly for improper torsions.
+
+    Currently, improper torsions all have period == 2 and phase == pi
+    """
+    a, b, c, d, e, f, g, h, i, j, k, l, m, n = np.random.rand(14)
+
+    src_idxs = [(0, 1, 2, 3), (2, 1, 3, 0), (3, 1, 0, 2)]
+    src_params = [(a, b, 2), (c, d, 1), (e, f, 3)]
+    dst_idxs = [(2, 1, 3, 0), (3, 1, 0, 2), (0, 1, 2, 3)]
+    dst_params = [(i, b, 2), (j, k, 1), (l, f, 3)]
+
+    test_set = interpolate.align_improper_idxs_and_params(src_idxs, src_params, dst_idxs, dst_params)
+    ref_set = {
+        ((0, 1, 2, 3), (a, b, 2), (l, f, 3)),
+        ((2, 1, 3, 0), (c, d, 1), (i, b, 2)),
+        ((3, 1, 0, 2), (e, f, 3), (j, k, 1)),
+    }
+
+    assert test_set == ref_set
+
+    src_idxs = [(0, 1, 2, 3)]
+    src_params = [(a, b, 2)]
+    dst_idxs = [(0, 1, 3, 2)]
+    dst_params = [(i, c, 2)]
+
+    test_set = interpolate.align_improper_idxs_and_params(src_idxs, src_params, dst_idxs, dst_params)
+    ref_set = {
+        ((0, 1, 2, 3), (a, b, 2), (0, b, 2)),
+        ((0, 1, 3, 2), (0, c, 2), (i, c, 2)),
+    }
+
+    assert test_set == ref_set
 
 
 def test_align_nonbonded():

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -90,10 +90,10 @@ def test_align_harmonic_angle():
     assert test_set == ref_set
 
 
-def test_align_torsion():
+def test_align_proper():
     """
-    Test that we can align idxs and parameters correctly for periodic torsions.
-    Periodic torsions differ from bonds and angles in that their uniqueness is
+    Test that we can align idxs and parameters correctly for proper torsions.
+    Proper torsions differ from bonds and angles in that their uniqueness is
     also determined by the "period", which is currently encoded as one of the parameters.
 
     We expect that decoupled terms have their force constants turned set to zero,
@@ -109,7 +109,7 @@ def test_align_torsion():
     dst_idxs = [(2, 3, 9, 4), (2, 3, 9, 4), (0, 1, 4, 2), (3, 0, 2, 6)]
     dst_params = [(i, b, 2), (j, k, 1), (l, f, 3), (m, n, 4)]
 
-    test_set = interpolate.align_torsion_idxs_and_params(src_idxs, src_params, dst_idxs, dst_params)
+    test_set = interpolate.align_proper_idxs_and_params(src_idxs, src_params, dst_idxs, dst_params)
 
     ref_set = {
         ((2, 3, 9, 4), (a, b, 2), (i, b, 2)),
@@ -121,6 +121,9 @@ def test_align_torsion():
     }
 
     assert test_set == ref_set
+
+
+# TBD: implement a test_align_improper
 
 
 def test_align_nonbonded():
@@ -339,27 +342,27 @@ $$$$""",
     ff = Forcefield.load_default()
     st = SingleTopology(mol_a, mol_b, core, ff)
 
-    duplicate_torsion_idxs = (0, 1, 3, 4)
+    duplicate_proper_idxs = (0, 1, 3, 4)
 
     counts_kv_src = dict()
-    for idxs, p in zip(st.src_system.torsion.potential.idxs, st.src_system.torsion.params):
+    for idxs, p in zip(st.src_system.proper.potential.idxs, st.src_system.proper.params):
         key = tuple(idxs)
         if p[2] == 2.0:
             if key not in counts_kv_src:
                 counts_kv_src[key] = 0
             counts_kv_src[key] += 1  # store period
 
-    assert counts_kv_src[duplicate_torsion_idxs] == 2
+    assert counts_kv_src[duplicate_proper_idxs] == 2
 
     counts_kv_dst = dict()
-    for idxs, p in zip(st.dst_system.torsion.potential.idxs, st.dst_system.torsion.params):
+    for idxs, p in zip(st.dst_system.proper.potential.idxs, st.dst_system.proper.params):
         key = tuple(idxs)
         if p[2] == 2.0:
             if key not in counts_kv_dst:
                 counts_kv_dst[key] = 0
             counts_kv_dst[key] += 1  # store period
 
-    assert duplicate_torsion_idxs not in counts_kv_dst
+    assert duplicate_proper_idxs not in counts_kv_dst
 
     st.setup_intermediate_state(0.5)
 

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -384,6 +384,8 @@ $$$$""",
             if key not in counts_kv_src:
                 counts_kv_src[key] = 0
             counts_kv_src[key] += 1  # store period
+        else:
+            assert 0
 
     assert counts_kv_src[duplicate_proper_idxs] == 2
 
@@ -394,6 +396,8 @@ $$$$""",
             if key not in counts_kv_dst:
                 counts_kv_dst[key] = 0
             counts_kv_dst[key] += 1  # store period
+        else:
+            assert 0
 
     assert duplicate_proper_idxs not in counts_kv_dst
 

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -100,7 +100,7 @@ def run_triple(mol_a, mol_b, core, forcefield, md_params: MDParams, protein_path
             assert res.overlap_by_component_by_lambda.shape[1] == res.dG_err_by_component_by_lambda.shape[1]
             for overlaps in [res.overlaps, res.overlap_by_component_by_lambda]:
                 assert np.all(0.0 < np.asarray(overlaps))
-                assert np.all(np.asarray(overlaps) < 1.0)
+                assert np.all(np.asarray(overlaps) < 1.0 + 1e-5)  # epsilon to deal with loss of precision
 
             assert np.all(0.0 <= np.asarray(res.dG_err_by_component_by_lambda))
             assert np.linalg.norm(res.dG_err_by_component_by_lambda) < 0.1

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -1649,7 +1649,11 @@ def assert_symmetric_interpolation(mol_a, mol_b, core):
     conf_b = get_romol_conf(mol_b)
     test_conf = st_fwd.combine_confs(conf_a, conf_b, 0)
 
-    for lamb in np.linspace(0, 1, 12):
+    seed = 2024
+    np.random.seed(seed)
+    lambda_schedule = np.concatenate([np.linspace(0, 1, 12), np.random.rand(10)])
+
+    for lamb in lambda_schedule:
         sys_fwd = st_fwd.setup_intermediate_state(lamb)
         sys_rev = st_rev.setup_intermediate_state(1 - lamb)
 
@@ -1667,7 +1671,7 @@ def assert_symmetric_interpolation(mol_a, mol_b, core):
             sys_rev.proper,
             test_conf,
             fused_map,
-            canon_fn=lambda idxs, params: tuple([*canonicalize_bond(idxs), f"{params[1]:.5f}", int(params[2])]),
+            canon_fn=lambda idxs, params: tuple([*canonicalize_bond(idxs), f"{params[1]:.5f}", int(round(params[2]))]),
         )
 
         _assert_u_and_grad_consistent(

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -21,7 +21,7 @@ from timemachine.constants import (
     NBParamIdx,
 )
 from timemachine.fe import atom_mapping, single_topology
-from timemachine.fe.dummy import MultipleAnchorWarning
+from timemachine.fe.dummy import MultipleAnchorWarning, canonicalize_bond
 from timemachine.fe.free_energy import HostConfig
 from timemachine.fe.interpolate import align_nonbonded_idxs_and_params, linear_interpolation
 from timemachine.fe.single_topology import (
@@ -410,6 +410,11 @@ def chiral_atom_idxs_are_canonical(all_idxs):
     return np.all((all_idxs[:, 1] < all_idxs[:, 2]) & (all_idxs[:, 1] < all_idxs[:, 3]))
 
 
+def assert_improper_idxs_are_canonical(all_idxs):
+    for idxs in all_idxs:
+        np.testing.assert_array_equal(idxs, canonicalize_improper_idxs(idxs))
+
+
 @pytest.mark.nogpu
 @pytest.mark.nightly(reason="Takes awhile to run")
 def test_hif2a_end_state_stability(num_pairs_to_setup=25, num_pairs_to_simulate=5):
@@ -450,7 +455,8 @@ def test_hif2a_end_state_stability(num_pairs_to_setup=25, num_pairs_to_simulate=
             # assert that the idxs are canonicalized.
             assert bond_idxs_are_canonical(system.bond.potential.idxs)
             assert bond_idxs_are_canonical(system.angle.potential.idxs)
-            assert bond_idxs_are_canonical(system.torsion.potential.idxs)
+            assert bond_idxs_are_canonical(system.proper.potential.idxs)
+            assert_improper_idxs_are_canonical(system.improper.potential.idxs)
             assert bond_idxs_are_canonical(system.nonbonded.potential.idxs)
             assert bond_idxs_are_canonical(system.chiral_bond.potential.idxs)
             assert chiral_atom_idxs_are_canonical(system.chiral_atom.potential.idxs)
@@ -1205,116 +1211,6 @@ def test_interpolate_w_coord_monotonic():
     assert np.all(np.diff(ws) >= 0.0)
 
 
-@pytest.mark.skip(reason="schedule debug")
-@pytest.mark.nocuda
-def test_hif2a_plot_force_constants():
-    # generate plots of force constants
-    with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
-        mols = read_sdf(path_to_ligand)
-
-    pairs = [(mol_a, mol_b) for mol_a in mols for mol_b in mols]
-
-    np.random.seed(2023)
-    np.random.shuffle(pairs)
-    ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
-
-    # this has been tested for up to 50 random pairs
-    for pair_idx, (mol_a, mol_b) in enumerate(pairs[:10]):
-        if mol_a.GetProp("_Name") == mol_b.GetProp("_Name"):
-            continue
-
-        print("Checking pair", pair_idx, " | ", get_mol_name(mol_a), "->", get_mol_name(mol_b))
-        core = _get_core_by_mcs(mol_a, mol_b)
-        st = SingleTopology(mol_a, mol_b, core, ff)
-
-        n_windows = 128
-
-        bond_ks = []
-        angle_ks = []
-        torsion_ks = []
-        chiral_atom_ks = []
-
-        xs = np.linspace(0, 1, n_windows)
-        for lamb in xs:
-            vac_sys = st.setup_intermediate_state(lamb)
-            lamb_bond_ks = []
-            for k, _ in vac_sys.bond.params:
-                lamb_bond_ks.append(k)
-            bond_ks.append(lamb_bond_ks)
-
-            lamb_angle_ks = []
-            for k, _, _ in vac_sys.angle.params:
-                lamb_angle_ks.append(k)
-            angle_ks.append(lamb_angle_ks)
-
-            lamb_torsion_ks = []
-            for k, _, _ in vac_sys.torsion.params:
-                lamb_torsion_ks.append(k)
-            torsion_ks.append(lamb_torsion_ks)
-
-            lamb_chiral_atom_ks = []
-            for k in vac_sys.chiral_atom.params:
-                lamb_chiral_atom_ks.append(k)
-            chiral_atom_ks.append(lamb_chiral_atom_ks)
-
-        bond_ks = np.array(bond_ks).T
-        angle_ks = np.array(angle_ks).T
-        torsion_ks = np.array(torsion_ks).T
-        chiral_atom_ks = np.array(chiral_atom_ks).T
-
-        bond_ks /= np.amax(bond_ks, axis=1, keepdims=True)
-        angle_ks /= np.amax(angle_ks, axis=1, keepdims=True)
-        torsion_ks /= np.amax(torsion_ks, axis=1, keepdims=True)
-        chiral_atom_ks /= np.amax(chiral_atom_ks, axis=1, keepdims=True)
-
-        import matplotlib.pyplot as plt
-
-        fig, all_axes = plt.subplots(4, 1, figsize=(1 * 5, 4 * 3))
-        fig.tight_layout()
-
-        for v in bond_ks:
-            all_axes[0].plot(xs, v)
-        all_axes[0].set_title("bond")
-        all_axes[0].set_ylabel("fraction of full strength")
-        all_axes[0].set_xlabel("lambda")
-        all_axes[0].axvline(0.3, ls="--", color="gray")
-        all_axes[0].axvline(0.6, ls="--", color="gray")
-        all_axes[0].axvline(0.8, ls="--", color="gray")
-        all_axes[0].set_ylim(0, 1)
-
-        for v in angle_ks:
-            all_axes[1].plot(xs, v)
-        all_axes[1].set_title("angle")
-        all_axes[1].set_ylabel("fraction of full strength")
-        all_axes[1].set_xlabel("lambda")
-        all_axes[1].axvline(0.3, ls="--", color="gray")
-        all_axes[1].axvline(0.6, ls="--", color="gray")
-        all_axes[1].axvline(0.8, ls="--", color="gray")
-        all_axes[1].set_ylim(0, 1)
-
-        for v in torsion_ks:
-            all_axes[2].plot(xs, v)
-        all_axes[2].set_title("torsion")
-        all_axes[2].set_ylabel("fraction of full strength")
-        all_axes[2].set_xlabel("lambda")
-        all_axes[2].axvline(0.3, ls="--", color="gray")
-        all_axes[2].axvline(0.6, ls="--", color="gray")
-        all_axes[2].axvline(0.8, ls="--", color="gray")
-        all_axes[2].set_ylim(0, 1)
-
-        for v in chiral_atom_ks:
-            all_axes[3].plot(xs, v)
-        all_axes[3].set_title("chiral atom")
-        all_axes[3].set_ylabel("fraction of full strength")
-        all_axes[3].set_xlabel("lambda")
-        all_axes[3].axvline(0.3, ls="--", color="gray")
-        all_axes[3].axvline(0.6, ls="--", color="gray")
-        all_axes[3].axvline(0.8, ls="--", color="gray")
-        all_axes[3].set_ylim(0, 1)
-
-        plt.show()
-
-
 @pytest.mark.nightly(reason="Test setting up hif2a pairs for single topology.")
 @pytest.mark.nocuda
 def test_hif2a_pairs_setup_st():
@@ -1680,8 +1576,34 @@ def get_vacuum_system_and_conf(mol_a, mol_b, core, lamb):
     return st.setup_intermediate_state(lamb), conf
 
 
-def _assert_u_and_grad_consistent(u_fwd, u_rev, x_fwd, x_rev, fused_map):
-    assert len(fused_map) == len(x_fwd)
+def _assert_consistent_hamiltonian_term_impl(fwd_bonded_term, rev_bonded_term, rev_kv, canon_fn):
+    fwd_canonical_map = dict()
+    for fwd_idxs, fwd_params in zip(fwd_bonded_term.potential.idxs, fwd_bonded_term.params):
+        fwd_key = canon_fn(fwd_idxs, fwd_params)
+        fwd_canonical_map[fwd_key] = fwd_params
+
+    # tbd: if fwd has more terms than rev then this logic will miss the inconsistency, this checks
+    # only for subset equivalence
+    for rev_idxs, rev_params in zip(rev_bonded_term.potential.idxs, rev_bonded_term.params):
+        rev_key = canon_fn([rev_kv[x] for x in rev_idxs], rev_params)
+        np.testing.assert_allclose(fwd_canonical_map[rev_key], rev_params)
+
+
+def _assert_u_and_grad_consistent(u_fwd, u_rev, x_fwd, fused_map, canon_fn):
+    # test that the definition of the hamiltonian, the energies, and the forces are all consistent
+    rev_kv = dict()
+    fwd_kv = dict()
+    for x, y in fused_map:
+        fwd_kv[x] = y
+        rev_kv[y] = x
+    x_rev = np.zeros_like(x_fwd)
+    for atom_idx, xyz in enumerate(x_fwd):
+        x_rev[fwd_kv[atom_idx]] = xyz
+
+    # check hamiltonian
+    _assert_consistent_hamiltonian_term_impl(u_fwd, u_rev, rev_kv, canon_fn)
+
+    # check energies and forces
     box = 100.0 * np.eye(3)
     np.testing.assert_allclose(u_fwd(x_fwd, box), u_rev(x_rev, box))
     fwd_bond_grad_fn = jax.grad(u_fwd)
@@ -1691,52 +1613,46 @@ def _assert_u_and_grad_consistent(u_fwd, u_rev, x_fwd, x_rev, fused_map):
     )
 
 
-@pytest.mark.nocuda
-@pytest.mark.nightly(reason="slow")
-def test_hif2a_end_state_symmetry_nightly_test():
-    """
-    Test that end-states are symmetric
-    """
-    with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
-        mols = read_sdf(path_to_ligand)
+# @pytest.mark.nocuda
+# @pytest.mark.nightly(reason="slow")
+# def test_hif2a_end_state_symmetry_nightly_test():
+#     """
+#     Test that end-states are symmetric
+#     """
+#     with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
+#         mols = read_sdf(path_to_ligand)
 
-    for idx, mol_a in enumerate(mols):
-        for mol_b in mols[idx + 1 :]:
-            print("testing", mol_a.GetProp("_Name"), "->", mol_b.GetProp("_Name"))
-            core = atom_mapping.get_cores(mol_a, mol_b, **DEFAULT_ATOM_MAPPING_KWARGS)[0]
-            amm_fwd = AtomMapMixin(mol_a, mol_b, core)
-            amm_rev = AtomMapMixin(mol_b, mol_a, core[:, ::-1])
-            fused_map = np.concatenate(
-                [
-                    np.array([[x, y] for x, y in zip(amm_fwd.a_to_c, amm_rev.b_to_c)], dtype=np.int32).reshape(-1, 2),
-                    np.array(
-                        [
-                            [x, y]
-                            for x, y in zip(amm_fwd.b_to_c, amm_rev.a_to_c)
-                            if x not in core[:, 0] and y not in core[:, 1]
-                        ],
-                        dtype=np.int32,
-                    ).reshape(-1, 2),
-                ]
-            )
-            sys_fwd, conf_fwd = get_vacuum_system_and_conf(mol_a, mol_b, core, 0.0)
-            sys_rev, conf_rev = get_vacuum_system_and_conf(mol_b, mol_a, core[:, ::-1], 1.0)
+#     for idx, mol_a in enumerate(mols):
+#         for mol_b in mols[idx + 1 :]:
+#             print("testing", mol_a.GetProp("_Name"), "->", mol_b.GetProp("_Name"))
+#             core = atom_mapping.get_cores(mol_a, mol_b, **DEFAULT_ATOM_MAPPING_KWARGS)[0]
+#             amm_fwd = AtomMapMixin(mol_a, mol_b, core)
+#             amm_rev = AtomMapMixin(mol_b, mol_a, core[:, ::-1])
+#             fused_map = np.concatenate(
+#                 [
+#                     np.array([[x, y] for x, y in zip(amm_fwd.a_to_c, amm_rev.b_to_c)], dtype=np.int32).reshape(-1, 2),
+#                     np.array(
+#                         [
+#                             [x, y]
+#                             for x, y in zip(amm_fwd.b_to_c, amm_rev.a_to_c)
+#                             if x not in core[:, 0] and y not in core[:, 1]
+#                         ],
+#                         dtype=np.int32,
+#                     ).reshape(-1, 2),
+#                 ]
+#             )
+#             sys_fwd, conf_fwd = get_vacuum_system_and_conf(mol_a, mol_b, core, 0.0)
+#             sys_rev, conf_rev = get_vacuum_system_and_conf(mol_b, mol_a, core[:, ::-1], 1.0)
 
-            _assert_u_and_grad_consistent(sys_fwd.bond, sys_rev.bond, conf_fwd, conf_rev, fused_map)
-            _assert_u_and_grad_consistent(sys_fwd.angle, sys_rev.angle, conf_fwd, conf_rev, fused_map)
-            _assert_u_and_grad_consistent(sys_fwd.nonbonded, sys_rev.nonbonded, conf_fwd, conf_rev, fused_map)
-            _assert_u_and_grad_consistent(sys_fwd.torsion, sys_rev.torsion, conf_fwd, conf_rev, fused_map)
-            _assert_u_and_grad_consistent(sys_fwd.chiral_atom, sys_rev.chiral_atom, conf_fwd, conf_rev, fused_map)
+#             _assert_u_and_grad_consistent(sys_fwd.bond, sys_rev.bond, conf_fwd, conf_rev, fused_map)
+#             _assert_u_and_grad_consistent(sys_fwd.angle, sys_rev.angle, conf_fwd, conf_rev, fused_map)
+#             _assert_u_and_grad_consistent(sys_fwd.nonbonded, sys_rev.nonbonded, conf_fwd, conf_rev, fused_map)
+#             _assert_u_and_grad_consistent(sys_fwd.proper, sys_rev.proper, conf_fwd, conf_rev, fused_map)
+#             _assert_u_and_grad_consistent(sys_fwd.improper, sys_rev.improper, conf_fwd, conf_rev, fused_map)
+#             _assert_u_and_grad_consistent(sys_fwd.chiral_atom, sys_rev.chiral_atom, conf_fwd, conf_rev, fused_map)
 
 
-@pytest.mark.nocuda
-def test_hif2a_end_state_symmetry_unit_test():
-    with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
-        mols = read_sdf(path_to_ligand)
-
-    mol_a = mols[0]
-    mol_b = mols[1]
-    core = atom_mapping.get_cores(mol_a, mol_b, **DEFAULT_ATOM_MAPPING_KWARGS)[0]
+def get_fused_map(mol_a, mol_b, core):
     amm_fwd = AtomMapMixin(mol_a, mol_b, core)
     amm_rev = AtomMapMixin(mol_b, mol_a, core[:, ::-1])
     fused_map = np.concatenate(
@@ -1747,8 +1663,69 @@ def test_hif2a_end_state_symmetry_unit_test():
             ),
         ]
     )
+    return fused_map
 
-    sys_fwd, conf_fwd = get_vacuum_system_and_conf(mol_a, mol_b, core, 0.0)
-    sys_rev, conf_rev = get_vacuum_system_and_conf(mol_b, mol_a, core[:, ::-1], 1.0)
 
-    _assert_u_and_grad_consistent(sys_fwd.bond, sys_rev.bond, conf_fwd, conf_rev, fused_map)
+@pytest.mark.nocuda
+def test_hif2a_end_state_symmetry_unit_test():
+    with resources.path("timemachine.testsystems.data", "ligands_40.sdf") as path_to_ligand:
+        mols = read_sdf(path_to_ligand)
+
+    ff = Forcefield.load_default()
+    mol_a = mols[0]
+    mol_b = mols[1]
+    core = atom_mapping.get_cores(mol_a, mol_b, **DEFAULT_ATOM_MAPPING_KWARGS)[0]
+    # map atoms in the combined mol_ab to the atoms in the combined mol_ba
+    fused_map = get_fused_map(mol_a, mol_b, core)
+
+    st_fwd = SingleTopology(mol_a, mol_b, core, ff)
+    st_rev = SingleTopology(mol_b, mol_a, core[:, ::-1], ff)
+    conf_a = get_romol_conf(mol_a)
+    conf_b = get_romol_conf(mol_b)
+    test_conf = st_fwd.combine_confs(conf_a, conf_b, 0)
+
+    # We expect that SingleTopology(mol_a, mol_b, lamb) == SingleTopology(mol_b, mol_a, 1-lamb)
+    for lamb in np.linspace(0, 1, 12):
+        sys_fwd = st_fwd.setup_intermediate_state(lamb)
+        sys_rev = st_rev.setup_intermediate_state(1 - lamb)
+
+        _assert_u_and_grad_consistent(
+            sys_fwd.bond, sys_rev.bond, test_conf, fused_map, canon_fn=lambda idxs, _: tuple(canonicalize_bond(idxs))
+        )
+
+        _assert_u_and_grad_consistent(
+            sys_fwd.angle, sys_rev.angle, test_conf, fused_map, canon_fn=lambda idxs, _: tuple(canonicalize_bond(idxs))
+        )
+
+        # # for propers, we format the phase as a 5 decimal string to guard against loss of precision
+        _assert_u_and_grad_consistent(
+            sys_fwd.proper,
+            sys_rev.proper,
+            test_conf,
+            fused_map,
+            canon_fn=lambda idxs, params: tuple([*canonicalize_bond(idxs), f"{params[1]:.5f}", int(params[2])]),
+        )
+
+        _assert_u_and_grad_consistent(
+            sys_fwd.improper,
+            sys_rev.improper,
+            test_conf,
+            fused_map,
+            canon_fn=lambda idxs, _: tuple(canonicalize_improper_idxs(idxs)),
+        )
+
+        _assert_u_and_grad_consistent(
+            sys_fwd.chiral_atom,
+            sys_rev.chiral_atom,
+            test_conf,
+            fused_map,
+            canon_fn=lambda idxs, _: tuple(canonicalize_chiral_atom_idxs(np.array([idxs]))[0]),  # fn assumes ndim=2
+        )
+
+        _assert_u_and_grad_consistent(
+            sys_fwd.nonbonded,
+            sys_rev.nonbonded,
+            test_conf,
+            fused_map,
+            canon_fn=lambda idxs, _: tuple(canonicalize_bond(idxs)),
+        )

--- a/tests/test_single_topology_combined.py
+++ b/tests/test_single_topology_combined.py
@@ -62,11 +62,8 @@ def test_combined_parameters_bonded(host_system_fixture, lamb, hif2a_ligand_pair
     # check bonds
     check_bonded_idxs_consistency(hgs.bond.potential.idxs, len(host_sys.bond.potential.idxs))
     check_bonded_idxs_consistency(hgs.angle.potential.idxs, len(host_sys.angle.potential.idxs))
-
-    if host_sys.torsion:
-        check_bonded_idxs_consistency(hgs.torsion.potential.idxs, len(host_sys.torsion.potential.idxs))
-    else:
-        check_bonded_idxs_consistency(hgs.torsion.potential.idxs, 0)
+    check_bonded_idxs_consistency(hgs.proper.potential.idxs, len(host_sys.proper.potential.idxs))
+    check_bonded_idxs_consistency(hgs.improper.potential.idxs, len(host_sys.improper.potential.idxs))
 
     if host_sys.chiral_atom:
         check_bonded_idxs_consistency(hgs.chiral_atom.potential.idxs, len(host_sys.chiral_atom.potential.idxs))

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -392,7 +392,8 @@ class BaseFreeEnergy:
         params_potential_pairs = [
             topology.parameterize_harmonic_bond(ff_params.hb_params),
             topology.parameterize_harmonic_angle(ff_params.ha_params),
-            topology.parameterize_periodic_torsion(ff_params.pt_params, ff_params.it_params),
+            topology.parameterize_proper_torsion(ff_params.pt_params),
+            topology.parameterize_improper_torsion(ff_params.it_params),
             topology.parameterize_nonbonded(
                 ff_params.q_params,
                 ff_params.q_params_intra,

--- a/timemachine/fe/interpolate.py
+++ b/timemachine/fe/interpolate.py
@@ -119,12 +119,14 @@ align_harmonic_bond_idxs_and_params = partial(
 align_harmonic_angle_idxs_and_params = partial(align_idxs_and_params, make_default=lambda p: (0, p[1], 0))
 align_nonbonded_idxs_and_params = partial(align_idxs_and_params, make_default=lambda _: (0, 0, 0, 0))
 align_chiral_atom_idxs_and_params = partial(align_idxs_and_params, make_default=lambda _: 0)
-align_torsion_idxs_and_params = partial(
+align_proper_idxs_and_params = partial(
     align_idxs_and_params,
     make_default=lambda p: (0, p[1], p[2]),  # p[1], p[2] is phase, period
     key=lambda idxs, p: (idxs, p[1], p[2]),  # align on idxs, phase, period
     get_idxs=lambda key: key[0],
 )
+# impropers do not require key'ing on phase, period
+align_improper_idxs_and_params = partial(align_idxs_and_params, make_default=lambda p: (0, p[1], p[2]))
 
 
 def align_chiral_bond_idxs_and_params(src_idxs, src_params, src_signs, dst_idxs, dst_params, dst_signs):

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -590,49 +590,91 @@ def _plot_chiral_atom_interpolation(xs, systems, filter_fn, axs, row):
     # axs[row, 0].legend()
 
 
-def _plot_torsion_interpolation(xs, systems, filter_fn, axs, row):
-    torsion_ks = []  # K x # torsions
-    torsion_bs = []  # K x # torsions
+def _plot_proper_interpolation(xs, systems, filter_fn, axs, row):
+    proper_ks = []  # K x # propers
+    proper_bs = []  # K x # propers
     for sys in systems:
-        torsion_idxs = sys.torsion.potential.idxs
-        torsion_params = sys.torsion.params
+        proper_idxs = sys.proper.potential.idxs
+        proper_params = sys.proper.params
         keep_idxs = []
-        for b_idx, idxs in enumerate(torsion_idxs):
+        for b_idx, idxs in enumerate(proper_idxs):
             if filter_fn(idxs):
                 keep_idxs.append(b_idx)
         keep_idxs = np.array(keep_idxs, dtype=np.int32)
-        torsion_ks.append(torsion_params[keep_idxs, 0])
-        torsion_bs.append(torsion_params[keep_idxs, 1])
+        proper_ks.append(proper_params[keep_idxs, 0])
+        proper_bs.append(proper_params[keep_idxs, 1])
 
-    torsion_idxs = torsion_idxs[keep_idxs]
-    torsion_ks = np.array(torsion_ks).T  # torsions x K
-    torsion_bs = np.array(torsion_bs).T * (180 / np.pi)  # torsions x K *
-    num_torsions = torsion_ks.shape[0]
+    proper_idxs = proper_idxs[keep_idxs]
+    proper_ks = np.array(proper_ks).T  # propers x K
+    proper_bs = np.array(proper_bs).T * (180 / np.pi)  # propers x K *
+    num_propers = proper_ks.shape[0]
 
-    for b_idx in range(num_torsions):
-        if torsion_ks[b_idx][0] != torsion_ks[b_idx][-1]:
+    for b_idx in range(num_propers):
+        if proper_ks[b_idx][0] != proper_ks[b_idx][-1]:
             linestyle = "solid"
-            label = f"{torsion_idxs[b_idx]}"
+            label = f"{proper_idxs[b_idx]}"
             alpha = 1.0
         else:
             linestyle = "dotted"
             label = None
             alpha = 0.1
 
-        axs[row, 0].plot(xs, torsion_ks[b_idx], linestyle=linestyle, label=label, alpha=alpha)
-        axs[row, 1].plot(xs, torsion_bs[b_idx], linestyle=linestyle, label=label, alpha=alpha)
+        axs[row, 0].plot(xs, proper_ks[b_idx], linestyle=linestyle, label=label, alpha=alpha)
+        axs[row, 1].plot(xs, proper_bs[b_idx], linestyle=linestyle, label=label, alpha=alpha)
 
-    axs[row, 0].set_title("torsion force constants")
-    axs[row, 1].set_title("torsion degrees")
+    axs[row, 0].set_title("proper force constants")
+    axs[row, 1].set_title("proper degrees")
 
     axs[row, 0].set_ylabel("force constant")
-    axs[row, 1].set_ylabel("torsion degree")
+    axs[row, 1].set_ylabel("proper degree")
 
     axs[row, 0].set_xlabel("lambda window")
     axs[row, 1].set_xlabel("lambda window")
 
     # axs[row, 0].legend(bbox_to_anchor=(1, 0.5))
     # axs[row, 1].legend(bbox_to_anchor=(1, 0.5))
+
+
+def _plot_improper_interpolation(xs, systems, filter_fn, axs, row):
+    improper_ks = []  # K x # impropers
+    improper_bs = []  # K x # impropers
+    for sys in systems:
+        improper_idxs = sys.improper.potential.idxs
+        improper_params = sys.improper.params
+        keep_idxs = []
+        for b_idx, idxs in enumerate(improper_idxs):
+            if filter_fn(idxs):
+                keep_idxs.append(b_idx)
+        keep_idxs = np.array(keep_idxs, dtype=np.int32)
+        improper_ks.append(improper_params[keep_idxs, 0])
+        improper_bs.append(improper_params[keep_idxs, 1])
+
+    improper_idxs = improper_idxs[keep_idxs]
+    improper_ks = np.array(improper_ks).T  # impropers x K
+    improper_bs = np.array(improper_bs).T * (180 / np.pi)  # impropers x K *
+    num_impropers = improper_ks.shape[0]
+
+    for b_idx in range(num_impropers):
+        if improper_ks[b_idx][0] != improper_ks[b_idx][-1]:
+            linestyle = "solid"
+            label = f"{improper_idxs[b_idx]}"
+            alpha = 1.0
+        else:
+            linestyle = "dotted"
+            label = None
+            alpha = 0.1
+
+        axs[row, 0].plot(xs, improper_ks[b_idx], linestyle=linestyle, label=label, alpha=alpha)
+        axs[row, 1].plot(xs, improper_bs[b_idx], linestyle=linestyle, label=label, alpha=alpha)
+
+    axs[row, 0].set_title("improper force constants")
+    axs[row, 1].set_title("improper degrees")
+
+    axs[row, 0].set_ylabel("force constant")
+    axs[row, 1].set_ylabel("improper degree")
+
+    axs[row, 0].set_xlabel("lambda window")
+    axs[row, 1].set_xlabel("lambda window")
 
 
 def plot_interpolation_schedule(st, filter_fn, fig_title, n_windows):
@@ -645,7 +687,8 @@ def plot_interpolation_schedule(st, filter_fn, fig_title, n_windows):
     _plot_bond_interpolation(st, lambdas, systems, filter_fn, axs, row=0)
     _plot_chiral_atom_interpolation(lambdas, systems, filter_fn, axs, row=1)
     _plot_angle_interpolation(st, lambdas, systems, filter_fn, axs, row=2)
-    _plot_torsion_interpolation(lambdas, systems, filter_fn, axs, row=3)
+    _plot_proper_interpolation(lambdas, systems, filter_fn, axs, row=3)
+    _plot_improper_interpolation(lambdas, systems, filter_fn, axs, row=4)
     fig.suptitle(fig_title, fontsize=12)
     plt.tight_layout()
     # plt.show()

--- a/timemachine/fe/plots.py
+++ b/timemachine/fe/plots.py
@@ -606,7 +606,7 @@ def _plot_proper_interpolation(xs, systems, filter_fn, axs, row):
 
     proper_idxs = proper_idxs[keep_idxs]
     proper_ks = np.array(proper_ks).T  # propers x K
-    proper_bs = np.array(proper_bs).T * (180 / np.pi)  # propers x K *
+    proper_bs = np.array(proper_bs).T * (180 / np.pi)  # propers x K (in degrees)
     num_propers = proper_ks.shape[0]
 
     for b_idx in range(num_propers):
@@ -651,7 +651,7 @@ def _plot_improper_interpolation(xs, systems, filter_fn, axs, row):
 
     improper_idxs = improper_idxs[keep_idxs]
     improper_ks = np.array(improper_ks).T  # impropers x K
-    improper_bs = np.array(improper_bs).T * (180 / np.pi)  # impropers x K *
+    improper_bs = np.array(improper_bs).T * (180 / np.pi)  # of impropers x K (in degrees)
     num_impropers = improper_ks.shape[0]
 
     for b_idx in range(num_impropers):

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1641,7 +1641,9 @@ class SingleTopology(AtomMapMixin):
         assert bonded_idxs.ndim == src_idxs_ndim
         assert bonded_idxs.dtype == src_idxs_dtype
         assert bonded_params.ndim == src_params_ndim
-        assert bonded_params.dtype == src_params_dtype
+        # this will downcast automatically if 64bit jax is disabled
+        if jax.config.read("jax_enable_x64") is True:
+            assert bonded_params.dtype == src_params_dtype
 
         # if we had automatic reshaping, then bond_class automatically reshape everything down below
         bond_class = type(src_potential.potential)

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -690,37 +690,26 @@ def setup_end_state(ff, mol_a, mol_b, core, a_to_c, b_to_c, dummy_groups: Dict[i
     mol_c_angle_idxs = np.concatenate([mol_a_angle_idxs, all_dummy_angle_idxs])
     mol_c_angle_params = np.concatenate([mol_a_angle_params, all_dummy_angle_params])
 
-    mol_c_proper_idxs = mol_a_proper_idxs
+    mol_c_proper_idxs = np.array([canonicalize_bond(idxs) for idxs in mol_a_proper_idxs])
     mol_c_proper_params = mol_a_proper_params
+    proper_potential = PeriodicTorsion(mol_c_proper_idxs.reshape(-1, 4).astype(np.int32)).bind(
+        np.array(mol_c_proper_params.reshape(-1, 3), dtype=np.float64)
+    )
 
     mol_c_improper_idxs = np.concatenate([mol_a_improper_idxs, all_dummy_improper_idxs])
     mol_c_improper_params = np.concatenate([mol_a_improper_params, all_dummy_improper_params])
-
     # canonicalize improper with cw/ccw check
     mol_c_improper_idxs = np.array(
         [canonicalize_improper_idxs(idxs) for idxs in mol_c_improper_idxs], np.int32
     ).reshape(-1, 4)
-
-    # check that the improper idxs are canonical
-    def assert_improper_idxs_are_canonical(all_idxs):
-        for j, _, k, l in all_idxs:
-            jj, kk, ll = sorted((j, k, l))
-            assert (jj, kk, ll) == (j, k, l) or (kk, ll, jj) == (j, k, l) or (ll, jj, kk) == (j, k, l)
-
-    assert_improper_idxs_are_canonical(mol_c_improper_idxs)
-
-    # combine proper + improper
-    mol_c_torsion_idxs = np.concatenate([mol_c_proper_idxs, mol_c_improper_idxs])
-    mol_c_torsion_params = np.concatenate([mol_c_proper_params, mol_c_improper_params])
+    improper_potential = PeriodicTorsion(mol_c_improper_idxs.reshape(-1, 4).astype(np.int32)).bind(
+        np.array(mol_c_improper_params.reshape(-1, 3), dtype=np.float64)
+    )
 
     # canonicalize angles
     mol_c_angle_idxs_canon = np.array([canonicalize_bond(idxs) for idxs in mol_c_angle_idxs])
     mol_c_stable_angle_params = np.hstack([mol_c_angle_params, np.zeros((len(mol_c_angle_params), 1))])
     angle_potential = HarmonicAngleStable(mol_c_angle_idxs_canon).bind(np.array(mol_c_stable_angle_params))
-
-    # canonicalize torsions with idxs[0] < idxs[-1] check
-    mol_c_torsion_idxs_canon = np.array([canonicalize_bond(idxs) for idxs in mol_c_torsion_idxs])
-    torsion_potential = PeriodicTorsion(mol_c_torsion_idxs_canon).bind(np.array(mol_c_torsion_params))
 
     # dummy atoms do not have any nonbonded interactions, so we simply turn them off
     mol_c_nbpl_idxs_canon = np.array([canonicalize_bond(idxs) for idxs in mol_a_nbpl_idxs])
@@ -742,7 +731,8 @@ def setup_end_state(ff, mol_a, mol_b, core, a_to_c, b_to_c, dummy_groups: Dict[i
     return VacuumSystem(
         bond_potential,
         angle_potential,
-        torsion_potential,
+        proper_potential,
+        improper_potential,
         nonbonded_potential,
         chiral_atom_potential,
         chiral_bond_potential,
@@ -1604,13 +1594,56 @@ class SingleTopology(AtomMapMixin):
             dst_potential.potential.idxs,
             dst_potential.params,
         )
+
+        # (ytz): sigh, this is the garbage code that we need to write if we don't do re-shaping
+        # at the potential level, sigh. If we have zero length arrays, for both src_potential and dst_potential,
+        # then we lose information about the correct shapes.
+        src_idxs_ndim = src_potential.potential.idxs.ndim
+        dst_idxs_ndim = dst_potential.potential.idxs.ndim
+        assert src_idxs_ndim == 2
+        assert src_idxs_ndim == dst_idxs_ndim
+
+        src_idxs_last_shape = src_potential.potential.idxs.shape[1]
+        dst_idxs_last_shape = dst_potential.potential.idxs.shape[1]
+        assert src_idxs_last_shape == dst_idxs_last_shape
+
+        src_idxs_dtype = src_potential.potential.idxs.dtype
+        dst_idxs_dtype = dst_potential.potential.idxs.dtype
+        assert src_idxs_dtype == dst_idxs_dtype
+
+        src_params_ndim = src_potential.params.ndim
+        dst_params_ndim = dst_potential.params.ndim
+        assert src_params_ndim == dst_params_ndim
+
+        src_params_dtype = src_potential.params.dtype
+        dst_params_dtype = dst_potential.params.dtype
+        assert src_params_dtype == dst_params_dtype
+
         bonded_idxs = []
         bonded_params = []
         for idxs, src_params, dst_params in set_of_tuples:
             bonded_idxs.append(idxs)
             bonded_params.append(interpolate_fn(idxs, src_params, dst_params, lamb))
-        bonded_idxs = np.array(bonded_idxs)
-        bonded_params = jnp.array(bonded_params)
+
+        bonded_idxs = np.array(bonded_idxs, dtype=src_idxs_dtype).reshape(-1, src_idxs_last_shape)
+
+        if src_params_ndim == 1:
+            # chiral atom
+            bonded_params = jnp.array(bonded_params, dtype=src_params_dtype)
+            pass
+        elif src_params_ndim == 2:
+            # everything else
+            src_params_last_shape = src_potential.params.shape[1]
+            bonded_params = jnp.array(bonded_params, dtype=src_params_dtype).reshape(-1, src_params_last_shape)
+        else:
+            assert 0
+
+        assert bonded_idxs.ndim == src_idxs_ndim
+        assert bonded_idxs.dtype == src_idxs_dtype
+        assert bonded_params.ndim == src_params_ndim
+        assert bonded_params.dtype == src_params_dtype
+
+        # if we had automatic reshaping, then bond_class automatically reshape everything down below
         bond_class = type(src_potential.potential)
         return bond_class(bonded_idxs).bind(bonded_params)
 
@@ -1641,12 +1674,23 @@ class SingleTopology(AtomMapMixin):
             self._interpolate_bond,
         )
 
-    def align_and_interpolate_torsions(self, lamb):
+    # proper and impropers use the same logic for alignment
+    def align_and_interpolate_propers(self, lamb):
+        res = self._align_and_interpolate_bonded_term(
+            lamb,
+            self.src_system.proper,
+            self.dst_system.proper,
+            interpolate.align_proper_idxs_and_params,
+            self._interpolate_torsion,
+        )
+        return res
+
+    def align_and_interpolate_impropers(self, lamb):
         return self._align_and_interpolate_bonded_term(
             lamb,
-            self.src_system.torsion,
-            self.dst_system.torsion,
-            interpolate.align_torsion_idxs_and_params,
+            self.src_system.improper,
+            self.dst_system.improper,
+            interpolate.align_improper_idxs_and_params,
             self._interpolate_torsion,
         )
 
@@ -1696,7 +1740,8 @@ class SingleTopology(AtomMapMixin):
         bond = self.align_and_interpolate_bonds(lamb)
         angle = self.align_and_interpolate_angles(lamb)
         chiral_atom = self.align_and_interpolate_chiral_atoms(lamb)
-        torsion = self.align_and_interpolate_torsions(lamb)
+        proper = self.align_and_interpolate_propers(lamb)
+        improper = self.align_and_interpolate_impropers(lamb)
         nonbonded = self.align_and_interpolate_intramolecular_nonbonded(lamb)
 
         assert src_system.chiral_bond
@@ -1709,7 +1754,7 @@ class SingleTopology(AtomMapMixin):
             interpolate.linear_interpolation,
         )
 
-        return VacuumSystem(bond, angle, torsion, nonbonded, chiral_atom, chiral_bond)
+        return VacuumSystem(bond, angle, proper, improper, nonbonded, chiral_atom, chiral_bond)
 
     def mol(self, lamb, min_bond_k=DEFAULT_BOND_IS_PRESENT_K) -> Chem.Mol:
         """
@@ -1944,12 +1989,8 @@ class SingleTopology(AtomMapMixin):
         guest_system = self.setup_intermediate_state(lamb=lamb)
 
         num_host_atoms = host_system.nonbonded.params.shape[0]
-
-        assert guest_system.chiral_atom
         guest_chiral_atom_idxs = np.array(guest_system.chiral_atom.potential.idxs, dtype=np.int32) + num_host_atoms
         guest_system.chiral_atom.potential.idxs = guest_chiral_atom_idxs
-
-        assert guest_system.chiral_bond
         guest_chiral_bond_idxs = np.array(guest_system.chiral_bond.potential.idxs, dtype=np.int32) + num_host_atoms
         guest_system.chiral_bond.potential.idxs = guest_chiral_bond_idxs
 
@@ -1974,20 +2015,20 @@ class SingleTopology(AtomMapMixin):
         combined_angle_params = jnp.concatenate([host_angle_params, guest_system.angle.params])
         combined_angle = HarmonicAngleStable(combined_angle_idxs).bind(combined_angle_params)
 
-        assert guest_system.torsion
+        # print(host_system.proper.potential.idxs.shape, guest_system.proper.potential.idxs.shape)
+        combined_proper_idxs = np.concatenate(
+            [host_system.proper.potential.idxs, guest_system.proper.potential.idxs + num_host_atoms]
+        )
 
-        # complex proteins have torsions
-        if host_system.torsion:
-            combined_torsion_idxs = np.concatenate(
-                [host_system.torsion.potential.idxs, guest_system.torsion.potential.idxs + num_host_atoms]
-            )
-            combined_torsion_params = jnp.concatenate([host_system.torsion.params, guest_system.torsion.params])
-        else:
-            # solvent waters don't have torsions
-            combined_torsion_idxs = np.array(guest_system.torsion.potential.idxs, dtype=np.int32) + num_host_atoms
-            combined_torsion_params = jnp.array(guest_system.torsion.params)
+        # print(host_system.proper.params.shape, guest_system.proper.params.shape)
+        combined_proper_params = jnp.concatenate([host_system.proper.params, guest_system.proper.params])
+        combined_proper = PeriodicTorsion(combined_proper_idxs).bind(combined_proper_params)
 
-        combined_torsion = PeriodicTorsion(combined_torsion_idxs).bind(combined_torsion_params)
+        combined_improper_idxs = np.concatenate(
+            [host_system.improper.potential.idxs, guest_system.improper.potential.idxs + num_host_atoms]
+        )
+        combined_improper_params = jnp.concatenate([host_system.improper.params, guest_system.improper.params])
+        combined_improper = PeriodicTorsion(combined_improper_idxs).bind(combined_improper_params)
 
         host_nonbonded = self._parameterize_host_nonbonded(host_system.nonbonded)
         host_guest_nonbonded_ixn = self._parameterize_host_guest_nonbonded_ixn(
@@ -2001,7 +2042,8 @@ class SingleTopology(AtomMapMixin):
         return HostGuestSystem(
             combined_bond,
             combined_angle,
-            combined_torsion,
+            combined_proper,
+            combined_improper,
             guest_system.chiral_atom,
             guest_system.chiral_bond,
             guest_system.nonbonded,

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -1,6 +1,6 @@
 import multiprocessing
 from dataclasses import dataclass
-from typing import Generic, List, Optional, Sequence, Tuple, TypeVar, Union, cast
+from typing import Generic, List, Sequence, Tuple, TypeVar, Union, cast
 
 import jax
 import numpy as np
@@ -86,30 +86,20 @@ def simulate_system(U_fn, x0, num_samples=20000, steps_per_batch=500, num_worker
 
 
 def convert_bps_into_system(bps: Sequence[potentials.BoundPotential]):
-    bond = angle = torsion = nonbonded = chiral_atom = chiral_bond = None
+    assert isinstance(bps[0].potential, potentials.HarmonicBond)
+    assert isinstance(bps[1].potential, potentials.HarmonicAngle)
+    assert isinstance(bps[2].potential, potentials.PeriodicTorsion)  # proper
+    assert isinstance(bps[3].potential, potentials.PeriodicTorsion)  # improper
+    assert isinstance(bps[4].potential, potentials.Nonbonded)  # cursed: NB AllPairs in VacuumSystem
 
-    for bp in bps:
-        if isinstance(bp.potential, potentials.HarmonicBond):
-            bond = bp
-        elif isinstance(bp.potential, potentials.HarmonicAngle):
-            angle = bp
-        elif isinstance(bp.potential, potentials.PeriodicTorsion):
-            torsion = bp
-        elif isinstance(bp.potential, potentials.Nonbonded):
-            nonbonded = bp
-        elif isinstance(bp.potential, potentials.ChiralAtomRestraint):
-            chiral_atom = bp
-        # TODO: uncomment when re-enabling chiral_bond
-        # elif isinstance(bp.potential, potentials.ChiralBondRestraint):
-        #     chiral_bond = bp
-        else:
-            assert 0, "Unknown potential"
+    chiral_atom = ChiralAtomRestraint(np.array([[]], dtype=np.int32).reshape(-1, 4)).bind(
+        np.array([], dtype=np.float64).reshape(-1)
+    )
+    idxs = np.array([[]], dtype=np.int32).reshape(-1, 4)
+    signs = np.array([[]], dtype=np.int32).reshape(-1)
+    chiral_bond = ChiralBondRestraint(idxs, signs).bind(np.array([], dtype=np.float64).reshape(-1))
 
-    assert bond
-    assert angle
-    assert nonbonded
-
-    return VacuumSystem(bond, angle, torsion, nonbonded, chiral_atom, chiral_bond)
+    return VacuumSystem(bps[0], bps[1], bps[2], bps[3], bps[4], chiral_atom, chiral_bond)
 
 
 def convert_omm_system(omm_system) -> Tuple["VacuumSystem", List[float]]:
@@ -130,16 +120,16 @@ class VacuumSystem(Generic[_Nonbonded, _HarmonicAngle]):
     # utility system container
     bond: BoundPotential[HarmonicBond]
     angle: BoundPotential[_HarmonicAngle]
-    torsion: Optional[BoundPotential[PeriodicTorsion]]
+    proper: BoundPotential[PeriodicTorsion]
+    improper: BoundPotential[PeriodicTorsion]
     nonbonded: BoundPotential[_Nonbonded]
-    chiral_atom: Optional[BoundPotential[ChiralAtomRestraint]]
-    chiral_bond: Optional[BoundPotential[ChiralBondRestraint]]
+    chiral_atom: BoundPotential[ChiralAtomRestraint]
+    chiral_bond: BoundPotential[ChiralBondRestraint]
 
     def get_U_fn(self):
         """
         Return a jax function that evaluates the potential energy of a set of coordinates.
         """
-        assert self.torsion
         U_fns = self.get_U_fns()
 
         def U_fn(x):
@@ -151,7 +141,7 @@ class VacuumSystem(Generic[_Nonbonded, _HarmonicAngle]):
         # For molecules too small for to have certain terms,
         # skip when no params are present
         # Chiral bond restraints are disabled until checks are added (see GH #815)
-        potentials = [self.bond, self.angle, self.torsion, self.chiral_atom, self.nonbonded]
+        potentials = [self.bond, self.angle, self.proper, self.improper, self.chiral_atom, self.nonbonded]
         terms = cast(
             List[BoundPotential[Potential]],
             [p for p in potentials if p],
@@ -163,7 +153,8 @@ class VacuumSystem(Generic[_Nonbonded, _HarmonicAngle]):
 class HostGuestSystem:
     bond: BoundPotential[HarmonicBond]
     angle: BoundPotential[HarmonicAngleStable]
-    torsion: BoundPotential[PeriodicTorsion]
+    proper: BoundPotential[PeriodicTorsion]
+    improper: BoundPotential[PeriodicTorsion]
     chiral_atom: BoundPotential[ChiralAtomRestraint]
     chiral_bond: BoundPotential[ChiralBondRestraint]
     nonbonded_guest_pairs: BoundPotential[NonbondedPairListPrecomputed]
@@ -174,7 +165,8 @@ class HostGuestSystem:
         return [
             self.bond,
             self.angle,
-            self.torsion,
+            self.proper,
+            self.improper,
             # Chiral bond restraints are disabled until checks are added
             # for consistency.
             self.chiral_atom,

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -380,17 +380,6 @@ class BaseTopology:
         params, idxs = self.ff.it_handle.partial_parameterize(ff_params, self.mol)
         return params, potentials.PeriodicTorsion(idxs)
 
-    # def parameterize_periodic_torsion(self, proper_params, improper_params):
-    #     """
-    #     Parameterize all periodic torsions in the system.
-    #     """
-    #     proper_params, proper_potential = self.parameterize_proper_torsion(proper_params)
-    #     improper_params, improper_potential = self.parameterize_improper_torsion(improper_params)
-    #     combined_params = jnp.concatenate([proper_params, improper_params])
-    #     combined_idxs = np.concatenate([proper_potential.idxs, improper_potential.idxs])
-    #     combined_potential = potentials.PeriodicTorsion(combined_idxs)
-    #     return combined_params, combined_potential
-
     def setup_chiral_restraints(self, chiral_atom_restraint_k, chiral_bond_restraint_k):
         """
         Create chiral atom and bond potentials.
@@ -634,19 +623,6 @@ class DualTopology(BaseTopology):
 
     def parameterize_harmonic_angle(self, ff_params):
         return self._parameterize_bonded_term(ff_params, self.ff.ha_handle, potentials.HarmonicAngle)
-
-    # def parameterize_periodic_torsion(self, proper_params, improper_params):
-    #     """
-    #     Parameterize all periodic torsions in the system.
-    #     """
-    #     proper_params, proper_potential = self.parameterize_proper_torsion(proper_params)
-    #     improper_params, improper_potential = self.parameterize_improper_torsion(improper_params)
-
-    #     combined_params = jnp.concatenate([proper_params, improper_params])
-    #     combined_idxs = np.concatenate([proper_potential.idxs, improper_potential.idxs])
-
-    #     combined_potential = potentials.PeriodicTorsion(combined_idxs)
-    #     return combined_params, combined_potential
 
     def parameterize_proper_torsion(self, ff_params):
         return self._parameterize_bonded_term(ff_params, self.ff.pt_handle, potentials.PeriodicTorsion)

--- a/timemachine/fe/topology.py
+++ b/timemachine/fe/topology.py
@@ -458,13 +458,13 @@ class BaseTopology:
         )
         bond_potential = mol_hb.bind(mol_bond_params)
         angle_potential = mol_ha.bind(mol_angle_params)
-
-        torsion_params = np.concatenate([mol_proper_params, mol_improper_params])
-        torsion_idxs = np.concatenate([mol_pt.idxs, mol_it.idxs])
-        torsion_potential = potentials.PeriodicTorsion(torsion_idxs).bind(torsion_params)
+        proper_potential = mol_pt.bind(mol_proper_params)
+        improper_potential = mol_it.bind(mol_improper_params)
         nonbonded_potential = mol_nbpl.bind(mol_nbpl_params)
 
-        system = VacuumSystem(bond_potential, angle_potential, torsion_potential, nonbonded_potential, None, None)
+        system = VacuumSystem(
+            bond_potential, angle_potential, proper_potential, improper_potential, nonbonded_potential, None, None
+        )
 
         return system
 

--- a/timemachine/ff/handlers/openmm_deserializer.py
+++ b/timemachine/ff/handlers/openmm_deserializer.py
@@ -257,13 +257,6 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
             np.array([], dtype=np.float64).reshape(-1, 3)
         )
 
-    # chiral_atom = potentials.ChiralAtomRestraint(np.array([], dtype=np.int32).reshape(-1, 4)).bind(
-    #     np.array([], dtype=np.float64)
-    # )
-    # chiral_bond = potentials.ChiralBondRestraint(np.array([], dtype=np.int32).reshape(-1, 4)).bind(
-    #     np.array([], dtype=np.float64)
-    # )
-
     bps = [bond, angle, proper, improper, nonbonded]
 
     return bps, masses

--- a/timemachine/ff/handlers/openmm_deserializer.py
+++ b/timemachine/ff/handlers/openmm_deserializer.py
@@ -1,13 +1,11 @@
-from collections import defaultdict
-from typing import DefaultDict, List, Tuple
+from typing import List, Tuple
 
 import numpy as np
 import openmm as mm
 from openmm import unit
 
 from timemachine import constants, potentials
-
-ORDERED_FORCES = ["HarmonicBond", "HarmonicAngle", "PeriodicTorsion", "Nonbonded"]
+from timemachine.ff.handlers.utils import canonicalize_bond
 
 
 def value(quantity):
@@ -152,6 +150,8 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
 
     """
 
+    bond = angle = proper = improper = nonbonded = None
+
     masses = []
 
     for p in range(system.getNumParticles()):
@@ -162,8 +162,7 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
     # this should not be a dict since we may have more than one instance of a given
     # force.
 
-    bps_dict: DefaultDict[str, List[potentials.BoundPotential]] = defaultdict(list)
-
+    # process bonds and angles first to instantiate bond_idxs and angle_idxs
     for force in system.getForces():
         if isinstance(force, mm.HarmonicBondForce):
             bond_idxs_ = []
@@ -179,7 +178,7 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
 
             bond_idxs = np.array(bond_idxs_, dtype=np.int32)
             bond_params = np.array(bond_params_, dtype=np.float64)
-            bps_dict["HarmonicBond"].append(potentials.HarmonicBond(bond_idxs).bind(bond_params))
+            bond = potentials.HarmonicBond(bond_idxs).bind(bond_params)
 
         if isinstance(force, mm.HarmonicAngleForce):
             angle_idxs_ = []
@@ -195,9 +194,9 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
 
             angle_idxs = np.array(angle_idxs_, dtype=np.int32)
             angle_params = np.array(angle_params_, dtype=np.float64)
+            angle = potentials.HarmonicAngle(angle_idxs).bind(angle_params)
 
-            bps_dict["HarmonicAngle"].append(potentials.HarmonicAngle(angle_idxs).bind(angle_params))
-
+    for force in system.getForces():
         if isinstance(force, mm.PeriodicTorsionForce):
             torsion_idxs_ = []
             torsion_params_ = []
@@ -213,22 +212,58 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
 
             torsion_idxs = np.array(torsion_idxs_, dtype=np.int32)
             torsion_params = np.array(torsion_params_, dtype=np.float64)
-            bps_dict["PeriodicTorsion"].append(potentials.PeriodicTorsion(torsion_idxs).bind(torsion_params))
+
+            # (ytz): split torsion into proper and impropers, if both angles are present
+            # then it's a proper torsion, otherwise it's an improper torsion
+            canonical_angle_idxs = set(canonicalize_bond(tuple(idxs)) for idxs in angle_idxs)
+
+            proper_idxs = []
+            proper_params = []
+            improper_idxs = []
+            improper_params = []
+
+            for idxs, params in zip(torsion_idxs, torsion_params):
+                i, j, k, l = idxs
+                angle_ijk = canonicalize_bond((i, j, k))
+                angle_jkl = canonicalize_bond((j, k, l))
+                if angle_ijk in canonical_angle_idxs and angle_jkl in canonical_angle_idxs:
+                    proper_idxs.append(idxs)
+                    proper_params.append(params)
+                elif angle_ijk not in canonical_angle_idxs and angle_jkl not in canonical_angle_idxs:
+                    assert 0
+                else:
+                    # xor case imply improper
+                    improper_idxs.append(idxs)
+                    improper_params.append(params)
+
+            proper = potentials.PeriodicTorsion(np.array(proper_idxs)).bind(np.array(proper_params))
+            improper = potentials.PeriodicTorsion(np.array(improper_idxs)).bind(np.array(improper_params))
 
         if isinstance(force, mm.NonbondedForce):
             nb_params, exclusion_idxs, beta, scale_factors = deserialize_nonbonded_force(force, N)
 
-            bps_dict["Nonbonded"].append(
-                potentials.Nonbonded(N, exclusion_idxs, scale_factors, beta, cutoff).bind(nb_params)
-            )
+            nonbonded = potentials.Nonbonded(N, exclusion_idxs, scale_factors, beta, cutoff).bind(nb_params)
 
-            # nrg_fns.append(('Exclusions', (exclusion_idxs, scale_factors, es_scale_factors)))
+    assert bond
+    assert angle
+    assert nonbonded
 
-    # ugh, ... various parts of our code assume the bps are in a certain order
-    # so put them back in that order here
-    bps = []
-    for k in ORDERED_FORCES:
-        if bps_dict.get(k):
-            bps.extend(bps_dict[k])
+    if proper is None:
+        proper = potentials.PeriodicTorsion(np.array([], dtype=np.int32).reshape(-1, 4)).bind(
+            np.array([], dtype=np.float64).reshape(-1, 3)
+        )
+    if improper is None:
+        improper = potentials.PeriodicTorsion(np.array([], dtype=np.int32).reshape(-1, 4)).bind(
+            np.array([], dtype=np.float64).reshape(-1, 3)
+        )
+
+    # chiral_atom = potentials.ChiralAtomRestraint(np.array([], dtype=np.int32).reshape(-1, 4)).bind(
+    #     np.array([], dtype=np.float64)
+    # )
+    # chiral_bond = potentials.ChiralBondRestraint(np.array([], dtype=np.int32).reshape(-1, 4)).bind(
+    #     np.array([], dtype=np.float64)
+    # )
+
+    bps = [bond, angle, proper, improper, nonbonded]
 
     return bps, masses

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -83,7 +83,8 @@ def parameterize_system(topo, ff: Forcefield, lamb: float) -> Tuple[List[Potenti
     params_potential_pairs = [
         topo.parameterize_harmonic_bond(ff_params.hb_params),
         topo.parameterize_harmonic_angle(ff_params.ha_params),
-        topo.parameterize_periodic_torsion(ff_params.pt_params, ff_params.it_params),
+        topo.parameterize_proper_torsion(ff_params.pt_params),
+        topo.parameterize_improper_torsion(ff_params.it_params),
         topo.parameterize_nonbonded(
             ff_params.q_params,
             ff_params.q_params_intra,


### PR DESCRIPTION
This PR:

1. Splits improper and proper torsions from a single torsion array - this will allow us to fine-tune the alignment and the interpolation logic in a separate PR. This can change expected results for single topology simulations: since we no longer allow an proper torsion to be accidentally aligned and interpolated into an improper torsion - they are now strictly separated. For all other types of simulations, (eg. vanilla MD, AHFE, water sampling etc.) results should be bitwise identical.
2. Removes `Optional[]` tags from the `[Vacuum/HostGuest]System` classes, enforcing a stronger requirement upfront and removing the need to check for `None` downstream.   
3. Adds a strong symmetry check for consistency of energies, forces, and the *definition* of the potentials themselves. Roughly, we test that `ST(mol_a, mol_b, lamb) == ST(mol_b, mol_a, 1-lamb)`.
