### PR TITLE
Speed-up setup_intermediate_state by 30x

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -104,24 +104,26 @@ def test_plot_interpolation_schedule():
     plot_dummy_b_interpolation_schedule(st)
 
 
-# import time
-# def test_setup_intermediate_state():
-#     ff = Forcefield.load_default()
-#     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
-#     st = single_topology.SingleTopology(mol_a, mol_b, core, ff)
-
-#     import cProfile
-#     import pstats
-
-#     profiler = cProfile.Profile()
-#     profiler.enable()
-#     start_time = time.time()
-#     for lam in np.linspace(0, 1, 128):
-#         st.setup_intermediate_state(lam)
-#     print("total time", time.time() - start_time)
-#     profiler.disable()
-#     pstats.Stats(profiler).sort_stats(pstats.SortKey.CUMULATIVE).print_stats(100)
+import time
 
 
-# if __name__ == "__main__":
-#     test_setup_intermediate_state()
+def test_setup_intermediate_state():
+    ff = Forcefield.load_default()
+    mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
+    st = single_topology.SingleTopology(mol_a, mol_b, core, ff)
+
+    import cProfile
+    import pstats
+
+    profiler = cProfile.Profile()
+    profiler.enable()
+    start_time = time.time()
+    for lam in np.linspace(0, 1, 128):
+        st.setup_intermediate_state(lam)
+    print("total time", time.time() - start_time)
+    profiler.disable()
+    pstats.Stats(profiler).sort_stats(pstats.SortKey.CUMULATIVE).print_stats(100)
+
+
+if __name__ == "__main__":
+    test_setup_intermediate_state()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -102,3 +102,26 @@ def test_plot_interpolation_schedule():
     plot_core_interpolation_schedule(st)
     plot_dummy_a_interpolation_schedule(st)
     plot_dummy_b_interpolation_schedule(st)
+
+
+# import time
+# def test_setup_intermediate_state():
+#     ff = Forcefield.load_default()
+#     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
+#     st = single_topology.SingleTopology(mol_a, mol_b, core, ff)
+
+#     import cProfile
+#     import pstats
+
+#     profiler = cProfile.Profile()
+#     profiler.enable()
+#     start_time = time.time()
+#     for lam in np.linspace(0, 1, 128):
+#         st.setup_intermediate_state(lam)
+#     print("total time", time.time() - start_time)
+#     profiler.disable()
+#     pstats.Stats(profiler).sort_stats(pstats.SortKey.CUMULATIVE).print_stats(100)
+
+
+# if __name__ == "__main__":
+#     test_setup_intermediate_state()

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -631,6 +631,7 @@ def arbitrary_transformation():
 
 
 @pytest.mark.nocuda
+@pytest.skip("jax tracing is disabled - see PR https://github.com/proteneer/timemachine/pull/1523")
 def test_jax_transform_intermediate_potential(arbitrary_transformation):
     st, conf = arbitrary_transformation
 
@@ -703,18 +704,11 @@ def test_setup_intermediate_nonbonded_term(arbitrary_transformation):
     st, _ = arbitrary_transformation
 
     def setup_intermediate_nonbonded_term_ref(src_nonbonded, dst_nonbonded, lamb, align_fn, interpolate_qlj_fn):
-        pair_idxs_and_params = align_fn(
-            src_nonbonded.potential.idxs,
-            src_nonbonded.params,
-            dst_nonbonded.potential.idxs,
-            dst_nonbonded.params,
-        )
-
         cutoff = src_nonbonded.potential.cutoff
 
         pair_idxs = []
         pair_params = []
-        for idxs, src_params, dst_params in pair_idxs_and_params:
+        for idxs, src_params, dst_params in st.aligned_nonbonded_pairlist_tuples:
             src_qlj, src_w = src_params[:3], src_params[3]
             dst_qlj, dst_w = dst_params[:3], dst_params[3]
 
@@ -747,7 +741,6 @@ def test_setup_intermediate_nonbonded_term(arbitrary_transformation):
             st.src_system.nonbonded_pair_list,
             st.dst_system.nonbonded_pair_list,
             lamb,
-            align_nonbonded_idxs_and_params,
             linear_interpolation,
         )
 

--- a/timemachine/fe/interpolate.py
+++ b/timemachine/fe/interpolate.py
@@ -2,7 +2,8 @@ from collections.abc import Iterable
 from functools import partial
 from typing import Any, Callable
 
-import jax.numpy as jnp
+# import jax.numpy as jnp
+import numpy as jnp
 
 
 class DuplicateAlignmentKeysError(RuntimeError):
