### PR TITLE
Move fixed-output tests to separate CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,7 +160,7 @@ fixed-output-tests:
     - pip install .[test]
     - make fixed_output_tests
   artifacts:
-    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-tests"
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-fixed-output-tests"
     paths:
         - coverage/
         - $CI_ARTIFACT_DIR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,6 +148,25 @@ unit-tests:
     when: on_success
     expire_in: 1 week
 
+fixed-output-tests:
+  stage: test
+  image: $DOCKER_TAG
+  needs: ["lint"]
+  tags:
+    - aws-tardis-gpu
+  rules:
+    - if: $CI_EXTERNAL_PULL_REQUEST_IID
+  script:
+    - pip install .[test]
+    - make fixed_output_tests
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-tests"
+    paths:
+        - coverage/
+        - $CI_ARTIFACT_DIR
+    when: on_success
+    expire_in: 1 week
+
 nightly-tests:
   stage: test
   image: $DOCKER_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -245,22 +245,3 @@ nightly-tests-nogpu:
         - $CI_ARTIFACT_DIR
     when: on_success
     expire_in: 1 week
-
-nightly-tests-fixed-output:
-  stage: test
-  image: $DOCKER_TAG
-  needs: ["lint"]
-  tags:
-    - aws-tardis-gpu
-  rules:
-    - if: $NIGHTLY_TESTS
-  script:
-    - pip install .[test]
-    - make fixed_output_nightly_tests
-  artifacts:
-    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-fixed-output-nightly-tests"
-    paths:
-        - coverage/
-        - $CI_ARTIFACT_DIR
-    when: on_success
-    expire_in: 1 week

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,7 +164,6 @@ fixed-output-tests:
     paths:
         - coverage/
         - $CI_ARTIFACT_DIR
-    when: on_success
     expire_in: 1 week
 
 nightly-tests:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -245,3 +245,22 @@ nightly-tests-nogpu:
         - $CI_ARTIFACT_DIR
     when: on_success
     expire_in: 1 week
+
+nightly-tests-fixed-output:
+  stage: test
+  image: $DOCKER_TAG
+  needs: ["lint"]
+  tags:
+    - aws-tardis-gpu
+  rules:
+    - if: $NIGHTLY_TESTS
+  script:
+    - pip install .[test]
+    - make fixed_output_nightly_tests
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-fixed-output-nightly-tests"
+    paths:
+        - coverage/
+        - $CI_ARTIFACT_DIR
+    when: on_success
+    expire_in: 1 week

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ NOGPU_MARKER := nogpu
 
 MEMCHECK_MARKER := memcheck
 NIGHTLY_MARKER := nightly
+
+# pytest mark to indicate tests that compare the hash of a result with
+# a hardcoded reference. It's sometimes convenient to run these
+# separately during development to get updated hash values in cases
+# where we expect the output to change.
 FIXED_OUTPUT_MARKER := fixed_output
 
 COMPUTE_SANITIZER_CMD := compute-sanitizer --launch-timeout 120 --padding 2048 --tool memcheck --leak-check full --error-exitcode 1

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,9 @@ NOGPU_MARKER := nogpu
 MEMCHECK_MARKER := memcheck
 NIGHTLY_MARKER := nightly
 
-# pytest mark to indicate tests that compare the hash of a result with
-# a hardcoded reference. It's sometimes convenient to run these
-# separately during development to get updated hash values in cases
-# where we expect the output to change.
+# pytest mark to indicate tests that compare a computed result (or hash) with a hardcoded reference.
+# It's sometimes convenient to run these separately during development to compute updated values in cases where we
+# expect the output to change.
 FIXED_OUTPUT_MARKER := fixed_output
 
 COMPUTE_SANITIZER_CMD := compute-sanitizer --launch-timeout 120 --padding 2048 --tool memcheck --leak-check full --error-exitcode 1

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ fixed_output_tests:
 memcheck_tests:
 	$(COMPUTE_SANITIZER_CMD) pytest -m '$(MEMCHECK_MARKER) and not $(NIGHTLY_MARKER)' $(PYTEST_CI_ARGS)
 
