### PR TITLE
Keep Residue Ids when writing CIF files

### DIFF
--- a/timemachine/fe/cif_writer.py
+++ b/timemachine/fe/cif_writer.py
@@ -90,10 +90,8 @@ class CIFWriter:
                     new_residue = combined_topology.addResidue(
                         name=old_residue.name,
                         chain=chain_obj,
-                        id=old_residue.id + (old_residue.insertionCode if old_residue.insertionCode else "")
-                        if old_residue.name != "HOH"
-                        else str(max([*used_residue_ids, 0]) + 1),
-                        insertionCode=old_residue.insertionCode
+                        id=old_residue.id if old_residue.name != "HOH" else str(max([*used_residue_ids, 0]) + 1),
+                        insertionCode=old_residue.insertionCode,
                     )
 
                     try:
@@ -148,9 +146,6 @@ class CIFWriter:
         # assert that ids are unique.
         atom_ids = list([x.id for x in combined_topology.atoms()])
         assert len(atom_ids) == len(set(atom_ids))
-
-        residue_ids = list([x.id for x in combined_topology.residues()])
-        assert len(residue_ids) == len(set(residue_ids))
 
         self.topology = combined_topology
         self.out_handle = open(out_filepath, "w")

--- a/timemachine/fe/cif_writer.py
+++ b/timemachine/fe/cif_writer.py
@@ -128,7 +128,7 @@ class CIFWriter:
 
         self.topology = combined_topology
         self.out_handle = open(out_filepath, "w")
-        PDBxFile.writeHeader(self.topology, self.out_handle)
+        PDBxFile.writeHeader(self.topology, self.out_handle, keepIds=True)
         self.topology = self.topology
         self.frame_idx = 0
 

--- a/timemachine/fe/cif_writer.py
+++ b/timemachine/fe/cif_writer.py
@@ -90,9 +90,10 @@ class CIFWriter:
                     new_residue = combined_topology.addResidue(
                         name=old_residue.name,
                         chain=chain_obj,
-                        id=(old_residue.id + old_residue.insertionCode if old_residue.insertionCode else "")
+                        id=old_residue.id + (old_residue.insertionCode if old_residue.insertionCode else "")
                         if old_residue.name != "HOH"
                         else str(max([*used_residue_ids, 0]) + 1),
+                        insertionCode=old_residue.insertionCode
                     )
 
                     try:

--- a/timemachine/fe/cif_writer.py
+++ b/timemachine/fe/cif_writer.py
@@ -92,7 +92,7 @@ class CIFWriter:
                         chain=chain_obj,
                         id=(old_residue.id + old_residue.insertionCode if old_residue.insertionCode else "")
                         if old_residue.name != "HOH"
-                        else str(max(used_residue_ids) + 1),
+                        else str(max(used_residue_ids + [0]) + 1),
                     )
 
                     try:
@@ -117,7 +117,7 @@ class CIFWriter:
                 mol = obj
                 new_chain = combined_topology.addChain()
                 new_residue = combined_topology.addResidue(
-                    name="LIG", chain=new_chain, id=str(max(used_residue_ids) + 1)
+                    name="LIG", chain=new_chain, id=str(max(used_residue_ids + [0]) + 1)
                 )
 
                 try:

--- a/timemachine/fe/cif_writer.py
+++ b/timemachine/fe/cif_writer.py
@@ -92,7 +92,7 @@ class CIFWriter:
                         chain=chain_obj,
                         id=(old_residue.id + old_residue.insertionCode if old_residue.insertionCode else "")
                         if old_residue.name != "HOH"
-                        else str(max(used_residue_ids + [0]) + 1),
+                        else str(max([*used_residue_ids, 0]) + 1),
                     )
 
                     try:
@@ -117,7 +117,7 @@ class CIFWriter:
                 mol = obj
                 new_chain = combined_topology.addChain()
                 new_residue = combined_topology.addResidue(
-                    name="LIG", chain=new_chain, id=str(max(used_residue_ids + [0]) + 1)
+                    name="LIG", chain=new_chain, id=str(max([*used_residue_ids, 0]) + 1)
                 )
 
                 try:

--- a/timemachine/fe/cif_writer.py
+++ b/timemachine/fe/cif_writer.py
@@ -85,7 +85,7 @@ class CIFWriter:
                 old_atom_obj_kv = {}
                 for old_residue in old_topology.residues():
                     chain_obj = old_chain_obj_kv[old_residue.chain]
-                    new_residue = combined_topology.addResidue(name=old_residue.name, chain=chain_obj)
+                    new_residue = combined_topology.addResidue(name=old_residue.name, chain=chain_obj, id=old_residue.id)
                     for old_atom in old_residue.atoms():
                         new_atom = combined_topology.addAtom(old_atom.name, old_atom.element, new_residue)
                         assert old_atom not in old_atom_obj_kv
@@ -143,7 +143,7 @@ class CIFWriter:
 
         """
         self.frame_idx += 1
-        PDBxFile.writeModel(self.topology, x, self.out_handle, self.frame_idx)
+        PDBxFile.writeModel(self.topology, x, self.out_handle, self.frame_idx, keepIds=True)
 
     def close(self):
         # Need this final #

--- a/timemachine/fe/cif_writer.py
+++ b/timemachine/fe/cif_writer.py
@@ -90,8 +90,10 @@ class CIFWriter:
                     new_residue = combined_topology.addResidue(
                         name=old_residue.name,
                         chain=chain_obj,
-                        id=old_residue.id if old_residue.name != "HOH" else str(max([*used_residue_ids, 0]) + 1),
-                        insertionCode=old_residue.insertionCode,
+                        id=old_residue.id + (old_residue.insertionCode if old_residue.insertionCode else "")
+                        if old_residue.name != "HOH"
+                        else str(max([*used_residue_ids, 0]) + 1),
+                        insertionCode=old_residue.insertionCode
                     )
 
                     try:
@@ -146,6 +148,9 @@ class CIFWriter:
         # assert that ids are unique.
         atom_ids = list([x.id for x in combined_topology.atoms()])
         assert len(atom_ids) == len(set(atom_ids))
+
+        residue_ids = list([x.id for x in combined_topology.residues()])
+        assert len(residue_ids) == len(set(residue_ids))
 
         self.topology = combined_topology
         self.out_handle = open(out_filepath, "w")

--- a/timemachine/fe/cif_writer.py
+++ b/timemachine/fe/cif_writer.py
@@ -93,7 +93,7 @@ class CIFWriter:
                         id=old_residue.id + (old_residue.insertionCode if old_residue.insertionCode else "")
                         if old_residue.name != "HOH"
                         else str(max([*used_residue_ids, 0]) + 1),
-                        insertionCode=old_residue.insertionCode
+                        insertionCode=old_residue.insertionCode,
                     )
 
                     try:

--- a/timemachine/fe/cif_writer.py
+++ b/timemachine/fe/cif_writer.py
@@ -26,8 +26,8 @@ def convert_single_topology_mols(coords: np.ndarray, atom_map: AtomMapMixin) -> 
         >>> writer.close()
 
     """
-    xa = np.zeros((atom_map.num_atoms_a, 3))
-    xb = np.zeros((atom_map.num_atoms_b, 3))
+    xa = np.zeros((atom_map.mol_a.GetNumAtoms(), 3))
+    xb = np.zeros((atom_map.mol_b.GetNumAtoms(), 3))
     for a_idx, c_idx in enumerate(atom_map.a_to_c):
         xa[a_idx] = coords[c_idx]
     for b_idx, c_idx in enumerate(atom_map.b_to_c):


### PR DESCRIPTION
Keep residue ids from the topology when writing cif files using the CIFWriter. This allows users who use truncated proteins in FEP to keep residue ids consistent when looking at trajectories or representative structures from the simulation.