@@ -12,6 +13,10 @@ class DuplicateAlignmentKeysError(RuntimeError):
 Idxs = Any
 Params = Any
 Key = Any
+
+
+def to_hashable(x):
+    return tuple(to_hashable(e) for e in x) if isinstance(x, Iterable) else x
 
 
 def align_idxs_and_params(
@@ -80,9 +85,6 @@ def align_idxs_and_params(
             validate_idxs(idxs)
 
     # used to convert arrays to a hashable type for use as dict keys and in sets
-    def to_hashable(x):
-        return tuple(to_hashable(e) for e in x) if isinstance(x, Iterable) else x
-
     def make_kv(all_idxs, all_params):
         kvs = [(to_hashable(key(idxs, params)), params) for idxs, params in zip(all_idxs, all_params)]
 

--- a/timemachine/fe/interpolate.py
+++ b/timemachine/fe/interpolate.py
@@ -2,8 +2,7 @@ from collections.abc import Iterable
 from functools import partial
 from typing import Any, Callable
 
-# import jax.numpy as jnp
-import numpy as jnp
+import numpy as np
 
 
 class DuplicateAlignmentKeysError(RuntimeError):
@@ -164,11 +163,11 @@ def log_linear_interpolation(src_params, dst_params, lamb, min_value):
     """
 
     # clip to handle out-of-range end state values
-    src_params = jnp.maximum(src_params, min_value)
-    dst_params = jnp.maximum(dst_params, min_value)
+    src_params = np.maximum(src_params, min_value)
+    dst_params = np.maximum(dst_params, min_value)
 
     # tbd: handle 0s better if lamb = 0 and src_params == 0
-    return jnp.exp(linear_interpolation(jnp.log(src_params), jnp.log(dst_params), lamb))
+    return np.exp(linear_interpolation(np.log(src_params), np.log(dst_params), lamb))
 
 
 def pad(f, src_params, dst_params, lamb, lambda_min, lambda_max):
@@ -176,12 +175,9 @@ def pad(f, src_params, dst_params, lamb, lambda_min, lambda_max):
     Use the specified interpolation function in the interval (lambda_min, lambda_max), otherwise pin to the end-state
     values.
     """
-    return jnp.where(
-        lamb <= lambda_min,
-        src_params,
-        jnp.where(
-            lambda_max <= lamb,
-            dst_params,
-            f(src_params, dst_params, (lamb - lambda_min) / (lambda_max - lambda_min)),
-        ),
-    )
+    if lamb <= lambda_min:
+        return src_params
+    elif lambda_max <= lamb:
+        return dst_params
+    else:
+        return f(src_params, dst_params, (lamb - lambda_min) / (lambda_max - lambda_min))

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -5,8 +5,10 @@ from functools import partial
 from typing import Any, Optional
 
 import jax
-import jax.numpy as jnp
 import networkx as nx
+
+# import jax.numpy as jnp
+import numpy as jnp
 import numpy as np
 from numpy.typing import NDArray
 from rdkit import Chem
@@ -890,7 +892,7 @@ def interpolate_periodic_torsion_params(src_params, dst_params, lamb, lambda_min
     return jnp.array([k, phase, src_period])
 
 
-def interpolate_w_coord(w0: float | jax.Array, w1: float | jax.Array, lamb: float):
+def interpolate_w_coord(w0: float | NDArray, w1: float | NDArray, lamb: float):
     """Interpolate 4D coordinate using schedule optimized for RBFE calculations.
 
     Parameters
@@ -1133,6 +1135,57 @@ class SingleTopology(AtomMapMixin):
         assert_default_system_constraints(self.src_system)
         assert_default_system_constraints(self.dst_system)
 
+        self.aligned_bond_tuples = interpolate.align_harmonic_bond_idxs_and_params(
+            self.src_system.bond.potential.idxs,
+            self.src_system.bond.params,
+            self.dst_system.bond.potential.idxs,
+            self.dst_system.bond.params,
+        )
+
+        self.aligned_angle_tuples = interpolate.align_harmonic_angle_idxs_and_params(
+            self.src_system.angle.potential.idxs,
+            self.src_system.angle.params,
+            self.dst_system.angle.potential.idxs,
+            self.dst_system.angle.params,
+        )
+
+        self.aligned_proper_tuples = interpolate.align_proper_idxs_and_params(
+            self.src_system.proper.potential.idxs,
+            self.src_system.proper.params,
+            self.dst_system.proper.potential.idxs,
+            self.dst_system.proper.params,
+        )
+
+        self.aligned_improper_tuples = interpolate.align_improper_idxs_and_params(
+            self.src_system.improper.potential.idxs,
+            self.src_system.improper.params,
+            self.dst_system.improper.potential.idxs,
+            self.dst_system.improper.params,
+        )
+
+        self.aligned_nonbonded_pairlist_tuples = interpolate.align_nonbonded_idxs_and_params(
+            self.src_system.nonbonded_pair_list.potential.idxs,
+            self.src_system.nonbonded_pair_list.params,
+            self.dst_system.nonbonded_pair_list.potential.idxs,
+            self.dst_system.nonbonded_pair_list.params,
+        )
+
+        self.aligned_chiral_atom_tuples = interpolate.align_chiral_atom_idxs_and_params(
+            self.src_system.chiral_atom.potential.idxs,
+            self.src_system.chiral_atom.params,
+            self.dst_system.chiral_atom.potential.idxs,
+            self.dst_system.chiral_atom.params,
+        )
+
+        self.aligned_chiral_bond_tuples = interpolate.align_chiral_bond_idxs_and_params(
+            self.src_system.chiral_bond.potential.idxs,
+            self.src_system.chiral_bond.params,
+            self.src_system.chiral_bond.potential.signs,
+            self.dst_system.chiral_bond.potential.idxs,
+            self.dst_system.chiral_bond.params,
+            self.dst_system.chiral_bond.potential.signs,
+        )
+
     def combine_masses(self, use_hmr: bool = False) -> list[float]:
         """
         Combine masses between two end-states by taking the heavier of the two core atoms.
@@ -1277,7 +1330,6 @@ class SingleTopology(AtomMapMixin):
             self.src_system.nonbonded_pair_list,
             self.dst_system.nonbonded_pair_list,
             lamb,
-            interpolate.align_nonbonded_idxs_and_params,
             interpolate.linear_interpolation,
         )
 
@@ -1294,7 +1346,6 @@ class SingleTopology(AtomMapMixin):
         src_nonbonded: BoundPotential[NonbondedPairListPrecomputed],
         dst_nonbonded: BoundPotential[NonbondedPairListPrecomputed],
         lamb: float,
-        align_fn,
         interpolate_qlj_fn,
     ) -> BoundPotential[NonbondedPairListPrecomputed]:
         assert src_nonbonded.potential.beta == dst_nonbonded.potential.beta
@@ -1302,12 +1353,7 @@ class SingleTopology(AtomMapMixin):
 
         cutoff = src_nonbonded.potential.cutoff
 
-        pair_idxs_and_params = align_fn(
-            src_nonbonded.potential.idxs,
-            src_nonbonded.params,
-            dst_nonbonded.potential.idxs,
-            dst_nonbonded.params,
-        )
+        pair_idxs_and_params = self.aligned_nonbonded_pairlist_tuples
 
         pair_idxs = np.array([x for x, _, _ in pair_idxs_and_params], dtype=np.int32)
 
@@ -1532,13 +1578,13 @@ class SingleTopology(AtomMapMixin):
 
         return interpolate_periodic_torsion_params(src_params, dst_params, lamb, *min_max)
 
-    def _align_and_interpolate_bonded_term(self, lamb, src_potential, dst_potential, align_fn, interpolate_fn):
-        set_of_tuples = align_fn(
-            src_potential.potential.idxs,
-            src_potential.params,
-            dst_potential.potential.idxs,
-            dst_potential.params,
-        )
+    def _align_and_interpolate_bonded_term(self, lamb, src_potential, dst_potential, set_of_tuples, interpolate_fn):
+        # set_of_tuples = align_fn(
+        #     src_potential.potential.idxs,
+        #     src_potential.params,
+        #     dst_potential.potential.idxs,
+        #     dst_potential.params,
+        # )
 
         # (ytz): sigh, this is the garbage code that we need to write if we don't do re-shaping
         # at the potential level, sigh. If we have zero length arrays, for both src_potential and dst_potential,
@@ -1599,7 +1645,7 @@ class SingleTopology(AtomMapMixin):
             lamb,
             self.src_system.chiral_atom,
             self.dst_system.chiral_atom,
-            interpolate.align_chiral_atom_idxs_and_params,
+            self.aligned_chiral_atom_tuples,
             self._interpolate_chiral_atom,
         )
 
