### PR TITLE
Add support for None bond anchors

### DIFF
--- a/timemachine/fe/dummy.py
+++ b/timemachine/fe/dummy.py
@@ -17,7 +17,7 @@ class ZeroBondAnchorWarning(UserWarning):
 
 def generate_dummy_group_assignments(
     bond_graph: nx.Graph, core_atoms: Collection[int], assert_single_connected_component: bool = True
-) -> Iterator[dict[int, frozenset[int]]]:
+) -> Iterator[dict[Optional[int], frozenset[int]]]:
     """Returns an iterator over all possible dummy group assignments (i.e., candidate partitionings of dummy atoms with each
     partition assigned a bond anchor atom) for a given molecule (represented as a bond graph) and set of core atoms.
 
@@ -102,12 +102,12 @@ def generate_dummy_group_assignments(
 
 
 def generate_anchored_dummy_group_assignments(
-    dummy_groups: dict[int, frozenset[int]],
+    dummy_groups: dict[Optional[int], frozenset[int]],
     bond_graph_a: nx.Graph,
     bond_graph_b: nx.Graph,
     core_atoms_a: Sequence[int],
     core_atoms_b: Sequence[int],
-) -> Iterator[dict[int, tuple[Optional[int], frozenset[int]]]]:
+) -> Iterator[dict[Optional[int], tuple[Optional[int], frozenset[int]]]]:
     """Returns an iterator over candidate anchored dummy group assignments.
 
     By convention, dummy atoms are added to A to transform it into a supergraph of B. Indices in the dummy_groups
@@ -134,7 +134,7 @@ def generate_anchored_dummy_group_assignments(
 
     Parameters
     ----------
-    dummy_groups: dict[int, frozenset[int]]
+    dummy_groups: dict[Optional[int], frozenset[int]]
         Mapping from anchor atom to atoms in the associated dummy group. Indices refer to atoms in B.
 
     bond_graph_a, bond_graph_b: nx.Graph

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -682,7 +682,7 @@ def find_dummy_groups_and_anchors(
     mol_b,
     core_atoms_a: Sequence[int],
     core_atoms_b: Sequence[int],
-) -> dict[int, tuple[Optional[int], frozenset[int]]]:
+) -> dict[Optional[int], tuple[Optional[int], frozenset[int]]]:
     """Returns an arbitrary dummy group assignment for the A -> B transformation.
 
     Refer to :py:func:`assert_chiral_consistency` for definition of "chiral consistency".

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -144,7 +144,7 @@ def setup_dummy_bond_and_chiral_interactions(
     root_anchor_atom: int,
     core_atoms: NDArray,
 ):
-    assert root_anchor_atom in core_atoms
+    assert root_anchor_atom is None or root_anchor_atom in core_atoms
 
     dummy_group_arr = np.array(list(dummy_group))
 
@@ -286,7 +286,7 @@ def setup_dummy_interactions(
     (bonded_idxs, bonded_params)
         Returns bonds, angles, and improper idxs and parameters.
     """
-    assert root_anchor_atom in core_atoms
+    assert root_anchor_atom is None or root_anchor_atom in core_atoms
 
     dummy_angle_idxs = []
     dummy_angle_params = []
@@ -663,9 +663,8 @@ def setup_end_state(
     )
 
     num_atoms = mol_a.GetNumAtoms() + mol_b.GetNumAtoms() - len(core)
-    assert get_num_connected_components(num_atoms, bond_potential.potential.idxs) == 1, (
-        "hybrid molecule has multiple connected components"
-    )
+    if get_num_connected_components(num_atoms, bond_potential.potential.idxs) > 1:
+        warnings.warn("Hybrid molecule has multiple connected components")
 
     return GuestSystem(
         bond=bond_potential,


### PR DESCRIPTION
This PR adds support for handling dummy groups that are completely unanchored (i.e. devoid of bond anchors). The previous behavior was to omit the unanchored dummy groups entirely from the output of  `generate_dummy_group_assignments`.