### PR TITLE
Fix regression in computing overlap for low-overlap u_kln

### DIFF
--- a/tests/test_bar.py
+++ b/tests/test_bar.py
@@ -195,12 +195,19 @@ def test_pair_overlap_from_ukln():
 
     # non-overlapping
     u_kln, _ = make_gaussian_ukln_example((0, 0.01), (1, 0.01))
-    assert pair_overlap_from_ukln(u_kln) >= 0.0
-    assert pair_overlap_from_ukln(u_kln) < 1e-10
+    overlap = pair_overlap_from_ukln(u_kln)
+    assert overlap >= 0.0
+    assert overlap < 1e-10
 
     # overlapping
     u_kln, _ = make_gaussian_ukln_example((0, 0.1), (0.5, 0.2))
     assert pair_overlap_from_ukln(u_kln) > 0.1
+
+    # check overlap compared to PyMBAR default tolerance
+    u_kln, _ = make_gaussian_ukln_example((0, 0.01), (1, 0.01))
+    assert pair_overlap_from_ukln(u_kln) == pytest.approx(
+        pair_overlap_from_ukln(u_kln, maximum_iterations=10_000, relative_tolerance=1e-7)
+    )
 
 
 @pytest.mark.parametrize("frames_per_step", [1, 5, 10])

--- a/timemachine/fe/bar.py
+++ b/timemachine/fe/bar.py
@@ -305,7 +305,9 @@ def df_from_ukln_by_lambda(ukln_by_lambda: NDArray) -> tuple[float, float]:
     return np.sum(win_dfs), np.linalg.norm(win_errs)  # type: ignore
 
 
-def pair_overlap_from_ukln(u_kln: NDArray) -> float:
+def pair_overlap_from_ukln(
+    u_kln: NDArray, maximum_iterations=DEFAULT_MAXIMUM_ITERATIONS, relative_tolerance=DEFAULT_RELATIVE_TOLERANCE
+) -> float:
     """Compute the off-diagonal entry of 2x2 MBAR overlap matrix,
         and normalize to interval [0,1]
 
@@ -322,7 +324,13 @@ def pair_overlap_from_ukln(u_kln: NDArray) -> float:
 
     """
     u_kn, N_k = ukln_to_ukn(u_kln)
-    overlap = 2 * pymbar.MBAR(u_kn, N_k).compute_overlap()["matrix"][0, 1]  # type: ignore
+    overlap = (
+        2
+        * pymbar.MBAR(
+            u_kn, N_k, maximum_iterations=maximum_iterations, relative_tolerance=relative_tolerance
+        ).compute_overlap()["matrix"][0, 1]
+    )  # type: ignore
+
     overlap = np.clip(overlap, 0.0, 1.0)
     return overlap
 


### PR DESCRIPTION
- PyMBAR 4 is slower at computing the overlap
- Use a reduced max_iter/relative_tol (matching our default) to improve the performance