@@ -1608,7 +1654,7 @@ class SingleTopology(AtomMapMixin):
             lamb,
             self.src_system.angle,
             self.dst_system.angle,
-            interpolate.align_harmonic_angle_idxs_and_params,
+            self.aligned_angle_tuples,
             self._interpolate_angle,
         )
 
@@ -1617,7 +1663,7 @@ class SingleTopology(AtomMapMixin):
             lamb,
             self.src_system.bond,
             self.dst_system.bond,
-            interpolate.align_harmonic_bond_idxs_and_params,
+            self.aligned_bond_tuples,
             self._interpolate_bond,
         )
 
@@ -1627,7 +1673,7 @@ class SingleTopology(AtomMapMixin):
             lamb,
             self.src_system.proper,
             self.dst_system.proper,
-            interpolate.align_proper_idxs_and_params,
+            self.aligned_proper_tuples,
             self._interpolate_torsion,
         )
         return res
@@ -1637,7 +1683,7 @@ class SingleTopology(AtomMapMixin):
             lamb,
             self.src_system.improper,
             self.dst_system.improper,
-            interpolate.align_improper_idxs_and_params,
+            self.aligned_improper_tuples,
             self._interpolate_torsion,
         )
 
@@ -1767,7 +1813,7 @@ class SingleTopology(AtomMapMixin):
         # make read-only
         return Chem.Mol(mol)
 
