### PR TITLE
Fix REST heuristics

### DIFF
--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -114,8 +114,8 @@ def test_single_topology_rest_vacuum(mol_pair, temperature_scale_interpolation_f
         assert energy_scale < 1.0
 
         # check that a proper subset of ligand-ligand nonbonded interactions are scaled
-        assert U_nonbonded != U_nonbonded_ref
-        assert U_nonbonded != energy_scale * U_nonbonded_ref
+        assert not np.isclose(U_nonbonded, U_nonbonded_ref)
+        assert not np.isclose(U_nonbonded, energy_scale * U_nonbonded_ref)
 
         if has_rotatable_bonds or has_aliphatic_rings:
             assert 0 < len(st_rest.candidate_propers)

--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -119,6 +119,7 @@ def test_single_topology_rest_vacuum(mol_pair, temperature_scale_interpolation_f
 
         if has_rotatable_bonds or has_aliphatic_rings:
             assert 0 < len(st_rest.candidate_propers)
+            assert not np.isclose(U_proper, U_proper_ref)
             assert U_proper < U_proper_ref
 
         def compute_proper_energy(state: GuestSystem, ixn_idxs: Sequence[int]):

--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -13,6 +13,7 @@ from timemachine.constants import DEFAULT_ATOM_MAPPING_KWARGS
 from timemachine.fe import atom_mapping
 from timemachine.fe.free_energy import HostConfig
 from timemachine.fe.rbfe import Host, setup_optimized_host
+from timemachine.fe.rest.bond import mkproper
 from timemachine.fe.rest.interpolation import (
     Exponential,
     InterpolationFxnName,
@@ -86,7 +87,8 @@ def test_single_topology_rest_vacuum(mol_pair, temperature_scale_interpolation_f
 
     state = st_rest.setup_intermediate_state(lamb)
     state_ref = st.setup_intermediate_state(lamb)
-    assert len(st_rest.candidate_propers) < len(state_ref.proper.potential.idxs)
+    assert set(st_rest.propers) == set(mkproper(*idxs) for idxs in state_ref.proper.potential.idxs)
+    assert set(st_rest.candidate_propers.values()) < set(st_rest.propers)
 
     ligand_conf = st.combine_confs(get_romol_conf(mol_a), get_romol_conf(mol_b))
 

--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -113,7 +113,7 @@ def test_single_topology_rest_vacuum(mol_pair, temperature_scale_interpolation_f
     else:
         assert energy_scale < 1.0
 
-        # check that a subset of ligand-ligand nonbonded interactions are scaled
+        # check that a proper subset of ligand-ligand nonbonded interactions are scaled
         assert U_nonbonded != U_nonbonded_ref
         assert U_nonbonded != energy_scale * U_nonbonded_ref
 

--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -113,11 +113,13 @@ def test_single_topology_rest_vacuum(mol_pair, temperature_scale_interpolation_f
     else:
         assert energy_scale < 1.0
 
+        # check that a subset of ligand-ligand nonbonded interactions are scaled
+        assert U_nonbonded != U_nonbonded_ref
+        assert U_nonbonded != energy_scale * U_nonbonded_ref
+
         if has_rotatable_bonds or has_aliphatic_rings:
             assert 0 < len(st_rest.candidate_propers)
-
-            if energy_scale < 1.0:
-                assert U_proper < U_proper_ref
+            assert U_proper < U_proper_ref
 
         def compute_proper_energy(state: GuestSystem, ixn_idxs: Sequence[int]):
             assert state.proper

--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -202,6 +202,15 @@ def get_identity_transformation(mol):
 
 
 def test_single_topology_rest_propers():
+    """Example with some propers not in the REST region"""
+    mol_a = hif2a_ligands["15"]
+    mol_b = hif2a_ligands["30"]
+    core = get_core(mol_a, mol_b)
+    st = SingleTopologyREST(mol_a, mol_b, np.asarray(core), forcefield, 2.0)
+    assert set(st.target_propers.items()) < set(st.candidate_propers.items())
+
+
+def test_single_topology_rest_propers_identity():
     # benzene: no propers are scaled
     benzene = get_mol("c1ccccc1")
     st = get_identity_transformation(benzene)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -254,9 +254,9 @@ def test_run_rbfe_legs(
     # Hashes are of results.npz, lambda0_traj.npz and lambda1_traj.npz respectively.
     leg_results_hashes = {
         "vacuum": (
-            "3b2fe61d8df0d80edcf482d9dfe8c38aabf79b1108b17a9042321f7d8d380ee4",
+            "177ddb8c1b1fa62411d8657a7f21a48812d9490796fe810273728e073460d82d",
             "c74ba1b503532af7fe83be82090cca82c33f5fa72744e74613dcaad9d978283a",
-            "69bcc498fba25febbf1a9c0bd2bda6ebd8855ef382d731b17307d4b7a4ae2540",
+            "7a1a88079c2eb345947a6a380e18872a27d1f0ec5a29437e6c0560b3876375db",
         ),
         "solvent": (
             "d6464cc055e486acf6d6d1311aadc90d0ba27118d818be3750d569ace27f39bf",

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -259,14 +259,14 @@ def test_run_rbfe_legs(
             "7a1a88079c2eb345947a6a380e18872a27d1f0ec5a29437e6c0560b3876375db",
         ),
         "solvent": (
-            "d6464cc055e486acf6d6d1311aadc90d0ba27118d818be3750d569ace27f39bf",
+            "9ccc4cb16ea43c0eed4941a3485a591055ca9e68f30bdc6ae49113ca247ddbd4",
             "5c0f5fea16e7fad695fe48c4d7e9400de1ee081616e66d81c13cff975275785d",
             "18478e891fe7e5448df89c10e8eedba32f86bdf572a01749c63957da0dc315f6",
         ),
         "complex": (
-            "708233cf3dacaa9fe62ba7faf5f873bbe1ea34d1a8b8a5cf80a48d9553f65dc3",
-            "a9269276f75cc64dea521ea723a8af1f1ec7aa4dc99f79c6c940db66b3e576c6",
-            "cefc669291e5027c661be7eb9a3db225f980b1a5ab1b1dfa898da21eea2918ad",
+            "8f79bac368d05fb58fbd3a2f0fa0a0acb60b63e65351b3f94447de3b025865e6",
+            "9e66f5219a9d27331e5dbe38d458b6092dcdf15d1e9d11ff1595b40a46daa91a",
+            "a30c101c16373e17a10c062c3ab63fe6ee29d5d21e58c7f445361fc8be520848",
         ),
     }
     with resources.as_file(resources.files("timemachine.testsystems.fep_benchmark.hif2a")) as hif2a_dir:

--- a/timemachine/fe/rest/bond.py
+++ b/timemachine/fe/rest/bond.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC, abstractmethod, abstractproperty
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Callable, TypeVar
@@ -11,6 +11,9 @@ TCanonicalIxn = TypeVar("TCanonicalIxn", bound="CanonicalIxn")  # in Python 3.11
 
 @dataclass(frozen=True)
 class CanonicalIxn(ABC):
+    @abstractproperty
+    def idxs(self) -> tuple[int, ...]: ...
+
     @abstractmethod
     def map(self: TCanonicalIxn, f: Callable[[int], int]) -> TCanonicalIxn: ...
 
@@ -35,6 +38,10 @@ class CanonicalBond(CanonicalIxn):
     def from_idxs(cls, i: int, j: int):
         return cls(i, j, _unsafe=True) if i < j else cls(j, i, _unsafe=True)
 
+    @property
+    def idxs(self) -> tuple[int, int]:
+        return (self.i, self.j)
+
     def map(self, f: Callable[[int], int]) -> "CanonicalBond":
         return CanonicalBond.from_idxs(f(self.i), f(self.j))
 
@@ -56,6 +63,10 @@ class CanonicalAngle(CanonicalIxn):
     @classmethod
     def from_idxs(cls, i: int, j: int, k: int):
         return cls(i, j, k, _unsafe=True) if i < k else cls(k, j, i, _unsafe=True)
+
+    @property
+    def idxs(self) -> tuple[int, int, int]:
+        return (self.i, self.j, self.k)
 
     def map(self, f: Callable[[int], int]) -> "CanonicalAngle":
         return CanonicalAngle.from_idxs(f(self.i), f(self.j), f(self.k))
@@ -80,17 +91,24 @@ class CanonicalProper(CanonicalIxn):
     def from_idxs(cls, i: int, j: int, k: int, l: int):
         return cls(i, j, k, l, _unsafe=True) if i < l else cls(l, k, j, i, _unsafe=True)
 
+    @property
+    def idxs(self) -> tuple[int, int, int, int]:
+        return (self.i, self.j, self.k, self.l)
+
     def map(self, f: Callable[[int], int]) -> "CanonicalProper":
         return CanonicalProper.from_idxs(f(self.i), f(self.j), f(self.k), f(self.l))
 
 
-def mkbond(i: int, j: int) -> CanonicalBond:
-    return CanonicalBond.from_idxs(i, j)
+type Idx = int | np.integer
 
 
-def mkangle(i: int, j: int, k: int) -> CanonicalAngle:
-    return CanonicalAngle.from_idxs(i, j, k)
+def mkbond(i: Idx, j: Idx) -> CanonicalBond:
+    return CanonicalBond.from_idxs(int(i), int(j))
 
 
-def mkproper(i: int, j: int, k: int, l: int) -> CanonicalProper:
-    return CanonicalProper.from_idxs(i, j, k, l)
+def mkangle(i: Idx, j: Idx, k: Idx) -> CanonicalAngle:
+    return CanonicalAngle.from_idxs(int(i), int(j), int(k))
+
+
+def mkproper(i: Idx, j: Idx, k: Idx, l: Idx) -> CanonicalProper:
+    return CanonicalProper.from_idxs(int(i), int(j), int(k), int(l))

--- a/timemachine/fe/rest/single_topology.py
+++ b/timemachine/fe/rest/single_topology.py
@@ -1,4 +1,4 @@
-from dataclasses import astuple, replace
+from dataclasses import replace
 from functools import cached_property
 
 import jax.numpy as jnp
@@ -148,7 +148,7 @@ class SingleTopologyREST(SingleTopology):
         return {
             idx: proper
             for (idx, proper) in self.candidate_propers.items()
-            if any(idx in self.rest_region_atom_idxs for idx in astuple(proper))
+            if any(idx in self.rest_region_atom_idxs for idx in proper.idxs)
         }
 
     @cached_property

--- a/timemachine/fe/rest/single_topology.py
+++ b/timemachine/fe/rest/single_topology.py
@@ -171,12 +171,18 @@ class SingleTopologyREST(SingleTopology):
             params=jnp.asarray(ref_state.proper.params).at[self.target_proper_idxs, 0].mul(energy_scale),
         )
 
+        rest_region_pair_idxs = [
+            idx
+            for idx, (i, j) in enumerate(ref_state.nonbonded_pair_list.potential.idxs)
+            if i in self.rest_region_atom_idxs or j in self.rest_region_atom_idxs
+        ]
+
         nonbonded_pair_list = replace(
             ref_state.nonbonded_pair_list,
             params=jnp.asarray(ref_state.nonbonded_pair_list.params)
-            .at[:, NBParamIdx.Q_IDX]
+            .at[rest_region_pair_idxs, NBParamIdx.Q_IDX]
             .mul(energy_scale)  # scale q_ij
-            .at[:, NBParamIdx.LJ_EPS_IDX]
+            .at[rest_region_pair_idxs, NBParamIdx.LJ_EPS_IDX]
             .mul(energy_scale),  # scale eps_ij
         )
 


### PR DESCRIPTION
Fixes 2 separate bugs in the REST heuristics introduced in #1524.

1. Fixes the implementation of `target_torsions`. Previously, the filter predicate was trivially true due to a subtle issue with the implementation using `dataclasses.astuple`.
2. Refines REST softening of ligand-ligand nonbonded interactions to only include pairs with at least one atom in the REST region. (Previously all pairs were softened.)

TODO
- [x] Update result hashes in nightly tests