### PR TITLE
Pip install OpenMM

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ If using conda the following can be used to configure your environment
 ```shell
 conda env create -f environment.yml -n timemachine
 conda activate timemachine
-conda install openmm=8.0.0 -c conda-forge # only if using openmm from conda
 ```
 
 ### Install Time Machine

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ matplotlib==3.7.1
 rdkit==2022.3.5
 --extra-index-url https://pypi.anaconda.org/OpenEye/simple
 openeye-toolkits==2020.2.0
+openmm==8.2.0

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ setup(
         "rdkit",
         "scipy",
         "matplotlib",
+        "openmm",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
* Upgrades OpenMM from 8.0.0 to 8.2.0
* As of [8.2.0](https://github.com/openmm/openmm/releases/tag/8.2.0), can pip install OpenMM. Avoids the need to do a custom build and doesn't install its own version of Cuda.
* Reduces docker container size by 0.1GB by avoiding the custom OpenMM build