-    def _get_guest_params(self, q_handle, lj_handle, lamb: float, cutoff: float) -> jax.Array:
+    def _get_guest_params(self, q_handle, lj_handle, lamb: float, cutoff: float) -> NDArray:
         """
         Return an array containing the guest_charges, guest_sigmas, guest_epsilons, guest_w_coords
         for the guest at a given lambda.
@@ -1823,7 +1869,7 @@ class SingleTopology(AtomMapMixin):
             guest_epsilons.append(eps)
             guest_w_coords.append(w)
 
-        return jnp.stack(jnp.array([guest_charges, guest_sigmas, guest_epsilons, guest_w_coords]), axis=1)
+        return jnp.stack([guest_charges, guest_sigmas, guest_epsilons, guest_w_coords], axis=1)
 
     def _parameterize_host_nonbonded(self, host_nonbonded: BoundPotential[Nonbonded]) -> BoundPotential[Nonbonded]:
         """Parameterize host-host nonbonded interactions"""


### PR DESCRIPTION
This PR speeds-up `setup_intermediate_state()` considerably when called multiple times, bringing 128 calls from 21s -> 0.6s.

Main benefits come from

1) [5x speed-up] - switching from `jax.numpy` to `numpy`
2) [2x speed-up] - pre-align parameters in the constructor.
3) [1.5x speed-up] - caching `get_dummy_atoms_a`, `get_dummy_atoms_b`, `get_core_atoms` 
4) [1.5x speed-up] - caching `src_chiral_idxs` and `dst_chiral_idxs`

Main downside, `setup_intermediate_state` is no longer `jittable` nor `Traceable`. I think our previous motivation for this was mainly for speed anyways. 

`cProfile` now shows:

```
      640    0.017    0.000    0.341    0.001 /home/yzhao/Code/timemachine/timemachine/fe/single_topology.py:1587(_align_and_interpolate_bonded_term)
    53760    0.102    0.000    0.147    0.000 /home/yzhao/Code/timemachine/timemachine/fe/interpolate.py:174(pad)
    14848    0.008    0.000    0.142    0.000 /home/yzhao/Code/timemachine/timemachine/fe/single_topology.py:1570(_interpolate_torsion)
      128    0.000    0.000    0.127    0.001 /home/yzhao/Code/timemachine/timemachine/fe/single_topology.py:1651(align_and_interpolate_angles)
    14848    0.013    0.000    0.125    0.000 /home/yzhao/Code/timemachine/timemachine/fe/single_topology.py:853(interpolate_periodic_torsion_params)
     7424    0.007    0.000    0.119    0.000 /home/yzhao/Code/timemachine/timemachine/fe/single_topology.py:1510(_interpolate_angle)
      128    0.000    0.000    0.109    0.001 /home/yzhao/Code/timemachine/timemachine/fe/single_topology.py:1670(align_and_interpolate_propers)
     7424    0.014    0.000    0.092    0.000 /home/yzhao/Code/timemachine/timemachine/fe/single_topology.py:805(interpolate_harmonic_angle_params)
    22272    0.046    0.000    0.068    0.000 /home/yzhao/Code/timemachine/timemachine/fe/single_topology.py:787(cyclic_difference)
      128    0.000    0.000    0.052    0.000 /home/yzhao/Code/timemachine/timemachine/fe/single_topology.py:1660(align_and_interpolate_bonds)
      128    0.000    0.000    0.048    0.000 /home/yzhao/Code/timemachine/timemachine/fe/single_topology.py:1680(align_and_interpolate_impropers)
     4608    0.003    0.000    0.046    0.000 /home/yzhao/Code/timemachine/timemachine/fe/single_topology.py:1487(_interpolate_bond)
 ```