### PR TITLE
Refactor builder signatures and remove convert_* functions

### DIFF
--- a/examples/rbfe_edge_list.py
+++ b/examples/rbfe_edge_list.py
@@ -57,7 +57,7 @@ def run_edge_and_save_results(
         )
         core = all_cores[0]
 
-        complex_res, complex_top, _ = rbfe.run_complex(
+        complex_res, complex_host_config = rbfe.run_complex(
             mol_a,
             mol_b,
             core,
@@ -66,6 +66,8 @@ def run_edge_and_save_results(
             md_params,
             n_windows=n_windows,
         )
+
+        complex_top = complex_host_config.omm_topology
 
         if isinstance(complex_res, rbfe.HREXSimulationResult):
             file_client.store(
@@ -80,7 +82,7 @@ def run_edge_and_save_results(
                 complex_res.hrex_plots.replica_state_distribution_heatmap_png,
             )
 
-        solvent_res, solvent_top, _ = rbfe.run_solvent(
+        solvent_res, solvent_host_config = rbfe.run_solvent(
             mol_a,
             mol_b,
             core,
@@ -89,6 +91,7 @@ def run_edge_and_save_results(
             md_params,
             n_windows=n_windows,
         )
+        solvent_top = solvent_host_config.omm_topology
         if isinstance(solvent_res, rbfe.HREXSimulationResult):
             file_client.store(
                 f"{edge_prefix}_solvent_hrex_transition_matrix.png", solvent_res.hrex_plots.transition_matrix_png

--- a/examples/relative_free_energy.py
+++ b/examples/relative_free_energy.py
@@ -28,26 +28,23 @@ def write_trajectory_as_cif(mol_a, mol_b, core, all_frames, host_topology, prefi
 
 
 def run_pair(mol_a, mol_b, core, forcefield, md_params, protein_path):
-    solvent_res, solvent_top, solvent_host_config = run_solvent(
-        mol_a, mol_b, core, forcefield, None, md_params=md_params
-    )
+    solvent_res, solvent_host_config = run_solvent(mol_a, mol_b, core, forcefield, None, md_params=md_params)
 
     with open("solvent_overlap.png", "wb") as fh:
         fh.write(solvent_res.plots.overlap_detail_png)
 
     # this st is only needed to deal with visualization jank
-    write_trajectory_as_cif(mol_a, mol_b, core, solvent_res.frames, solvent_top, "solvent_traj")
+    write_trajectory_as_cif(mol_a, mol_b, core, solvent_res.frames, solvent_host_config.omm_topology, "solvent_traj")
 
     print(
         f"solvent dG: {np.sum(solvent_res.final_result.dGs):.3f} +- {np.linalg.norm(solvent_res.final_result.dG_errs):.3f} kJ/mol"
     )
 
-    complex_res, complex_top, complex_host_config = run_complex(
-        mol_a, mol_b, core, forcefield, protein_path, md_params=md_params
-    )
+    complex_res, complex_host_config = run_complex(mol_a, mol_b, core, forcefield, protein_path, md_params=md_params)
+
     with open("complex_overlap.png", "wb") as fh:
         fh.write(complex_res.plots.overlap_detail_png)
-    write_trajectory_as_cif(mol_a, mol_b, core, complex_res.frames, complex_top, "complex_traj")
+    write_trajectory_as_cif(mol_a, mol_b, core, complex_res.frames, complex_host_config.omm_topology, "complex_traj")
 
     print(
         f"complex dG: {np.sum(complex_res.final_result.dGs):.3f} +- {np.linalg.norm(complex_res.final_result.dG_errs):.3f} kJ/mol"

--- a/tests/nonbonded/test_atom_by_atom_energies.py
+++ b/tests/nonbonded/test_atom_by_atom_energies.py
@@ -4,7 +4,6 @@ from common import assert_energy_arrays_match
 
 from timemachine.constants import DEFAULT_TEMP
 from timemachine.ff import Forcefield
-from timemachine.ff.handlers import openmm_deserializer
 from timemachine.lib import custom_ops
 from timemachine.md import builders
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
@@ -23,8 +22,10 @@ def test_nonbonded_atom_by_atom_energies_match(num_mols, adjustments, precision,
     """Verify that if looking at not computing the subsets of energies matches the references"""
     rng = np.random.default_rng(2023)
     ff = Forcefield.load_default()
-    system, conf, box, top = builders.build_water_system(4.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    host_config = builders.build_water_system(4.0, ff.water_ff)
+    bps = host_config.host_system.get_U_fns()
+    conf = host_config.conf
+    box = host_config.box
     nb = get_bound_potential_by_type(bps, Nonbonded)
     bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
 

--- a/tests/nonbonded/test_nonbonded.py
+++ b/tests/nonbonded/test_nonbonded.py
@@ -8,9 +8,7 @@ from numpy.typing import NDArray
 
 from timemachine import potentials
 from timemachine.ff import Forcefield
-from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md import builders
-from timemachine.potentials.potential import get_bound_potential_by_type
 
 np.set_printoptions(linewidth=500)
 
@@ -169,11 +167,11 @@ def test_nblist_box_resize(precision, rtol, atol, du_dp_rtol, du_dp_atol):
     # since we should be rebuilding the nblist when the box sizes change.
     ff = Forcefield.load_default()
 
-    host_system, host_conf, box, top = builders.build_water_system(3.0, ff.water_ff)
+    host_config = builders.build_water_system(3.0, ff.water_ff)
 
-    host_fns, host_masses = openmm_deserializer.deserialize_system(host_system, cutoff=1.2)
-
-    test_bp = get_bound_potential_by_type(host_fns, potentials.Nonbonded)
+    # host_fns, host_masses = openmm_deserializer.deserialize_system(host_system, cutoff=1.2)
+    box = host_config.box
+    test_bp = host_config.host_system.nonbonded_all_pairs
     assert test_bp.params is not None
 
     big_box = box + np.eye(3) * 1000
@@ -182,7 +180,7 @@ def test_nblist_box_resize(precision, rtol, atol, du_dp_rtol, du_dp_atol):
     # the rebuild is triggered as long as the box *changes*.
     for test_box in [big_box, box]:
         GradientTest().compare_forces(
-            host_conf,
+            host_config.conf,
             test_bp.params,
             test_box,
             test_bp.potential,
@@ -200,15 +198,14 @@ def test_nblist_box_resize(precision, rtol, atol, du_dp_rtol, du_dp_atol):
 def test_nonbonded_water(size, cutoff, precision, rtol, atol):
     np.random.seed(4321)
     ff = Forcefield.load_default()
-
-    _, all_coords, box, _ = builders.build_water_system(3.0, ff.water_ff)
-    coords = all_coords[:size]
+    host_config = builders.build_water_system(3.0, ff.water_ff)
+    coords = host_config.conf[:size]
 
     # E = 0 # DEBUG!
     charge_params, potential = prepare_water_system(coords, p_scale=5.0, cutoff=cutoff)
     test_impl = potential.to_gpu(precision)
     for params in gen_nonbonded_params_with_4d_offsets(np.random.default_rng(2022), charge_params, cutoff):
-        GradientTest().compare_forces(coords, params, box, potential, test_impl, rtol=rtol, atol=atol)
+        GradientTest().compare_forces(coords, params, host_config.box, potential, test_impl, rtol=rtol, atol=atol)
 
 
 @pytest.mark.parametrize("precision,rtol", [(np.float64, 1e-8), (np.float32, 1e-4)])
@@ -221,14 +218,14 @@ def test_nonbonded_exclusions(precision, rtol):
     np.random.seed(2020)
     ff = Forcefield.load_default()
 
-    _, water_coords, box, _ = builders.build_water_system(3.0, ff.water_ff)
+    host_config = builders.build_water_system(3.0, ff.water_ff)
     N = 126  # multiple of 3
-    test_system = water_coords[:N]
+    test_coords = host_config.conf[:N]
     box = np.eye(3) * 3
 
     EA = 10
 
-    atom_idxs = np.arange(test_system.shape[0])
+    atom_idxs = np.arange(test_coords.shape[0])
 
     # pick a set of atoms that will be mutually excluded from each other.
     # we will need to set their exclusions manually
@@ -245,13 +242,13 @@ def test_nonbonded_exclusions(precision, rtol):
     scales = np.ones((E, 2), dtype=np.float64)
     # perturb the system
     for idx in exclusion_atoms:
-        test_system[idx] = np.zeros(3) + np.random.rand() / 1000 + 2
+        test_coords[idx] = np.zeros(3) + np.random.rand() / 1000 + 2
 
     beta = 2.0
     cutoff = 1.2
 
     potential = potentials.Nonbonded(N, exclusion_idxs, scales, beta, cutoff)
 
-    params = prepare_system_params(test_system, cutoff)
+    params = prepare_system_params(test_coords, cutoff)
 
-    GradientTest().compare_forces(test_system, params, box, potential, potential.to_gpu(precision), rtol)
+    GradientTest().compare_forces(test_coords, params, box, potential, potential.to_gpu(precision), rtol)

--- a/tests/nonbonded/test_nonbonded.py
+++ b/tests/nonbonded/test_nonbonded.py
@@ -166,10 +166,7 @@ def test_nblist_box_resize(precision, rtol, atol, du_dp_rtol, du_dp_atol):
     # test that running the coordinates under two different boxes produces correct results
     # since we should be rebuilding the nblist when the box sizes change.
     ff = Forcefield.load_default()
-
     host_config = builders.build_water_system(3.0, ff.water_ff)
-
-    # host_fns, host_masses = openmm_deserializer.deserialize_system(host_system, cutoff=1.2)
     box = host_config.box
     test_bp = host_config.host_system.nonbonded_all_pairs
     assert test_bp.params is not None

--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -120,15 +120,9 @@ def test_single_topology_rest_vacuum(mol_pair, temperature_scale_interpolation_f
 
 @cache
 def get_solvent_host(st: SingleTopology) -> tuple[Host, HostConfig]:
-    def get_solvent_host_config(box_width=4.0):
-        solvent_sys, solvent_conf, solvent_box, omm_topology = builders.build_water_system(
-            box_width, forcefield.water_ff, mols=[st.mol_a, st.mol_b]
-        )
-        solvent_box += np.diag([0.1, 0.1, 0.1])
-        return HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0], omm_topology)
-
-    host_config = get_solvent_host_config()
-
+    box_width = 4.0
+    host_config = builders.build_water_system(box_width, forcefield.water_ff, mols=[st.mol_a, st.mol_b])
+    host_config.box += np.diag([0.1, 0.1, 0.1])
     host = setup_optimized_host(st, host_config)
 
     return host, host_config

--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -88,7 +88,6 @@ def test_barostat_with_clashes():
     host_config.box -= np.eye(3) * 0.1
     bt = BaseTopology(mol_a, ff)
     afe = AbsoluteFreeEnergy(mol_a, bt)
-    # host_config = HostConfig(host_system, host_coords, box, host_coords.shape[0], host_top)
     unbound_potentials, sys_params, masses = afe.prepare_host_edge(ff, host_config, 0.0)
     coords = afe.prepare_combined_coords(host_coords=host_config.conf)
 

--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -3,10 +3,9 @@ import pytest
 
 from timemachine.constants import AVOGADRO, BAR_TO_KJ_PER_NM3, BOLTZ, DEFAULT_PRESSURE, DEFAULT_TEMP
 from timemachine.fe import model_utils
-from timemachine.fe.free_energy import AbsoluteFreeEnergy, HostConfig
+from timemachine.fe.free_energy import AbsoluteFreeEnergy
 from timemachine.fe.topology import BaseTopology
 from timemachine.ff import Forcefield
-from timemachine.ff.handlers import openmm_deserializer
 from timemachine.lib import LangevinIntegrator, custom_ops
 from timemachine.md.barostat.moves import CentroidRescaler
 from timemachine.md.barostat.utils import compute_box_center, compute_box_volume, get_bond_list, get_group_indices
@@ -14,7 +13,7 @@ from timemachine.md.builders import build_water_system
 from timemachine.md.enhanced import get_solvent_phase_system
 from timemachine.md.thermostat.utils import sample_velocities
 from timemachine.potentials import HarmonicBond, Nonbonded, NonbondedInteractionGroup, NonbondedPairListPrecomputed
-from timemachine.potentials.potential import get_bound_potential_by_type, get_potential_by_type
+from timemachine.potentials.potential import get_potential_by_type
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
 
 
@@ -84,14 +83,14 @@ def test_barostat_with_clashes():
     ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
 
     # Construct water box without removing the waters around the ligand to ensure clashes
-    host_system, host_coords, box, host_top = build_water_system(3.0, ff.water_ff)
+    host_config = build_water_system(3.0, ff.water_ff)
     # Shrink the box to ensure the energies are NaN
-    box -= np.eye(3) * 0.1
+    host_config.box -= np.eye(3) * 0.1
     bt = BaseTopology(mol_a, ff)
     afe = AbsoluteFreeEnergy(mol_a, bt)
-    host_config = HostConfig(host_system, host_coords, box, host_coords.shape[0], host_top)
+    # host_config = HostConfig(host_system, host_coords, box, host_coords.shape[0], host_top)
     unbound_potentials, sys_params, masses = afe.prepare_host_edge(ff, host_config, 0.0)
-    coords = afe.prepare_combined_coords(host_coords=host_coords)
+    coords = afe.prepare_combined_coords(host_coords=host_config.conf)
 
     # get list of molecules for barostat by looking at bond table
     harmonic_bond_potential = get_potential_by_type(unbound_potentials, HarmonicBond)
@@ -106,7 +105,7 @@ def test_barostat_with_clashes():
         u_impls.append(unbound_pot.bind(params).to_gpu(precision=np.float32).bound_impl)
 
     # The energy of the system should be non-finite
-    nrg = np.sum([bp.execute(coords, box, compute_du_dx=False)[1] for bp in u_impls])
+    nrg = np.sum([bp.execute(coords, host_config.box, compute_du_dx=False)[1] for bp in u_impls])
     assert not np.isfinite(nrg)
 
     integrator = LangevinIntegrator(
@@ -125,14 +124,14 @@ def test_barostat_with_clashes():
     )
 
     # The clashes will result in overflows, so the box should never change as no move is accepted
-    ctxt = custom_ops.Context(coords, v_0, box, integrator_impl, u_impls, movers=[baro])
+    ctxt = custom_ops.Context(coords, v_0, host_config.box, integrator_impl, u_impls, movers=[baro])
     # Will trigger the unstable check since the box is so small.
     with pytest.raises(
         RuntimeError,
         match="simulation unstable: dimensions of coordinates two orders of magnitude larger than max box dimension",
     ):
         ctxt.multiple_steps(barostat_interval * 100)
-    assert np.all(box == ctxt.get_box())
+    assert np.all(host_config.box == ctxt.get_box())
 
 
 @pytest.mark.memcheck
@@ -307,19 +306,14 @@ def test_barostat_varying_pressure():
 
     # Start out with a very large pressure
     pressure = 1013.0
-    host_system, coords, box, host_top = build_water_system(3.0, ff.water_ff)
-    box += np.eye(3) * 0.1
-    bps, masses_ = openmm_deserializer.deserialize_system(host_system, cutoff=1.2)
-
-    masses = np.array(masses_)
-
-    # get list of molecules for barostat by looking at bond table
-    harmonic_bond_potential = get_bound_potential_by_type(bps, HarmonicBond)
+    host_config = build_water_system(3.0, ff.water_ff)
+    host_config.box += np.eye(3) * 0.1
+    harmonic_bond_potential = host_config.host_system.bond
     bond_list = get_bond_list(harmonic_bond_potential.potential)
-    group_indices = get_group_indices(bond_list, len(masses))
+    group_indices = get_group_indices(bond_list, len(host_config.masses))
 
     u_impls = []
-    for bp in bps:
+    for bp in host_config.host_system.get_U_fns():
         bp_impl = bp.to_gpu(precision=np.float32).bound_impl
         u_impls.append(bp_impl)
 
@@ -327,23 +321,23 @@ def test_barostat_varying_pressure():
         temperature,
         timestep,
         collision_rate,
-        masses,
+        host_config.masses,
         seed,
     )
     integrator_impl = integrator.impl()
 
-    v_0 = sample_velocities(masses, temperature, seed)
+    v_0 = sample_velocities(host_config.masses, temperature, seed)
 
     baro = custom_ops.MonteCarloBarostat(
-        coords.shape[0], pressure, temperature, group_indices, barostat_interval, u_impls, seed, True, 0.0
+        host_config.conf.shape[0], pressure, temperature, group_indices, barostat_interval, u_impls, seed, True, 0.0
     )
 
-    ctxt = custom_ops.Context(coords, v_0, box, integrator_impl, u_impls, movers=[baro])
+    ctxt = custom_ops.Context(host_config.conf, v_0, host_config.box, integrator_impl, u_impls, movers=[baro])
     ctxt.multiple_steps(1000)
     ten_atm_box = ctxt.get_box()
     ten_atm_box_vol = compute_box_volume(ten_atm_box)
     # Expect the box to shrink thanks to the barostat
-    assert compute_box_volume(box) - ten_atm_box_vol > 0.4
+    assert compute_box_volume(host_config.box) - ten_atm_box_vol > 0.4
 
     # Set the pressure to 1 atm
     baro.set_pressure(DEFAULT_PRESSURE)

--- a/tests/test_benchmark_free_energy.py
+++ b/tests/test_benchmark_free_energy.py
@@ -67,18 +67,13 @@ def setup_hif2a_single_topology_leg(host_name: str, n_windows: int, lambda_endpo
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     if host_name == "complex":
         with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as protein_path:
-            host_sys, host_conf, box, host_top, num_water_atoms = builders.build_protein_system(
+            host_config = builders.build_protein_system(
                 str(protein_path), forcefield.protein_ff, forcefield.water_ff, mols=[mol_a, mol_b]
             )
-            box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-        host_config = HostConfig(host_sys, host_conf, box, num_water_atoms, host_top)
+            host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     elif host_name == "solvent":
-        solvent_sys, solvent_conf, box, solvent_top = builders.build_water_system(
-            4.0, forcefield.water_ff, mols=[mol_a, mol_b]
-        )
-        box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-        host_config = HostConfig(solvent_sys, solvent_conf, box, solvent_conf.shape[0], solvent_top)
-
+        host_config = builders.build_water_system(4.0, forcefield.water_ff, mols=[mol_a, mol_b])
+        host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     single_topology = SingleTopology(mol_a, mol_b, core, forcefield)
     host = setup_optimized_host(single_topology, host_config) if host_config else None
 

--- a/tests/test_chiral_restraints.py
+++ b/tests/test_chiral_restraints.py
@@ -839,7 +839,7 @@ def test_chiral_inversion_in_single_topology_solvent():
     md_params = DEFAULT_HREX_PARAMS
     md_params = replace(md_params, n_frames=100)
 
-    res, _, _ = run_solvent(atom_map.mol_a, atom_map.mol_b, atom_map.core, ff, None, md_params, n_windows=3)
+    res, _ = run_solvent(atom_map.mol_a, atom_map.mol_b, atom_map.core, ff, None, md_params, n_windows=3)
     heatmap_a, heatmap_b = make_chiral_flip_heatmaps(res, atom_map)
     assert (heatmap_a[0] == 0).all(), "chirality in end state A was not preserved"
     assert (heatmap_b[-1] == 0).all(), "chirality in end state B was not preserved"

--- a/tests/test_cuda_bd_exchange_mover.py
+++ b/tests/test_cuda_bd_exchange_mover.py
@@ -795,7 +795,6 @@ def hif2a_complex():
     host_config.conf = conf
     host_config.box = box
     return host_config
-    # return complex_system, conf, box, complex_top
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cuda_bd_exchange_mover.py
+++ b/tests/test_cuda_bd_exchange_mover.py
@@ -434,7 +434,6 @@ def test_bd_exchange_deterministic_batch_moves(proposals_per_move, batch_size, p
     """
     conf, _, group_idxs, nb = get_water_system_and_all_group_idxs(1.0)
     rng = np.random.default_rng(seed)
-    # (ytz): ask fyork if we intended to set a very large box
     box = np.eye(3) * 100.0
     N = conf.shape[0]
 

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -568,7 +568,6 @@ def test_tibd_exchange_deterministic_batch_moves(radius, proposals_per_move, bat
     increase the number of proposals per move in the constructor that the results should be identical
     """
     rng = np.random.default_rng(seed)
-    # (YTZ): check with fyork that we intended this to be a 1 nm box width
     conf, box, all_group_idxs, nb = get_water_system_and_all_group_idxs(1.0)
 
     group_idxs = all_group_idxs[1:]

--- a/tests/test_cuda_targeted_insertion_mover.py
+++ b/tests/test_cuda_targeted_insertion_mover.py
@@ -14,7 +14,6 @@ from timemachine.constants import DEFAULT_ATOM_MAPPING_KWARGS, DEFAULT_TEMP
 from timemachine.fe import atom_mapping
 from timemachine.fe.free_energy import (
     AbsoluteFreeEnergy,
-    HostConfig,
     InitialState,
     MDParams,
     get_water_sampler_params,
@@ -25,7 +24,6 @@ from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.topology import BaseTopology
 from timemachine.fe.utils import read_sdf
 from timemachine.ff import Forcefield
-from timemachine.ff.handlers import openmm_deserializer
 from timemachine.lib import custom_ops
 from timemachine.md import builders
 from timemachine.md.barostat.utils import compute_box_volume, get_bond_list, get_group_indices
@@ -170,22 +168,30 @@ def verify_targeted_moves(
     np.testing.assert_allclose(bdem.acceptance_fraction(), bdem.n_accepted() / bdem.n_proposed())
 
 
+# (YTZ) not-@cacheable for some reason, maybe results are being modified? investigate later
+# (failure is in): FAILED tests/test_cuda_targeted_insertion_mover.py::test_targeted_moves_in_bulk_water[2023-float64-2e-05-2e-05-1-500-1-4.0-1.2]
+# - RuntimeError: Molecules are not contiguous: mol 502
+def get_water_system_and_all_group_idxs(box_width):
+    ff = Forcefield.load_default()
+    host_config = builders.build_water_system(box_width, ff.water_ff)
+    box = host_config.box
+    coords = host_config.conf
+    bond_pot = host_config.host_system.bond.potential
+    all_group_idxs = get_group_indices(get_bond_list(bond_pot), coords.shape[0])
+    nb = host_config.host_system.nonbonded_all_pairs
+
+    return coords, box, all_group_idxs, nb
+
+
 @pytest.mark.memcheck
 @pytest.mark.parametrize("seed", [2023, 2024])
 @pytest.mark.parametrize("radius", [0.1, 0.5, 1.2, 2.0])
 @pytest.mark.parametrize("precision", [np.float64, np.float32])
 def test_inner_and_outer_water_groups(seed, radius, precision):
     rng = np.random.default_rng(seed)
-    ff = Forcefield.load_default()
-    system, coords, box, top = builders.build_water_system(4.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
-
-    bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
-
-    all_group_idxs = get_group_indices(get_bond_list(bond_pot), coords.shape[0])
+    coords, box, all_group_idxs, _ = get_water_system_and_all_group_idxs(4.0)
 
     center_group_idx = rng.choice(np.arange(len(all_group_idxs)))
-
     center_group = all_group_idxs.pop(center_group_idx)
 
     group_idxs = np.delete(np.array(all_group_idxs).reshape(-1), center_group)
@@ -216,16 +222,8 @@ def test_inner_and_outer_water_groups(seed, radius, precision):
 @pytest.mark.parametrize("precision", [np.float64, np.float32])
 def test_translations_inside_and_outside_sphere(seed, n_translations, radius, precision):
     rng = np.random.default_rng(seed)
-    ff = Forcefield.load_default()
-    system, coords, box, top = builders.build_water_system(4.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
-
-    bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
-
-    all_group_idxs = get_group_indices(get_bond_list(bond_pot), coords.shape[0])
-
+    coords, box, all_group_idxs, _ = get_water_system_and_all_group_idxs(4.0)
     center_group_idx = rng.choice(np.arange(len(all_group_idxs)))
-
     center_group = all_group_idxs.pop(center_group_idx)
 
     center = np.mean(coords[center_group], axis=0)
@@ -388,13 +386,10 @@ def brd4_rbfe_state() -> InitialState:
     # BRD4 is a known target that has waters in the binding site, use the structure with the water stripped from
     # the binding pocket
     with resources.path("timemachine.datasets.water_exchange", "brd4_no_water.pdb") as pdb_path:
-        complex_system, complex_conf, box, complex_top, num_water_atoms = builders.build_protein_system(
-            str(pdb_path), ff.protein_ff, ff.water_ff, mols=[mol_a, mol_b]
-        )
-    box += np.diag([0.1, 0.1, 0.1])
+        host_config = builders.build_protein_system(str(pdb_path), ff.protein_ff, ff.water_ff, mols=[mol_a, mol_b])
+        host_config.box += np.diag([0.1, 0.1, 0.1])
 
     core = atom_mapping.get_cores(mol_a, mol_b, **DEFAULT_ATOM_MAPPING_KWARGS)[0]
-    host_config = HostConfig(complex_system, complex_conf, box, num_water_atoms, complex_top)
     st = SingleTopology(mol_a, mol_b, core, ff)
 
     initial_state = prepare_single_topology_initial_state(st, host_config, lamb=lamb)
@@ -436,20 +431,17 @@ def test_targeted_insertion_buckyball_edge_cases(
         mol = mols[0]
 
     # Build the protein system using the solvent PDB for buckyball
-    host_sys, host_conf, host_box, host_topology, num_water_atoms = builders.build_protein_system(
-        str(host_pdb), ff.protein_ff, ff.water_ff
-    )
-    host_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-    host_config = HostConfig(host_sys, host_conf, host_box, num_water_atoms, host_topology)
+    host_config = builders.build_protein_system(str(host_pdb), ff.protein_ff, ff.water_ff)
+    host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
+    box = host_config.box
+    num_water_atoms = host_config.num_water_atoms
 
     bt = BaseTopology(mol, ff)
     afe = AbsoluteFreeEnergy(mol, bt)
     # Fully embed the ligand
-    potentials, params, combined_masses = afe.prepare_host_edge(ff, host_config, 0.0)
+    potentials, params, _ = afe.prepare_host_edge(ff, host_config, 0.0)
     ligand_idxs = np.arange(num_water_atoms, num_water_atoms + mol.GetNumAtoms())
-
     conf = afe.prepare_combined_coords(host_config.conf)
-    box = host_box
 
     bps = [pot.bind(p) for pot, p in zip(potentials, params)]
     nb = get_bound_potential_by_type(bps, Nonbonded)
@@ -576,14 +568,8 @@ def test_tibd_exchange_deterministic_batch_moves(radius, proposals_per_move, bat
     increase the number of proposals per move in the constructor that the results should be identical
     """
     rng = np.random.default_rng(seed)
-    ff = Forcefield.load_default()
-    system, conf, _, top = builders.build_water_system(1.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
-
-    nb = get_bound_potential_by_type(bps, Nonbonded)
-    bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
-
-    all_group_idxs = get_group_indices(get_bond_list(bond_pot), conf.shape[0])
+    # (YTZ): check with fyork that we intended this to be a 1 nm box width
+    conf, box, all_group_idxs, nb = get_water_system_and_all_group_idxs(1.0)
 
     group_idxs = all_group_idxs[1:]
 
@@ -669,16 +655,15 @@ def test_targeted_insertion_buckyball_determinism(radius, proposals_per_move, ba
         mol = mols[0]
 
     # Build the protein system using the solvent PDB for buckyball
-    host_sys, host_conf, host_box, host_topology, num_water_atoms = builders.build_protein_system(
-        str(host_pdb), ff.protein_ff, ff.water_ff
-    )
-    host_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-    host_config = HostConfig(host_sys, host_conf, host_box, num_water_atoms, host_topology)
+    host_config = builders.build_protein_system(str(host_pdb), ff.protein_ff, ff.water_ff)
+    host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
+    host_box = host_config.box
+    num_water_atoms = host_config.num_water_atoms
 
     bt = BaseTopology(mol, ff)
     afe = AbsoluteFreeEnergy(mol, bt)
     # Fully embed the ligand
-    potentials, params, combined_masses = afe.prepare_host_edge(ff, host_config, 0.0)
+    potentials, params, _ = afe.prepare_host_edge(ff, host_config, 0.0)
     ligand_idxs = np.arange(num_water_atoms, num_water_atoms + mol.GetNumAtoms())
 
     conf = afe.prepare_combined_coords(host_config.conf)
@@ -754,22 +739,13 @@ def test_tibd_exchange_deterministic_moves(radius, proposals_per_move, batch_siz
     """Given a set of waters in a large box the exchange mover should nearly accept every move and the results should be deterministic
     if the seed and proposals per move are the same.
 
-
     There are three forms of determinism we require:
     * Constructing an exchange move produces the same results every time
     * Calling an exchange move with one proposals per move or K proposals per move produce the same state.
       * It is difficult to test each move when there are K proposals per move so we need to know that it matches the single proposals per move case
     * When batch size is greater than one (each batch is made up of K proposals) it produces the same result as the serial version (batch size == 1)
     """
-    ff = Forcefield.load_default()
-    system, conf, _, top = builders.build_water_system(1.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
-
-    nb = get_bound_potential_by_type(bps, Nonbonded)
-    bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
-
-    all_group_idxs = get_group_indices(get_bond_list(bond_pot), conf.shape[0])
-
+    conf, _, all_group_idxs, nb = get_water_system_and_all_group_idxs(1.0)
     group_idxs = all_group_idxs[1:]
 
     # Target the first water
@@ -851,15 +827,7 @@ def test_targeted_moves_in_bulk_water(
     radius, proposals_per_move, total_num_proposals, batch_size, box_size, precision, rtol, atol, seed
 ):
     """Given bulk water molecules with one of them treated as the targeted region"""
-    ff = Forcefield.load_default()
-    system, conf, ref_box, top = builders.build_water_system(box_size, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
-
-    nb = get_bound_potential_by_type(bps, Nonbonded)
-    bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
-
-    all_group_idxs = get_group_indices(get_bond_list(bond_pot), conf.shape[0])
-
+    conf, ref_box, all_group_idxs, nb = get_water_system_and_all_group_idxs(box_size)
     center_group = all_group_idxs[-1]
     box = np.eye(3) * (radius * 2)
     # If box volume of system is larger than the box defined by radius, use that instead
@@ -868,7 +836,6 @@ def test_targeted_moves_in_bulk_water(
 
     # Re-image coords so that everything is imaged to begin with
     conf = image_frame(all_group_idxs, conf, box)
-
     group_idxs = all_group_idxs[:-1]
 
     N = conf.shape[0]
@@ -918,15 +885,7 @@ def test_moves_with_three_waters(
     radius, proposals_per_move, batch_size, total_num_proposals, precision, rtol, atol, seed
 ):
     """Given three water molecules with one of them treated as the targeted region."""
-    ff = Forcefield.load_default()
-    system, host_conf, _, top = builders.build_water_system(1.0, ff.water_ff)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
-
-    nb = get_bound_potential_by_type(bps, Nonbonded)
-    bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
-
-    all_group_idxs = get_group_indices(get_bond_list(bond_pot), host_conf.shape[0])
-
+    host_conf, box, all_group_idxs, nb = get_water_system_and_all_group_idxs(1.0)
     # Get first two mols as the ones two move
     group_idxs = all_group_idxs[:2]
 

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -38,16 +38,12 @@ def test_deterministic_energies(precision, rtol, atol):
     # build the protein system.
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as path_to_pdb:
         host_config = builders.build_protein_system(str(path_to_pdb), ff.protein_ff, ff.water_ff)
-    # host_fns, host_masses = openmm_deserializer.deserialize_system(complex_system, cutoff=1.2)
 
-    # resolve host clashes
-    # host_config = HostConfig(complex_system, complex_coords, complex_box, num_water_atoms, complex_top)
     min_coords = minimizer.fire_minimize_host([mol_a, mol_b], host_config, ff)
 
     x0 = min_coords
     v0 = np.zeros_like(x0)
 
-    # harmonic_bond_potential = get_bound_potential_by_type(host_fns, HarmonicBond)
     bond_list = get_bond_list(host_config.host_system.bond.potential)
     group_idxs = get_group_indices(bond_list, len(host_config.masses))
     water_idxs = [group for group in group_idxs if len(group) == 3]

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -37,7 +37,7 @@ def test_deterministic_energies(precision, rtol, atol):
 
     # build the protein system.
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as path_to_pdb:
-        host_config = builders.build_protein_system(str(path_to_pdb), ff.protein_ff, ff.water_ff)
+        host_config = builders.build_protein_system(str(path_to_pdb), ff.protein_ff, ff.water_ff, mols=[mol_a, mol_b])
 
     min_coords = minimizer.fire_minimize_host([mol_a, mol_b], host_config, ff)
 

--- a/tests/test_exchange_mover.py
+++ b/tests/test_exchange_mover.py
@@ -6,24 +6,19 @@ import numpy as np
 import pytest
 
 from timemachine.constants import DEFAULT_KT, DEFAULT_WATER_FF
-from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md.barostat.utils import get_bond_list, get_group_indices
 from timemachine.md.builders import build_water_system
 from timemachine.md.exchange import exchange_mover
 from timemachine.md.exchange.exchange_mover import delta_r_np
-from timemachine.potentials import HarmonicBond
-from timemachine.potentials.potential import get_bound_potential_by_type
 
 pytestmark = [pytest.mark.nocuda]
 
 
 @pytest.mark.parametrize("num_lig_atoms", [1, 2, 3, 4, 10])
 def test_get_water_idxs(num_lig_atoms):
-    system, host_conf, _, top = build_water_system(3.0, DEFAULT_WATER_FF)
-    bps, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
-
-    bond_pot = get_bound_potential_by_type(bps, HarmonicBond).potential
-
+    host_config = build_water_system(3.0, DEFAULT_WATER_FF)
+    host_conf = host_config.conf
+    bond_pot = host_config.host_system.bond.potential
     all_group_idxs = get_group_indices(get_bond_list(bond_pot), host_conf.shape[0])
 
     assert exchange_mover.get_water_idxs(all_group_idxs) == all_group_idxs

--- a/tests/test_fe_absolute_hydration.py
+++ b/tests/test_fe_absolute_hydration.py
@@ -15,7 +15,7 @@ def test_run_solvent_absolute_hydration():
     mol, _ = testsystems.ligands.get_biphenyl()
     ff = Forcefield.load_default()
     md_params = MDParams(seed=seed, n_eq_steps=n_eq_steps, n_frames=n_frames, steps_per_frame=steps_per_frame)
-    res, _, host_config = absolute_hydration.run_solvent(mol, ff, None, md_params=md_params, n_windows=n_windows)
+    res, host_config = absolute_hydration.run_solvent(mol, ff, None, md_params=md_params, n_windows=n_windows)
 
     assert res.plots.overlap_summary_png is not None
     assert res.plots.overlap_detail_png is not None

--- a/tests/test_fe_absolute_hydration.py
+++ b/tests/test_fe_absolute_hydration.py
@@ -27,7 +27,7 @@ def test_run_solvent_absolute_hydration():
     assert len(res.boxes[0]) == n_frames
     assert len(res.boxes[-1]) == n_frames
     assert res.md_params == md_params
-    assert host_config.omm_system is not None
+    assert host_config.omm_topology is not None
     # The number of waters in the system should stay constant
     assert host_config.num_water_atoms == 6282
     assert host_config.conf.shape == (res.frames[0][0].shape[0] - mol.GetNumAtoms(), 3)

--- a/tests/test_forcefields.py
+++ b/tests/test_forcefields.py
@@ -157,9 +157,6 @@ def test_amber14_tip3p_matches_tip3p():
     assert constants.DEFAULT_WATER_FF != tip3p_water_ff
     ref_host_config = builders.build_water_system(4.0, constants.DEFAULT_WATER_FF)
     tip3p_host_config = builders.build_water_system(4.0, tip3p_water_ff)
-
-    # ref_pots, ref_masses = openmm_deserializer.deserialize_system(ref_host_config.host_system, cutoff)
-    # test_pots, test_masses = openmm_deserializer.deserialize_system(tip3p_host_config, cutoff)
     np.testing.assert_array_equal(ref_host_config.masses, tip3p_host_config.masses)
     ref_pots = ref_host_config.host_system.get_U_fns()
     test_pots = tip3p_host_config.host_system.get_U_fns()

--- a/tests/test_forcefields.py
+++ b/tests/test_forcefields.py
@@ -12,7 +12,7 @@ from rdkit import Chem
 
 from timemachine import constants
 from timemachine.ff import Forcefield, combine_params
-from timemachine.ff.handlers import nonbonded, openmm_deserializer
+from timemachine.ff.handlers import nonbonded
 from timemachine.ff.handlers.deserialize import deserialize_handlers
 from timemachine.md import builders
 
@@ -154,15 +154,15 @@ def test_amber14_tip3p_matches_tip3p():
     """Verify that given a water box, the same parameters are produced for amber14/tip3p as tip3p, but with additional
     support for Ions"""
     tip3p_water_ff = "tip3p"
-    cutoff = 1.2
     assert constants.DEFAULT_WATER_FF != tip3p_water_ff
-    ref_system, _, _, ref_top = builders.build_water_system(4.0, constants.DEFAULT_WATER_FF)
-    tip3p_system, _, _, tip3p_top = builders.build_water_system(4.0, tip3p_water_ff)
+    ref_host_config = builders.build_water_system(4.0, constants.DEFAULT_WATER_FF)
+    tip3p_host_config = builders.build_water_system(4.0, tip3p_water_ff)
 
-    ref_pots, ref_masses = openmm_deserializer.deserialize_system(ref_system, cutoff)
-    test_pots, test_masses = openmm_deserializer.deserialize_system(tip3p_system, cutoff)
-    np.testing.assert_array_equal(ref_masses, test_masses)
-
+    # ref_pots, ref_masses = openmm_deserializer.deserialize_system(ref_host_config.host_system, cutoff)
+    # test_pots, test_masses = openmm_deserializer.deserialize_system(tip3p_host_config, cutoff)
+    np.testing.assert_array_equal(ref_host_config.masses, tip3p_host_config.masses)
+    ref_pots = ref_host_config.host_system.get_U_fns()
+    test_pots = tip3p_host_config.host_system.get_U_fns()
     assert len(ref_pots) == len(test_pots)
     for ref, test in zip(ref_pots, test_pots):
         np.testing.assert_array_equal(ref.params, test.params)

--- a/tests/test_handler_utils.py
+++ b/tests/test_handler_utils.py
@@ -32,12 +32,12 @@ def residue_mol_inputs():
     for protein_path in ["5dfr_solv_equil.pdb", "hif2a_nowater_min.pdb"]:
         with resources.path("timemachine.testsystems.data", protein_path) as path_to_pdb:
             host_pdb = app.PDBFile(str(path_to_pdb))
-            _, _, _, topology, _ = builders.build_protein_system(host_pdb, DEFAULT_PROTEIN_FF, DEFAULT_WATER_FF)
+            host_config = builders.build_protein_system(host_pdb, DEFAULT_PROTEIN_FF, DEFAULT_WATER_FF)
         ff = OMMForceField(f"{DEFAULT_PROTEIN_FF}.xml", f"{DEFAULT_WATER_FF}.xml")
-        data = OMMForceField._SystemData(topology)
+        data = OMMForceField._SystemData(host_config.omm_topology)
         residueTemplates = {}
         template_for_residue = ff._matchAllResiduesToTemplates(
-            data, topology, residueTemplates, ignoreExternalBonds=False
+            data, host_config.omm_topology, residueTemplates, ignoreExternalBonds=False
         )
 
         for tfr in template_for_residue:

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1321,15 +1321,19 @@ def test_environment_bcc_full_protein(protein_path, is_nn, env_nn_args):
     """
     with resources.path("timemachine.testsystems.data", protein_path) as path_to_pdb:
         host_pdb = app.PDBFile(str(path_to_pdb))
-        _, _, _, topology, _ = builders.build_protein_system(host_pdb, DEFAULT_PROTEIN_FF, DEFAULT_WATER_FF)
+        host_config = builders.build_protein_system(host_pdb, DEFAULT_PROTEIN_FF, DEFAULT_WATER_FF)
 
     if is_nn:
         patterns, params, props = env_nn_args
-        pbcc = nonbonded.EnvironmentNNHandler(patterns, params, props, DEFAULT_PROTEIN_FF, DEFAULT_WATER_FF, topology)
+        pbcc = nonbonded.EnvironmentNNHandler(
+            patterns, params, props, DEFAULT_PROTEIN_FF, DEFAULT_WATER_FF, host_config.omm_topology
+        )
     else:
         patterns = [smirks for (smirks, param) in AM1CCC_CHARGES["patterns"]]
         params = np.random.rand(len(patterns)) - 0.5
-        pbcc = nonbonded.EnvironmentBCCHandler(patterns, params, DEFAULT_PROTEIN_FF, DEFAULT_WATER_FF, topology)
+        pbcc = nonbonded.EnvironmentBCCHandler(
+            patterns, params, DEFAULT_PROTEIN_FF, DEFAULT_WATER_FF, host_config.omm_topology
+        )
 
     # test that we can mechanically parameterize everything
     final_q_params = pbcc.parameterize(params)

--- a/tests/test_hrex_rbfe.py
+++ b/tests/test_hrex_rbfe.py
@@ -41,17 +41,13 @@ def get_hif2a_single_topology_leg(host_name: str | None):
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     if host_name == "complex":
         with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as protein_path:
-            host_sys, host_conf, box, host_top, num_water_atoms = builders.build_protein_system(
+            host_config = builders.build_protein_system(
                 str(protein_path), forcefield.protein_ff, forcefield.water_ff, mols=[mol_a, mol_b]
             )
-            box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-        host_config = HostConfig(host_sys, host_conf, box, num_water_atoms, host_top)
+            host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     elif host_name == "solvent":
-        solvent_sys, solvent_conf, box, solvent_top = builders.build_water_system(
-            4.0, forcefield.water_ff, mols=[mol_a, mol_b]
-        )
-        box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-        host_config = HostConfig(solvent_sys, solvent_conf, box, solvent_conf.shape[0], solvent_top)
+        host_config = builders.build_water_system(4.0, forcefield.water_ff, mols=[mol_a, mol_b])
+        host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
 
     return mol_a, mol_b, core, forcefield, host_config
 

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -300,7 +300,7 @@ def test_local_minimize_restrained_waters_trigger_failure(seed, minimizer_config
     # Setup a water box without a void for the mol
     host_config = builders.build_water_system(4.0, ff.water_ff)
     host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes at the boundary
-    box = host_config
+    box = host_config.box
     host_coords = host_config.conf
 
     bt = BaseTopology(benzene, ff)

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -71,7 +71,6 @@ from timemachine.potentials.jax_utils import distance_on_pairs, idxs_within_cuto
         ),
     ],
 )
-
 def test_fire_minimize_host_protein(pdb_path, sdf_path, mol_a_name, mol_b_name, run_one_test):
     ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
     with sdf_path as ligand_path:

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -7,12 +7,11 @@ from rdkit import Chem
 from rdkit.Chem import AllChem
 
 from timemachine.constants import MAX_FORCE_NORM
-from timemachine.fe.free_energy import AbsoluteFreeEnergy, HostConfig
+from timemachine.fe.free_energy import AbsoluteFreeEnergy
 from timemachine.fe.model_utils import get_vacuum_val_and_grad_fn
 from timemachine.fe.topology import BaseTopology
 from timemachine.fe.utils import get_romol_conf, read_sdf, read_sdf_mols_by_name
 from timemachine.ff import Forcefield
-from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md import builders, minimizer
 from timemachine.md.barostat.utils import compute_box_volume
 from timemachine.md.minimizer import equilibrate_host_barker, make_host_du_dx_fxn
@@ -72,6 +71,7 @@ from timemachine.potentials.jax_utils import distance_on_pairs, idxs_within_cuto
         ),
     ],
 )
+
 def test_fire_minimize_host_protein(pdb_path, sdf_path, mol_a_name, mol_b_name, run_one_test):
     ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
     with sdf_path as ligand_path:
@@ -80,16 +80,10 @@ def test_fire_minimize_host_protein(pdb_path, sdf_path, mol_a_name, mol_b_name, 
     mol_b = mols_by_name[mol_b_name]
 
     with pdb_path as host_path:
-        for mols in [[mol_a, mol_b], [mol_a], [mol_b]]:
-            complex_system, complex_coords, complex_box, complex_top, num_water_atoms = builders.build_protein_system(
-                str(host_path), ff.protein_ff, ff.water_ff, mols=mols
-            )
-            host_config = HostConfig(complex_system, complex_coords, complex_box, num_water_atoms, complex_top)
+        for mols in [[mol_a], [mol_b], [mol_a, mol_b]]:
+            host_config = builders.build_protein_system(str(host_path), ff.protein_ff, ff.water_ff, mols=mols)
             x_host = minimizer.fire_minimize_host(mols, host_config, ff)
-            assert x_host.shape == complex_coords.shape
-            # To speed up unit tests
-            if run_one_test:
-                break
+            assert x_host.shape == host_config.conf.shape
 
 
 def test_fire_minimize_host_solvent():
@@ -100,12 +94,9 @@ def test_fire_minimize_host_solvent():
     mol_b = all_mols[4]
 
     for mols in [[mol_a], [mol_b], [mol_a, mol_b]]:
-        solvent_system, solvent_coords, solvent_box, solvent_top = builders.build_water_system(
-            4.0, ff.water_ff, mols=mols
-        )
-        host_config = HostConfig(solvent_system, solvent_coords, solvent_box, len(solvent_coords), solvent_top)
+        host_config = builders.build_water_system(4.0, ff.water_ff, mols=mols)
         x_host = minimizer.fire_minimize_host(mols, host_config, ff)
-        assert x_host.shape == solvent_coords.shape
+        assert x_host.shape == host_config.conf.shape
 
 
 @pytest.mark.parametrize("host_name", ["solvent", pytest.param("complex", marks=pytest.mark.nightly(reason="slow"))])
@@ -119,16 +110,10 @@ def test_pre_equilibrate_host_pfkfb3(host_name, mol_pair):
     mol_b = mols_by_name[mol_b_name]
     mols = [mol_a, mol_b]
     if host_name == "solvent":
-        solvent_system, solvent_coords, solvent_box, solvent_top = builders.build_water_system(
-            4.0, ff.water_ff, mols=mols
-        )
-        host_config = HostConfig(solvent_system, solvent_coords, solvent_box, len(solvent_coords), solvent_top)
+        host_config = builders.build_water_system(4.0, ff.water_ff, mols=mols)
     else:
         with resources.path("timemachine.datasets.fep_benchmark.pfkfb3", "6hvi_prepared.pdb") as pdb_path:
-            complex_system, complex_coords, complex_box, complex_top, num_water_atoms = builders.build_protein_system(
-                str(pdb_path), ff.protein_ff, ff.water_ff, mols=mols
-            )
-        host_config = HostConfig(complex_system, complex_coords, complex_box, num_water_atoms, complex_top)
+            host_config = builders.build_protein_system(str(pdb_path), ff.protein_ff, ff.water_ff, mols=mols)
     x_host, x_box = minimizer.pre_equilibrate_host(mols, host_config, ff)
     assert x_host.shape == host_config.conf.shape
     box_vol_before = compute_box_volume(host_config.box)
@@ -144,10 +129,9 @@ def test_fire_minimize_host_adamantane():
     mol = Chem.AddHs(Chem.MolFromSmiles("C1C3CC2CC(CC1C2)C3"))
     AllChem.EmbedMolecule(mol, randomSeed=2024)
     # If don't delete the relevant water this minimization fails
-    solvent_system, solvent_coords, solvent_box, solvent_top = builders.build_water_system(4.0, ff.water_ff, mols=[mol])
-    host_config = HostConfig(solvent_system, solvent_coords, solvent_box, len(solvent_coords), solvent_top)
+    host_config = builders.build_water_system(4.0, ff.water_ff, mols=[mol])
     x_host = minimizer.fire_minimize_host([mol], host_config, ff)
-    assert x_host.shape == solvent_coords.shape
+    assert x_host.shape == host_config.conf.shape
 
 
 @pytest.mark.nightly(reason="Currently not used in practice")
@@ -159,10 +143,7 @@ def test_equilibrate_host_barker():
     mol_b = all_mols[4]
 
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as path_to_pdb:
-        complex_system, complex_coords, complex_box, complex_top, num_water_atoms = builders.build_protein_system(
-            str(path_to_pdb), ff.protein_ff, ff.water_ff, mols=[mol_a, mol_b]
-        )
-        host_config = HostConfig(complex_system, complex_coords, complex_box, num_water_atoms, complex_top)
+        host_config = builders.build_protein_system(str(path_to_pdb), ff.protein_ff, ff.water_ff, mols=[mol_a, mol_b])
 
     # TODO[requirements-gathering]:
     #   do we really want to minimize here ("equilibrate to temperature ~= 0"),
@@ -183,23 +164,23 @@ def test_equilibrate_host_barker():
         print(f"using unadjusted Barker proposal @ temperature = {room_temperature} K...")
         t0 = time()
         x_host = equilibrate_host_barker(mols, host_config, ff, temperature=room_temperature)
-        assert x_host.shape == complex_coords.shape
+        assert x_host.shape == host_config.conf.shape
         t1 = time()
         max_frc = np.linalg.norm(host_du_dx_fxn(x_host), axis=-1).max()
         print(f"\tforce norm after room-temperature equilibration: {max_frc:.3f} kJ/mol / nm")
-        print(f"\tmax distance traveled = {np.linalg.norm(np.array(complex_coords) - x_host, axis=-1).max():.3f} nm")
+        print(f"\tmax distance traveled = {np.linalg.norm(np.array(host_config.conf) - x_host, axis=-1).max():.3f} nm")
         print(f"\tdone in {(t1 - t0):.3f} s")
 
         print(f"using unadjusted Barker proposal @ temperature = {zero_temperature} K...")
         t0 = time()
         x_host = equilibrate_host_barker(mols, host_config, ff, temperature=zero_temperature)
-        assert x_host.shape == complex_coords.shape
+        assert x_host.shape == host_config.conf.shape
         t1 = time()
 
         max_frc = np.linalg.norm(host_du_dx_fxn(x_host), axis=-1).max()
 
         print(f"\tforce norm after low-temperature 'equilibration': {max_frc:.3f} kJ/mol / nm")
-        print(f"\tmax distance traveled = {np.linalg.norm(np.array(complex_coords) - x_host, axis=-1).max():.3f} nm")
+        print(f"\tmax distance traveled = {np.linalg.norm(np.array(host_config.conf) - x_host, axis=-1).max():.3f} nm")
         print(f"\tdone in {(t1 - t0):.3f} s")
 
 
@@ -216,11 +197,11 @@ def test_local_minimize_water_box(minimizer_config):
     Test that we can locally relax a box of water by selecting some random indices.
     """
     ff = Forcefield.load_default()
-
-    system, x0, box0, top = builders.build_water_system(4.0, ff.water_ff)
-    host_fns, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    host_config = builders.build_water_system(4.0, ff.water_ff)
+    box0 = host_config.box
     box0 += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes at the boundary
-
+    host_fns = host_config.host_system.get_U_fns()
+    x0 = host_config.conf
     val_and_grad_fn = minimizer.get_val_and_grad_fn(host_fns, box0)
 
     free_idxs = [0, 2, 3, 6, 7, 9, 15, 16]
@@ -257,8 +238,10 @@ def test_local_minimize_restrained_subset(seed, minimizer_config):
     rng = np.random.default_rng(seed)
     ff = Forcefield.load_default()
 
-    system, x0, box0, top = builders.build_water_system(4.0, ff.water_ff)
-    host_fns, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
+    host_config = builders.build_water_system(4.0, ff.water_ff)
+    host_fns = host_config.host_system.get_U_fns()
+    x0 = host_config.conf
+    box0 = host_config.box
     box0 += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes at the boundary
 
     val_and_grad_fn = minimizer.get_val_and_grad_fn(host_fns, box0)
@@ -266,8 +249,6 @@ def test_local_minimize_restrained_subset(seed, minimizer_config):
     free_idxs = rng.choice(np.arange(len(x0), dtype=np.int32), size=128, replace=False)
     frozen_idxs = set(range(len(x0))).difference(set(free_idxs))
     frozen_idxs = list(frozen_idxs)
-
-    u_init, g_init = val_and_grad_fn(x0)
 
     with pytest.raises(AssertionError, match="Restraint k be greater than 0.0 if restrained indices provided"):
         minimizer.local_minimize(x0, box0, val_and_grad_fn, free_idxs, minimizer_config, restrained_idxs=frozen_idxs)
@@ -318,12 +299,13 @@ def test_local_minimize_restrained_waters_trigger_failure(seed, minimizer_config
     lamb = 0.1
 
     # Setup a water box without a void for the mol
-    host_system, host_coords, box, host_top = builders.build_water_system(4.0, ff.water_ff)
-    box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes at the boundary
+    host_config = builders.build_water_system(4.0, ff.water_ff)
+    host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes at the boundary
+    box = host_config
+    host_coords = host_config.conf
 
     bt = BaseTopology(benzene, ff)
     afe = AbsoluteFreeEnergy(benzene, bt)
-    host_config = HostConfig(host_system, host_coords, box, host_coords.shape[0], host_top)
     unbound_potentials, sys_params, masses = afe.prepare_host_edge(ff, host_config, lamb)
     coords = afe.prepare_combined_coords(host_coords=host_coords)
 
@@ -362,10 +344,11 @@ def test_local_minimize_water_box_with_bounds():
     """
     ff = Forcefield.load_default()
 
-    system, x0, box0, top = builders.build_water_system(4.0, ff.water_ff)
-    host_fns, _ = openmm_deserializer.deserialize_system(system, cutoff=1.2)
-    box0 += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes at the boundary
-
+    host_config = builders.build_water_system(4.0, ff.water_ff)
+    host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes at the boundary
+    box0 = host_config.box
+    x0 = host_config.conf
+    host_fns = host_config.host_system.get_U_fns()
     val_and_grad_fn = minimizer.get_val_and_grad_fn(host_fns, box0)
 
     free_idxs = [0, 2, 3, 6, 7, 9, 15, 16]

--- a/tests/test_missing_gpu.py
+++ b/tests/test_missing_gpu.py
@@ -14,7 +14,7 @@ pytestmark = [pytest.mark.nogpu, pytest.mark.nightly]
 
 def test_no_gpu_raises_exception():
     ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
-    solvent_system, solvent_coords, solvent_box, top = builders.build_water_system(3.0, ff.water_ff)
+    solvent_system = builders.build_water_system(3.0, ff.water_ff).host_system
 
     host_fns, _ = openmm_deserializer.deserialize_system(solvent_system, cutoff=1.2)
 

--- a/tests/test_nblist.py
+++ b/tests/test_nblist.py
@@ -315,7 +315,7 @@ def test_neighborlist_on_subset_of_system():
     ligand_coords = get_romol_conf(ligand)
     ff = Forcefield.load_default()
 
-    system, host_coords, box, top = build_water_system(4.0, ff.water_ff, mols=[ligand])
+    host_coords = build_water_system(4.0, ff.water_ff, mols=[ligand]).conf
     num_host_atoms = host_coords.shape[0]
     host_coords = np.array(host_coords)
 
@@ -397,23 +397,19 @@ def setup_hif2a_initial_state(host_name: str):
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
     if host_name == "complex":
         with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as protein_path:
-            host_sys, host_conf, box, host_top, num_water_atoms = build_protein_system(
+            host_config = build_protein_system(
                 str(protein_path), forcefield.protein_ff, forcefield.water_ff, mols=[mol_a, mol_b]
             )
-            box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-        host_config = HostConfig(host_sys, host_conf, box, num_water_atoms, host_top)
+            host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     elif host_name == "solvent":
-        solvent_sys, solvent_conf, box, sovlent_top = build_water_system(4.0, forcefield.water_ff, mols=[mol_a, mol_b])
-        box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-        host_config = HostConfig(solvent_sys, solvent_conf, box, solvent_conf.shape[0], sovlent_top)
+        host_config = build_water_system(4.0, forcefield.water_ff, mols=[mol_a, mol_b])
+        host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     else:
         assert 0, "Invalid host name"
 
     st = SingleTopology(mol_a, mol_b, core, forcefield)
     host = setup_optimized_host(st, host_config)
-
     lambda_grid = np.array([0.0])
-
     initial_state = setup_initial_states(st, host, DEFAULT_TEMP, lambda_grid, seed=2024, min_cutoff=None)[0]
 
     return st, host, host_name, initial_state

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -22,7 +22,6 @@ from timemachine.constants import (
 )
 from timemachine.fe import atom_mapping, single_topology
 from timemachine.fe.dummy import MultipleAnchorWarning, canonicalize_bond
-from timemachine.fe.free_energy import HostConfig
 from timemachine.fe.interpolate import align_nonbonded_idxs_and_params, linear_interpolation
 from timemachine.fe.single_topology import (
     AtomMapMixin,
@@ -37,10 +36,9 @@ from timemachine.fe.single_topology import (
     interpolate_w_coord,
     setup_dummy_interactions_from_ff,
 )
-from timemachine.fe.system import convert_bps_into_system, minimize_scipy, simulate_system
+from timemachine.fe.system import minimize_scipy, simulate_system
 from timemachine.fe.utils import get_mol_name, get_romol_conf, read_sdf, read_sdf_mols_by_name, set_mol_name
 from timemachine.ff import Forcefield
-from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md import minimizer
 from timemachine.md.builders import build_protein_system, build_water_system
 from timemachine.potentials.jax_utils import pairwise_distances
@@ -766,23 +764,26 @@ def test_combine_achiral_ligand_with_host():
     core = np.array([[1, 0], [2, 1], [3, 2], [4, 3], [5, 4], [6, 5]])
     ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
 
-    solvent_sys, solvent_conf, _, top = build_water_system(4.0, ff.water_ff, mols=[mol_a, mol_b])
-    host_bps, _ = openmm_deserializer.deserialize_system(solvent_sys, cutoff=1.2)
-
+    host_config = build_water_system(4.0, ff.water_ff, mols=[mol_a, mol_b])
     st = SingleTopology(mol_a, mol_b, core, ff)
-    combined_system = st.combine_with_host(convert_bps_into_system(host_bps), 0.5, solvent_conf.shape[0], ff, top)
-    assert set(type(bp.potential) for bp in combined_system.get_U_fns()) == {
-        potentials.HarmonicBond,
-        potentials.HarmonicAngleStable,
-        potentials.PeriodicTorsion,
-        potentials.NonbondedPairListPrecomputed,
-        potentials.Nonbonded,
-        potentials.NonbondedInteractionGroup,  # L-P + L-W interactions
-        # potentials.ChiralAtomRestraint, # this is missing since the atoms do not define tetrahedral chiral centers
-        # potentials.ChiralBondRestraint,
-        # NOTE: chiral bond restraints excluded
-        # This should be updated when chiral restraints are re-enabled.
-    }
+    combined_system = st.combine_with_host(
+        host_config.host_system, 0.5, host_config.conf.shape[0], ff, host_config.omm_topology
+    )
+    assert (
+        set(type(bp.potential) for bp in combined_system.get_U_fns())
+        == {
+            potentials.HarmonicBond,
+            potentials.HarmonicAngleStable,
+            potentials.PeriodicTorsion,
+            potentials.NonbondedPairListPrecomputed,
+            potentials.Nonbonded,
+            potentials.NonbondedInteractionGroup,  # L-P + L-W interactions
+            potentials.ChiralAtomRestraint,  # this is no longer missing since we now emit all potentials, even if they're length 0
+            # potentials.ChiralBondRestraint,
+            # NOTE: chiral bond restraints excluded
+            # This should be updated when chiral restraints are re-enabled.
+        }
+    )
 
 
 @pytest.mark.nocuda
@@ -793,12 +794,11 @@ def test_combine_chiral_ligand_with_host():
 
     core = np.array([[1, 0], [2, 1], [3, 2], [4, 3], [5, 4], [6, 5]])
     ff = Forcefield.load_from_file("smirnoff_1_1_0_sc.py")
-
-    solvent_sys, solvent_conf, _, top = build_water_system(4.0, ff.water_ff, mols=[mol_a, mol_b])
-    host_bps, _ = openmm_deserializer.deserialize_system(solvent_sys, cutoff=1.2)
-
+    host_config = build_water_system(4.0, ff.water_ff, mols=[mol_a, mol_b])
     st = SingleTopology(mol_a, mol_b, core, ff)
-    combined_system = st.combine_with_host(convert_bps_into_system(host_bps), 0.5, solvent_conf.shape[0], ff, top)
+    combined_system = st.combine_with_host(
+        host_config.host_system, 0.5, host_config.conf.shape[0], ff, host_config.omm_topology
+    )
     assert set(type(bp.potential) for bp in combined_system.get_U_fns()) == {
         potentials.HarmonicBond,
         potentials.HarmonicAngleStable,
@@ -831,13 +831,9 @@ def test_nonbonded_intra_split(precision, rtol, atol, use_tiny_mol):
 
     # split forcefield has different parameters for intramol and intermol terms
     ffs = load_split_forcefields()
-    solvent_sys, solvent_conf, solvent_box, solvent_top = build_water_system(4.0, ffs.ref.water_ff, mols=[mol_a, mol_b])
-    solvent_box += np.eye(3) * 0.1
-    solvent_conf = minimizer.fire_minimize_host(
-        [mol_a, mol_b], HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0], solvent_top), ffs.ref
-    )
-    solvent_bps, _ = openmm_deserializer.deserialize_system(solvent_sys, cutoff=1.2)
-    solv_sys = convert_bps_into_system(solvent_bps)
+    solvent_host_config = build_water_system(4.0, ffs.ref.water_ff, mols=[mol_a, mol_b])
+    solvent_host_config.box += np.eye(3) * 0.1
+    solvent_conf = minimizer.fire_minimize_host([mol_a, mol_b], solvent_host_config, ffs.ref)
 
     def get_vacuum_solvent_u_grads(ff, lamb):
         st = SingleTopology(mol_a, mol_b, core, ff)
@@ -846,12 +842,16 @@ def test_nonbonded_intra_split(precision, rtol, atol, use_tiny_mol):
 
         vacuum_system = st.setup_intermediate_state(lamb)
         vacuum_potentials = vacuum_system.get_U_fns()
-        val_and_grad_fn = minimizer.get_val_and_grad_fn(vacuum_potentials, solvent_box, precision=precision)
+        val_and_grad_fn = minimizer.get_val_and_grad_fn(vacuum_potentials, solvent_host_config.box, precision=precision)
         vacuum_u, vacuum_grad = val_and_grad_fn(ligand_conf)
 
-        solvent_system = st.combine_with_host(solv_sys, lamb, solvent_conf.shape[0], ff, solvent_top)
+        solvent_system = st.combine_with_host(
+            solvent_host_config.host_system, lamb, solvent_conf.shape[0], ff, solvent_host_config.omm_topology
+        )
         solvent_potentials = solvent_system.get_U_fns()
-        solv_val_and_grad_fn = minimizer.get_val_and_grad_fn(solvent_potentials, solvent_box, precision=precision)
+        solv_val_and_grad_fn = minimizer.get_val_and_grad_fn(
+            solvent_potentials, solvent_host_config.box, precision=precision
+        )
         solvent_u, solvent_grad = solv_val_and_grad_fn(combined_conf)
         return vacuum_grad, vacuum_u, solvent_grad, solvent_u
 
@@ -930,16 +930,14 @@ def test_nonbonded_intra_split_bitwise_identical(precision, lamb):
     ff = Forcefield.load_default()
 
     with resources.path("timemachine.testsystems.data", "hif2a_nowater_min.pdb") as path_to_pdb:
-        complex_system, complex_coords, box, complex_top, num_water_atoms = build_protein_system(
-            str(path_to_pdb), ff.protein_ff, ff.water_ff
-        )
-        box += np.diag([0.1, 0.1, 0.1])
+        host_config = build_protein_system(str(path_to_pdb), ff.protein_ff, ff.water_ff)
+        host_config.box += np.diag([0.1, 0.1, 0.1])
 
-    host_bps, host_masses = openmm_deserializer.deserialize_system(complex_system, cutoff=1.2)
-    host_system = convert_bps_into_system(host_bps)
     st_ref = SingleTopologyRef(mol_a, mol_b, core, ff)
 
-    combined_ref = st_ref.combine_with_host(host_system, lamb, num_water_atoms, ff, complex_top)
+    combined_ref = st_ref.combine_with_host(
+        host_config.host_system, lamb, host_config.num_water_atoms, ff, host_config.omm_topology
+    )
     ref_potentials = combined_ref.get_U_fns()
     ref_summed = potentials.SummedPotential(
         [bp.potential for bp in ref_potentials], [bp.params for bp in ref_potentials]
@@ -947,7 +945,9 @@ def test_nonbonded_intra_split_bitwise_identical(precision, lamb):
     flattened_ref_params = np.concatenate([bp.params.reshape(-1) for bp in ref_potentials])
 
     st_split = SingleTopology(mol_a, mol_b, core, ff)
-    combined_split = st_split.combine_with_host(host_system, lamb, num_water_atoms, ff, complex_top)
+    combined_split = st_split.combine_with_host(
+        host_config.host_system, lamb, host_config.num_water_atoms, ff, host_config.omm_topology
+    )
     split_potentials = combined_split.get_U_fns()
     split_summed = potentials.SummedPotential(
         [bp.potential for bp in split_potentials], [bp.params for bp in split_potentials]
@@ -955,14 +955,14 @@ def test_nonbonded_intra_split_bitwise_identical(precision, lamb):
     flattened_split_params = np.concatenate([bp.params.reshape(-1) for bp in split_potentials])
 
     ligand_conf = st_ref.combine_confs(get_romol_conf(mol_a), get_romol_conf(mol_b), lamb)
-    combined_conf = np.concatenate([complex_coords, ligand_conf])
+    combined_conf = np.concatenate([host_config.conf, ligand_conf])
 
     # Ensure that the du_dx and du_dp are exactly identical, ignore du_dp as shapes are different
     ref_du_dx, _, ref_u = ref_summed.to_gpu(precision).unbound_impl.execute(
-        combined_conf, flattened_ref_params, box, True, False, True
+        combined_conf, flattened_ref_params, host_config.box, True, False, True
     )
     split_du_dx, _, split_u = split_summed.to_gpu(precision).unbound_impl.execute(
-        combined_conf, flattened_split_params, box, True, False, True
+        combined_conf, flattened_split_params, host_config.box, True, False, True
     )
     np.testing.assert_array_equal(ref_du_dx, split_du_dx)
     np.testing.assert_equal(ref_u, split_u)
@@ -981,9 +981,8 @@ def test_combine_with_host_split(precision, rtol, atol):
     mol_b = mols["43"]
     core = _get_core_by_mcs(mol_a, mol_b)
 
-    def compute_ref_grad_u(ff: Forcefield, precision, x0, box, lamb, num_water_atoms, host_bps, omm_topology):
+    def compute_ref_grad_u(ff: Forcefield, precision, x0, box, lamb, num_water_atoms, host_system, omm_topology):
         # Use the original code to compute the nb grads and potential
-        host_system = convert_bps_into_system(host_bps)
         st = SingleTopologyRef(mol_a, mol_b, core, ff)
         ligand_conf = st.combine_confs(get_romol_conf(mol_a), get_romol_conf(mol_b), lamb)
         num_host_atoms = x0.shape[0] - ligand_conf.shape[0]
@@ -994,8 +993,7 @@ def test_combine_with_host_split(precision, rtol, atol):
         u, grad = minimizer.get_val_and_grad_fn(potentials, box, precision=precision)(combined_conf)
         return grad, u
 
-    def compute_new_grad_u(ff: Forcefield, precision, x0, box, lamb, num_water_atoms, host_bps, omm_topology):
-        host_system = convert_bps_into_system(host_bps)
+    def compute_new_grad_u(ff: Forcefield, precision, x0, box, lamb, num_water_atoms, host_system, omm_topology):
         st = SingleTopology(mol_a, mol_b, core, ff)
         ligand_conf = st.combine_confs(get_romol_conf(mol_a), get_romol_conf(mol_b), lamb)
         num_host_atoms = x0.shape[0] - ligand_conf.shape[0]
@@ -1025,7 +1023,7 @@ def test_combine_with_host_split(precision, rtol, atol):
         box,
         lamb,
         num_water_atoms,
-        host_bps,
+        host_system,
         water_idxs,
         ligand_idxs,
         protein_idxs,
@@ -1033,7 +1031,6 @@ def test_combine_with_host_split(precision, rtol, atol):
         is_solvent=False,
     ):
         assert num_water_atoms == len(water_idxs)
-        host_system = convert_bps_into_system(host_bps)
         st = SingleTopology(mol_a, mol_b, core, ff)
         ligand_conf = st.combine_confs(get_romol_conf(mol_a), get_romol_conf(mol_b), lamb)
         num_host_atoms = x0.shape[0] - ligand_conf.shape[0]

--- a/tests/test_single_topology_combined.py
+++ b/tests/test_single_topology_combined.py
@@ -6,8 +6,9 @@ import pytest
 
 from timemachine import potentials
 from timemachine.fe.single_topology import SingleTopology
-from timemachine.fe.system import convert_omm_system
+from timemachine.fe.system import HostSystem
 from timemachine.ff import Forcefield
+from timemachine.ff.handlers import openmm_deserializer
 from timemachine.md import builders
 from timemachine.testsystems.dhfr import get_dhfr_system
 from timemachine.testsystems.relative import get_hif2a_ligand_pair_single_topology
@@ -24,17 +25,20 @@ def hif2a_ligand_pair_single_topology():
 
 @pytest.fixture(scope="module")
 def complex_host_system():
+    # (YTZ): we need to clean this up later, since it uses a pre-solvated xml file.
     host_sys_omm, host_top = get_dhfr_system()
     # Hardcoded to match 5dfr_solv_equil.pdb file
     num_water_atoms = 21069
-    return convert_omm_system(host_sys_omm), num_water_atoms, host_top
+    (bond, angle, proper, improper, nonbonded), masses = openmm_deserializer.deserialize_system(host_sys_omm, 1.2)
+    host_system = HostSystem(bond=bond, angle=angle, proper=proper, improper=improper, nonbonded_all_pairs=nonbonded)
+    return host_system, masses, num_water_atoms, host_top
 
 
 @pytest.fixture(scope="module")
 def solvent_host_system():
     ff = Forcefield.load_default()
-    host_sys_omm, conf, _, top = builders.build_water_system(3.0, ff.water_ff)
-    return convert_omm_system(host_sys_omm), conf.shape[0], top
+    host_config = builders.build_water_system(3.0, ff.water_ff)
+    return host_config.host_system, host_config.masses, host_config.conf.shape[0], host_config.omm_topology
 
 
 @pytest.mark.parametrize("lamb", [0.0, 1.0])
@@ -46,7 +50,7 @@ def test_combined_parameters_bonded(host_system_fixture, lamb, hif2a_ligand_pair
     # 3) we expected nonbonded parameters on the core to be linearly interpolated
 
     st = hif2a_ligand_pair_single_topology
-    (host_sys, host_masses), num_water_atoms, omm_topology = request.getfixturevalue(host_system_fixture)
+    host_sys, host_masses, num_water_atoms, omm_topology = request.getfixturevalue(host_system_fixture)
     num_host_atoms = len(host_masses)
 
     def check_bonded_idxs_consistency(bonded_idxs, num_host_idxs):
@@ -57,16 +61,16 @@ def test_combined_parameters_bonded(host_system_fixture, lamb, hif2a_ligand_pair
                 assert np.all(atom_idxs >= num_host_atoms)
 
     # generate host guest system
-    hgs = st.combine_with_host(host_sys, lamb, num_water_atoms, st.ff, omm_topology)
+    host_guest_sys = st.combine_with_host(host_sys, lamb, num_water_atoms, st.ff, omm_topology)
 
     # check bonds
-    check_bonded_idxs_consistency(hgs.bond.potential.idxs, len(host_sys.bond.potential.idxs))
-    check_bonded_idxs_consistency(hgs.angle.potential.idxs, len(host_sys.angle.potential.idxs))
-    check_bonded_idxs_consistency(hgs.proper.potential.idxs, len(host_sys.proper.potential.idxs))
-    check_bonded_idxs_consistency(hgs.improper.potential.idxs, len(host_sys.improper.potential.idxs))
-    check_bonded_idxs_consistency(hgs.chiral_atom.potential.idxs, 0)
-    check_bonded_idxs_consistency(hgs.chiral_bond.potential.idxs, 0)
-    check_bonded_idxs_consistency(hgs.nonbonded_pair_list.potential.idxs, 0)
+    check_bonded_idxs_consistency(host_guest_sys.bond.potential.idxs, len(host_sys.bond.potential.idxs))
+    check_bonded_idxs_consistency(host_guest_sys.angle.potential.idxs, len(host_sys.angle.potential.idxs))
+    check_bonded_idxs_consistency(host_guest_sys.proper.potential.idxs, len(host_sys.proper.potential.idxs))
+    check_bonded_idxs_consistency(host_guest_sys.improper.potential.idxs, len(host_sys.improper.potential.idxs))
+    check_bonded_idxs_consistency(host_guest_sys.chiral_atom.potential.idxs, 0)
+    check_bonded_idxs_consistency(host_guest_sys.chiral_bond.potential.idxs, 0)
+    check_bonded_idxs_consistency(host_guest_sys.nonbonded_pair_list.potential.idxs, 0)
 
 
 @pytest.mark.parametrize("lamb", [0.0, 1.0])
@@ -78,7 +82,7 @@ def test_combined_parameters_nonbonded(host_system_fixture, lamb, hif2a_ligand_p
     # 3) we expected nonbonded parameters on the core to be linearly interpolated
 
     st = hif2a_ligand_pair_single_topology
-    (host_sys, host_masses), num_water_atoms, omm_topology = request.getfixturevalue(host_system_fixture)
+    host_sys, host_masses, num_water_atoms, omm_topology = request.getfixturevalue(host_system_fixture)
     num_host_atoms = len(host_masses)
 
     hgs = st.combine_with_host(host_sys, lamb, num_water_atoms, st.ff, omm_topology)
@@ -166,7 +170,7 @@ def test_combined_parameters_nonbonded_intermediate(
     host_system_fixture, lamb, hif2a_ligand_pair_single_topology: SingleTopology, request
 ):
     st = hif2a_ligand_pair_single_topology
-    (host_sys, host_masses), num_water_atoms, omm_topology = request.getfixturevalue(host_system_fixture)
+    host_sys, host_masses, num_water_atoms, omm_topology = request.getfixturevalue(host_system_fixture)
     num_host_atoms = len(host_masses)
 
     hgs = st.combine_with_host(host_sys, lamb, num_water_atoms, st.ff, omm_topology)
@@ -203,7 +207,7 @@ def test_nonbonded_host_params_independent_of_lambda(
     host_system_fixture, hif2a_ligand_pair_single_topology: SingleTopology, request
 ):
     st = hif2a_ligand_pair_single_topology
-    (host_sys, _), num_water_atoms, omm_topology = request.getfixturevalue(host_system_fixture)
+    host_sys, _, num_water_atoms, omm_topology = request.getfixturevalue(host_system_fixture)
 
     @jax.jit
     def get_nonbonded_host_params(lamb):

--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -180,7 +180,7 @@ def test_min_cutoff_failure(pair, seed, n_windows):
     lambda_grid = np.linspace(0.0, 1.0, n_windows)
 
     solvent_host_config = builders.build_water_system(box_width, ff.water_ff, mols=[mol_a, mol_b])
-    solvent_host_config += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
+    solvent_host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     solvent_host = setup_optimized_host(st, solvent_host_config)
     ligand_idxs = np.arange(st.get_num_atoms()) + solvent_host.conf.shape[0]
     expected_moved = ligand_idxs[st.c_flags != 2]

--- a/tests/test_single_topology_confgen.py
+++ b/tests/test_single_topology_confgen.py
@@ -6,7 +6,6 @@ from rdkit import Chem
 
 from timemachine.constants import DEFAULT_ATOM_MAPPING_KWARGS, DEFAULT_TEMP
 from timemachine.fe import atom_mapping, cif_writer, utils
-from timemachine.fe.free_energy import HostConfig
 from timemachine.fe.rbfe import (
     get_free_idxs,
     optimize_coords_state,
@@ -54,11 +53,8 @@ def run_edge(mol_a, mol_b, protein_path, n_windows):
 
     # solvent
     box_width = 4.0
-    solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(
-        box_width, ff.water_ff, mols=[mol_a, mol_b]
-    )
-    solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0], solvent_top)
+    solvent_host_config = builders.build_water_system(box_width, ff.water_ff, mols=[mol_a, mol_b])
+    solvent_host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     solvent_host = setup_optimized_host(st, solvent_host_config)
     initial_states = setup_initial_states(st, solvent_host, DEFAULT_TEMP, lambda_schedule, seed)
 
@@ -69,16 +65,13 @@ def run_edge(mol_a, mol_b, protein_path, n_windows):
             mol_b,
             core,
             all_frames,
-            solvent_top,
+            solvent_host_config.omm_topology,
             f"solvent_{get_mol_name(mol_a)}_{get_mol_name(mol_b)}.cif",
         )
 
     # complex
-    complex_sys, complex_conf, complex_box, complex_top, num_water_atoms = builders.build_protein_system(
-        protein_path, ff.protein_ff, ff.water_ff, mols=[mol_a, mol_b]
-    )
-    complex_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-    complex_host_config = HostConfig(complex_sys, complex_conf, complex_box, num_water_atoms, complex_top)
+    complex_host_config = builders.build_protein_system(protein_path, ff.protein_ff, ff.water_ff, mols=[mol_a, mol_b])
+    complex_host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     complex_host = setup_optimized_host(st, complex_host_config)
     initial_states = setup_initial_states(st, complex_host, DEFAULT_TEMP, lambda_schedule, seed, min_cutoff=0.7)
 
@@ -89,7 +82,7 @@ def run_edge(mol_a, mol_b, protein_path, n_windows):
             mol_b,
             core,
             all_frames,
-            complex_top,
+            complex_host_config.omm_topology,
             f"complex_{get_mol_name(mol_a)}_{get_mol_name(mol_b)}.cif",
         )
 
@@ -186,11 +179,8 @@ def test_min_cutoff_failure(pair, seed, n_windows):
     # Use the lambda grid as defined for Bisection
     lambda_grid = np.linspace(0.0, 1.0, n_windows)
 
-    solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(
-        box_width, ff.water_ff, mols=[mol_a, mol_b]
-    )
-    solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
-    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0], solvent_top)
+    solvent_host_config = builders.build_water_system(box_width, ff.water_ff, mols=[mol_a, mol_b])
+    solvent_host_config += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes
     solvent_host = setup_optimized_host(st, solvent_host_config)
     ligand_idxs = np.arange(st.get_num_atoms()) + solvent_host.conf.shape[0]
     expected_moved = ligand_idxs[st.c_flags != 2]

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -99,10 +99,10 @@ def test_host_guest_nonbonded(ctor, precision, rtol, atol, use_tiny_mol):
 
 @no_type_check
 def host_guest_nonbonded_impl(ctor, precision, rtol, atol, use_tiny_mol):
-    def compute_ref_grad_u(ff: Forcefield, precision, x0, box, lamb, num_water_atoms, host_bps, omm_topology):
+    def compute_ref_grad_u(ff: Forcefield, precision, x0, box, lamb, num_water_atoms, host_system, omm_topology):
         # Use the original code to compute the nb grads and potential
         bt = Topology(ff)
-        hgt = topology.HostGuestTopology(host_bps, bt, num_water_atoms, ff, omm_topology)
+        hgt = topology.HostGuestTopology(host_system.get_U_fns(), bt, num_water_atoms, ff, omm_topology)
         params, us = parameterize_nonbonded_full(
             hgt,
             ff.q_handle.params,
@@ -114,10 +114,10 @@ def host_guest_nonbonded_impl(ctor, precision, rtol, atol, use_tiny_mol):
         u_impl = us.bind(params).to_gpu(precision=precision).bound_impl
         return u_impl.execute(x0, box)
 
-    def compute_new_grad_u(ff: Forcefield, precision, x0, box, lamb, num_water_atoms, host_bps, omm_topology):
+    def compute_new_grad_u(ff: Forcefield, precision, x0, box, lamb, num_water_atoms, host_system, omm_topology):
         # Use the updated topology code to compute the nb grads and potential
         bt = Topology(ff)
-        hgt = topology.HostGuestTopology(host_bps, bt, num_water_atoms, ff, omm_topology)
+        hgt = topology.HostGuestTopology(host_system.get_U_fns(), bt, num_water_atoms, ff, omm_topology)
         params, us = hgt.parameterize_nonbonded(
             ff.q_handle.params,
             ff.q_handle_intra.params,
@@ -152,7 +152,7 @@ def host_guest_nonbonded_impl(ctor, precision, rtol, atol, use_tiny_mol):
         box,
         lamb,
         num_water_atoms,
-        host_bps,
+        host_system,
         water_idxs,
         ligand_idxs,
         protein_idxs,
@@ -162,7 +162,7 @@ def host_guest_nonbonded_impl(ctor, precision, rtol, atol, use_tiny_mol):
         assert num_water_atoms == len(water_idxs)
         num_total_atoms = len(ligand_idxs) + len(protein_idxs) + num_water_atoms
         bt = Topology(ff)
-        hgt = topology.HostGuestTopology(host_bps, bt, num_water_atoms, ff, omm_topology)
+        hgt = topology.HostGuestTopology(host_system.get_U_fns(), bt, num_water_atoms, ff, omm_topology)
         u = potentials.NonbondedInteractionGroup(
             num_total_atoms,
             ligand_idxs,

--- a/timemachine/fe/rbfe.py
+++ b/timemachine/fe/rbfe.py
@@ -37,7 +37,7 @@ from timemachine.fe.plots import (
 )
 from timemachine.fe.rest.single_topology import SingleTopologyREST
 from timemachine.fe.single_topology import AtomMapFlags, SingleTopology, assert_default_system_constraints
-from timemachine.fe.system import HostSystem, convert_omm_system
+from timemachine.fe.system import HostSystem
 from timemachine.fe.utils import bytes_to_id, get_mol_name, get_romol_conf
 from timemachine.ff import Forcefield
 from timemachine.lib import LangevinIntegrator, MonteCarloBarostat
@@ -224,9 +224,8 @@ def setup_optimized_host(st: SingleTopology, config: HostConfig) -> Host:
     Host
         Minimized host state
     """
-    system, masses = convert_omm_system(config.omm_system)
     conf, box = minimizer.pre_equilibrate_host([st.mol_a, st.mol_b], config, st.ff)
-    return Host(system, masses, conf, box, config.num_water_atoms, config.omm_topology)
+    return Host(config.host_system, config.masses, conf, box, config.num_water_atoms, config.omm_topology)
 
 
 def setup_initial_states(
@@ -1087,11 +1086,8 @@ def run_solvent(
         md_params = replace(md_params, water_sampling_params=None)
         warnings.warn("Solvent simulations don't benefit from water sampling, disabling")
     box_width = 4.0
-    solvent_sys, solvent_conf, solvent_box, solvent_top = builders.build_water_system(
-        box_width, forcefield.water_ff, mols=[mol_a, mol_b]
-    )
-    solvent_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes, deboggle later
-    solvent_host_config = HostConfig(solvent_sys, solvent_conf, solvent_box, solvent_conf.shape[0], solvent_top)
+    solvent_host_config = builders.build_water_system(box_width, forcefield.water_ff, mols=[mol_a, mol_b])
+    solvent_host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes, deboggle later
     # min_cutoff defaults to None since the original poses tend to come from posing in a complex and
     # in solvent the molecules may adopt significantly different poses
     solvent_res = estimate_relative_free_energy_bisection_or_hrex(
@@ -1106,7 +1102,7 @@ def run_solvent(
         min_overlap=min_overlap,
         min_cutoff=min_cutoff,
     )
-    return solvent_res, solvent_top, solvent_host_config
+    return solvent_res, solvent_host_config
 
 
 def run_complex(
@@ -1120,11 +1116,10 @@ def run_complex(
     min_overlap: Optional[float] = None,
     min_cutoff: Optional[float] = 0.7,
 ):
-    complex_sys, complex_conf, complex_box, complex_top, nwa = builders.build_protein_system(
+    complex_host_config = builders.build_protein_system(
         protein, forcefield.protein_ff, forcefield.water_ff, mols=[mol_a, mol_b]
     )
-    complex_box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes, deboggle later
-    complex_host_config = HostConfig(complex_sys, complex_conf, complex_box, nwa, complex_top)
+    complex_host_config.box += np.diag([0.1, 0.1, 0.1])  # remove any possible clashes, deboggle later
     complex_res = estimate_relative_free_energy_bisection_or_hrex(
         mol_a,
         mol_b,
@@ -1137,4 +1132,4 @@ def run_complex(
         min_overlap=min_overlap,
         min_cutoff=min_cutoff,
     )
-    return complex_res, complex_top, complex_host_config
+    return complex_res, complex_host_config

--- a/timemachine/fe/system.py
+++ b/timemachine/fe/system.py
@@ -106,7 +106,6 @@ class AbstractSystem(ABC):
         for f in fields(self):
             bp = getattr(self, f.name)
             # (TODO): chiral_bonds currently disabled
-            # if f.name != "chiral_bond" and len(bp.params) > 0:
             if f.name != "chiral_bond":
                 potentials.append(bp)
 

--- a/timemachine/ff/handlers/openmm_deserializer.py
+++ b/timemachine/ff/handlers/openmm_deserializer.py
@@ -145,9 +145,6 @@ def deserialize_system(system: mm.System, cutoff: float) -> Tuple[List[potential
     -------
     list of lib.Potential, masses
 
-    Note: We add a small epsilon (1e-3) to all zero eps values to prevent
-    a singularity from occurring in the lennard jones derivatives
-
     """
 
     bond = angle = proper = improper = nonbonded = None

--- a/timemachine/md/builders.py
+++ b/timemachine/md/builders.py
@@ -167,7 +167,6 @@ def build_protein_system(
         modeller.topology, nonbondedMethod=app.NoCutoff, constraints=None, rigidWater=False
     )
 
-    # note, masses are not needed....
     (bond, angle, proper, improper, nonbonded), masses = openmm_deserializer.deserialize_system(
         solvated_omm_host_system, cutoff=1.2
     )
@@ -253,7 +252,6 @@ def build_water_system(box_width: float, water_ff: str, mols: Optional[List[Chem
     # Determine box from the system's coordinates
     box = get_box_from_coords(solvated_host_coords)
 
-    # note, masses are not needed....
     (bond, angle, proper, improper, nonbonded), masses = openmm_deserializer.deserialize_system(
         omm_host_system, cutoff=1.2
     )

--- a/timemachine/md/builders.py
+++ b/timemachine/md/builders.py
@@ -6,8 +6,11 @@ from numpy.typing import NDArray
 from openmm import app, unit
 from rdkit import Chem
 
+from timemachine.fe.free_energy import HostConfig
+from timemachine.fe.system import HostSystem
 from timemachine.fe.utils import get_romol_conf
 from timemachine.ff import sanitize_water_ff
+from timemachine.ff.handlers import openmm_deserializer
 from timemachine.potentials.jax_utils import idxs_within_cutoff
 
 WATER_RESIDUE_NAME = "HOH"
@@ -92,7 +95,7 @@ def replace_clashy_waters(
 
 def build_protein_system(
     host_pdbfile: Union[app.PDBFile, str], protein_ff: str, water_ff: str, mols: Optional[List[Chem.Mol]] = None
-):
+) -> HostConfig:
     """
     Build a solvated protein system with a 10A padding.
 
@@ -113,8 +116,7 @@ def build_protein_system(
 
     Returns
     -------
-    5-Tuple
-        OpenMM host system, coordinates, box, OpenMM topology, number of water atoms
+    HostConfig
     """
 
     host_ff = app.ForceField(f"{protein_ff}.xml", f"{water_ff}.xml")
@@ -161,17 +163,39 @@ def build_protein_system(
     assert modeller.getTopology().getNumAtoms() == solvated_host_coords.shape[0]
 
     print("building a protein system with", num_host_atoms, "protein atoms and", num_water_atoms, "water atoms")
-    solvated_host_system = host_ff.createSystem(
+    solvated_omm_host_system = host_ff.createSystem(
         modeller.topology, nonbondedMethod=app.NoCutoff, constraints=None, rigidWater=False
+    )
+
+    # note, masses are not needed....
+    (bond, angle, proper, improper, nonbonded), masses = openmm_deserializer.deserialize_system(
+        solvated_omm_host_system, cutoff=1.2
+    )
+
+    solvated_host_system = HostSystem(
+        bond=bond,
+        angle=angle,
+        proper=proper,
+        improper=improper,
+        nonbonded_all_pairs=nonbonded,
     )
 
     # Determine box from the system's coordinates
     box = get_box_from_coords(solvated_host_coords)
 
-    return solvated_host_system, solvated_host_coords, box, modeller.topology, num_water_atoms
+    assert len(list(modeller.topology.atoms())) == len(solvated_host_coords)
+
+    return HostConfig(
+        host_system=solvated_host_system,
+        conf=solvated_host_coords,
+        box=box,
+        num_water_atoms=num_water_atoms,
+        omm_topology=modeller.topology,
+        masses=masses,
+    )
 
 
-def build_water_system(box_width: float, water_ff: str, mols: Optional[List[Chem.Mol]] = None):
+def build_water_system(box_width: float, water_ff: str, mols: Optional[List[Chem.Mol]] = None) -> HostConfig:
     """
     Build a water system with a cubic box with each side of length box_width.
 
@@ -223,9 +247,36 @@ def build_water_system(box_width: float, water_ff: str, mols: Optional[List[Chem
 
     assert modeller.getTopology().getNumAtoms() == solvated_host_coords.shape[0]
 
-    system = ff.createSystem(modeller.getTopology(), nonbondedMethod=app.NoCutoff, constraints=None, rigidWater=False)
+    omm_host_system = ff.createSystem(
+        modeller.getTopology(), nonbondedMethod=app.NoCutoff, constraints=None, rigidWater=False
+    )
     # Determine box from the system's coordinates
     box = get_box_from_coords(solvated_host_coords)
 
-    # TODO: minimize the water box (BFGS or scipy.optimize)
-    return system, solvated_host_coords, box, modeller.getTopology()
+    # note, masses are not needed....
+    (bond, angle, proper, improper, nonbonded), masses = openmm_deserializer.deserialize_system(
+        omm_host_system, cutoff=1.2
+    )
+
+    solvated_host_system = HostSystem(
+        bond=bond,
+        angle=angle,
+        proper=proper,
+        improper=improper,
+        nonbonded_all_pairs=nonbonded,
+    )
+
+    # Determine box from the system's coordinates
+    box = get_box_from_coords(solvated_host_coords)
+    num_water_atoms = len(solvated_host_coords)
+
+    assert len(list(modeller.topology.atoms())) == len(solvated_host_coords)
+
+    return HostConfig(
+        host_system=solvated_host_system,
+        conf=solvated_host_coords,
+        box=box,
+        num_water_atoms=num_water_atoms,
+        omm_topology=modeller.topology,
+        masses=masses,
+    )

--- a/timemachine/md/minimizer.py
+++ b/timemachine/md/minimizer.py
@@ -232,8 +232,6 @@ def pre_equilibrate_host(
         max_lambda=minimizer_max_lambda,
     )
 
-    # host_bps, host_masses = openmm_deserializer.deserialize_system(host_config.host_system, cutoff=1.2)
-
     num_host_atoms = host_config.conf.shape[0]
 
     if len(mols) == 1:
@@ -379,9 +377,6 @@ def make_host_du_dx_fxn(
     """construct function to compute du_dx w.r.t. host coords, given fixed mols and box"""
 
     assert host_config.box.shape == (3, 3)
-
-    # openmm host_system -> timemachine host_bps
-    # host_bps, _ = openmm_deserializer.deserialize_system(host_config.host_syste, cutoff=1.2)
 
     # construct appropriate topology from (mols, ff)
     if len(mols) == 1:


### PR DESCRIPTION
This PR addresses a lot of the weird inconsistencies we had in our code with how we do system setup.

The key issues it addresses are:

1) `convert_bps_into_system` and `convert_omm_system` are deprecated
2) `build_protein_system` and `build_water_system` now returns a `HostConfig` with a `HostSystem` member, so there's no longer a need to chain together `system, ... = builders.build_water_system(...)` followed by  `openmm_deserializer.deserialize_system(system, cutoff=1.2)`
3) `HostConfig` now contains an additional `masses` field, and is now isomorphic to be `rbfe.Host` class.
4) `HostConfig` now takes in a `HostSystem` instead of an  `OpenMM.System` - improving the decoupling of the two code bases