### PR TITLE
Speed-up setup_intermediate_state while maintaining trace-ability.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ memcheck_tests:
 
 .PHONY: unit_tests
 unit_tests:
-	pytest -m 'not $(NOCUDA_MARKER) and not $(NOGPU_MARKER) and not $(MEMCHECK_MARKER) and not $(NIGHTLY_MARKER)' $(PYTEST_CI_ARGS)
+	pytest -x -m 'not $(NOCUDA_MARKER) and not $(NOGPU_MARKER) and not $(MEMCHECK_MARKER) and not $(NIGHTLY_MARKER)' $(PYTEST_CI_ARGS)
 
 .PHONY: nightly_tests
 nightly_tests:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 xfail_strict = true
 verbosity_assertions = 2
-addopts = -svx --hypothesis-profile=no-deadline
+addopts = -sv --hypothesis-profile=no-deadline
 testpaths =
     tests/
 markers =

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -259,14 +259,14 @@ def test_run_rbfe_legs(
             "59ca76d1c5d43925ae6b163667c4b3e60f6c765ce10ad85d4f1d14c7d7854933",
         ),
         "solvent": (
-            "b4af69c91a1cfdbdf911c27f929de56f2436b20d5c6d0b3bc3f59021065df2a2",
+            "d6464cc055e486acf6d6d1311aadc90d0ba27118d818be3750d569ace27f39bf",
             "5c0f5fea16e7fad695fe48c4d7e9400de1ee081616e66d81c13cff975275785d",
             "18478e891fe7e5448df89c10e8eedba32f86bdf572a01749c63957da0dc315f6",
         ),
         "complex": (
-            "1fb7f275f66dc0c4122dbdeeed488074c5e20065aa7836116937d98710619479",
-            "4b858b8b851e7dc642b58ead7468e1ddc6aac13ed7b5961768e75d8d638b3f41",
-            "81ec6f3634d110a8b360a97f09a40f562cd5958aff48c646ae4d0a45c22c6582",
+            "708233cf3dacaa9fe62ba7faf5f873bbe1ea34d1a8b8a5cf80a48d9553f65dc3",
+            "a9269276f75cc64dea521ea723a8af1f1ec7aa4dc99f79c6c940db66b3e576c6",
+            "cefc669291e5027c661be7eb9a3db225f980b1a5ab1b1dfa898da21eea2918ad",
         ),
     }
     with resources.as_file(resources.files("timemachine.testsystems.fep_benchmark.hif2a")) as hif2a_dir:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -254,9 +254,9 @@ def test_run_rbfe_legs(
     # Hashes are of results.npz, lambda0_traj.npz and lambda1_traj.npz respectively.
     leg_results_hashes = {
         "vacuum": (
-            "e71c2c30a18ea154f4eb6c6fb544aeadb0e9dda91c592115cd3eb6f40947df42",
+            "3b2fe61d8df0d80edcf482d9dfe8c38aabf79b1108b17a9042321f7d8d380ee4",
             "c74ba1b503532af7fe83be82090cca82c33f5fa72744e74613dcaad9d978283a",
-            "59ca76d1c5d43925ae6b163667c4b3e60f6c765ce10ad85d4f1d14c7d7854933",
+            "69bcc498fba25febbf1a9c0bd2bda6ebd8855ef382d731b17307d4b7a4ae2540",
         ),
         "solvent": (
             "d6464cc055e486acf6d6d1311aadc90d0ba27118d818be3750d569ace27f39bf",

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -1105,6 +1105,8 @@ def test_assert_torsions_defined_over_non_linear_angles(mol_a, mol_b, core, monk
 
     monkeypatch.setattr(single_topology, "CORE_TORSION_OFF_TO_ON_MIN_MAX", [0.0, 1.0])
     monkeypatch.setattr(single_topology, "CORE_TORSION_ON_TO_OFF_MIN_MAX", [0.0, 1.0])
+    # re-align since min/maxes are changed.
+    st.aligned_proper = st._align_propers()
 
     def assert_fn(lam):
         vs = st.setup_intermediate_state(lam)

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -659,43 +659,6 @@ def test_setup_intermediate_state_not_unreasonably_slow(arbitrary_transformation
     assert elapsed_time / n_states <= 1.0
 
 
-# @pytest.mark.nocuda
-# def test_setup_intermediate_bonded_term(arbitrary_transformation):
-#     """Tests that the current vectorized implementation _setup_intermediate_bonded_term is consistent with the previous
-#     implementation"""
-#     st, _ = arbitrary_transformation
-#     interpolate_fn = functools.partial(interpolate_harmonic_bond_params, k_min=0.1, lambda_min=0.0, lambda_max=0.7)
-
-#     def setup_intermediate_bonded_term_ref(src_bond, dst_bond, lamb, align_fn, interpolate_fn):
-#         bond_idxs_and_params = align_fn(
-#             src_bond.potential.idxs,
-#             src_bond.params,
-#             dst_bond.potential.idxs,
-#             dst_bond.params,
-#         )
-
-#         bond_idxs = []
-#         bond_params = []
-
-#         for idxs, src_params, dst_params in bond_idxs_and_params:
-#             bond_idxs.append(idxs)
-#             new_params = interpolate_fn(src_params, dst_params, lamb)
-#             bond_params.append(new_params)
-
-#         return type(src_bond.potential)(np.array(bond_idxs)).bind(jnp.array(bond_params))
-
-#     for lamb in np.linspace(0.0, 1.0, 10):
-#         bonded_ref = setup_intermediate_bonded_term_ref(
-#             st.src_system.bond, st.dst_system.bond, lamb, align_harmonic_bond_idxs_and_params, interpolate_fn
-#         )
-#         bonded_test = st._setup_intermediate_bonded_term(
-#             st.src_system.bond, st.dst_system.bond, lamb, align_harmonic_bond_idxs_and_params, interpolate_fn
-#         )
-
-#         np.testing.assert_array_equal(bonded_ref.potential.idxs, bonded_test.potential.idxs)
-#         np.testing.assert_array_equal(bonded_ref.params, bonded_test.params)
-
-
 @pytest.mark.nocuda
 def test_setup_intermediate_nonbonded_term(arbitrary_transformation):
     """Tests that the current vectorized implementation _setup_intermediate_nonbonded_term is consistent with the
@@ -703,20 +666,19 @@ def test_setup_intermediate_nonbonded_term(arbitrary_transformation):
     st, _ = arbitrary_transformation
 
     def setup_intermediate_nonbonded_term_ref(src_nonbonded, dst_nonbonded, lamb, align_fn, interpolate_qlj_fn):
-        pair_idxs_and_params = align_fn(
-            src_nonbonded.potential.idxs,
-            src_nonbonded.params,
-            dst_nonbonded.potential.idxs,
-            dst_nonbonded.params,
-        )
-
         cutoff = src_nonbonded.potential.cutoff
-
         pair_idxs = []
         pair_params = []
-        for idxs, src_params, dst_params in pair_idxs_and_params:
+        for idxs, src_params, dst_params in zip(
+            st.aligned_nonbonded_pairlist.idxs,
+            st.aligned_nonbonded_pairlist.src_params,
+            st.aligned_nonbonded_pairlist.dst_params,
+        ):
             src_qlj, src_w = src_params[:3], src_params[3]
             dst_qlj, dst_w = dst_params[:3], dst_params[3]
+
+            src_qlj = tuple(src_qlj.tolist())
+            dst_qlj = tuple(dst_qlj.tolist())
 
             if src_qlj == (0, 0, 0):  # i.e. excluded in src state
                 new_params = (*dst_qlj, interpolate_w_coord(cutoff, 0, lamb))
@@ -743,16 +705,10 @@ def test_setup_intermediate_nonbonded_term(arbitrary_transformation):
             align_nonbonded_idxs_and_params,
             linear_interpolation,
         )
-        nonbonded_test = st._setup_intermediate_nonbonded_term(
-            st.src_system.nonbonded_pair_list,
-            st.dst_system.nonbonded_pair_list,
-            lamb,
-            align_nonbonded_idxs_and_params,
-            linear_interpolation,
-        )
+        nonbonded_test = st.aligned_nonbonded_pairlist.interpolate(lamb)
 
         np.testing.assert_array_equal(nonbonded_ref.potential.idxs, nonbonded_test.potential.idxs)
-        np.testing.assert_array_equal(nonbonded_ref.params, nonbonded_test.params)
+        np.testing.assert_array_almost_equal(nonbonded_ref.params, nonbonded_test.params)
 
 
 @pytest.mark.nocuda

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -670,9 +670,9 @@ def test_setup_intermediate_nonbonded_term(arbitrary_transformation):
         pair_idxs = []
         pair_params = []
         for idxs, src_params, dst_params in zip(
-            st.aligned_nonbonded_pairlist.idxs,
-            st.aligned_nonbonded_pairlist.src_params,
-            st.aligned_nonbonded_pairlist.dst_params,
+            st.aligned_nonbonded_pair_list.idxs,
+            st.aligned_nonbonded_pair_list.src_params,
+            st.aligned_nonbonded_pair_list.dst_params,
         ):
             src_qlj, src_w = src_params[:3], src_params[3]
             dst_qlj, dst_w = dst_params[:3], dst_params[3]

--- a/tests/test_single_topology.py
+++ b/tests/test_single_topology.py
@@ -705,7 +705,7 @@ def test_setup_intermediate_nonbonded_term(arbitrary_transformation):
             align_nonbonded_idxs_and_params,
             linear_interpolation,
         )
-        nonbonded_test = st.aligned_nonbonded_pairlist.interpolate(lamb)
+        nonbonded_test = st.aligned_nonbonded_pair_list.interpolate(lamb)
 
         np.testing.assert_array_equal(nonbonded_ref.potential.idxs, nonbonded_test.potential.idxs)
         np.testing.assert_array_almost_equal(nonbonded_ref.params, nonbonded_test.params)

--- a/timemachine/fe/interpolate.py
+++ b/timemachine/fe/interpolate.py
@@ -14,6 +14,11 @@ Params = Any
 Key = Any
 
 
+# used to convert arrays to a hashable type for use as dict keys and in sets
+def to_hashable(x):
+    return tuple(to_hashable(e) for e in x) if isinstance(x, Iterable) else x
+
+
 def align_idxs_and_params(
     src_idxs,
     src_params,
@@ -78,10 +83,6 @@ def align_idxs_and_params(
     for all_idxs in [src_idxs, dst_idxs]:
         for idxs in all_idxs:
             validate_idxs(idxs)
-
-    # used to convert arrays to a hashable type for use as dict keys and in sets
-    def to_hashable(x):
-        return tuple(to_hashable(e) for e in x) if isinstance(x, Iterable) else x
 
     def make_kv(all_idxs, all_params):
         kvs = [(to_hashable(key(idxs, params)), params) for idxs, params in zip(all_idxs, all_params)]


### PR DESCRIPTION
This PR speeds-up `setup_intermediate_state` by about 30-50x while still maintaining our calling to call `jax.jit`, `jax.vmap`, and `jax.grad` on functions that invoke `setup_intermediate_state()`

[2x speed-up] - pre-align idxs and parameters in the constructor.
[2x speed-up] - pre-compute min/max bounds used by interpolation code in the constructor.
[2x speed-up] - vectorize `interpolate_*_params` with `jax.vmap` and `jax.jit`
[1.5x speed-up] - caching `get_dummy_atoms_a, get_dummy_atoms_b, get_core_atoms`.
[1.5x speed-up] - caching `src_chiral_idxs` and `dst_chiral_idxs`.

timings for 128 calls to `setup_intermediate_state()` on the hif2a ligand pair:

master:

jit time: 0.63s
run time: 20.91s

this pr:

jit time: 0.41s
run time: 0.56s


``` python
import time

def test_setup_intermediate_state():
    ff = Forcefield.load_default()
    mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
    st = single_topology.SingleTopology(mol_a, mol_b, core, ff)

    import cProfile
    import pstats

    # call once to warm-up jit
    start_time = time.time()
    st.setup_intermediate_state(0.5)
    print("jit time", time.time() - start_time)
    profiler = cProfile.Profile()
    profiler.enable()
    start_time = time.time()
    for lam in np.linspace(0, 1, 128):
        st.setup_intermediate_state(lam)
    print("run time", time.time() - start_time)
    profiler.disable()
    pstats.Stats(profiler).sort_stats(pstats.SortKey.CUMULATIVE).print_stats(100)


if __name__ == "__main__":
    test_setup_intermediate_state()
```