+# NOTE: unit_tests pass -x to pytest to exit after first failure
 .PHONY: unit_tests
 unit_tests:
 	pytest -x -m 'not $(NOCUDA_MARKER) and not $(NOGPU_MARKER) and not $(FIXED_OUTPUT_MARKER) and not $(MEMCHECK_MARKER) and not $(NIGHTLY_MARKER)' $(PYTEST_CI_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ NOGPU_MARKER := nogpu
 
 MEMCHECK_MARKER := memcheck
 NIGHTLY_MARKER := nightly
+FIXED_OUTPUT_MARKER := fixed_output
 
 COMPUTE_SANITIZER_CMD := compute-sanitizer --launch-timeout 120 --padding 2048 --tool memcheck --leak-check full --error-exitcode 1
 
@@ -42,13 +43,17 @@ nocuda_tests:
 nogpu_tests:
 	pytest -m '$(NOGPU_MARKER) and not $(NIGHTLY_MARKER)' $(PYTEST_CI_ARGS)
 
+.PHONY: fixed_output_tests
+fixed_output_tests:
+	pytest -m '$(FIXED_OUTPUT_MARKER) and not $(NIGHTLY_MARKER)' $(PYTEST_CI_ARGS)
+
 .PHONY: memcheck_tests
 memcheck_tests:
 	$(COMPUTE_SANITIZER_CMD) pytest -m '$(MEMCHECK_MARKER) and not $(NIGHTLY_MARKER)' $(PYTEST_CI_ARGS)
 
 .PHONY: unit_tests
 unit_tests:
-	pytest -x -m 'not $(NOCUDA_MARKER) and not $(NOGPU_MARKER) and not $(MEMCHECK_MARKER) and not $(NIGHTLY_MARKER)' $(PYTEST_CI_ARGS)
+	pytest -x -m 'not $(NOCUDA_MARKER) and not $(NOGPU_MARKER) and not $(FIXED_OUTPUT_MARKER) and not $(MEMCHECK_MARKER) and not $(NIGHTLY_MARKER)' $(PYTEST_CI_ARGS)
 
 .PHONY: nightly_tests
 nightly_tests:
@@ -65,6 +70,10 @@ nocuda_nightly_tests:
 .PHONY: nogpu_nightly_tests
 nogpu_nightly_tests:
 	pytest -m '$(NIGHTLY_MARKER) and $(NOGPU_MARKER)' $(PYTEST_CI_ARGS)
+
+.PHONY: fixed_output_nightly_tests
+fixed_output_nightly_tests:
+	pytest -m '$(NIGHTLY_MARKER) and $(FIXED_OUTPUT_MARKER)' $(PYTEST_CI_ARGS)
 
 .PHONY: ci
 ci: verify memcheck_tests unit_tests

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ nogpu_tests:
 
 .PHONY: fixed_output_tests
 fixed_output_tests:
-	pytest -m '$(FIXED_OUTPUT_MARKER) and not $(NIGHTLY_MARKER)' $(PYTEST_CI_ARGS)
+	pytest -m '$(FIXED_OUTPUT_MARKER)' $(PYTEST_CI_ARGS)
 
 .PHONY: memcheck_tests
 memcheck_tests:
@@ -74,10 +74,6 @@ nocuda_nightly_tests:
 .PHONY: nogpu_nightly_tests
 nogpu_nightly_tests:
 	pytest -m '$(NIGHTLY_MARKER) and $(NOGPU_MARKER)' $(PYTEST_CI_ARGS)
-
-.PHONY: fixed_output_nightly_tests
-fixed_output_nightly_tests:
-	pytest -m '$(NIGHTLY_MARKER) and $(FIXED_OUTPUT_MARKER)' $(PYTEST_CI_ARGS)
 
 .PHONY: ci
 ci: verify memcheck_tests unit_tests

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -212,11 +212,7 @@ def test_water_sampling_mc_buckyball(batch_size, insertion_type):
 @pytest.mark.fixed_output
 @pytest.mark.parametrize(
     "leg, n_windows, n_frames, n_eq_steps",
-    [
-        ("vacuum", 6, 50, 1000),
-        pytest.param("solvent", 5, 50, 1000, marks=pytest.mark.nightly),
-        pytest.param("complex", 5, 50, 1000, marks=pytest.mark.nightly),
-    ],
+    [("vacuum", 6, 50, 1000), ("solvent", 5, 50, 1000), ("complex", 5, 50, 1000)],
 )
 @pytest.mark.parametrize("mol_a, mol_b", [("15", "30")])
 @pytest.mark.parametrize("seed", [2025])

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -209,6 +209,7 @@ def test_water_sampling_mc_buckyball(batch_size, insertion_type):
             np.testing.assert_array_equal(test_data[key], reference_data[key])
 
 
+@pytest.mark.fixed_output
 @pytest.mark.parametrize(
     "leg, n_windows, n_frames, n_eq_steps",
     [

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -133,26 +133,6 @@ def get_smc_free_solv_results(result_path: str) -> tuple[Array, Array]:
     return dG_preds, dG_expts
 
 
-@pytest.mark.skip("needs update since removal of lambda dependence in nonbonded potentials")
-def test_smc_freesolv(smc_free_solv_path):
-    """run_smc_on_freesolv.py with reasonable settings on a small subset of FreeSolv, and expect
-    * output in summary_smc_result_*.pkl
-    * no NaNs in accumulated log weights
-    * predictions within 2 kcal/mol of experiment
-    """
-    dG_preds, dG_expts = get_smc_free_solv_results(smc_free_solv_path)
-    # compute error summaries
-    mean_abs_err_kcalmol = np.mean(np.abs(dG_preds - dG_expts))
-    print(dG_preds, dG_expts, mean_abs_err_kcalmol)
-
-    # expect small error
-    # * MAE of ~1.5 kcal/mol: run with these settings on 10 molecules from FreeSolv
-    # * MAE of ~1.5 kcal/mol: run with these settings on ~500 molecules from FreeSolv
-    # * MAE of ~1.1 kcal/mol: FreeSolv reference calculations
-    #   https://www.biorxiv.org/content/10.1101/104281v1.full
-    assert mean_abs_err_kcalmol <= 2
-
-
 @pytest.mark.nightly
 @pytest.mark.parametrize("insertion_type", ["untargeted"])
 def test_water_sampling_mc_bulk_water(insertion_type):


### PR DESCRIPTION
Addresses some pain points with the current organization of fixed-output (i.e. stable hash) tests in CI:
1. hash diffs are not printed until all tests have run (currently ~6 hours for nightly tests)
1. in cases where we expect hash diffs, we'd like the fixed-output tests to start running immediately for faster feedback

A partial workaround could be overriding `PYTEST_CI_ARGS` in the pipeline, but this is a manual step that must be remembered.

This PR moves all fixed-output tests to a separate (non-nightly) CI job.