### PR TITLE
Remove trivial assertions

### DIFF
--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -808,6 +808,7 @@ def test_setup_context_with_references():
 
     # Without barostat
     ctxt, reffed_objs = build_context(0)
+    assert all(ref() is not None for ref in reffed_objs)
     xs, boxes = ctxt.multiple_steps(100)
     assert np.all(np.isfinite(xs))
     assert np.all(np.isfinite(boxes))
@@ -821,6 +822,7 @@ def test_setup_context_with_references():
 
     # With Barostat
     ctxt, reffed_objs = build_context(10)
+    assert all(ref() is not None for ref in reffed_objs)
     xs, boxes = ctxt.multiple_steps(100)
     assert np.all(np.isfinite(xs))
     assert np.all(np.isfinite(boxes))


### PR DESCRIPTION
We currently assert that Python weakrefs to C++ objects are cleaned up after `gc.collect()`, but in general they can be cleaned up any time after all Python references go out of scope.