### PR TITLE
Revert REST region heuristic

### DIFF
--- a/timemachine/fe/rest/single_topology.py
+++ b/timemachine/fe/rest/single_topology.py
@@ -1,14 +1,13 @@
-from dataclasses import astuple, replace
+from dataclasses import replace
 from functools import cached_property
 
 import jax.numpy as jnp
-import numpy as np
 from numpy.typing import NDArray
 from openmm import app
 from rdkit import Chem
 
 from timemachine.constants import NBParamIdx
-from timemachine.fe.single_topology import AlignedPotential, SingleTopology
+from timemachine.fe.single_topology import SingleTopology
 from timemachine.fe.system import GuestSystem, HostGuestSystem, HostSystem
 from timemachine.ff import Forcefield
 
@@ -81,37 +80,7 @@ class SingleTopologyREST(SingleTopology):
         )
 
     @cached_property
-    def rest_region_atom_idxs(self) -> set[int]:
-        """Returns the set of indices of atoms in the combined ligand that are in the REST region.
-
-        Here the REST region is defined to include combined ligand atoms involved in bond, angle, or improper torsion
-        interactions that differ in the end states. Note that proper torsions are omitted from this heuristic as this
-        tends to result in larger REST regions than seem desirable.
-        """
-
-        aligned_potentials: list[AlignedPotential] = [
-            self.aligned_bond,
-            self.aligned_angle,
-            self.aligned_improper,
-        ]
-
-        idxs = {
-            int(idx)
-            for aligned in aligned_potentials
-            for idxs, params_a, params_b in zip(aligned.idxs, aligned.src_params, aligned.dst_params)
-            if not np.all(params_a == params_b)
-            for idx in idxs  # type: ignore[attr-defined]
-        }
-
-        # Ensure all dummy atoms are included in the REST region
-        idxs |= self.get_dummy_atoms_a()
-        idxs |= self.get_dummy_atoms_b()
-
-        return idxs
-
-    @cached_property
     def aliphatic_ring_bonds(self) -> set[CanonicalBond]:
-        """Returns the set of aliphatic ring bonds in the combined ligand."""
         ring_bonds_a = {bond.translate(self.a_to_c) for bond in get_aliphatic_ring_bonds(self.mol_a)}
         ring_bonds_b = {bond.translate(self.b_to_c) for bond in get_aliphatic_ring_bonds(self.mol_b)}
         ring_bonds_c = ring_bonds_a | ring_bonds_b
@@ -119,7 +88,6 @@ class SingleTopologyREST(SingleTopology):
 
     @cached_property
     def rotatable_bonds(self) -> set[CanonicalBond]:
-        """Returns the set of rotatable bonds in the combined ligand."""
         rotatable_bonds_a = {bond.translate(self.a_to_c) for bond in get_rotatable_bonds(self.mol_a)}
         rotatable_bonds_b = {bond.translate(self.b_to_c) for bond in get_rotatable_bonds(self.mol_b)}
         rotatable_bonds_c = rotatable_bonds_a | rotatable_bonds_b
@@ -127,35 +95,21 @@ class SingleTopologyREST(SingleTopology):
 
     @cached_property
     def propers(self) -> list[CanonicalProper]:
-        """Returns a list of proper torsions in the combined ligand."""
         # TODO: refactor SingleTopology to compute src and dst alignment at initialization
         return [mkproper(*idxs) for idxs in super().setup_intermediate_state(0.0).proper.potential.idxs]
 
     @cached_property
-    def candidate_propers(self) -> dict[int, CanonicalProper]:
-        """Returns a dict of propers in the combined ligand, keyed on index, that are candidates for softening."""
-        return {
-            idx: proper
+    def target_proper_idxs(self) -> list[int]:
+        return [
+            idx
             for idx, proper in enumerate(self.propers)
             for bond in [mkbond(proper.j, proper.k)]
             if bond in self.rotatable_bonds or bond in self.aliphatic_ring_bonds
-        }
+        ]
 
     @cached_property
-    def target_propers(self) -> dict[int, CanonicalProper]:
-        """Returns a dict of propers in the combined ligand, keyed on index, that are candidates for softening and
-        involve an atom in the REST region."""
-        return {
-            idx: proper
-            for (idx, proper) in self.candidate_propers.items()
-            if any(idx in self.rest_region_atom_idxs for idx in astuple(proper))
-        }
-
-    @cached_property
-    def target_proper_idxs(self) -> list[int]:
-        """Returns a list of indices of propers in the combined ligand that are candidates for softening and involve an
-        atom in the REST region."""
-        return list(self.target_propers.keys())
+    def target_propers(self) -> set[CanonicalProper]:
+        return {self.propers[i] for i in self.target_proper_idxs}
 
     def get_energy_scale_factor(self, lamb: float) -> float:
         temperature_factor = float(self._temperature_scale_interpolation_fxn(lamb))
@@ -192,28 +146,25 @@ class SingleTopologyREST(SingleTopology):
     ) -> HostGuestSystem:
         ref_state = super().combine_with_host(host_system, lamb, num_water_atoms, ff, omm_topology)
 
