### PR TITLE
Refine selection of atoms in REST region using simple heuristic

### DIFF
--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from dataclasses import replace
 from functools import cache
 
@@ -113,7 +114,7 @@ def test_single_topology_rest_vacuum(mol_pair, temperature_scale_interpolation_f
             if energy_scale < 1.0:
                 assert U_proper < U_proper_ref
 
-        def compute_proper_energy(state: GuestSystem, ixn_idxs):
+        def compute_proper_energy(state: GuestSystem, ixn_idxs: Sequence[int]):
             assert state.proper
             proper = replace(
                 state.proper,

--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -210,12 +210,12 @@ def test_single_topology_rest_propers():
     # cyclohexane: all 9 * 6 ring propers are scaled (|{H1, H2, C1}-C2-C3-{C4, H3, H4}| = 9 propers per C-C bond)
     cyclohexane = get_mol("C1CCCCC1")
     st = get_identity_transformation(cyclohexane)
-    assert len({t for _, t in st.candidate_propers}) == 9 * 6
+    assert len(set(st.candidate_propers.values())) == 9 * 6
 
     # phenylcyclohexane: all 9 * 6 cyclohexane ring propers and 6 rotatable bond propers are scaled
     phenylcyclohexane = get_mol("c1ccc(C2CCCCC2)cc1")
     st = get_identity_transformation(phenylcyclohexane)
-    assert len({t for _, t in st.candidate_propers}) == 9 * 6 + 6
+    assert len(set(st.candidate_propers.values())) == 9 * 6 + 6
 
 
 @pytest.mark.parametrize(

--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -78,6 +78,8 @@ def test_single_topology_rest_vacuum(mol_pair, temperature_scale_interpolation_f
     st = get_single_topology(mol_a, mol_b, core)
     st_rest = get_single_topology_rest(mol_a, mol_b, core, 2.0, temperature_scale_interpolation_fxn)
 
+    assert 0 < len(st_rest.rest_region_atom_idxs) < st_rest.get_num_atoms()
+
     state = st_rest.setup_intermediate_state(lamb)
     state_ref = st.setup_intermediate_state(lamb)
     assert len(st_rest.candidate_propers) < len(state_ref.proper.potential.idxs)

--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -79,6 +79,9 @@ def test_single_topology_rest_vacuum(mol_pair, temperature_scale_interpolation_f
     st = get_single_topology(mol_a, mol_b, core)
     st_rest = get_single_topology_rest(mol_a, mol_b, core, 2.0, temperature_scale_interpolation_fxn)
 
+    # NOTE: This assertion is not guaranteed to hold in general (i.e. the REST region may be empty, or the whole
+    # combined ligand), but it does hold for typical cases, including the edges tested here. The stronger assertion here
+    # ensures that later assertions (e.g. that we only soften interactions in the REST region) are not trivially true.
     assert 0 < len(st_rest.rest_region_atom_idxs) < st_rest.get_num_atoms()
 
     state = st_rest.setup_intermediate_state(lamb)

--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -135,7 +135,7 @@ def test_single_topology_rest_vacuum(mol_pair, temperature_scale_interpolation_f
         rest_complement_proper_idxs = list(rest_complement_proper_idxs)
         U_proper_complement = compute_proper_energy(state, rest_complement_proper_idxs)
         U_proper_complement_ref = compute_proper_energy(state_ref, rest_complement_proper_idxs)
-        np.testing.assert_allclose(U_proper_complement, U_proper_complement_ref)
+        np.testing.assert_array_equal(U_proper_complement, U_proper_complement_ref)
 
 
 @cache
@@ -183,7 +183,7 @@ def test_single_topology_rest_solvent(mol_pair, temperature_scale_interpolation_
     rest_complement_atom_idxs = set(range(st_rest.get_num_atoms())) - st_rest.rest_region_atom_idxs
     U_complement = compute_host_guest_ixn_energy(st_rest, rest_complement_atom_idxs)
     U_complement_ref = compute_host_guest_ixn_energy(st, rest_complement_atom_idxs)
-    np.testing.assert_allclose(U_complement, U_complement_ref, rtol=1e-5)
+    np.testing.assert_array_equal(U_complement, U_complement_ref)
 
 
 def get_mol(smiles: str):

--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -11,8 +11,15 @@ from timemachine.constants import DEFAULT_ATOM_MAPPING_KWARGS
 from timemachine.fe import atom_mapping
 from timemachine.fe.free_energy import HostConfig
 from timemachine.fe.rbfe import Host, setup_optimized_host
-from timemachine.fe.rest.interpolation import Exponential, Linear, Quadratic, Symmetric, plot_interpolation_fxn
-from timemachine.fe.rest.single_topology import InterpolationFxnName, SingleTopologyREST
+from timemachine.fe.rest.interpolation import (
+    Exponential,
+    InterpolationFxnName,
+    Linear,
+    Quadratic,
+    Symmetric,
+    plot_interpolation_fxn,
+)
+from timemachine.fe.rest.single_topology import SingleTopologyREST
 from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.system import GuestSystem
 from timemachine.fe.utils import get_romol_conf, read_sdf_mols_by_name
@@ -73,7 +80,7 @@ def test_single_topology_rest_vacuum(mol_pair, temperature_scale_interpolation_f
 
     state = st_rest.setup_intermediate_state(lamb)
     state_ref = st.setup_intermediate_state(lamb)
-    assert len(st_rest.target_propers) < len(state_ref.proper.potential.idxs)
+    assert len(st_rest.candidate_propers) < len(state_ref.proper.potential.idxs)
 
     ligand_conf = st.combine_confs(get_romol_conf(mol_a), get_romol_conf(mol_b))
 
@@ -99,7 +106,7 @@ def test_single_topology_rest_vacuum(mol_pair, temperature_scale_interpolation_f
         assert energy_scale < 1.0
 
         if has_rotatable_bonds or has_aliphatic_rings:
-            assert 0 < len(st_rest.target_propers)
+            assert 0 < len(st_rest.candidate_propers)
 
             if energy_scale < 1.0:
                 assert U_proper < U_proper_ref
@@ -170,17 +177,17 @@ def test_single_topology_rest_propers():
     # benzene: no propers are scaled
     benzene = get_mol("c1ccccc1")
     st = get_identity_transformation(benzene)
-    assert st.target_propers == set()
+    assert st.candidate_propers == set()
 
     # cyclohexane: all 9 * 6 ring propers are scaled (|{H1, H2, C1}-C2-C3-{C4, H3, H4}| = 9 propers per C-C bond)
     cyclohexane = get_mol("C1CCCCC1")
     st = get_identity_transformation(cyclohexane)
-    assert len(st.target_propers) == 9 * 6
+    assert len({t for _, t in st.candidate_propers}) == 9 * 6
 
     # phenylcyclohexane: all 9 * 6 cyclohexane ring propers and 6 rotatable bond propers are scaled
     phenylcyclohexane = get_mol("c1ccc(C2CCCCC2)cc1")
     st = get_identity_transformation(phenylcyclohexane)
-    assert len(st.target_propers) == 9 * 6 + 6
+    assert len({t for _, t in st.candidate_propers}) == 9 * 6 + 6
 
 
 @pytest.mark.parametrize(

--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -205,7 +205,7 @@ def test_single_topology_rest_propers():
     # benzene: no propers are scaled
     benzene = get_mol("c1ccccc1")
     st = get_identity_transformation(benzene)
-    assert st.candidate_propers == set()
+    assert len(st.candidate_propers) == 0
 
     # cyclohexane: all 9 * 6 ring propers are scaled (|{H1, H2, C1}-C2-C3-{C4, H3, H4}| = 9 propers per C-C bond)
     cyclohexane = get_mol("C1CCCCC1")

--- a/timemachine/fe/rest/single_topology.py
+++ b/timemachine/fe/rest/single_topology.py
@@ -97,7 +97,7 @@ class SingleTopologyREST(SingleTopology):
         # Heuristic: include in the rest region atoms involved in bond, angle, or improper torsion interactions that
         # differ in the end states. Note that proper torsions are omitted from the heuristic as this tends to result in
         # larger REST regions than seem desirable.
-        aligned_tuples_by_potential: list[AlignedPotential] = [
+        aligned_potentials: list[AlignedPotential] = [
             self.aligned_bond,
             self.aligned_angle,
             self.aligned_improper,
@@ -105,7 +105,7 @@ class SingleTopologyREST(SingleTopology):
 
         idxs = {
             int(idx)
-            for aligned in aligned_tuples_by_potential
+            for aligned in aligned_potentials
             for idxs, params_a, params_b in zip(aligned.idxs, aligned.src_params, aligned.dst_params)
             if not params_eq(params_a, params_b)
             for idx in idxs  # type: ignore[attr-defined]

--- a/timemachine/fe/rest/single_topology.py
+++ b/timemachine/fe/rest/single_topology.py
@@ -130,22 +130,22 @@ class SingleTopologyREST(SingleTopology):
         return [mkproper(*idxs) for idxs in super().setup_intermediate_state(0.0).proper.potential.idxs]
 
     @cached_property
-    def candidate_propers(self) -> set[tuple[int, CanonicalProper]]:
+    def candidate_propers(self) -> dict[int, CanonicalProper]:
         """Returns the set of propers in the combined ligand that are candidates for softening."""
         return {
-            (idx, proper)
+            idx: proper
             for idx, proper in enumerate(self.propers)
             for bond in [mkbond(proper.j, proper.k)]
             if bond in self.rotatable_bonds or bond in self.aliphatic_ring_bonds
         }
 
     @cached_property
-    def target_propers(self) -> set[tuple[int, CanonicalProper]]:
+    def target_propers(self) -> dict[int, CanonicalProper]:
         """Returns the set of propers in the combined ligand that are candidates for softening and involve an atom in
         the REST region."""
         return {
-            (idx, proper)
-            for (idx, proper) in self.candidate_propers
+            idx: proper
+            for (idx, proper) in self.candidate_propers.items()
             if any(idx in self.rest_region_atom_idxs for idx in astuple(proper))
         }
 
@@ -153,7 +153,7 @@ class SingleTopologyREST(SingleTopology):
     def target_proper_idxs(self) -> list[int]:
         """Returns a list of indices of propers in the combined ligand that are candidates for softening and involve an
         atom in the REST region."""
-        return [idx for idx, _ in self.target_propers]
+        return list(self.target_propers.keys())
 
     def get_energy_scale_factor(self, lamb: float) -> float:
         temperature_factor = float(self._temperature_scale_interpolation_fxn(lamb))

--- a/timemachine/fe/rest/single_topology.py
+++ b/timemachine/fe/rest/single_topology.py
@@ -192,7 +192,7 @@ class SingleTopologyREST(SingleTopology):
 
         # compute indices corresponding to REST-region ligand atoms in the host-guest interaction potential
         num_atoms_host = host_system.nonbonded_all_pairs.potential.num_atoms
-        ligand_idxs = np.array(sorted(self.rest_region_atom_idxs)) + num_atoms_host
+        rest_region_atom_idxs = np.array(sorted(self.rest_region_atom_idxs)) + num_atoms_host
 
         # NOTE: the following methods of scaling the ligand-environment interaction energy are all equivalent:
         #
@@ -209,9 +209,9 @@ class SingleTopologyREST(SingleTopology):
         nonbonded_host_guest_ixn = replace(
             ref_state.nonbonded_ixn_group,
             params=jnp.asarray(ref_state.nonbonded_ixn_group.params)
-            .at[ligand_idxs, NBParamIdx.Q_IDX]
+            .at[rest_region_atom_idxs, NBParamIdx.Q_IDX]
             .mul(energy_scale)  # scale ligand charges
-            .at[ligand_idxs, NBParamIdx.LJ_EPS_IDX]
+            .at[rest_region_atom_idxs, NBParamIdx.LJ_EPS_IDX]
             .mul(energy_scale),  # scale ligand epsilons
         )
 

--- a/timemachine/fe/rest/single_topology.py
+++ b/timemachine/fe/rest/single_topology.py
@@ -81,6 +81,7 @@ class SingleTopologyREST(SingleTopology):
 
     @cached_property
     def aliphatic_ring_bonds(self) -> set[CanonicalBond]:
+        """Returns the set of aliphatic ring bonds in the combined ligand."""
         ring_bonds_a = {bond.translate(self.a_to_c) for bond in get_aliphatic_ring_bonds(self.mol_a)}
         ring_bonds_b = {bond.translate(self.b_to_c) for bond in get_aliphatic_ring_bonds(self.mol_b)}
         ring_bonds_c = ring_bonds_a | ring_bonds_b
@@ -88,6 +89,7 @@ class SingleTopologyREST(SingleTopology):
 
     @cached_property
     def rotatable_bonds(self) -> set[CanonicalBond]:
+        """Returns the set of rotatable bonds in the combined ligand."""
         rotatable_bonds_a = {bond.translate(self.a_to_c) for bond in get_rotatable_bonds(self.mol_a)}
         rotatable_bonds_b = {bond.translate(self.b_to_c) for bond in get_rotatable_bonds(self.mol_b)}
         rotatable_bonds_c = rotatable_bonds_a | rotatable_bonds_b
@@ -95,11 +97,14 @@ class SingleTopologyREST(SingleTopology):
 
     @cached_property
     def propers(self) -> list[CanonicalProper]:
+        """Returns a list of proper torsions in the combined ligand."""
         # TODO: refactor SingleTopology to compute src and dst alignment at initialization
         return [mkproper(*idxs) for idxs in super().setup_intermediate_state(0.0).proper.potential.idxs]
 
     @cached_property
     def target_proper_idxs(self) -> list[int]:
+        """Returns a list of indices of the proper torsion interactions in the combined ligand that are targeted for
+        softening."""
         return [
             idx
             for idx, proper in enumerate(self.propers)
@@ -109,6 +114,7 @@ class SingleTopologyREST(SingleTopology):
 
     @cached_property
     def target_propers(self) -> set[CanonicalProper]:
+        """Returns the set of proper torsions in the combined ligand that are targeted for softening."""
         return {self.propers[i] for i in self.target_proper_idxs}
 
     def get_energy_scale_factor(self, lamb: float) -> float:

--- a/timemachine/fe/rest/single_topology.py
+++ b/timemachine/fe/rest/single_topology.py
@@ -82,11 +82,13 @@ class SingleTopologyREST(SingleTopology):
 
     @cached_property
     def rest_region_atom_idxs(self) -> set[int]:
-        """Returns the set of indices of atoms in the combined ligand that are in the REST region."""
+        """Returns the set of indices of atoms in the combined ligand that are in the REST region.
 
-        # Heuristic: include in the rest region atoms involved in bond, angle, or improper torsion interactions that
-        # differ in the end states. Note that proper torsions are omitted from the heuristic as this tends to result in
-        # larger REST regions than seem desirable.
+        Here the REST region is defined to include combined ligand atoms involved in bond, angle, or improper torsion
+        interactions that differ in the end states. Note that proper torsions are omitted from this heuristic as this
+        tends to result in larger REST regions than seem desirable.
+        """
+
         aligned_potentials: list[AlignedPotential] = [
             self.aligned_bond,
             self.aligned_angle,
@@ -131,7 +133,7 @@ class SingleTopologyREST(SingleTopology):
 
     @cached_property
     def candidate_propers(self) -> dict[int, CanonicalProper]:
-        """Returns the set of propers in the combined ligand that are candidates for softening."""
+        """Returns a dict of propers in the combined ligand, keyed on index, that are candidates for softening."""
         return {
             idx: proper
             for idx, proper in enumerate(self.propers)
@@ -141,8 +143,8 @@ class SingleTopologyREST(SingleTopology):
 
     @cached_property
     def target_propers(self) -> dict[int, CanonicalProper]:
-        """Returns the set of propers in the combined ligand that are candidates for softening and involve an atom in
-        the REST region."""
+        """Returns a dict of propers in the combined ligand, keyed on index, that are candidates for softening and
+        involve an atom in the REST region."""
         return {
             idx: proper
             for (idx, proper) in self.candidate_propers.items()

--- a/timemachine/fe/rest/single_topology.py
+++ b/timemachine/fe/rest/single_topology.py
@@ -80,6 +80,24 @@ class SingleTopologyREST(SingleTopology):
         )
 
     @cached_property
+    def rest_region_atom_idxs(self) -> set[int]:
+        """Returns the set of indices of atoms in the combined ligand that are in the REST region."""
+        return {
+            idx
+            for diffs in [
+                self.aligned_bond_tuples,
+                self.aligned_angle_tuples,
+                self.aligned_proper_tuples,
+                self.aligned_improper_tuples,
+                self.aligned_chiral_atom_tuples,
+                # self.aligned_chiral_bond_tuples, # NOTE: chiral bonds not implemented
+                self.aligned_nonbonded_pairlist_tuples,
+            ]
+            for diff_idxs, _, _ in diffs
+            for idx in diff_idxs
+        }
+
+    @cached_property
     def aliphatic_ring_bonds(self) -> set[CanonicalBond]:
         """Returns the set of aliphatic ring bonds in the combined ligand."""
         ring_bonds_a = {bond.translate(self.a_to_c) for bond in get_aliphatic_ring_bonds(self.mol_a)}

--- a/timemachine/fe/rest/single_topology.py
+++ b/timemachine/fe/rest/single_topology.py
@@ -146,7 +146,9 @@ class SingleTopologyREST(SingleTopology):
     ) -> HostGuestSystem:
         ref_state = super().combine_with_host(host_system, lamb, num_water_atoms, ff, omm_topology)
 
-        num_host_atoms = host_system.nonbonded_all_pairs.params.shape[0]
+        num_atoms_host = host_system.nonbonded_all_pairs.potential.num_atoms
+        ligand_idxs = slice(num_atoms_host, None, None)
+
         # NOTE: the following methods of scaling the ligand-environment interaction energy are all equivalent:
         #
         # 1. scaling ligand charges and LJ epsilons by energy_scale
@@ -162,9 +164,9 @@ class SingleTopologyREST(SingleTopology):
         nonbonded_host_guest_ixn = replace(
             ref_state.nonbonded_ixn_group,
             params=jnp.asarray(ref_state.nonbonded_ixn_group.params)
-            .at[num_host_atoms:, NBParamIdx.Q_IDX]
+            .at[ligand_idxs, NBParamIdx.Q_IDX]
             .mul(energy_scale)  # scale ligand charges
-            .at[num_host_atoms:, NBParamIdx.LJ_EPS_IDX]
+            .at[ligand_idxs, NBParamIdx.LJ_EPS_IDX]
             .mul(energy_scale),  # scale ligand epsilons
         )
 

--- a/timemachine/fe/rest/single_topology.py
+++ b/timemachine/fe/rest/single_topology.py
@@ -153,9 +153,9 @@ class SingleTopologyREST(SingleTopology):
         # 2. scaling environment charges and LJ epsilons by energy_scale
         # 3. scaling all charges and LJ epsilons by sqrt(energy_scale)
         #
-        # Here, we choose (1) because water sampling infers parameters from the NonbondedInteractionGroup.Changing
-        # the environment parameters prevents easy construction of equivalent parameters for water sampling, which
-        # leads to incorrect sampling.
+        # However, (2) and (3) are incompatible with the current water sampling implementation, which assumes that the
+        # parameters corresponding to water atoms are identical in the host-host all-pairs potential and the host-guest
+        # interaction group potential. Therefore we choose option (1).
 
         energy_scale = self.get_energy_scale_factor(lamb)
 

--- a/timemachine/fe/rest/single_topology.py
+++ b/timemachine/fe/rest/single_topology.py
@@ -2,6 +2,7 @@ from dataclasses import astuple, replace
 from functools import cached_property
 
 import jax.numpy as jnp
+import numpy as np
 from numpy.typing import NDArray
 from openmm import app
 from rdkit import Chem
@@ -180,8 +181,9 @@ class SingleTopologyREST(SingleTopology):
     ) -> HostGuestSystem:
         ref_state = super().combine_with_host(host_system, lamb, num_water_atoms, ff, omm_topology)
 
+        # compute indices corresponding to REST-region ligand atoms in the host-guest interaction potential
         num_atoms_host = host_system.nonbonded_all_pairs.potential.num_atoms
-        ligand_idxs = slice(num_atoms_host, None, None)
+        ligand_idxs = np.array(sorted(self.rest_region_atom_idxs)) + num_atoms_host
 
         # NOTE: the following methods of scaling the ligand-environment interaction energy are all equivalent:
         #

--- a/timemachine/fe/rest/single_topology.py
+++ b/timemachine/fe/rest/single_topology.py
@@ -1,7 +1,6 @@
 from dataclasses import astuple, replace
 from functools import cached_property
 
-import jax
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import NDArray
@@ -85,15 +84,6 @@ class SingleTopologyREST(SingleTopology):
     def rest_region_atom_idxs(self) -> set[int]:
         """Returns the set of indices of atoms in the combined ligand that are in the REST region."""
 
-        def params_eq(params_a, params_b) -> bool:
-            eq_p = params_a == params_b
-            if isinstance(eq_p, bool):
-                return eq_p
-            elif isinstance(eq_p, (np.ndarray, jax.Array)):
-                return bool(np.all(eq_p))
-            else:
-                assert False
-
         # Heuristic: include in the rest region atoms involved in bond, angle, or improper torsion interactions that
         # differ in the end states. Note that proper torsions are omitted from the heuristic as this tends to result in
         # larger REST regions than seem desirable.
@@ -107,7 +97,7 @@ class SingleTopologyREST(SingleTopology):
             int(idx)
             for aligned in aligned_potentials
             for idxs, params_a, params_b in zip(aligned.idxs, aligned.src_params, aligned.dst_params)
-            if not params_eq(params_a, params_b)
+            if not np.all(params_a == params_b)
             for idx in idxs  # type: ignore[attr-defined]
         }
 

--- a/timemachine/fe/single_topology.py
+++ b/timemachine/fe/single_topology.py
@@ -1133,6 +1133,57 @@ class SingleTopology(AtomMapMixin):
         assert_default_system_constraints(self.src_system)
         assert_default_system_constraints(self.dst_system)
 
+        self.aligned_bond_tuples = interpolate.align_harmonic_bond_idxs_and_params(
+            self.src_system.bond.potential.idxs,
+            self.src_system.bond.params,
+            self.dst_system.bond.potential.idxs,
+            self.dst_system.bond.params,
+        )
+
+        self.aligned_angle_tuples = interpolate.align_harmonic_angle_idxs_and_params(
+            self.src_system.angle.potential.idxs,
+            self.src_system.angle.params,
+            self.dst_system.angle.potential.idxs,
+            self.dst_system.angle.params,
+        )
+
+        self.aligned_proper_tuples = interpolate.align_proper_idxs_and_params(
+            self.src_system.proper.potential.idxs,
+            self.src_system.proper.params,
+            self.dst_system.proper.potential.idxs,
+            self.dst_system.proper.params,
+        )
+
+        self.aligned_improper_tuples = interpolate.align_improper_idxs_and_params(
+            self.src_system.improper.potential.idxs,
+            self.src_system.improper.params,
+            self.dst_system.improper.potential.idxs,
+            self.dst_system.improper.params,
+        )
+
+        self.aligned_nonbonded_pairlist_tuples = interpolate.align_nonbonded_idxs_and_params(
+            self.src_system.nonbonded_pair_list.potential.idxs,
+            self.src_system.nonbonded_pair_list.params,
+            self.dst_system.nonbonded_pair_list.potential.idxs,
+            self.dst_system.nonbonded_pair_list.params,
+        )
+
+        self.aligned_chiral_atom_tuples = interpolate.align_chiral_atom_idxs_and_params(
+            self.src_system.chiral_atom.potential.idxs,
+            self.src_system.chiral_atom.params,
+            self.dst_system.chiral_atom.potential.idxs,
+            self.dst_system.chiral_atom.params,
+        )
+
+        self.aligned_chiral_bond_tuples = interpolate.align_chiral_bond_idxs_and_params(
+            self.src_system.chiral_bond.potential.idxs,
+            self.src_system.chiral_bond.params,
+            self.src_system.chiral_bond.potential.signs,
+            self.dst_system.chiral_bond.potential.idxs,
+            self.dst_system.chiral_bond.params,
+            self.dst_system.chiral_bond.potential.signs,
+        )
+
     def combine_masses(self, use_hmr: bool = False) -> list[float]:
         """
         Combine masses between two end-states by taking the heavier of the two core atoms.
@@ -1277,7 +1328,6 @@ class SingleTopology(AtomMapMixin):
             self.src_system.nonbonded_pair_list,
             self.dst_system.nonbonded_pair_list,
             lamb,
-            interpolate.align_nonbonded_idxs_and_params,
             interpolate.linear_interpolation,
         )
 
@@ -1294,7 +1344,6 @@ class SingleTopology(AtomMapMixin):
         src_nonbonded: BoundPotential[NonbondedPairListPrecomputed],
         dst_nonbonded: BoundPotential[NonbondedPairListPrecomputed],
         lamb: float,
-        align_fn,
         interpolate_qlj_fn,
     ) -> BoundPotential[NonbondedPairListPrecomputed]:
         assert src_nonbonded.potential.beta == dst_nonbonded.potential.beta
@@ -1302,12 +1351,7 @@ class SingleTopology(AtomMapMixin):
 
         cutoff = src_nonbonded.potential.cutoff
 
-        pair_idxs_and_params = align_fn(
-            src_nonbonded.potential.idxs,
-            src_nonbonded.params,
-            dst_nonbonded.potential.idxs,
-            dst_nonbonded.params,
-        )
+        pair_idxs_and_params = self.aligned_nonbonded_pairlist_tuples
 
         pair_idxs = np.array([x for x, _, _ in pair_idxs_and_params], dtype=np.int32)
 
@@ -1532,14 +1576,7 @@ class SingleTopology(AtomMapMixin):
 
         return interpolate_periodic_torsion_params(src_params, dst_params, lamb, *min_max)
 
-    def _align_and_interpolate_bonded_term(self, lamb, src_potential, dst_potential, align_fn, interpolate_fn):
-        set_of_tuples = align_fn(
-            src_potential.potential.idxs,
-            src_potential.params,
-            dst_potential.potential.idxs,
-            dst_potential.params,
-        )
-
+    def _align_and_interpolate_bonded_term(self, lamb, src_potential, dst_potential, set_of_tuples, interpolate_fn):
         # (ytz): sigh, this is the garbage code that we need to write if we don't do re-shaping
         # at the potential level, sigh. If we have zero length arrays, for both src_potential and dst_potential,
         # then we lose information about the correct shapes.
@@ -1599,7 +1636,7 @@ class SingleTopology(AtomMapMixin):
             lamb,
             self.src_system.chiral_atom,
             self.dst_system.chiral_atom,
-            interpolate.align_chiral_atom_idxs_and_params,
+            self.aligned_chiral_atom_tuples,
             self._interpolate_chiral_atom,
         )
 
@@ -1608,7 +1645,7 @@ class SingleTopology(AtomMapMixin):
             lamb,
             self.src_system.angle,
             self.dst_system.angle,
-            interpolate.align_harmonic_angle_idxs_and_params,
+            self.aligned_angle_tuples,
             self._interpolate_angle,
         )
 
@@ -1617,7 +1654,7 @@ class SingleTopology(AtomMapMixin):
             lamb,
             self.src_system.bond,
             self.dst_system.bond,
-            interpolate.align_harmonic_bond_idxs_and_params,
+            self.aligned_bond_tuples,
             self._interpolate_bond,
         )
 
@@ -1627,7 +1664,7 @@ class SingleTopology(AtomMapMixin):
             lamb,
             self.src_system.proper,
             self.dst_system.proper,
-            interpolate.align_proper_idxs_and_params,
+            self.aligned_proper_tuples,
             self._interpolate_torsion,
         )
         return res
@@ -1637,7 +1674,7 @@ class SingleTopology(AtomMapMixin):
             lamb,
             self.src_system.improper,
             self.dst_system.improper,
-            interpolate.align_improper_idxs_and_params,
+            self.aligned_improper_tuples,
             self._interpolate_torsion,
         )
 

--- a/timemachine/fe/utils.py
+++ b/timemachine/fe/utils.py
@@ -271,10 +271,13 @@ def plot_atom_mapping_grid(
     )
 
 
+type _Core = Sequence[Sequence[int]] | NDArray
+
+
 def view_atom_mapping_3d(
     mol_a: Chem.rdchem.Mol,
     mol_b: Chem.rdchem.Mol,
-    cores: Sequence[Sequence[Sequence[int]]] | NDArray = (),
+    cores: Sequence[_Core] | NDArray = (),
     colors: Sequence[str] = (
         # https://colorbrewer2.org/#type=qualitative&scheme=Paired&n=12
         "#a6cee3",

--- a/timemachine/fe/utils.py
+++ b/timemachine/fe/utils.py
@@ -338,8 +338,12 @@ def view_atom_mapping_3d(
     for core in cores:
         assert np.asarray(core).ndim == 2, "expect a list of cores"
 
-    make_style = lambda props: {"stick": props}
-    atom_style = lambda color: make_style({"color": color})
+    def make_style(props):
+        return {"stick": props}
+
+    def atom_style(color):
+        return make_style({"color": color})
+
     dummy_style = atom_style("white")
 
     num_rows = 1 + len(cores)
@@ -376,6 +380,51 @@ def view_atom_mapping_3d(
         for (ia, ib), color in zip(core, colors_):
             view.setStyle({"serial": ia}, atom_style(color), viewer=(row, 0))
             view.setStyle({"serial": ib}, atom_style(color), viewer=(row, 1))
+
+    view.zoomTo()
+
+    if show_atom_idx_labels:
+        view.addPropertyLabels("serial", "", {"alignment": "center", "fontSize": 10})
+
+    return view
+
+
+def view_rest_region_3d(
+    mol_a: Chem.rdchem.Mol,
+    mol_b: Chem.rdchem.Mol,
+    rest_region_atom_idxs_a: Sequence[int],
+    rest_region_atom_idxs_b: Sequence[int],
+    show_atom_idx_labels: bool = False,
+):
+    try:
+        import py3Dmol
+    except ImportError as e:
+        raise RuntimeError("requires py3Dmol to be installed") from e
+
+    def make_style(props):
+        return {"stick": props}
+
+    def atom_style(color):
+        return make_style({"color": color})
+
+    view = py3Dmol.view(viewergrid=(2, 2))
+
+    def add_mol(mol, viewer):
+        view.addModel(Chem.MolToMolBlock(mol), "mol", viewer=viewer)
+
+    add_mol(mol_a, (0, 0))
+    add_mol(mol_b, (0, 1))
+    view.setStyle(make_style({}))
+
+    add_mol(mol_a, (1, 0))
+    view.setStyle(atom_style("white"), viewer=(1, 0))
+    for idx in rest_region_atom_idxs_a:
+        view.setStyle({"serial": idx}, {"stick": {"color": "red"}}, viewer=(1, 0))
+
+    add_mol(mol_b, (1, 1))
+    view.setStyle(atom_style("white"), viewer=(1, 1))
+    for idx in rest_region_atom_idxs_b:
+        view.setStyle({"serial": idx}, atom_style("red"), viewer=(1, 1))
 
     view.zoomTo()
 


### PR DESCRIPTION
The initial implementation of REST in single topology transformations in #1424 applies temperature scaling to all ligand-environment nonbonded interactions, and all ligand-ligand proper torsions that are rotatable or in aliphatic rings. I.e., the "REST region" (here, the set of ligand atoms whose interactions may potentially be scaled), is implicitly _all_ of the combined ligand atoms.

This PR refines the REST region using a simple heuristic: a combined ligand atom in included iff it is involved in a bond, angle, or improper torsion interaction whose parameters differ between the end states of the transformation. The logic for scaling the relevant interactions is retained from the previous version, except that we now exclude interactions from scaling that do not involve an atom in the REST region.

This is intentionally a very minimal heuristic. Later on, we might extend this for example to include in the REST region ligand atoms that are not directly mutated in the transformation, but are nearby (e.g. by graph distance) to a mutation.

This PR also adds a utility to visualize the REST region using `py3Dmol` (similar to the existing `view_atom_mapping_3d`). Example from the hif2a public benchmark:
<img src=https://github.com/user-attachments/assets/a56ea806-a5fd-49c1-8fd4-7527435cb5cc width=500/>


TODO:
- [x] add tests exercising heuristic
- [x] rebase once #1523 is merged