### PR TITLE
Restore dropped pycodestyle, Pyflakes rules in ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,13 @@ line-length = 120
 
 [tool.ruff.lint]
 select = [
+   "E", # pycodestyle
    "F", # Pyflakes
-   "I", # sort imports
+   "I", # isort
 ]
 ignore = [
   "E402", # Module level import not at top of file
+  "E501", # Line too long
   "E731", # Do not assign a lambda expression, use a def
   "E741", # Do not use variables named 'I', 'O', or 'l'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ line-length = 120
 
 [tool.ruff.lint]
 select = [
+   "F", # Pyflakes
    "I", # sort imports
 ]
 ignore = [

--- a/timemachine/fe/rest/single_topology.py
+++ b/timemachine/fe/rest/single_topology.py
@@ -11,7 +11,6 @@ from timemachine.constants import NBParamIdx
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.system import GuestSystem, HostGuestSystem, HostSystem
 from timemachine.ff import Forcefield
-from timemachine.potentials import HarmonicAngleStable, NonbondedPairListPrecomputed
 
 from .bond import CanonicalBond, mkbond
 from .interpolation import InterpolationFxn, InterpolationFxnName, Symmetric, get_interpolation_fxn

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1,7 +1,7 @@
 import warnings
 from enum import IntEnum
 from functools import partial
-from typing import Any, Collection, List, Optional, Sequence
+from typing import Any, Collection, Optional, Sequence
 
 import jax
 import jax.numpy as jnp

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1,7 +1,7 @@
 import warnings
 from enum import IntEnum
 from functools import partial
-from typing import Any, Collection, Optional, Sequence
+from typing import Any, Collection, List, Optional, Sequence
 
 import jax
 import jax.numpy as jnp


### PR DESCRIPTION
In the transition to ruff (#1459), we unintentionally dropped the Pyflakes linting rules (e.g. unused imports) that were previously handled by `flake8`. This PR adds them back in by selecting the `F` rules in the ruff configuration ([reference](https://docs.astral.sh/ruff/linter/#rule-selection)). 