### PR TITLE
Move HostConfig into submodule to prevent circular imports

### DIFF
--- a/examples/biphenyl_torsion_sampling_hrex.py
+++ b/examples/biphenyl_torsion_sampling_hrex.py
@@ -19,7 +19,8 @@ from numpy.typing import NDArray
 
 from timemachine.constants import DEFAULT_TEMP
 from timemachine.fe import model_utils
-from timemachine.fe.free_energy import HostConfig, HREXParams, InitialState, MDParams, run_sims_bisection, run_sims_hrex
+from timemachine.fe.free_energy import HREXParams, InitialState, MDParams, run_sims_bisection, run_sims_hrex
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.plots import plot_hrex_replica_state_distribution_heatmap, plot_hrex_transition_matrix
 from timemachine.fe.topology import BaseTopology, HostGuestTopology
 from timemachine.fe.utils import get_mol_masses, get_romol_conf

--- a/examples/water_sampling_common.py
+++ b/examples/water_sampling_common.py
@@ -4,7 +4,8 @@ import numpy as np
 from openmm import app
 
 from timemachine.constants import AVOGADRO, DEFAULT_PRESSURE, DEFAULT_TEMP
-from timemachine.fe.free_energy import AbsoluteFreeEnergy, HostConfig, InitialState
+from timemachine.fe.free_energy import AbsoluteFreeEnergy, InitialState
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.model_utils import apply_hmr
 from timemachine.fe.topology import BaseTopology
 from timemachine.fe.utils import get_romol_conf

--- a/tests/common.py
+++ b/tests/common.py
@@ -15,7 +15,7 @@ from numpy.typing import NDArray
 
 from timemachine.constants import DEFAULT_TEMP, ONE_4PI_EPS0
 from timemachine.fe import rbfe
-from timemachine.fe.free_energy import HostConfig
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers import nonbonded, openmm_deserializer

--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -3,7 +3,8 @@ import pytest
 
 from timemachine.constants import AVOGADRO, BAR_TO_KJ_PER_NM3, BOLTZ, DEFAULT_PRESSURE, DEFAULT_TEMP
 from timemachine.fe import model_utils
-from timemachine.fe.free_energy import AbsoluteFreeEnergy, HostConfig
+from timemachine.fe.free_energy import AbsoluteFreeEnergy
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.topology import BaseTopology
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers import openmm_deserializer

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -16,14 +16,8 @@ from numpy.typing import NDArray
 
 from timemachine import constants
 from timemachine.fe import absolute_hydration
