### PR TITLE
Stagger interpolation for core torsions that are turning on or off.

### DIFF
--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -29,6 +29,7 @@ from timemachine.fe.single_topology import (
     ChargePertubationError,
     CoreBondChangeWarning,
     SingleTopology,
+    assert_default_system_constraints,
     canonicalize_bonds,
     canonicalize_chiral_atom_idxs,
     canonicalize_improper_idxs,
@@ -1656,6 +1657,9 @@ def assert_symmetric_interpolation(mol_a, mol_b, core):
     for lamb in lambda_schedule:
         sys_fwd = st_fwd.setup_intermediate_state(lamb)
         sys_rev = st_rev.setup_intermediate_state(1 - lamb)
+
+        assert_default_system_constraints(sys_fwd)
+        assert_default_system_constraints(sys_rev)
 
         _assert_u_and_grad_consistent(
             sys_fwd.bond, sys_rev.bond, test_conf, fused_map, canon_fn=lambda idxs, _: tuple(canonicalize_bond(idxs))

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -32,7 +32,7 @@ from timemachine.fe.plots import (
     plot_hrex_swap_acceptance_rates_convergence,
     plot_hrex_transition_matrix,
 )
-from timemachine.fe.single_topology import AtomMapFlags, SingleTopology, assert_bonds_defined_for_chiral_volumes
+from timemachine.fe.single_topology import AtomMapFlags, SingleTopology, assert_default_system_constraints
 from timemachine.fe.system import VacuumSystem, convert_omm_system
 from timemachine.fe.utils import bytes_to_id, get_mol_name, get_romol_conf
 from timemachine.ff import Forcefield
@@ -72,7 +72,7 @@ def setup_in_vacuum(st: SingleTopology, ligand_conf, lamb):
     """Prepare potentials, initial coords, large 10x10x10nm box, and HMR masses"""
 
     system = st.setup_intermediate_state(lamb)
-    assert_bonds_defined_for_chiral_volumes(system)
+    assert_default_system_constraints(system)
     hmr_masses = np.array(st.combine_masses(use_hmr=True))
 
     potentials = system.get_U_fns()
@@ -95,7 +95,7 @@ def setup_in_env(
     """Prepare potentials, concatenate environment and ligand coords, apply HMR, and construct barostat"""
     barostat_interval = 25
     system = st.combine_with_host(host.system, lamb, host.num_water_atoms, st.ff, host.omm_topology)
-    assert_bonds_defined_for_chiral_volumes(system)
+    assert_default_system_constraints(system)
     host_hmr_masses = model_utils.apply_hmr(host.physical_masses, host.system.bond.potential.idxs)
     hmr_masses = np.concatenate([host_hmr_masses, st.combine_masses(use_hmr=True)])
 

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1164,16 +1164,24 @@ def assert_torsions_defined_over_non_linear_angles(vacuum_system):
     for (i, j, k, l), (proper_k, _, _) in zip(vacuum_system.proper.potential.idxs, vacuum_system.proper.params):
         if proper_k > 0:
             if canonicalize_bond((i, j, k)) in linear_angles:
-                raise TorsionsDefinedOverLinearAngleException(f"angle {(i,j,k)} is linear in torsion {(i,j,k,l)}")
+                raise TorsionsDefinedOverLinearAngleException(
+                    f"angle {(i,j,k)} is linear in proper torsion {(i,j,k,l)}"
+                )
             if canonicalize_bond((j, k, l)) in linear_angles:
-                raise TorsionsDefinedOverLinearAngleException(f"angle {(j,k,l)} is linear in torsion {(i,j,k,l)}")
+                raise TorsionsDefinedOverLinearAngleException(
+                    f"angle {(j,k,l)} is linear in proper torsion {(i,j,k,l)}"
+                )
 
     for (i, j, k, l), (improper_k, _, _) in zip(vacuum_system.improper.potential.idxs, vacuum_system.improper.params):
         if improper_k > 0:
             if canonicalize_bond((i, j, k)) in linear_angles:
-                raise TorsionsDefinedOverLinearAngleException(f"angle {(i,j,k)} is linear in torsion {(i,j,k,l)}")
+                raise TorsionsDefinedOverLinearAngleException(
+                    f"angle {(i,j,k)} is linear in improper torsion {(i,j,k,l)}"
+                )
             if canonicalize_bond((j, k, l)) in linear_angles:
-                raise TorsionsDefinedOverLinearAngleException(f"angle {(j,k,l)} is linear in torsion {(i,j,k,l)}")
+                raise TorsionsDefinedOverLinearAngleException(
+                    f"angle {(j,k,l)} is linear in improper torsion {(i,j,k,l)}"
+                )
 
 
 def assert_chiral_consistency(src_chiral_idxs: NDArray, dst_chiral_idxs: NDArray):

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -68,6 +68,9 @@ def _flip_min_max(min_max):
 CORE_BOND_MIN_MAX = [0.0, 1.0]
 CORE_ANGLE_MIN_MAX = [0.0, 1.0]
 CORE_TORSION_MIN_MAX = [0.0, 1.0]
+CORE_TORSION_OFF_TO_ON_MIN_MAX = [0.7, 1.0]
+CORE_TORSION_ON_TO_OFF_MIN_MAX = _flip_min_max(CORE_TORSION_OFF_TO_ON_MIN_MAX)
+
 
 # core terms that are involved in chiral volumes being turned on or off
 CORE_CHIRAL_ATOM_CONVERTING_ON_MIN_MAX = [0.0, 0.5]
@@ -1115,6 +1118,16 @@ class MissingBondsInChiralVolumeException(Exception):
     pass
 
 
+class TorsionsDefinedOverLinearAngleException(Exception):
+    pass
+
+
+def assert_default_system_constraints(vacuum_system):
+    # Assert that the vacuum_system objects satisfy a set of constraints
+    assert_bonds_defined_for_chiral_volumes(vacuum_system)
+    assert_torsions_defined_over_non_linear_angles(vacuum_system)
+
+
 def assert_bonds_defined_for_chiral_volumes(vacuum_system, bond_k_min=DEFAULT_BOND_IS_PRESENT_K):
     """
     Assert that bonds defined for every chiral volume is present and has a force constant greater than bond_k_min
@@ -1133,6 +1146,34 @@ def assert_bonds_defined_for_chiral_volumes(vacuum_system, bond_k_min=DEFAULT_BO
                 raise MissingBondsInChiralVolumeException(f"bond {(c, j)} missing from Chiral Volume {(c, i, j, k)}")
             if canonicalize_bond((c, k)) not in bonds_present:
                 raise MissingBondsInChiralVolumeException(f"bond {(c, k)} missing from Chiral Volume {(c, i, j, k)}")
+
+
+def assert_torsions_defined_over_non_linear_angles(vacuum_system):
+    """
+    Assert that torsions are never defined over angle terms with an equilibrium value close to 180.
+    """
+    linear_angles = set()
+
+    for idxs, angle_params in zip(vacuum_system.angle.potential.idxs, vacuum_system.angle.params):
+        angle_k, angle_a0 = angle_params[0], angle_params[1]
+
+        if angle_k > 0:
+            if abs(angle_a0 - np.pi) < 0.174533:  # 10 degrees, arbitrary but conservative threshold
+                linear_angles.add(tuple(idxs))
+
+    for (i, j, k, l), (proper_k, _, _) in zip(vacuum_system.proper.potential.idxs, vacuum_system.proper.params):
+        if proper_k > 0:
+            if canonicalize_bond((i, j, k)) in linear_angles:
+                raise TorsionsDefinedOverLinearAngleException(f"angle {(i,j,k)} is linear in torsion {(i,j,k,l)}")
+            if canonicalize_bond((j, k, l)) in linear_angles:
+                raise TorsionsDefinedOverLinearAngleException(f"angle {(j,k,l)} is linear in torsion {(i,j,k,l)}")
+
+    for (i, j, k, l), (improper_k, _, _) in zip(vacuum_system.improper.potential.idxs, vacuum_system.improper.params):
+        if improper_k > 0:
+            if canonicalize_bond((i, j, k)) in linear_angles:
+                raise TorsionsDefinedOverLinearAngleException(f"angle {(i,j,k)} is linear in torsion {(i,j,k,l)}")
+            if canonicalize_bond((j, k, l)) in linear_angles:
+                raise TorsionsDefinedOverLinearAngleException(f"angle {(j,k,l)} is linear in torsion {(i,j,k,l)}")
 
 
 def assert_chiral_consistency(src_chiral_idxs: NDArray, dst_chiral_idxs: NDArray):
@@ -1195,10 +1236,8 @@ class SingleTopology(AtomMapMixin):
         assert_chiral_consistency(
             self.src_system.chiral_atom.potential.idxs, self.dst_system.chiral_atom.potential.idxs
         )
-
-        assert_bonds_defined_for_chiral_volumes(self.src_system, DEFAULT_BOND_IS_PRESENT_K)
-
-        assert_bonds_defined_for_chiral_volumes(self.dst_system, DEFAULT_BOND_IS_PRESENT_K)
+        assert_default_system_constraints(self.src_system)
+        assert_default_system_constraints(self.dst_system)
 
     def combine_masses(self, use_hmr=False):
         """
@@ -1577,7 +1616,12 @@ class SingleTopology(AtomMapMixin):
 
     def _interpolate_torsion(self, idxs, src_params, dst_params, lamb):
         if self.all_idxs_belong_to_core(idxs):
-            min_max = CORE_TORSION_MIN_MAX
+            if src_params[0] == 0:
+                min_max = CORE_TORSION_OFF_TO_ON_MIN_MAX
+            elif dst_params[0] == 0:
+                min_max = CORE_TORSION_ON_TO_OFF_MIN_MAX
+            else:
+                min_max = CORE_TORSION_MIN_MAX
         elif self.any_idxs_belong_to_dummy_a(idxs):
             min_max = DUMMY_A_TORSION_MIN_MAX
         elif self.any_idxs_belong_to_dummy_b(idxs):


### PR DESCRIPTION
This PR addresses issues where a core torsion is turning from off to on with a dependency on a non-linear angle terms. For example, morphing a linear H-C#C-H into a H-O-O-H requires us to first partially convert the angles *before* we turn on the associated torsion. This PR also adds a system constraint to ensure that torsions (both propers and impropers) are never defined over linear angles. 

Note that dummy torsions that are being turned on/off are already interpolated at the 0.7 to 1.0 range. 