### PR TITLE
Add invert_permutation utility

### DIFF
--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -41,7 +41,7 @@ from timemachine.ff import Forcefield
 from timemachine.md import minimizer
 from timemachine.md.builders import build_protein_system, build_water_system
 from timemachine.potentials.jax_utils import pairwise_distances
-from timemachine.utils import path_to_internal_file
+from timemachine.utils import invert_permutation, path_to_internal_file
 
 setup_chiral_dummy_interactions_from_ff = functools.partial(
     setup_dummy_interactions_from_ff,
@@ -1569,8 +1569,8 @@ def permute_atom_indices(mol_a, mol_b, core, seed):
 
     # RenumberAtoms takes inverse permutations
     # e.g. [3, 2, 0, 1] means atom 3 in the original mol will be atom 0 in the new one
-    inv_perm_a = np.argsort(perm_a)
-    inv_perm_b = np.argsort(perm_b)
+    inv_perm_a = invert_permutation(perm_a)
+    inv_perm_b = invert_permutation(perm_b)
     mol_a = Chem.RenumberAtoms(mol_a, inv_perm_a.tolist())
     mol_b = Chem.RenumberAtoms(mol_b, inv_perm_b.tolist())
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+from hypothesis import given, seed
+from hypothesis.strategies import integers, permutations
+from numpy.typing import NDArray
+
+from timemachine.utils import batches, invert_permutation
+
+pytestmark = [pytest.mark.nocuda]
+
+
+@given(integers(min_value=1))
+@seed(2023)
+def test_batches_of_nothing(batch_size):
+    assert list(batches(0, batch_size)) == []
+
+
+@given(integers(min_value=1, max_value=1000), integers(min_value=1))
+@seed(2023)
+def test_batches(n, batch_size):
+    assert sum(batches(n, batch_size)) == n
+    assert all(batch == batch_size for batch in list(batches(n, batch_size))[:-1])
+    *_, last = batches(n, batch_size)
+    assert 0 < last <= batch_size
+
+
+@given(integers(min_value=1, max_value=100).flatmap(lambda n: permutations(range(n))).map(np.asarray))
+@seed(2025)
+def test_invert_permutation_property(p: NDArray):
+    q = invert_permutation(p)
+    arr = np.arange(len(p))
+    np.testing.assert_array_equal(arr[p][q], arr)

--- a/timemachine/md/hrex.py
+++ b/timemachine/md/hrex.py
@@ -11,7 +11,7 @@ from numpy.typing import NDArray
 from scipy.stats import entropy
 
 from timemachine.md.moves import MixtureOfMoves, MonteCarloMove
-from timemachine.utils import batches, not_ragged
+from timemachine.utils import batches, invert_permutation, not_ragged
 
 Replica = TypeVar("Replica")
 Samples = TypeVar("Samples")
@@ -347,7 +347,7 @@ def get_samples_by_iter_by_replica(
     assert not_ragged(replica_idx_by_state_by_iter)
 
     samples_by_replica_by_iter = [
-        [samples_by_state[state_idx] for state_idx in np.argsort(replica_idx_by_state)]
+        [samples_by_state[state_idx] for state_idx in invert_permutation(replica_idx_by_state)]
         for samples_by_state, replica_idx_by_state in zip(samples_by_state_by_iter, replica_idx_by_state_by_iter)
     ]
 

--- a/timemachine/utils.py
+++ b/timemachine/utils.py
@@ -1,6 +1,10 @@
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from importlib import resources
+from typing import Any
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
 
 
 def batches(n: int, batch_size: int) -> Iterator[int]:
@@ -21,3 +25,11 @@ def not_ragged(xss: Sequence[Sequence]) -> bool:
 def path_to_internal_file(module: str, file_name: str):
     with resources.as_file(resources.files(module).joinpath(file_name)) as path:
         yield path
+
+
+def invert_permutation(p: ArrayLike) -> NDArray[Any]:
+    """Given a permutation p of the integers 0..len(p)-1, returns an array q such that np.array_equal(arr[p][q], arr) is True."""
+    p = np.asarray(p)
+    q = np.empty_like(p)
+    q[p] = np.arange(len(p))
+    return q


### PR DESCRIPTION
Adds a minor utility `invert_permutation`, used to invert a permutation of the integers 1..len(p). The main purpose is to clarify the intent of the code at usage sites.