-from timemachine.fe.free_energy import (
-    AbsoluteFreeEnergy,
-    HostConfig,
-    InitialState,
-    MDParams,
-    WaterSamplingParams,
-    get_context,
-)
+from timemachine.fe.free_energy import AbsoluteFreeEnergy, InitialState, MDParams, WaterSamplingParams, get_context
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.model_utils import apply_hmr
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.topology import BaseTopology
@@ -84,6 +78,7 @@ def plot_batch_times(steps_per_batch: int, dt: float, batch_times: List[float], 
 
     plt.title(label)
     fig, axes = plt.subplots(ncols=2)
+    assert isinstance(axes, np.ndarray)
     fig.suptitle(label)
     axes[0].plot(ns_per_day)
     axes[0].axhline(np.mean(ns_per_day), linestyle="--", c="gray", label="Mean")

--- a/tests/test_benchmark_free_energy.py
+++ b/tests/test_benchmark_free_energy.py
@@ -14,13 +14,13 @@ import pytest
 
 from timemachine.constants import DEFAULT_TEMP
 from timemachine.fe.free_energy import (
-    HostConfig,
     MDParams,
     WaterSamplingParams,
     run_sims_bisection,
     run_sims_hrex,
     run_sims_sequential,
 )
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.lambda_schedule import bisection_lambda_schedule
 from timemachine.fe.rbfe import (
     DEFAULT_HREX_PARAMS,
@@ -213,7 +213,8 @@ if __name__ == "__main__":
         )
     fig, axes = plt.subplots(ncols=len(args.modes), sharey=True)
     if len(args.modes) == 1:
-        axes = [axes]
+        axes = np.array([axes])
+    assert isinstance(axes, np.ndarray)
     fig.suptitle(f"Leg: {args.leg}, Frames {args.n_frames}, Water Sampling {args.water_sampling}")
     for i, (ax, mode) in enumerate(zip(axes, args.modes)):
         ax.set_title(mode)

--- a/tests/test_cuda_bd_exchange_mover.py
+++ b/tests/test_cuda_bd_exchange_mover.py
@@ -10,7 +10,8 @@ from scipy.spatial.transform import Rotation
 from scipy.special import logsumexp
 
 from timemachine.constants import DEFAULT_PRESSURE, DEFAULT_TEMP
-from timemachine.fe.free_energy import HostConfig, InitialState, MDParams, get_water_sampler_params, sample
+from timemachine.fe.free_energy import InitialState, MDParams, get_water_sampler_params, sample
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.model_utils import apply_hmr, image_frame
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.ff import Forcefield

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -12,14 +12,8 @@ from scipy.special import logsumexp
 
 from timemachine.constants import DEFAULT_ATOM_MAPPING_KWARGS, DEFAULT_TEMP
 from timemachine.fe import atom_mapping
-from timemachine.fe.free_energy import (
-    AbsoluteFreeEnergy,
-    HostConfig,
-    InitialState,
-    MDParams,
-    get_water_sampler_params,
-    sample,
-)
+from timemachine.fe.free_energy import AbsoluteFreeEnergy, InitialState, MDParams, get_water_sampler_params, sample
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.model_utils import image_frame
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.topology import BaseTopology

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -5,7 +5,7 @@ import pytest
 from common import fixed_overflowed
 
 from timemachine.constants import DEFAULT_PRESSURE, DEFAULT_TEMP
-from timemachine.fe.free_energy import HostConfig
+from timemachine.fe.host_config import HostConfig
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers import openmm_deserializer
 from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, custom_ops

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -19,7 +19,6 @@ from timemachine.fe import free_energy, topology, utils
 from timemachine.fe.bar import ukln_to_ukn
 from timemachine.fe.free_energy import (
     BarResult,
-    HostConfig,
     HREXSimulationResult,
     IndeterminateEnergyWarning,
     MDParams,
@@ -27,7 +26,6 @@ from timemachine.fe.free_energy import (
     PairBarResult,
     Trajectory,
     assert_potentials_compatible,
-    batches,
     compute_potential_matrix,
     estimate_free_energy_bar,
     get_water_sampler_params,
@@ -36,6 +34,7 @@ from timemachine.fe.free_energy import (
     sample,
     trajectories_by_replica_to_by_state,
 )
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.rbfe import Host, setup_initial_state, setup_initial_states, setup_optimized_host
 from timemachine.fe.single_topology import AtomMapFlags, SingleTopology
 from timemachine.fe.stored_arrays import StoredArrays
@@ -54,6 +53,7 @@ from timemachine.potentials import (
 )
 from timemachine.potentials.potential import get_bound_potential_by_type
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
+from timemachine.utils import batches
 
 
 def assert_shapes_consistent(U, coords, sys_params, box):

--- a/tests/test_hrex_rbfe.py
+++ b/tests/test_hrex_rbfe.py
@@ -13,13 +13,13 @@ from psutil import Process
 from scipy import stats
 
 from timemachine.fe.free_energy import (
-    HostConfig,
     HREXParams,
     HREXSimulationResult,
     MDParams,
     WaterSamplingParams,
     sample_with_context_iter,
 )
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.plots import (
     plot_hrex_replica_state_distribution_heatmap,
     plot_hrex_swap_acceptance_rates_convergence,

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -6,7 +6,7 @@ import pytest
 from rdkit import Chem
 from rdkit.Chem import AllChem
 
-from timemachine.fe.free_energy import HostConfig
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.model_utils import get_vacuum_val_and_grad_fn
 from timemachine.fe.utils import get_romol_conf, read_sdf, read_sdf_mols_by_name
 from timemachine.ff import Forcefield

--- a/tests/test_nblist.py
+++ b/tests/test_nblist.py
@@ -7,7 +7,8 @@ from common import hilbert_sort
 from numpy.typing import NDArray
 
 from timemachine.constants import DEFAULT_TEMP
-from timemachine.fe.free_energy import HostConfig, MDParams, sample
+from timemachine.fe.free_energy import MDParams, sample
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.rbfe import setup_initial_states, setup_optimized_host
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.utils import get_romol_conf

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 
 from timemachine.fe.free_energy import (
-    HostConfig,
     HREXParams,
     HREXSimulationResult,
     MDParams,
@@ -16,6 +15,7 @@ from timemachine.fe.free_energy import (
     image_frames,
     sample,
 )
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.rbfe import (
     estimate_relative_free_energy,
     estimate_relative_free_energy_bisection,

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -22,7 +22,7 @@ from timemachine.constants import (
 )
 from timemachine.fe import atom_mapping, single_topology
 from timemachine.fe.dummy import MultipleAnchorWarning, canonicalize_bond
-from timemachine.fe.free_energy import HostConfig
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.interpolate import align_nonbonded_idxs_and_params, linear_interpolation
 from timemachine.fe.single_topology import (
     AtomMapMixin,

--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -6,7 +6,7 @@ from rdkit import Chem
 
 from timemachine.constants import DEFAULT_ATOM_MAPPING_KWARGS, DEFAULT_TEMP
 from timemachine.fe import atom_mapping, cif_writer, utils
-from timemachine.fe.free_energy import HostConfig
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.rbfe import (
     get_free_idxs,
     optimize_coords_state,

--- a/timemachine/fe/absolute_hydration.py
+++ b/timemachine/fe/absolute_hydration.py
@@ -13,13 +13,13 @@ from timemachine.constants import BOLTZ, DEFAULT_TEMP
 from timemachine.fe import model_utils
 from timemachine.fe.free_energy import (
     AbsoluteFreeEnergy,
-    HostConfig,
     InitialState,
     MDParams,
     SimulationResult,
     make_pair_bar_plots,
     run_sims_sequential,
 )
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.lambda_schedule import construct_pre_optimized_absolute_lambda_schedule_solvent
 from timemachine.fe.topology import BaseTopology
 from timemachine.fe.utils import get_mol_name, get_romol_conf

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -18,6 +18,7 @@ from timemachine.fe.bar import (
     works_from_ukln,
 )
 from timemachine.fe.energy_decomposition import EnergyDecomposedState, compute_energy_decomposed_u_kln, get_batch_u_fns
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.plots import (
     plot_as_png_fxn,
     plot_dG_errs_figure,
@@ -50,15 +51,6 @@ WATER_SAMPLER_MOVERS = (
     custom_ops.TIBDExchangeMove_f32,
     custom_ops.TIBDExchangeMove_f64,
 )
-
-
-class HostConfig:
-    def __init__(self, omm_system, conf, box, num_water_atoms, omm_topology):
-        self.omm_system = omm_system
-        self.conf = conf
-        self.box = box
-        self.num_water_atoms = num_water_atoms
-        self.omm_topology = omm_topology
 
 
 @dataclass(frozen=True)

--- a/timemachine/fe/host_config.py
+++ b/timemachine/fe/host_config.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+import numpy as np
+import openmm.app.topology as ommt
+import openmm.openmm as omm
+from numpy.typing import NDArray
+
+
+@dataclass(frozen=True)
+class HostConfig:
+    omm_system: omm.System
+    conf: NDArray[np.float64]
+    box: NDArray[np.float64]
+    num_water_atoms: int
+    omm_topology: ommt.Topology

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -12,7 +12,6 @@ from rdkit import Chem
 from timemachine.constants import DEFAULT_POSITIONAL_RESTRAINT_K, DEFAULT_PRESSURE, DEFAULT_TEMP
 from timemachine.fe import model_utils
 from timemachine.fe.free_energy import (
-    HostConfig,
     HREXParams,
     HREXPlots,
     HREXSimulationResult,
@@ -25,6 +24,7 @@ from timemachine.fe.free_energy import (
     run_sims_hrex,
     run_sims_sequential,
 )
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.lambda_schedule import bisection_lambda_schedule
 from timemachine.fe.plots import (
     plot_as_png_fxn,

--- a/timemachine/md/enhanced.py
+++ b/timemachine/md/enhanced.py
@@ -18,7 +18,7 @@ from scipy.special import logsumexp
 from timemachine import lib
 from timemachine.constants import BOLTZ
 from timemachine.fe import free_energy, topology
-from timemachine.fe.free_energy import HostConfig
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.utils import get_mol_masses, get_romol_conf
 from timemachine.integrator import simulate
 from timemachine.lib import custom_ops

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -11,7 +11,7 @@ from rdkit import Chem
 
 from timemachine.constants import BOLTZ, DEFAULT_PRESSURE, DEFAULT_TEMP, MAX_FORCE_NORM
 from timemachine.fe import topology
-from timemachine.fe.free_energy import HostConfig
+from timemachine.fe.host_config import HostConfig
 from timemachine.fe.utils import get_romol_conf, set_romol_conf
 from timemachine.ff import Forcefield
 from timemachine.ff.handlers import openmm_deserializer


### PR DESCRIPTION
Cherry-picked from #1424 to simplify review of the latter.

Currently `timemachine.fe.free_energy.HostConfig` is imported by many submodules, e.g. https://github.com/proteneer/timemachine/blob/374a2de64596135e82b1cea30004f2749aa6c2d2/timemachine/md/enhanced.py#L21

This means that importing (even transitively) these submodules from `free_energy` will result in a circular import. Since `free_energy` is currently a higher-level submodule containing application logic, this is difficult to avoid (e.g., I ran into this in #1424 with the following dependency cycle: `fe.free_energy > fe.rest > md.enhanced > fe.free_energy`). Moving `HostConfig` into a separate submodule is a relatively minimal change to work around this issue.

This PR:

* moves `timemachine.fe.free_energy.HostConfig` to `timemachine.fe.host_config.HostConfig`
* converts  `HostConfig` to a (frozen) dataclass