-        # compute indices corresponding to REST-region ligand atoms in the host-guest interaction potential
-        num_atoms_host = host_system.nonbonded_all_pairs.potential.num_atoms
-        rest_region_atom_idxs = np.array(sorted(self.rest_region_atom_idxs)) + num_atoms_host
-
+        num_host_atoms = host_system.nonbonded_all_pairs.params.shape[0]
         # NOTE: the following methods of scaling the ligand-environment interaction energy are all equivalent:
         #
         # 1. scaling ligand charges and LJ epsilons by energy_scale
         # 2. scaling environment charges and LJ epsilons by energy_scale
         # 3. scaling all charges and LJ epsilons by sqrt(energy_scale)
         #
-        # However, (2) and (3) are incompatible with the current water sampling implementation, which assumes that the
-        # parameters corresponding to water atoms are identical in the host-host all-pairs potential and the host-guest
-        # interaction group potential. Therefore we choose option (1).
+        # Here, we choose (1) because water sampling infers parameters from the NonbondedInteractionGroup.Changing
+        # the environment parameters prevents easy construction of equivalent parameters for water sampling, which
+        # leads to incorrect sampling.
 
         energy_scale = self.get_energy_scale_factor(lamb)
 
         nonbonded_host_guest_ixn = replace(
             ref_state.nonbonded_ixn_group,
             params=jnp.asarray(ref_state.nonbonded_ixn_group.params)
-            .at[rest_region_atom_idxs, NBParamIdx.Q_IDX]
+            .at[num_host_atoms:, NBParamIdx.Q_IDX]
             .mul(energy_scale)  # scale ligand charges
-            .at[rest_region_atom_idxs, NBParamIdx.LJ_EPS_IDX]
+            .at[num_host_atoms:, NBParamIdx.LJ_EPS_IDX]
             .mul(energy_scale),  # scale ligand epsilons
         )
 

--- a/timemachine/fe/utils.py
+++ b/timemachine/fe/utils.py
@@ -271,13 +271,10 @@ def plot_atom_mapping_grid(
     )
 
 
-type _Core = Sequence[Sequence[int]] | NDArray
-
-
 def view_atom_mapping_3d(
     mol_a: Chem.rdchem.Mol,
     mol_b: Chem.rdchem.Mol,
-    cores: Sequence[_Core] | NDArray = (),
+    cores: Sequence[Sequence[Sequence[int]]] | NDArray = (),
     colors: Sequence[str] = (
         # https://colorbrewer2.org/#type=qualitative&scheme=Paired&n=12
         "#a6cee3",
@@ -338,12 +335,8 @@ def view_atom_mapping_3d(
     for core in cores:
         assert np.asarray(core).ndim == 2, "expect a list of cores"
 
-    def make_style(props):
-        return {"stick": props}
-
-    def atom_style(color):
-        return make_style({"color": color})
-
+    make_style = lambda props: {"stick": props}
+    atom_style = lambda color: make_style({"color": color})
     dummy_style = atom_style("white")
 
     num_rows = 1 + len(cores)
@@ -380,51 +373,6 @@ def view_atom_mapping_3d(
         for (ia, ib), color in zip(core, colors_):
             view.setStyle({"serial": ia}, atom_style(color), viewer=(row, 0))
             view.setStyle({"serial": ib}, atom_style(color), viewer=(row, 1))
-
-    view.zoomTo()
-
-    if show_atom_idx_labels:
-        view.addPropertyLabels("serial", "", {"alignment": "center", "fontSize": 10})
-
-    return view
-
-
-def view_rest_region_3d(
-    mol_a: Chem.rdchem.Mol,
-    mol_b: Chem.rdchem.Mol,
-    rest_region_atom_idxs_a: Sequence[int],
-    rest_region_atom_idxs_b: Sequence[int],
-    show_atom_idx_labels: bool = False,
-):
-    try:
-        import py3Dmol
-    except ImportError as e:
-        raise RuntimeError("requires py3Dmol to be installed") from e
-
-    def make_style(props):
-        return {"stick": props}
-
-    def atom_style(color):
-        return make_style({"color": color})
-
-    view = py3Dmol.view(viewergrid=(2, 2))
-
-    def add_mol(mol, viewer):
-        view.addModel(Chem.MolToMolBlock(mol), "mol", viewer=viewer)
-
-    add_mol(mol_a, (0, 0))
-    add_mol(mol_b, (0, 1))
-    view.setStyle(make_style({}))
-
-    add_mol(mol_a, (1, 0))
-    view.setStyle(atom_style("white"), viewer=(1, 0))
-    for idx in rest_region_atom_idxs_a:
-        view.setStyle({"serial": idx}, {"stick": {"color": "red"}}, viewer=(1, 0))
-
-    add_mol(mol_b, (1, 1))
-    view.setStyle(atom_style("white"), viewer=(1, 1))
-    for idx in rest_region_atom_idxs_b:
-        view.setStyle({"serial": idx}, atom_style("red"), viewer=(1, 1))
 
     view.zoomTo()
 


### PR DESCRIPTION
This reverts #1524 temporarily due to the discovery of a bug that resulted in all proper torsions being softened regardless of the inferred REST region (i.e., similar to the previous behavior).

The latter should be an easy fix, but reverting this in the meantime to fix the nightly tests, since this seems preferable to updating the result hashes for a flawed version.

This reverts commit 51248370bdd32ec207bb706fd5c0bfb6568a3e2f.