### PR TITLE
Move slow tests to nightly

### DIFF
--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -335,8 +335,14 @@ def hif2a_ligand_pair_single_topology_lam0_state():
 
 
 @pytest.mark.parametrize("seed", [2024])
-@pytest.mark.parametrize("host_name", [None, "solvent", "complex"])
-@pytest.mark.nightly(reason="slow")
+@pytest.mark.parametrize(
+    "host_name",
+    [
+        None,
+        pytest.param("solvent", marks=pytest.mark.nightly(reason="slow")),
+        pytest.param("complex", marks=pytest.mark.nightly(reason="slow")),
+    ],
+)
 def test_initial_state_interacting_ligand_atoms(host_name, seed):
     lambdas = np.linspace(0.0, 1.0, 4)
     forcefield = Forcefield.load_default()

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -336,6 +336,7 @@ def hif2a_ligand_pair_single_topology_lam0_state():
 
 @pytest.mark.parametrize("seed", [2024])
 @pytest.mark.parametrize("host_name", [None, "solvent", "complex"])
+@pytest.mark.nightly(reason="slow")
 def test_initial_state_interacting_ligand_atoms(host_name, seed):
     lambdas = np.linspace(0.0, 1.0, 4)
     forcefield = Forcefield.load_default()

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -93,14 +93,13 @@ def test_fire_minimize_host_protein_spot(pdb_path, sdf_path, mol_a_name, mol_b_n
     mol_b = mols_by_name[mol_b_name]
 
     with pdb_path as host_path:
-        for mols in [[mol_a], [mol_b], [mol_a, mol_b]]:
+        for mols in [[mol_a, mol_b]]:
             complex_system, complex_coords, complex_box, complex_top, num_water_atoms = builders.build_protein_system(
                 str(host_path), ff.protein_ff, ff.water_ff, mols=mols
             )
             host_config = HostConfig(complex_system, complex_coords, complex_box, num_water_atoms, complex_top)
             x_host = minimizer.fire_minimize_host(mols, host_config, ff)
             assert x_host.shape == complex_coords.shape
-            break
 
 
 def test_fire_minimize_host_solvent():
@@ -119,9 +118,8 @@ def test_fire_minimize_host_solvent():
         assert x_host.shape == solvent_coords.shape
 
 
-@pytest.mark.parametrize("host_name", ["solvent", "complex"])
+@pytest.mark.parametrize("host_name", ["solvent", pytest.param("complex", marks=pytest.mark.nightly(reason="slow"))])
 @pytest.mark.parametrize("mol_pair", [("20", "43")])
-@pytest.mark.nightly(reason="slow")
 def test_pre_equilibrate_host_pfkfb3(host_name, mol_pair):
     ff = Forcefield.load_default()
     mol_a_name, mol_b_name = mol_pair

--- a/tests/test_relative_free_energy.py
+++ b/tests/test_relative_free_energy.py
@@ -165,7 +165,7 @@ def run_triple(mol_a, mol_b, core, forcefield, md_params: MDParams, protein_path
     check_sim_result(complex_res)
 
 
-# @pytest.mark.nightly(reason="Slow!")
+@pytest.mark.nightly(reason="Slow!")
 @pytest.mark.parametrize(
     "estimate_relative_free_energy_fn",
     [

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -940,8 +940,10 @@ def test_nonbonded_intra_split_bitwise_identical(precision, lamb):
     np.testing.assert_equal(ref_u, split_u)
 
 
-@pytest.mark.parametrize("precision, rtol, atol", [(np.float64, 1e-8, 1e-8), (np.float32, 1e-4, 5e-4)])
-@pytest.mark.nightly(reason="slow")
+@pytest.mark.parametrize(
+    "precision, rtol, atol",
+    [pytest.param(np.float64, 1e-8, 1e-8, marks=pytest.mark.nightly(reason="slow")), (np.float32, 1e-4, 5e-4)],
+)
 def test_combine_with_host_split(precision, rtol, atol):
     # test the split P-L and L-W interactions
 

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -941,6 +941,7 @@ def test_nonbonded_intra_split_bitwise_identical(precision, lamb):
 
 
 @pytest.mark.parametrize("precision, rtol, atol", [(np.float64, 1e-8, 1e-8), (np.float32, 1e-4, 5e-4)])
+@pytest.mark.nightly(reason="slow")
 def test_combine_with_host_split(precision, rtol, atol):
     # test the split P-L and L-W interactions
 

--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -116,6 +116,8 @@ def run_edge(mol_a, mol_b, protein_path, n_windows):
         ("290", "84"),  # failure, B-ring, core-hopping into oxazole
         ("290", "256"),  # failure, should be a simple transformation
         ("164", "163"),  # failure, B-ring has a different conformation
+        ("35", "84"),  # failure, B-ring, core-hopping into oxazole, <-- this fails
+        ("41", "50"),  # failure, moves beyond 7 A in the solvent leg
     ],
 )
 @pytest.mark.nightly(reason="Takes a while to run")
@@ -138,7 +140,6 @@ def test_confgen_hard_edges(src, dst):
     "src, dst",
     [
         ("35", "84"),  # failure, B-ring, core-hopping into oxazole, <-- this fails
-        ("41", "50"),  # failure, moves beyond 7 A in the solvent leg
     ],
 )
 def test_confgen_spot_edges(src, dst):
@@ -147,7 +148,7 @@ def test_confgen_spot_edges(src, dst):
     with resources.path("timemachine.datasets.fep_benchmark.hif2a", "ligands.sdf") as ligand_path:
         mols_by_name = read_sdf_mols_by_name(ligand_path)
 
-    n_windows = 12
+    n_windows = 3
 
     print("\nProcessing", src, "->", dst, "\n")
     mol_a = mols_by_name[src]

--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -148,7 +148,7 @@ def test_confgen_spot_edges(src, dst):
     with resources.path("timemachine.datasets.fep_benchmark.hif2a", "ligands.sdf") as ligand_path:
         mols_by_name = read_sdf_mols_by_name(ligand_path)
 
-    n_windows = 3
+    n_windows = 4
 
     print("\nProcessing", src, "->", dst, "\n")
     mol_a = mols_by_name[src]

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -81,11 +81,24 @@ def parameterize_nonbonded_full(
 
 
 @no_type_check
+def test_host_guest_nonbonded_tiny_mol():
+    ctor = BaseTopology
+    precision, rtol, atol = (np.float32, 1e-4, 5e-4)
+    use_tiny_mol = True
+    test_host_guest_nonbonded_impl(ctor, precision, rtol, atol, use_tiny_mol)
+
+
+@no_type_check
 @pytest.mark.parametrize("precision, rtol, atol", [(np.float64, 1e-8, 1e-8), (np.float32, 1e-4, 5e-4)])
 @pytest.mark.parametrize("ctor", [BaseTopology, DualTopology])
 @pytest.mark.parametrize("use_tiny_mol", [True, False])
 @pytest.mark.nightly(reason="slow")
 def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
+    test_host_guest_nonbonded_impl(ctor, precision, rtol, atol, use_tiny_mol)
+
+
+@no_type_check
+def test_host_guest_nonbonded_impl(ctor, precision, rtol, atol, use_tiny_mol):
     def compute_ref_grad_u(ff: Forcefield, precision, x0, box, lamb, num_water_atoms, host_bps, omm_topology):
         # Use the original code to compute the nb grads and potential
         bt = Topology(ff)

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -84,6 +84,7 @@ def parameterize_nonbonded_full(
 @pytest.mark.parametrize("precision, rtol, atol", [(np.float64, 1e-8, 1e-8), (np.float32, 1e-4, 5e-4)])
 @pytest.mark.parametrize("ctor", [BaseTopology, DualTopology])
 @pytest.mark.parametrize("use_tiny_mol", [True, False])
+@pytest.mark.nightly(reason="slow")
 def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
     def compute_ref_grad_u(ff: Forcefield, precision, x0, box, lamb, num_water_atoms, host_bps, omm_topology):
         # Use the original code to compute the nb grads and potential

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -85,7 +85,7 @@ def test_host_guest_nonbonded_tiny_mol():
     ctor = BaseTopology
     precision, rtol, atol = (np.float32, 1e-4, 5e-4)
     use_tiny_mol = True
-    test_host_guest_nonbonded_impl(ctor, precision, rtol, atol, use_tiny_mol)
+    host_guest_nonbonded_impl(ctor, precision, rtol, atol, use_tiny_mol)
 
 
 @no_type_check
@@ -94,11 +94,11 @@ def test_host_guest_nonbonded_tiny_mol():
 @pytest.mark.parametrize("use_tiny_mol", [True, False])
 @pytest.mark.nightly(reason="slow")
 def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
-    test_host_guest_nonbonded_impl(ctor, precision, rtol, atol, use_tiny_mol)
+    host_guest_nonbonded_impl(ctor, precision, rtol, atol, use_tiny_mol)
 
 
 @no_type_check
-def test_host_guest_nonbonded_impl(ctor, precision, rtol, atol, use_tiny_mol):
+def host_guest_nonbonded_impl(ctor, precision, rtol, atol, use_tiny_mol):
     def compute_ref_grad_u(ff: Forcefield, precision, x0, box, lamb, num_water_atoms, host_bps, omm_topology):
         # Use the original code to compute the nb grads and potential
         bt = Topology(ff)


### PR DESCRIPTION
- Reduces the time needed to run the unit tests from 94 mins to 51 mins
- Note this increases the nightly test runtime by the equivalent amount (to about 7.5 hours) but I think we could improve this by pruning tests/test_single_topology_confgen.py::test_confgen_hard_edges (which takes about half of this time)