### PR TITLE
Handle Water Sampling with AbsoluteFreeEnergy

### DIFF
--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -13,7 +13,7 @@ from timemachine.md.barostat.utils import compute_box_center, compute_box_volume
 from timemachine.md.builders import build_water_system
 from timemachine.md.enhanced import get_solvent_phase_system
 from timemachine.md.thermostat.utils import sample_velocities
-from timemachine.potentials import HarmonicBond, SummedPotential
+from timemachine.potentials import HarmonicBond, Nonbonded, NonbondedInteractionGroup, NonbondedPairListPrecomputed
 from timemachine.potentials.potential import get_bound_potential_by_type, get_potential_by_type
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
 
@@ -454,10 +454,11 @@ def test_molecular_ideal_gas():
     unbound_potentials = list(_unbound_potentials)
     sys_params = list(_sys_params)
 
-    # drop the nonbonded potential
-    nb_pot_idx = next(i for i, pot in enumerate(unbound_potentials) if isinstance(pot, SummedPotential))
-    unbound_potentials.pop(nb_pot_idx)
-    sys_params.pop(nb_pot_idx)
+    # drop the nonbonded potentials
+    for nb_type in (Nonbonded, NonbondedInteractionGroup, NonbondedPairListPrecomputed):
+        nb_pot_idx = next(i for i, pot in enumerate(unbound_potentials) if isinstance(pot, nb_type))
+        unbound_potentials.pop(nb_pot_idx)
+        sys_params.pop(nb_pot_idx)
 
     # get list of molecules for barostat by looking at bond table
     harmonic_bond_potential = get_potential_by_type(unbound_potentials, HarmonicBond)

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -37,7 +37,7 @@ from timemachine.md.exchange.exchange_mover import (
     get_water_idxs,
 )
 from timemachine.md.minimizer import check_force_norm
-from timemachine.potentials import HarmonicBond, Nonbonded, SummedPotential
+from timemachine.potentials import HarmonicBond, Nonbonded
 from timemachine.potentials.potential import get_bound_potential_by_type
 
 
@@ -447,10 +447,7 @@ def test_targeted_insertion_buckyball_edge_cases(radius, moves, precision, rtol,
     box = host_box
 
     bps = [pot.bind(p) for pot, p in zip(potentials, params)]
-    summed_pot = get_bound_potential_by_type(bps, SummedPotential).potential
-    nb = next(
-        pot.bind(p) for pot, p in zip(summed_pot.potentials, summed_pot.params_init) if isinstance(pot, Nonbonded)
-    )
+    nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
     bond_list = get_bond_list(bond_pot)
@@ -684,10 +681,7 @@ def test_targeted_insertion_buckyball_determinism(radius, proposals_per_move, ba
     box = host_box
 
     bps = [pot.bind(p) for pot, p in zip(potentials, params)]
-    summed_pot = get_bound_potential_by_type(bps, SummedPotential).potential
-    nb = next(
-        pot.bind(p) for pot, p in zip(summed_pot.potentials, summed_pot.params_init) if isinstance(pot, Nonbonded)
-    )
+    nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 
     bond_list = get_bond_list(bond_pot)

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -14,7 +14,7 @@ from timemachine.lib import LangevinIntegrator, MonteCarloBarostat, VelocityVerl
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.md.enhanced import get_solvent_phase_system
 from timemachine.md.minimizer import check_force_norm, replace_conformer_with_minimized
-from timemachine.potentials import HarmonicBond, SummedPotential
+from timemachine.potentials import HarmonicBond, Nonbonded, NonbondedInteractionGroup, SummedPotential
 from timemachine.potentials.potential import get_potential_by_type
 from timemachine.testsystems.ligands import get_biphenyl
 
@@ -959,8 +959,8 @@ def test_context_invalid_boxes_without_nonbonded_potentials():
 
     bps = []
     for p, pot in zip(sys_params, unbound_potentials):
-        # Skip the nonbonded all pairs, which is a SummedPotential, will result in no check
-        if isinstance(pot, SummedPotential):
+        # Skip the nonbonded all pairs, will result in no check
+        if isinstance(pot, (Nonbonded, NonbondedInteractionGroup)):
             continue
         bound_impl = pot.bind(p).to_gpu(np.float32).bound_impl
         bps.append(bound_impl)

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -428,7 +428,7 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
 
     def prepare_host_edge(
         self, ff: Forcefield, host_config: HostConfig, lamb: float
-    ) -> tuple[list[Potential], list, NDArray]:
+    ) -> tuple[tuple[Potential, ...], tuple, NDArray]:
         """
         Prepares the host-guest system
 
@@ -468,10 +468,10 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
             else:
                 final_params.append(params)
                 final_potentials.append(pot)
-        combined_masses = self._combine(ligand_masses, host_masses)
-        return final_potentials, final_params, combined_masses
+        combined_masses = self._combine(ligand_masses, np.array(host_masses))
+        return tuple(final_potentials), tuple(final_params), combined_masses
 
-    def prepare_vacuum_edge(self, ff: Forcefield):
+    def prepare_vacuum_edge(self, ff: Forcefield) -> tuple[tuple[Potential, ...], tuple, NDArray]:
         """
         Prepares the vacuum system
 
@@ -491,7 +491,7 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
         final_params, final_potentials = self._get_system_params_and_potentials(ff_params, self.top, 0.0)
         return final_potentials, final_params, ligand_masses
 
-    def prepare_combined_coords(self, host_coords=None):
+    def prepare_combined_coords(self, host_coords: Optional[NDArray] = None) -> NDArray:
         """
         Returns the combined coordinates.
 
@@ -508,7 +508,7 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
         ligand_coords = get_romol_conf(self.mol)
         return self._combine(ligand_coords, host_coords)
 
-    def _combine(self, ligand_values, host_values=None):
+    def _combine(self, ligand_values: NDArray, host_values: Optional[NDArray] = None) -> NDArray:
         """
         Combine the values along the 0th axis.
         The host values will be first, if given.

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -459,7 +459,8 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
         final_potentials = []
         combined_params, combined_potentials = self._get_system_params_and_potentials(ff_params, hgt, lamb)
         for params, pot in zip(combined_params, combined_potentials):
-            # Unpack the summed potential to be consistent with SingleTopology
+            # Unpack the summed potential to be consistent with SingleTopology and so
+            # that downstream code which relies on the potential types works properly
             # TBD: Deboggle and unify the topology classes
             if isinstance(pot, SummedPotential):
                 for partial_params, sub_pot in zip(pot.params_init, pot.potentials):

--- a/timemachine/fe/free_energy.py
+++ b/timemachine/fe/free_energy.py
@@ -464,6 +464,7 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
             # TBD: Deboggle and unify the topology classes
             if isinstance(pot, SummedPotential):
                 for partial_params, sub_pot in zip(pot.params_init, pot.potentials):
+                    assert not isinstance(sub_pot, SummedPotential), "Multiple levels of nesting of summed potentials"
                     final_params.append(partial_params)
                     final_potentials.append(sub_pot)
             else:


### PR DESCRIPTION
* Low priority bug where we can't run water sampling with InitialState objects constructed from AbsoluteFreeEnergy. User can work around this themselves by unwrapping the summed potential, but thought I would put up a quick fix. 
* Unable to find NonbondedInteractionGroup triggers failure due to wrapping up with a SummedPotential